### PR TITLE
[Improvement][CI] Replace token with github secrets

### DIFF
--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -66,7 +66,9 @@ jobs:
           mvn test -B -Dmaven.test.skip=false
       - name: Upload coverage report to codecov
         run: |
-          CODECOV_TOKEN="09c2663f-b091-4258-8a47-c981827eb29a" bash <(curl -s https://codecov.io/bash)
+          bash <(curl -s https://codecov.io/bash)
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       # Set up JDK 11 for SonarCloud.
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
@@ -81,7 +83,7 @@ jobs:
           -Dsonar.organization=apache
           -Dsonar.core.codeCoveragePlugin=jacoco
           -Dsonar.projectKey=apache-dolphinscheduler
-          -Dsonar.login=e4058004bc6be89decf558ac819aa1ecbee57682
+          -Dsonar.login=$SONAR_TOKEN
           -Dsonar.exclusions=dolphinscheduler-ui/src/**/i18n/locale/*.js,dolphinscheduler-microbench/src/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What is the purpose of the pull request

*Replace token with github secrets*

This closes the outdated pr #4102

## Brief change log

  - *Replace `CODECOV_TOKEN` with github secrets*
  - *Replace `SONAR_TOKEN` with github secrets*

## Requirements

The following variables need to be set under the `Actions secrets` in the `Secrets` settings page of `apache/incubator-dolphinscheduler` repository:

  - `CODECOV_TOKEN`
  - `SONAR_TOKEN` 

![image](https://user-images.githubusercontent.com/4902714/109522019-e05b1900-7ae8-11eb-8090-71d3d9e9af4d.png)