### PR TITLE
[Fix-4963][Dao] fix Mybtis Mapper used foreach syntax to traverse collections and the collection was empty

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/DataSourceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/DataSourceMapper.xml
@@ -91,7 +91,7 @@
         where
         id in (select datasource_id from t_ds_relation_datasource_user where user_id=#{userId}
         union select id as datasource_id from t_ds_datasource where user_id=#{userId})
-        <if test="dataSourceIds != null and dataSourceIds != ''">
+        <if test="dataSourceIds != null and dataSourceIds.length > 0">
             and id in
             <foreach collection="dataSourceIds" item="i" open="(" close=")" separator=",">
                 #{i}

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
@@ -104,7 +104,7 @@
         <if test="startTime != null ">
             and instance.start_time > #{startTime} and instance.start_time <![CDATA[ <=]]> #{endTime}
         </if>
-        <if test="states != null and states != ''">
+        <if test="states != null and states.length > 0">
             and instance.state in
             <foreach collection="states" index="index" item="i" open="(" separator="," close=")">
                 #{i}

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ResourceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ResourceMapper.xml
@@ -102,7 +102,7 @@
         where type=0
         and id in (select resources_id from t_ds_relation_resources_user where user_id=#{userId} and perm=7
         union select id as resources_id from t_ds_resources where user_id=#{userId})
-        <if test="resNames != null and resNames != ''">
+        <if test="resNames != null and resNames.length > 0">
             and full_name in
             <foreach collection="resNames" item="i" open="(" close=")" separator=",">
                 #{i}
@@ -115,7 +115,7 @@
         from t_ds_resources
         where id in (select resources_id from t_ds_relation_resources_user where user_id=#{userId} and perm=7
         union select id as resources_id from t_ds_resources where user_id=#{userId})
-        <if test="resIds != null and resIds != ''">
+        <if test="resIds != null and resIds.length > 0">
             and id in
             <foreach collection="resIds" item="i" open="(" close=")" separator=",">
                 #{i}

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/UdfFuncMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/UdfFuncMapper.xml
@@ -40,7 +40,7 @@
         </include>
         from t_ds_udfs udf
         where 1 = 1
-        <if test="ids != null and ids != ''">
+        <if test="ids != null and ids.length > 0">
             and udf.id in
             <foreach collection="ids" item="i" open="(" close=")" separator=",">
                 #{i}
@@ -107,7 +107,7 @@
         where
         udf.id in (select udf_id from t_ds_relation_udfs_user where user_id=#{userId}
         union select id as udf_id from t_ds_udfs where user_id=#{userId})
-        <if test="udfIds != null and udfIds != ''">
+        <if test="udfIds != null and udfIds.length > 0">
             and udf.id in
             <foreach collection="udfIds" item="i" open="(" close=")" separator=",">
                 #{i}
@@ -121,7 +121,7 @@
         </include>
         from t_ds_udfs udf
         where 1=1
-        <if test="resourceIds != null and resourceIds != ''">
+        <if test="resourceIds != null and resourceIds.length > 0">
             and udf.resource_id in
             <foreach collection="resourceIds" item="i" open="(" close=")" separator=",">
                 #{i}
@@ -137,7 +137,7 @@
         where
         udf.id in (select udf_id from t_ds_relation_udfs_user where user_id=#{userId}
         union select id as udf_id from t_ds_udfs where user_id=#{userId})
-        <if test="resourceIds != null and resourceIds != ''">
+        <if test="resourceIds != null and resourceIds.length > 0">
             and udf.resource_id in
             <foreach collection="resourceIds" item="i" open="(" close=")" separator=",">
                 #{i}


### PR DESCRIPTION
## What is the purpose of the pull request
this PR close #4963 
fix Mybtis Mapper used foreach syntax to traverse collections and the collection was empty

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
