### PR TITLE
[Fix-4796][UI] Fix child file upload failure and file id mixed problem

### DIFF
--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/definitionUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/definitionUpdate.vue
@@ -46,7 +46,7 @@
             <template slot="content">
               <div class="file-update-box">
                 <template v-if="progress === 0">
-                  <input name="file" id="file" type="file" class="file-update">
+                  <input ref="file" name="file" type="file" class="file-update" @change="_onChange">
                   <el-button size="mini">{{$t('Upload')}}<em class="el-icon-upload"></em></el-button>
                 </template>
                 <div class="progress-box" v-if="progress !== 0">
@@ -188,14 +188,13 @@
         this.file = file
         this.name = file.name
         this.dragOver = false
-      }
-    },
-    mounted () {
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
+      },
+      _onChange () {
+        let file = this.$refs.file.files[0]
         this.file = file
         this.name = file.name
-      })
+        this.$refs.file.value = null
+      }
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildReUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildReUpdate.vue
@@ -69,7 +69,7 @@
             <template slot="content">
               <div class="file-update-box">
                 <template v-if="progress === 0">
-                  <input name="file" id="file" type="file" class="file-update">
+                  <input ref="file" name="file" type="file" class="file-update" @change="_onChange">
                   <el-button size="mini">{{$t('Upload')}}<em class="el-icon-upload"></em></el-button>
                 </template>
                 <div class="progress-box" v-if="progress !== 0">
@@ -239,16 +239,17 @@
         this.file = file
         this.name = file.name
         this.dragOver = false
+      },
+      _onChange () {
+        let file = this.$refs.file.files[0]
+        this.file = file
+        this.name = file.name
+        this.$refs.file.value = null
       }
     },
     mounted () {
       this.name = this.fileName
       this.description = this.desc
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
-        this.file = file
-        this.name = file.name
-      })
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileChildUpdate.vue
@@ -70,7 +70,7 @@
             <template slot="content">
               <div class="file-update-box">
                 <template v-if="progress === 0">
-                  <input name="file" id="file" type="file" class="file-update">
+                  <input ref="file" name="file" type="file" class="file-update" @change="_onChange">
                   <el-button size="mini">{{$t('Upload')}}<em class="el-icon-upload"></em></el-button>
                 </template>
                 <div class="progress-box" v-if="progress !== 0">
@@ -226,16 +226,15 @@
         this.progress = 0
         this.file = ''
         this.currentDir = localStore.getItem('currentDir')
-        this.pid = -1
+        this.pid = this.id
         this.dragOver = false
-      }
-    },
-    mounted () {
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
+      },
+      _onChange () {
+        let file = this.$refs.file.files[0]
         this.file = file
         this.name = file.name
-      })
+        this.$refs.file.value = null
+      }
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileReUpload.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileReUpload.vue
@@ -69,7 +69,7 @@
             <template slot="content">
               <div class="file-update-box">
                 <template v-if="progress === 0">
-                  <input name="file" id="file" type="file" class="file-update">
+                  <input ref="file" name="file" type="file" class="file-update" @change="_onChange">
                   <el-button size="mini"> {{$t('Upload')}} </el-button>
                 </template>
                 <div class="progress-box" v-if="progress !== 0">
@@ -238,16 +238,17 @@
         this.file = file
         this.name = file.name
         this.dragOver = false
+      },
+      _onChange () {
+        let file = this.$refs.file.files[0]
+        this.file = file
+        this.name = file.name
+        this.$refs.file.value = null
       }
     },
     mounted () {
       this.name = this.fileName
       this.description = this.desc
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
-        this.file = file
-        this.name = file.name
-      })
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileUpdate.vue
@@ -70,7 +70,7 @@
             <template slot="content">
               <div class="file-update-box">
                 <template v-if="progress === 0">
-                  <input name="file" id="file" type="file" class="file-update">
+                  <input ref="file" name="file" type="file" class="file-update" @change="_onChange">
                   <el-button type="dashed" size="mini">{{$t('Upload')}}<em class="el-icon-upload"></em></el-button>
                 </template>
                 <div class="progress-box" v-if="progress !== 0">
@@ -226,14 +226,13 @@
         this.file = file
         this.name = file.name
         this.dragOver = false
-      }
-    },
-    mounted () {
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
+      },
+      _onChange () {
+        let file = this.$refs.file.files[0]
         this.file = file
         this.name = file.name
-      })
+        this.$refs.file.value = null
+      }
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/resourceChildUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/resourceChildUpdate.vue
@@ -70,7 +70,7 @@
             <template slot="content">
               <div class="file-update-box">
                 <template v-if="progress === 0">
-                  <input name="file" id="file" type="file" class="file-update">
+                  <input ref="file" name="file" type="file" class="file-update" @change="_onChange">
                   <el-button size="mini">{{$t('Upload')}}<em class="el-icon-upload"></em></el-button>
                 </template>
                 <div class="progress-box" v-if="progress !== 0">
@@ -214,7 +214,7 @@
         this.progress = 0
         this.file = ''
         this.currentDir = localStore.getItem('currentDir')
-        this.pid = -1
+        this.pid = this.id
         this.dragOver = false
       },
       /**
@@ -226,16 +226,15 @@
         this.name = file.name
         this.dragOver = false
       },
+      _onChange () {
+        let file = this.$refs.file.files[0]
+        this.file = file
+        this.name = file.name
+        this.$refs.file.value = null
+      },
       close () {
         this.$emit('closeResourceChildUpdate')
       }
-    },
-    mounted () {
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
-        this.file = file
-        this.name = file.name
-      })
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/udfUpdate.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/udfUpdate.vue
@@ -29,7 +29,7 @@
                     :placeholder="$t('Please enter name')">
             </el-input>
             <div class="p1" style="position: absolute;">
-              <input name="file" id="file" type="file" class="file-update" v-if="!progress">
+              <input ref="file" name="file" type="file" class="file-update" @change="_onChange" v-if="!progress">
               <el-button type="dashed" size="small" :disabled="progress !== 0">{{$t('Upload')}}<em class="el-icon-upload"></em></el-button>
             </div>
           </div>
@@ -159,26 +159,14 @@
         this.spinnerLoading = false
         this.pid = null
         this.currentDir = ''
-      }
-    },
-    watch: {},
-    created () {
-    },
-    mounted () {
-      $('#file').change(() => {
-        let file = $('#file')[0].files[0]
+      },
+      _onChange () {
+        let file = this.$refs.file.files[0]
         this.file = file
         this.udfName = file.name
-      })
-    },
-    updated () {
-    },
-    beforeDestroy () {
-    },
-    destroyed () {
-    },
-    computed: {},
-    components: {}
+        this.$refs.file.value = null
+      }
+    }
   }
 </script>
 

--- a/dolphinscheduler-ui/src/js/module/components/nav/nav.vue
+++ b/dolphinscheduler-ui/src/js/module/components/nav/nav.vue
@@ -283,7 +283,7 @@
           this._toggleArchive()
           return
         }
-        this.type = true
+        this.type = type
         this.id = data
         this.fileChildUpdateDialog = true
       },


### PR DESCRIPTION
## What is the purpose of the pull request

*Fix child file upload failure and file id mixed problem*

This closes #4796

## Brief change log

  - *Fix code error `this.type = type` instead of `this.type = true` in `js/module/components/nav/nav.vue` which resulting the child file upload failure*
  - *Remove file id attribution and add `file` reference*
  - *Bind `_onChange` function on the Input instead of listening change event in mount lifecycle*

## Verify this pull request

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*

Video Check: [https://recordit.co/kX9L4SyQen](https://recordit.co/kX9L4SyQen)
Gif Check: ![image](http://g.recordit.co/kX9L4SyQen.gif)