### PR TITLE
chore: fix case of GitHub and JavaScript

### DIFF
--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -2,7 +2,7 @@
 
 Dolphin Scheduler is a distributed and easy-to-expand visual DAG workflow scheduling system, dedicated to solving the complex dependencies in data processing, making the scheduling system out of the box for data processing.
 
-Github URL: https://github.com/apache/incubator-dolphinscheduler
+GitHub URL: https://github.com/apache/incubator-dolphinscheduler
 
 Official Website: https://dolphinscheduler.apache.org
 

--- a/docker/build/README_zh_CN.md
+++ b/docker/build/README_zh_CN.md
@@ -2,7 +2,7 @@
 
 一个分布式易扩展的可视化DAG工作流任务调度系统。致力于解决数据处理流程中错综复杂的依赖关系，使调度系统在数据处理流程中`开箱即用`。
 
-Github URL: https://github.com/apache/incubator-dolphinscheduler
+GitHub URL: https://github.com/apache/incubator-dolphinscheduler
 
 Official Website: https://dolphinscheduler.apache.org
 

--- a/e2e/src/test/java/org/apache/dolphinscheduler/common/BrowserCommon.java
+++ b/e2e/src/test/java/org/apache/dolphinscheduler/common/BrowserCommon.java
@@ -43,7 +43,7 @@ public class BrowserCommon {
     protected Actions actions;
 
     /**
-     * Javascript
+     * JavaScript
      */
     protected JavascriptExecutor je;
 


### PR DESCRIPTION
Changes are:

- `Github` -> `GitHub`
- `Javascript` -> `JavaScript`

## What is the purpose of the pull request

Fixes the brand names.

## Brief change log

## Verify this pull request

This pull request is code cleanup without any test coverage.


