### PR TITLE
[Fix-4760][api] Repair dolphinscheduler-postgre.sql error sql

### DIFF
--- a/sql/dolphinscheduler-postgre.sql
+++ b/sql/dolphinscheduler-postgre.sql
@@ -767,9 +767,10 @@ INSERT INTO t_ds_user(user_name, user_password, user_type, email, phone, tenant_
 VALUES ('admin', '7ad2410b2f4c074479a8937a28a22b8f', '0', 'xxx@qq.com', '', '0', 1, '2018-03-27 15:48:50',
         '2018-10-24 17:40:22');
 
--- Records of t_ds_alertgroup，dolphinscheduler warning group
-INSERT INTO t_ds_alertgroup(id,alert_instance_ids, create_user_id, group_name, description, create_time, update_time)
-VALUES (1,'1,2', 1, 'default admin warning group', 'default admin warning group', '2018-11-29 10:20:39', '2018-11-29 10:20:39');
+-- Records of t_ds_alertgroup, default admin warning group
+INSERT INTO t_ds_alertgroup(alert_instance_ids, create_user_id, group_name, description, create_time, update_time)
+VALUES ('1,2', 1, 'default admin warning group', 'default admin warning group', '2018-11-29 10:20:39',
+        '2018-11-29 10:20:39');
 
 -- Records of t_ds_queue,default queue name : default
 INSERT INTO t_ds_queue(queue_name, queue, create_time, update_time)

--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -812,7 +812,7 @@ VALUES ('1', '1.3.0');
 -- Records of t_ds_alertgroup
 -- ----------------------------
 INSERT INTO `t_ds_alertgroup`
-VALUES (1,"1,2", 1, 'default admin warning group', 'default admin warning group', '2018-11-29 10:20:39',
+VALUES ("1,2", 1, 'default admin warning group', 'default admin warning group', '2018-11-29 10:20:39',
         '2018-11-29 10:20:39');
 
 -- ----------------------------


### PR DESCRIPTION
## What is the purpose of the pull request

*[Fix-4760][api] Repair dolphinscheduler-postgre.sql error sql*

The pr #4763 introduced the failed unit test as follow, resulting that this problem occurs in subsequent commit and pr:

```
Error:  Errors: 
Error:    AlertGroupMapperTest.testQueryAllGroupList:170->createAlertGroups:265->createAlertGroup:228 » DuplicateKey
[INFO] 
Error:  Tests run: 179, Failures: 0, Errors: 1, Skipped: 0
```

![image](https://user-images.githubusercontent.com/4902714/107945174-364c9e80-6fca-11eb-8ac7-653b6deb8b14.png)

## Brief change log

  - *[Fix-4760][api] Repair dolphinscheduler-postgre.sql error sql*

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.