### PR TITLE
[Fix][CI] Fix error: unable to resolve action apache/skywalking-eyes@9bd5feb

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           submodule: true
       - name: Check License Header
-        uses: apache/skywalking-eyes@9bd5feb
+        uses: apache/skywalking-eyes@ec88b7d850018c8983f87729ea88549e100c5c82
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/ci_e2e.yml
+++ b/.github/workflows/ci_e2e.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           submodule: true
       - name: Check License Header
-        uses: apache/skywalking-eyes@9bd5feb
+        uses: apache/skywalking-eyes@ec88b7d850018c8983f87729ea88549e100c5c82
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodule: true
       - name: Check License Header
-        uses: apache/skywalking-eyes@9bd5feb
+        uses: apache/skywalking-eyes@ec88b7d850018c8983f87729ea88549e100c5c82
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Only enable review / suggestion here
       - uses: actions/cache@v1


### PR DESCRIPTION
## What is the purpose of the pull request

*Fix error: unable to resolve action apache/skywalking-eyes@9bd5feb*

```
Error: Unable to resolve action `apache/skywalking-eyes@9bd5feb`, the provided ref `9bd5feb` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `9bd5feb86b5817aa6072b008f9866a2c3bbc8587` instead.
```

![image](https://user-images.githubusercontent.com/4902714/108101698-8d359f00-70c2-11eb-8ef5-6924ca753122.png)

## Brief change log

*(for example:)*
  - *Replace `apache/skywalking-eyes@9bd5feb` with `apache/skywalking-eyes@ec88b7d850018c8983f87729ea88549e100c5c82`*
  - *`ec88b7d850018c8983f87729ea88549e100c5c82` is the latest commit, which is newer than `9bd5feb`*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.