### PR TITLE
[Fix-4738][Mail] Fix send mail failed instead of execute sql error

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
@@ -298,8 +298,12 @@ public class SqlTask extends AbstractTask {
         String result = JSONUtils.toJsonString(resultJSONArray);
         logger.debug("execute sql : {}", result);
 
-        sendAttachment(sqlParameters.getGroupId(), StringUtils.isNotEmpty(sqlParameters.getTitle()) ? sqlParameters.getTitle() : taskExecutionContext.getTaskName() + " query result sets",
-                JSONUtils.toJsonString(resultJSONArray));
+        try {
+            sendAttachment(sqlParameters.getGroupId(), StringUtils.isNotEmpty(sqlParameters.getTitle()) ? sqlParameters.getTitle() : taskExecutionContext.getTaskName() + " query result sets",
+                    JSONUtils.toJsonString(resultJSONArray));
+        } catch (Exception e) {
+            logger.warn("sql task sendAttachment error! msg : {} ", e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

**Fix send mail failed instead of execute sql error**

This closes #4738 #4710 #4621

## Brief change log

*(for example:)*
  - *Capture the `RuntimeException("send mail failed!")` in `server/worker/task/sql/SqlTask.java`*

## Verify this pull request

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*

After fix:
![image](https://user-images.githubusercontent.com/4902714/107212020-4fd96d80-6a41-11eb-93b9-2db1c9de9c0d.png)
