### PR TITLE
[Improvement][SQL] Remove unused table: t_ds_master_server and t_ds_worker_server

### DIFF
--- a/sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -105,21 +105,6 @@ CREATE TABLE `t_escheduler_datasource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
--- Table structure for t_escheduler_master_server
--- ----------------------------
-DROP TABLE IF EXISTS `t_escheduler_master_server`;
-CREATE TABLE `t_escheduler_master_server` (
-  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'key',
-  `host` varchar(45) DEFAULT NULL COMMENT 'ip',
-  `port` int(11) DEFAULT NULL COMMENT 'port',
-  `zk_directory` varchar(64) DEFAULT NULL COMMENT 'the server path in zk directory',
-  `res_info` varchar(256) DEFAULT NULL COMMENT 'json resource information:{"cpu":xxx,"memroy":xxx}',
-  `create_time` datetime DEFAULT NULL COMMENT 'create time',
-  `last_heartbeat_time` datetime DEFAULT NULL COMMENT 'last head beat time',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
--- ----------------------------
 -- Table structure for t_escheduler_process_definition
 -- ----------------------------
 DROP TABLE IF EXISTS `t_escheduler_process_definition`;
@@ -425,21 +410,6 @@ CREATE TABLE `t_escheduler_user` (
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_name_unique` (`user_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
--- ----------------------------
--- Table structure for t_escheduler_worker_server
--- ----------------------------
-DROP TABLE IF EXISTS `t_escheduler_worker_server`;
-CREATE TABLE `t_escheduler_worker_server` (
-  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'key',
-  `host` varchar(45) DEFAULT NULL COMMENT 'ip',
-  `port` int(11) DEFAULT NULL COMMENT 'process id',
-  `zk_directory` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL COMMENT 'zk path',
-  `res_info` varchar(255) DEFAULT NULL COMMENT 'json resource info,{"cpu":xxx,"memroy":xxx}',
-  `create_time` datetime DEFAULT NULL COMMENT 'create time',
-  `last_heartbeat_time` datetime DEFAULT NULL COMMENT 'update time',
-  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
  /*drop table first */

--- a/sql/create/release-1.2.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/sql/create/release-1.2.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -279,21 +279,6 @@ CREATE TABLE t_ds_error_command (
   message text ,
   PRIMARY KEY (id)
 );
---
--- Table structure for table t_ds_master_server
---
-
-DROP TABLE IF EXISTS t_ds_master_server;
-CREATE TABLE t_ds_master_server (
-  id int NOT NULL  ,
-  host varchar(45) DEFAULT NULL ,
-  port int DEFAULT NULL ,
-  zk_directory varchar(64) DEFAULT NULL ,
-  res_info varchar(256) DEFAULT NULL ,
-  create_time timestamp DEFAULT NULL ,
-  last_heartbeat_time timestamp DEFAULT NULL ,
-  PRIMARY KEY (id)
-) ;
 
 --
 -- Table structure for table t_ds_process_definition
@@ -658,22 +643,6 @@ CREATE TABLE t_ds_worker_group (
   PRIMARY KEY (id)
 ) ;
 
---
--- Table structure for table t_ds_worker_server
---
-
-DROP TABLE IF EXISTS t_ds_worker_server;
-CREATE TABLE t_ds_worker_server (
-  id int NOT NULL  ,
-  host varchar(45) DEFAULT NULL ,
-  port int DEFAULT NULL ,
-  zk_directory varchar(64)   DEFAULT NULL ,
-  res_info varchar(255) DEFAULT NULL ,
-  create_time timestamp DEFAULT NULL ,
-  last_heartbeat_time timestamp DEFAULT NULL ,
-  PRIMARY KEY (id)
-) ;
-
 
 DROP SEQUENCE IF EXISTS t_ds_access_token_id_sequence;
 CREATE SEQUENCE  t_ds_access_token_id_sequence;
@@ -691,9 +660,6 @@ ALTER TABLE t_ds_command ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_command_id_se
 DROP SEQUENCE IF EXISTS t_ds_datasource_id_sequence;
 CREATE SEQUENCE  t_ds_datasource_id_sequence;
 ALTER TABLE t_ds_datasource ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_datasource_id_sequence');
-DROP SEQUENCE IF EXISTS t_ds_master_server_id_sequence;
-CREATE SEQUENCE  t_ds_master_server_id_sequence;
-ALTER TABLE t_ds_master_server ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_master_server_id_sequence');
 DROP SEQUENCE IF EXISTS t_ds_process_definition_id_sequence;
 CREATE SEQUENCE  t_ds_process_definition_id_sequence;
 ALTER TABLE t_ds_process_definition ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_process_definition_id_sequence');
@@ -752,6 +718,3 @@ ALTER TABLE t_ds_version ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_version_id_se
 DROP SEQUENCE IF EXISTS t_ds_worker_group_id_sequence;
 CREATE SEQUENCE  t_ds_worker_group_id_sequence;
 ALTER TABLE t_ds_worker_group ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_worker_group_id_sequence');
-DROP SEQUENCE IF EXISTS t_ds_worker_server_id_sequence;
-CREATE SEQUENCE  t_ds_worker_server_id_sequence;
-ALTER TABLE t_ds_worker_server ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_worker_server_id_sequence');

--- a/sql/dolphinscheduler_postgre.sql
+++ b/sql/dolphinscheduler_postgre.sql
@@ -276,9 +276,6 @@ CREATE TABLE t_ds_error_command (
   message text ,
   PRIMARY KEY (id)
 );
---
--- Table structure for table t_ds_master_server
---
 
 --
 -- Table structure for table t_ds_process_definition
@@ -664,22 +661,6 @@ CREATE TABLE t_ds_worker_group (
   PRIMARY KEY (id)
 ) ;
 
---
--- Table structure for table t_ds_worker_server
---
-
-DROP TABLE IF EXISTS t_ds_worker_server;
-CREATE TABLE t_ds_worker_server (
-  id int NOT NULL  ,
-  host varchar(45) DEFAULT NULL ,
-  port int DEFAULT NULL ,
-  zk_directory varchar(64)   DEFAULT NULL ,
-  res_info varchar(255) DEFAULT NULL ,
-  create_time timestamp DEFAULT NULL ,
-  last_heartbeat_time timestamp DEFAULT NULL ,
-  PRIMARY KEY (id)
-) ;
-
 
 DROP SEQUENCE IF EXISTS t_ds_access_token_id_sequence;
 CREATE SEQUENCE  t_ds_access_token_id_sequence;
@@ -755,9 +736,6 @@ ALTER TABLE t_ds_version ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_version_id_se
 DROP SEQUENCE IF EXISTS t_ds_worker_group_id_sequence;
 CREATE SEQUENCE  t_ds_worker_group_id_sequence;
 ALTER TABLE t_ds_worker_group ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_worker_group_id_sequence');
-DROP SEQUENCE IF EXISTS t_ds_worker_server_id_sequence;
-CREATE SEQUENCE t_ds_worker_server_id_sequence;
-ALTER TABLE t_ds_worker_server ALTER COLUMN id SET DEFAULT NEXTVAL('t_ds_worker_server_id_sequence');
 
 
 -- Records of t_ds_user?user : admin , password : dolphinscheduler123

--- a/sql/upgrade/1.2.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.2.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -124,24 +124,6 @@ delimiter ;
 CALL ut_dolphin_T_t_ds_error_command;
 DROP PROCEDURE ut_dolphin_T_t_ds_error_command;
 
--- ut_dolphin_T_t_ds_master_server
-drop PROCEDURE if EXISTS ut_dolphin_T_t_ds_master_server;
-delimiter d//
-CREATE PROCEDURE ut_dolphin_T_t_ds_master_server()
-	BEGIN
-		IF EXISTS (SELECT 1 FROM information_schema.TABLES
-			WHERE TABLE_NAME='t_escheduler_master_server'
-			AND TABLE_SCHEMA=(SELECT DATABASE()))
-		THEN
-			ALTER TABLE t_escheduler_master_server RENAME t_ds_master_server;
-		END IF;
-	END;
-d//
-
-delimiter ;
-CALL ut_dolphin_T_t_ds_master_server;
-DROP PROCEDURE ut_dolphin_T_t_ds_master_server;
-
 -- ut_dolphin_T_t_ds_process_definition
 drop PROCEDURE if EXISTS ut_dolphin_T_t_ds_process_definition;
 delimiter d//
@@ -483,24 +465,6 @@ d//
 delimiter ;
 CALL ut_dolphin_T_t_ds_worker_group;
 DROP PROCEDURE ut_dolphin_T_t_ds_worker_group;
-
--- ut_dolphin_T_t_ds_worker_server
-drop PROCEDURE if EXISTS ut_dolphin_T_t_ds_worker_server;
-delimiter d//
-CREATE PROCEDURE ut_dolphin_T_t_ds_worker_server()
-	BEGIN
-		IF EXISTS (SELECT 1 FROM information_schema.TABLES
-			WHERE TABLE_NAME='t_escheduler_worker_server'
-			AND TABLE_SCHEMA=(SELECT DATABASE()))
-		THEN
-			ALTER TABLE t_escheduler_worker_server RENAME t_ds_worker_server;
-		END IF;
-	END;
-d//
-
-delimiter ;
-CALL ut_dolphin_T_t_ds_worker_server;
-DROP PROCEDURE ut_dolphin_T_t_ds_worker_server;
 
 -- uc_dolphin_T_t_ds_alertgroup_C_desc
 drop PROCEDURE if EXISTS uc_dolphin_T_t_ds_alertgroup_C_desc;


### PR DESCRIPTION
## What is the purpose of the pull request

**Remove unused table: t_ds_master_server and t_ds_worker_server**

## Brief change log

*Remove unused t_ds_master_server and t_ds_worker_server*: 

  - *`sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql`*
  - *`sql/create/release-1.2.0_schema/postgresql/dolphinscheduler_ddl.sql`*
  - *`sql/upgrade/1.2.0_schema/mysql/dolphinscheduler_ddl.sql`*
  - *`sql/dolphinscheduler_postgre.sql`*

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.