### PR TITLE
[Fix-4734][UI] Fix file update dialog not reset after re-open the dialog

### DIFF
--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/definitionUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/definitionUpdate.vue
@@ -143,10 +143,12 @@
             this.$message.success(res.msg)
             resolve()
             self.$emit('onUpdateDefinition')
+            this.reset()
           }, e => {
             reject(e)
             self.$emit('closeDefinition')
             this.$message.error(e.msg || '')
+            this.reset()
           }, {
             data: formData,
             emulateJSON: false,
@@ -170,6 +172,13 @@
       },
       close () {
         this.$emit('closeDefinition')
+      },
+      reset () {
+        this.name = ''
+        this.description = ''
+        this.progress = 0
+        this.file = ''
+        this.dragOver = false
       },
       /**
        * Drag and drop upload

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildReUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildReUpdate.vue
@@ -196,10 +196,12 @@
             this.$message.success(res.msg)
             resolve()
             self.$emit('onUpdate')
+            this.reset()
           }, e => {
             reject(e)
             self.$emit('close')
             this.$message.error(e.msg || '')
+            this.reset()
           }, {
             data: formData,
             emulateJSON: false,
@@ -220,6 +222,14 @@
       _ckArchive () {
         $('.update-file-modal').hide()
         this.$emit('onArchive')
+      },
+      reset () {
+        this.name = ''
+        this.description = ''
+        this.progress = 0
+        this.file = null
+        this.currentDir = localStore.getItem('currentDir')
+        this.dragOver = false
       },
       /**
        * Drag and drop upload

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildUpdate.vue
@@ -181,10 +181,12 @@
             this.$message.success(res.msg)
             resolve()
             self.$emit('onUpdateFileChildUpdate')
+            this.reset()
           }, e => {
             reject(e)
             self.$emit('close')
             this.$message.error(e.msg || '')
+            this.reset()
           }, {
             data: formData,
             emulateJSON: false,
@@ -217,6 +219,15 @@
       },
       close () {
         this.$emit('closeFileChildUpdate')
+      },
+      reset () {
+        this.name = ''
+        this.description = ''
+        this.progress = 0
+        this.file = ''
+        this.currentDir = localStore.getItem('currentDir')
+        this.pid = -1
+        this.dragOver = false
       }
     },
     mounted () {

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileReUpload.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileReUpload.vue
@@ -195,10 +195,12 @@
             this.$message.success(res.msg)
             resolve()
             self.$emit('onUpdate')
+            this.reset()
           }, e => {
             reject(e)
             self.$emit('close')
             this.$message.error(e.msg || '')
+            this.reset()
           }, {
             data: formData,
             emulateJSON: false,
@@ -219,6 +221,14 @@
       _ckArchive () {
         $('.update-file-modal').hide()
         this.$emit('onArchive')
+      },
+      reset () {
+        this.name = ''
+        this.description = ''
+        this.progress = 0
+        this.file = null
+        this.currentDir = '/'
+        this.dragOver = false
       },
       /**
        * Drag and drop upload

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileUpdate.vue
@@ -179,10 +179,12 @@
             this.$message.success(res.msg)
             resolve()
             self.$emit('onUpdateFileUpdate')
+            this.reset()
           }, e => {
             reject(e)
             self.$emit('closeFileUpdate')
             this.$message.error(e.msg || '')
+            this.reset()
           }, {
             data: formData,
             emulateJSON: false,
@@ -206,6 +208,15 @@
       },
       close () {
         this.$emit('closeFileUpdate')
+      },
+      reset () {
+        this.name = ''
+        this.description = ''
+        this.progress = 0
+        this.file = ''
+        this.currentDir = '/'
+        this.pid = -1
+        this.dragOver = false
       },
       /**
        * Drag and drop upload

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/resourceChildUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/resourceChildUpdate.vue
@@ -181,10 +181,12 @@
             this.$message.success(res.msg)
             resolve()
             self.$emit('onUpdateResourceChildUpdate')
+            this.reset()
           }, e => {
             reject(e)
             self.$emit('close')
             this.$message.error(e.msg || '')
+            this.reset()
           }, {
             data: formData,
             emulateJSON: false,
@@ -205,6 +207,15 @@
       _ckArchive () {
         $('.update-file-modal').hide()
         this.$emit('onArchiveResourceChildUpdate')
+      },
+      reset () {
+        this.name = ''
+        this.description = ''
+        this.progress = 0
+        this.file = ''
+        this.currentDir = localStore.getItem('currentDir')
+        this.pid = -1
+        this.dragOver = false
       },
       /**
        * Drag and drop upload

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/udfUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/udfUpdate.vue
@@ -124,11 +124,13 @@
           this.spinnerLoading = false
           this.progress = 0
           this.$emit('on-update', res.data)
+          this.reset()
         }, e => {
           this.spinnerLoading = false
           this.progress = 0
           this.$message.error(e.msg || '')
           this.$emit('on-update', e)
+          this.reset()
         }, {
           data: formData,
           emulateJSON: false,
@@ -148,6 +150,15 @@
             this._formDataUpdate()
           })
         }
+      },
+      reset () {
+        this.udfName = ''
+        this.udfDesc = ''
+        this.file = ''
+        this.progress = 0
+        this.spinnerLoading = false
+        this.pid = null
+        this.currentDir = ''
       }
     },
     watch: {},


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

**Fix file update dialog not reset after re-open the dialog**

This closes #4734

## Brief change log

  - *Add method `reset` and call it after dialog closed*

## Verify this pull request

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*
