### PR TITLE
chore: fix license checker to allow nested directories

### DIFF
--- a/tools/dependencies/check-LICENSE.sh
+++ b/tools/dependencies/check-LICENSE.sh
@@ -25,12 +25,10 @@ tar -zxf dolphinscheduler-dist/target/apache-dolphinscheduler*-bin.tar.gz --stri
 # licenses
 echo '=== Self modules: ' && ./mvnw --batch-mode --quiet -Dexec.executable='echo' -Dexec.args='${project.artifactId}-${project.version}.jar' exec:exec | tee self-modules.txt
 
-echo '=== Distributed dependencies: ' && find dist/lib -name "*.jar" | tee all-dependencies.txt
-# The prefix "dist/lib/" (9 chars) should be stripped to be ready to compare
-sed -i 's/.\{9\}//' all-dependencies.txt
+echo '=== Distributed dependencies: ' && find dist/lib -name "*.jar" -exec basename {} + | uniq | sort | tee all-dependencies.txt
 
 # Exclude all self modules(jars) to generate all third-party dependencies
-echo '=== Third party dependencies: ' && grep -vf self-modules.txt all-dependencies.txt | tee third-party-dependencies.txt
+echo '=== Third party dependencies: ' && grep -vf self-modules.txt all-dependencies.txt | uniq | sort | tee third-party-dependencies.txt
 
 # 1. Compare the third-party dependencies with known dependencies, expect that all third-party dependencies are KNOWN
 # and the exit code of the command is 0, otherwise we should add its license to LICENSE file and add the dependency to

--- a/tools/dependencies/check-LICENSE.sh
+++ b/tools/dependencies/check-LICENSE.sh
@@ -25,7 +25,7 @@ tar -zxf dolphinscheduler-dist/target/apache-dolphinscheduler*-bin.tar.gz --stri
 # licenses
 echo '=== Self modules: ' && ./mvnw --batch-mode --quiet -Dexec.executable='echo' -Dexec.args='${project.artifactId}-${project.version}.jar' exec:exec | tee self-modules.txt
 
-echo '=== Distributed dependencies: ' && find dist/lib -name "*.jar" -exec basename {} + | uniq | sort | tee all-dependencies.txt
+echo '=== Distributed dependencies: ' && find dist/lib -name "*.jar" -exec basename {} \; | uniq | sort | tee all-dependencies.txt
 
 # Exclude all self modules(jars) to generate all third-party dependencies
 echo '=== Third party dependencies: ' && grep -vf self-modules.txt all-dependencies.txt | uniq | sort | tee third-party-dependencies.txt


### PR DESCRIPTION
## What is the purpose of the pull request

Enhance `check-LICENSE.sh` to enable checking libs in nested directories.

## Brief change log

- `tools/dependencies/check-LICENSE.sh`: only check base name of the lib file.

## Verify this pull request

This pull request is code cleanup without any test coverage.
