### PR TITLE
[Fix-3298][K8s] Fix wrong host of task instance in k8s

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -72,6 +72,17 @@ public class NetUtils {
         return getAddr(getHost(), port);
     }
 
+    /**
+     * get host
+     * @return host
+     */
+    public static String getHost(InetAddress inetAddress) {
+        if (inetAddress != null) {
+            return Constants.KUBERNETES_MODE ? inetAddress.getHostName() : inetAddress.getHostAddress();
+        }
+        return null;
+    }
+
     public static String getHost() {
         if (HOST_ADDRESS != null) {
             return HOST_ADDRESS;
@@ -79,7 +90,7 @@ public class NetUtils {
 
         InetAddress address = getLocalAddress();
         if (address != null) {
-            HOST_ADDRESS = Constants.KUBERNETES_MODE ? address.getHostName() : address.getHostAddress();
+            HOST_ADDRESS = getHost(address);
             return HOST_ADDRESS;
         }
         return Constants.KUBERNETES_MODE ? "localhost" : "127.0.0.1";

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/utils/ChannelUtils.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/utils/ChannelUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.remote.utils;
 
+import org.apache.dolphinscheduler.common.utils.NetUtils;
+
 import java.net.InetSocketAddress;
 
 import io.netty.channel.Channel;
@@ -37,7 +39,7 @@ public class ChannelUtils {
      * @return local address
      */
     public static String getLocalAddress(Channel channel) {
-        return ((InetSocketAddress) channel.localAddress()).getAddress().getHostAddress();
+        return NetUtils.getHost(((InetSocketAddress) channel.localAddress()).getAddress());
     }
 
     /**
@@ -47,7 +49,7 @@ public class ChannelUtils {
      * @return remote address
      */
     public static String getRemoteAddress(Channel channel) {
-        return ((InetSocketAddress) channel.remoteAddress()).getAddress().getHostAddress();
+        return NetUtils.getHost(((InetSocketAddress) channel.remoteAddress()).getAddress());
     }
 
     /**
@@ -58,7 +60,7 @@ public class ChannelUtils {
      */
     public static Host toAddress(Channel channel) {
         InetSocketAddress socketAddress = ((InetSocketAddress) channel.remoteAddress());
-        return new Host(socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+        return new Host(NetUtils.getHost(socketAddress.getAddress()), socketAddress.getPort());
     }
 
 }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryTest.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.server.master.registry;
 
 import static org.apache.dolphinscheduler.common.Constants.HEARTBEAT_FOR_ZOOKEEPER_INFO_LENGTH;
 
+import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.remote.utils.Constants;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.registry.ZookeeperRegistryCenter;
@@ -59,7 +60,7 @@ public class MasterRegistryTest {
         masterRegistry.registry();
         String masterPath = zookeeperRegistryCenter.getMasterPath();
         TimeUnit.SECONDS.sleep(masterConfig.getMasterHeartbeatInterval() + 2); //wait heartbeat info write into zk node
-        String masterNodePath = masterPath + "/" + (Constants.LOCAL_ADDRESS + ":" + masterConfig.getListenPort());
+        String masterNodePath = masterPath + "/" + (NetUtils.getAddr(Constants.LOCAL_ADDRESS, masterConfig.getListenPort()));
         String heartbeat = zookeeperRegistryCenter.getZookeeperCachedOperator().get(masterNodePath);
         Assert.assertEquals(HEARTBEAT_FOR_ZOOKEEPER_INFO_LENGTH, heartbeat.split(",").length);
         masterRegistry.unRegistry();


### PR DESCRIPTION
## What is the purpose of the pull request

*Fix wrong host of task instance in k8s*

This closes #3298

The last pr #4755 has cherry-picked all changes except for `ChannelUtils.java`. This pr cherry-picks the change of `ChannelUtils.java` from #4703

## Brief change log

  - *Modify `ChannelUtils.java`*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by testing locally.*