### PR TITLE
optimize tenant code validation

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -89,7 +89,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             return result;
         }
 
-        if (RegexUtils.isNumeric(tenantCode)) {
+        if (!RegexUtils.isValidLinuxUserName(tenantCode)) {
             putMsg(result, Status.CHECK_OS_TENANT_CODE_ERROR);
             return result;
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/RegexUtils.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/RegexUtils.java
@@ -30,6 +30,8 @@ public class RegexUtils {
      */
     private static final String CHECK_NUMBER = "^-?\\d+(\\.\\d+)?$";
 
+    private static final String LINUX_USERNAME_PATTERN = "[a-z_][a-z\\d_]{0,30}";
+
     private RegexUtils() {
     }
 
@@ -43,6 +45,16 @@ public class RegexUtils {
         Pattern pattern = Pattern.compile(CHECK_NUMBER);
         Matcher isNum = pattern.matcher(str);
         return isNum.matches();
+    }
+
+    /**
+     * check if the input is a valid linux username
+     * @param str input
+     * @return boolean
+     */
+    public static boolean isValidLinuxUserName(String str){
+        Pattern pattern = Pattern.compile(LINUX_USERNAME_PATTERN);
+        return pattern.matcher(str).matches();
     }
 
     public static String escapeNRT(String str) {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/RegexUtilsTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/RegexUtilsTest.java
@@ -37,6 +37,27 @@ public class RegexUtilsTest {
     }
 
     @Test
+    public void testIsValidLinuxUserName() {
+        String name1 = "10000";
+        Assert.assertFalse(RegexUtils.isValidLinuxUserName(name1));
+
+        String name2 = "00hayden";
+        Assert.assertFalse(RegexUtils.isValidLinuxUserName(name2));
+
+        String name3 = "hayde123456789123456789123456789";
+        Assert.assertFalse(RegexUtils.isValidLinuxUserName(name3));
+
+        String name4 = "hayd123456789123456789123456789";
+        Assert.assertTrue(RegexUtils.isValidLinuxUserName(name4));
+
+        String name5 = "h";
+        Assert.assertTrue(RegexUtils.isValidLinuxUserName(name5));
+
+        String name6 = "hayden";
+        Assert.assertTrue(RegexUtils.isValidLinuxUserName(name6));
+    }
+
+    @Test
     public void testEscapeNRT() {
         String result1 = RegexUtils.escapeNRT("abc\n");
         Assert.assertEquals("abc_", result1);

--- a/dolphinscheduler-dao/src/main/resources/datasource.properties
+++ b/dolphinscheduler-dao/src/main/resources/datasource.properties
@@ -16,16 +16,16 @@
 #
 
 # postgresql
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/dolphinscheduler
-spring.datasource.username=test
-spring.datasource.password=test
+#spring.datasource.driver-class-name=org.postgresql.Driver
+#spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/dolphinscheduler
+#spring.datasource.username=test
+#spring.datasource.password=test
 
 # mysql
-#spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
-#spring.datasource.username=xxxx
-#spring.datasource.password=xxxx
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/dolphinscheduler
+spring.datasource.username=ds_user
+spring.datasource.password=dolphinscheduler
 
 # connection configuration
 #spring.datasource.initialSize=5

--- a/dolphinscheduler-ui/.env
+++ b/dolphinscheduler-ui/.env
@@ -14,7 +14,7 @@
  # limitations under the License.
 
 # back end interface address
-API_BASE = http://192.168.xx.xx:12345
+API_BASE = http://127.0.0.1:12345
 
 # If IP access is required for local development, remove the "#"
 #DEV_HOST = 192.168.xx.xx

--- a/dolphinscheduler-ui/src/js/conf/login/App.vue
+++ b/dolphinscheduler-ui/src/js/conf/login/App.vue
@@ -138,6 +138,9 @@
       }
     },
     created () {
+      console.log(process.env.NODE_ENV)
+      console.log(process.env.API_BASE)
+      console.log(process.env.VUE_APP_API_BASE)
     },
     mounted () {
     }

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.connector.version}</version>
-                <scope>test</scope>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

`isNumeric` method can not be used to validate a Linux username.
just add an `isValidLinuxUserName` method to check out if the string is a valid Linux username.
a valid Linux username will match the pattern `[a-z_][a-z\d_]{0,30}` according to https://stackoverflow.com/questions/6949667/what-are-the-real-rules-for-linux-usernames-on-centos-6-and-rhel-6

## Brief change log


  - *Add isValidLinuxUserName to check if tenant cod is valid*

## Verify this pull request

This change added tests and can be verified as follows:

<!--*(example:)*
 
  - *Added `testIsValidLinuxUserName` test in RegexUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* 
