### PR TITLE
[Improvement-4881][Docker] Add Default Login Credentials For the Web UI are not listed in the README

### DIFF
--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -25,6 +25,8 @@ The default **zookeeper** is created in the `docker-compose.yml`.
 
 Access the Web UI：http://192.168.xx.xx:12345/dolphinscheduler
 
+The default username is `admin` and the default password is `dolphinscheduler123`
+
 #### Or via Environment Variables **`DATABASE_HOST`** **`DATABASE_PORT`** **`DATABASE_DATABASE`** **`ZOOKEEPER_QUORUM`**
 
 You can specify **existing postgres and zookeeper service**. Example:


### PR DESCRIPTION
Added the default login credentials for the web UI.

fix #4881 

## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: Add details to the documentation.)*

## Brief change log

*(for example:)*
  - *Add default login credentials to docker/build/README.md*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.
