### PR TITLE
[BUG][API]Fix format2Duration when parameter has one is null

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
@@ -260,7 +260,7 @@ public class DateUtils {
      */
     public static String format2Duration(Date d1, Date d2) {
         if (d1 == null || d2 == null) {
-            return "";
+            return null;
         }
         return format2Duration(differMs(d1, d2));
     }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
@@ -259,6 +259,9 @@ public class DateUtils {
      * @return format time
      */
     public static String format2Duration(Date d1, Date d2) {
+        if (d1 == null || d2 == null) {
+            return "";
+        }
         return format2Duration(differMs(d1, d2));
     }
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
@@ -196,4 +196,12 @@ public class DateUtilsTest {
 
     }
 
+    @Test
+    public void testNullDuration() {
+        // days hours minutes seconds
+        Date d1 = DateUtils.stringToDate("2020-01-20 11:00:00");
+        Date d2 = null;
+        Assert.assertEquals("",DateUtils.format2Duration(d1,d2));
+    }
+
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
@@ -201,7 +201,7 @@ public class DateUtilsTest {
         // days hours minutes seconds
         Date d1 = DateUtils.stringToDate("2020-01-20 11:00:00");
         Date d2 = null;
-        Assert.assertEquals("", DateUtils.format2Duration(d1, d2));
+        Assert.assertNull(DateUtils.format2Duration(d1, d2));
     }
 
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
@@ -153,7 +153,7 @@ public class DateUtilsTest {
 
     @Test
     public void getCurrentTimeStamp() {
-        String timeStamp =  DateUtils.getCurrentTimeStamp();
+        String timeStamp = DateUtils.getCurrentTimeStamp();
         Assert.assertNotNull(timeStamp);
     }
 
@@ -201,7 +201,7 @@ public class DateUtilsTest {
         // days hours minutes seconds
         Date d1 = DateUtils.stringToDate("2020-01-20 11:00:00");
         Date d2 = null;
-        Assert.assertEquals("",DateUtils.format2Duration(d1,d2));
+        Assert.assertEquals("", DateUtils.format2Duration(d1, d2));
     }
 
 }


### PR DESCRIPTION
ThIs Close #4803 

When querying a workflow instance, a process instance is running and the query will fail。

---

当查询工作流实例时，一个流程实例正在运行，查询将会失败

The reason is that the end time is currently empty when calculating the process duration.
---
原因是因为，计算流程持续时间时，结束时间目前还是空。

So the query failed.

---

所以导致查询失败。