### PR TITLE
[Improvement][UI] The display order of complement parameters page is adjusted

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
@@ -110,21 +110,6 @@
         </div>
       </div>
     </div>
-    <div class="clearfix list">
-      <div class="text">
-        <span>{{$t('Startup parameter')}}</span>
-      </div>
-      <div class="cont" style="width: 688px;">
-        <div style="padding-top: 6px;">
-          <m-local-params
-                  ref="refLocalParams"
-                  @on-local-params="_onLocalParams"
-                  :udp-list="udpList"
-                  :hide="false">
-          </m-local-params>
-        </div>
-      </div>
-    </div>
     <template v-if="execType">
       <div class="clearfix list" style="margin:-6px 0 16px 0">
         <div class="text">
@@ -156,6 +141,21 @@
         </div>
       </div>
     </template>
+    <div class="clearfix list">
+      <div class="text">
+        <span>{{$t('Startup parameter')}}</span>
+      </div>
+      <div class="cont" style="width: 688px;">
+        <div style="padding-top: 6px;">
+          <m-local-params
+            ref="refLocalParams"
+            @on-local-params="_onLocalParams"
+            :udp-list="udpList"
+            :hide="false">
+          </m-local-params>
+        </div>
+      </div>
+    </div>
     <div class="submit">
       <el-button type="text" size="small" @click="close()"> {{$t('Cancel')}} </el-button>
       <el-button type="primary" size="small" round :loading="spinnerLoading" @click="ok()">{{spinnerLoading ? 'Loading...' : $t('Start')}} </el-button>


### PR DESCRIPTION

## What is the purpose of the pull request

The display order of complement parameters page is adjusted

change
![image](https://user-images.githubusercontent.com/37063904/108804438-440cb000-75d8-11eb-8772-9a8b6d1280d0.png)

to
![image](https://user-images.githubusercontent.com/37063904/108804463-4c64eb00-75d8-11eb-8823-b7327cf1a57e.png)


## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*
