### PR TITLE
[Improvement-4884][Common] fix the subsequent processing of getting the YARN ResourceManager address to be empty

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/exception/BaseException.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/exception/BaseException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.common.exception;
+
+/**
+ * Base Exception class for DolphinScheduler
+ */
+public class BaseException extends Exception {
+
+    public BaseException() {
+    }
+
+    public BaseException(String message) {
+        super(message);
+    }
+
+    public BaseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BaseException(Throwable cause) {
+        super(cause);
+    }
+
+    public BaseException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -23,9 +23,9 @@ import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.enums.ResUploadType;
 import org.apache.dolphinscheduler.common.enums.ResourceType;
+import org.apache.dolphinscheduler.common.exception.BaseException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.dolphinscheduler.common.exception.BaseException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -25,6 +25,7 @@ import org.apache.dolphinscheduler.common.enums.ResUploadType;
 import org.apache.dolphinscheduler.common.enums.ResourceType;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.dolphinscheduler.common.exception.BaseException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -207,7 +208,7 @@ public class HadoopUtils implements Closeable {
         yarnEnabled = true;
         String appUrl = StringUtils.isEmpty(rmHaIds) ? appAddress : getAppAddress(appAddress, rmHaIds);
         if (StringUtils.isBlank(appUrl)) {
-            throw new Exception("yarn application url generation failed");
+            throw new BaseException("yarn application url generation failed");
         }
         if (logger.isDebugEnabled()) {
             logger.debug("yarn application url:{}, applicationId:{}", appUrl, applicationId);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -660,12 +660,7 @@ public class HadoopUtils implements Closeable {
                 }
 
             } catch (Exception e) {
-                for (int i = 1; i < rmIdArr.length; i++) {
-                    String  state = getRMState(String.format(yarnUrl, rmIdArr[i]));
-                    if (Constants.HADOOP_RM_STATE_ACTIVE.equals(state)) {
-                        return rmIdArr[i];
-                    }
-                }
+                logger.error("yarn ha application url generation failed, message:{}", e.getMessage());
             }
             return null;
         }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -204,21 +204,13 @@ public class HadoopUtils implements Closeable {
          *  if rmHaIds is empty, single resourcemanager enabled
          *  if rmHaIds not empty: resourcemanager HA enabled
          */
-        String appUrl = "";
-
-        if (StringUtils.isEmpty(rmHaIds)) {
-            //single resourcemanager enabled
-            appUrl = appAddress;
-            yarnEnabled = true;
-        } else {
-            //resourcemanager HA enabled
-            appUrl = getAppAddress(appAddress, rmHaIds);
-            yarnEnabled = true;
-            logger.info("application url : {}", appUrl);
-        }
-
+        yarnEnabled = true;
+        String appUrl = StringUtils.isEmpty(rmHaIds) ? appAddress : getAppAddress(appAddress, rmHaIds);
         if (StringUtils.isBlank(appUrl)) {
-            throw new Exception("application url is blank");
+            throw new Exception("yarn application url generation failed");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("yarn application url:{}, applicationId:{}", appUrl, applicationId);
         }
         return String.format(appUrl, applicationId);
     }
@@ -600,6 +592,10 @@ public class HadoopUtils implements Closeable {
 
         //get active ResourceManager
         String activeRM = YarnHAAdminUtils.getAcitveRMName(rmHa);
+
+        if (StringUtils.isEmpty(activeRM)) {
+            return null;
+        }
 
         String[] split1 = appAddress.split(Constants.DOUBLE_SLASH);
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
@@ -184,7 +184,7 @@ public class HadoopUtilsTest {
         }
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void getApplicationUrl() throws Exception {
         String application_1516778421218_0042 = hadoopUtils.getApplicationUrl("application_1529051418016_0167");
         logger.info(application_1516778421218_0042);


### PR DESCRIPTION
## What is the purpose of the pull request
this PR close #4884 
Acitve ReSourceManager IP = null when obtaining Acitve ReSourceManager address in YARN HA mode fails,the yarn application URL generation failed exception should be thrown here


## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*
