### PR TITLE
If the database is dead and can't be connected all the time, the master is easy to fill the log and let the user decide the maximum number of failures.

### DIFF
--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -21,7 +21,6 @@
 # master execute task number in parallel
 #master.exec.task.num=20
 
-
 # master dispatch task number
 #master.dispatch.task.num = 3
 
@@ -34,7 +33,6 @@
 # master commit task interval
 #master.task.commit.interval=1000
 
-
 # only less than cpu avg load, master server can work.  default value -1 : the number of cpu cores * 2
 #master.max.cpuload.avg=-1
 
@@ -44,6 +42,5 @@
 # master listen port
 #master.listen.port=5678
 
-
-#Maximum number of failed database retries
+# maximum number of failed database retries
 #maxdbconnretrytimes=360

--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -43,3 +43,7 @@
 
 # master listen port
 #master.listen.port=5678
+
+
+#Maximum number of failed database retries
+#maxdbconnretrytimes=360


### PR DESCRIPTION
If the database is dead and can't be connected all the time, the master is easy to fill the log and let the user decide the maximum number of failures. If the number of failures is reached, the master exits. In this way, the maximum number of logs is controlled. The default number of database reconnections is 360.
