### PR TITLE
[Improvement][API] Make the return value clearer #5015

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AccessTokenController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AccessTokenController.java
@@ -23,15 +23,16 @@ import static org.apache.dolphinscheduler.api.enums.Status.GENERATE_TOKEN_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_ACCESSTOKEN_LIST_PAGING_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_ACCESS_TOKEN_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.AccessTokenService;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,15 +80,14 @@ public class AccessTokenController extends BaseController {
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_ACCESS_TOKEN_ERROR)
-    public Result createToken(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> createToken(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                               @RequestParam(value = "userId") int userId,
                               @RequestParam(value = "expireTime") String expireTime,
                               @RequestParam(value = "token") String token) {
         logger.info("login user {}, create token , userId : {} , token expire time : {} , token : {}", loginUser.getUserName(),
                 userId, expireTime, token);
 
-        Map<String, Object> result = accessTokenService.createToken(loginUser, userId, expireTime, token);
-        return returnDataList(result);
+        return accessTokenService.createToken(loginUser, userId, expireTime, token);
     }
 
     /**
@@ -102,12 +102,11 @@ public class AccessTokenController extends BaseController {
     @PostMapping(value = "/generate")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(GENERATE_TOKEN_ERROR)
-    public Result generateToken(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<String> generateToken(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                 @RequestParam(value = "userId") int userId,
                                 @RequestParam(value = "expireTime") String expireTime) {
         logger.info("login user {}, generate token , userId : {} , token expire time : {}", loginUser, userId, expireTime);
-        Map<String, Object> result = accessTokenService.generateToken(loginUser, userId, expireTime);
-        return returnDataList(result);
+        return accessTokenService.generateToken(loginUser, userId, expireTime);
     }
 
     /**
@@ -128,20 +127,19 @@ public class AccessTokenController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_ACCESSTOKEN_LIST_PAGING_ERROR)
-    public Result queryAccessTokenList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestParam("pageNo") Integer pageNo,
-                                       @RequestParam(value = "searchVal", required = false) String searchVal,
-                                       @RequestParam("pageSize") Integer pageSize) {
+    public Result<PageListVO<AccessToken>> queryAccessTokenList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                @RequestParam("pageNo") Integer pageNo,
+                                                                @RequestParam(value = "searchVal", required = false) String searchVal,
+                                                                @RequestParam("pageSize") Integer pageSize) {
         logger.info("login user {}, list access token paging, pageNo: {}, searchVal: {}, pageSize: {}",
                 loginUser.getUserName(), pageNo, searchVal, pageSize);
 
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult result = checkPageParams(pageNo, pageSize);
+        if (result.getStatus() != Status.SUCCESS) {
+            return error(result);
         }
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = accessTokenService.queryAccessTokenList(loginUser, searchVal, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return accessTokenService.queryAccessTokenList(loginUser, searchVal, pageNo, pageSize);
     }
 
     /**
@@ -155,11 +153,10 @@ public class AccessTokenController extends BaseController {
     @PostMapping(value = "/delete")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_ACCESS_TOKEN_ERROR)
-    public Result delAccessTokenById(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> delAccessTokenById(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                      @RequestParam(value = "id") int id) {
         logger.info("login user {}, delete access token, id: {},", loginUser.getUserName(), id);
-        Map<String, Object> result = accessTokenService.delAccessTokenById(loginUser, id);
-        return returnDataList(result);
+        return accessTokenService.delAccessTokenById(loginUser, id);
     }
 
 
@@ -177,7 +174,7 @@ public class AccessTokenController extends BaseController {
     @PostMapping(value = "/update")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_ACCESS_TOKEN_ERROR)
-    public Result updateToken(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> updateToken(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                               @RequestParam(value = "id") int id,
                               @RequestParam(value = "userId") int userId,
                               @RequestParam(value = "expireTime") String expireTime,
@@ -185,8 +182,7 @@ public class AccessTokenController extends BaseController {
         logger.info("login user {}, update token , userId : {} , token expire time : {} , token : {}", loginUser.getUserName(),
                 userId, expireTime, token);
 
-        Map<String, Object> result = accessTokenService.updateToken(loginUser, id, userId, expireTime, token);
-        return returnDataList(result);
+        return accessTokenService.updateToken(loginUser, id, userId, expireTime, token);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertGroupController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertGroupController.java
@@ -23,16 +23,19 @@ import static org.apache.dolphinscheduler.api.enums.Status.LIST_PAGING_ALERT_GRO
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_ALL_ALERTGROUP_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_ALERT_GROUP_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.AlertGroupService;
 import org.apache.dolphinscheduler.api.utils.RegexUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,15 +86,14 @@ public class AlertGroupController extends BaseController {
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_ALERT_GROUP_ERROR)
-    public Result createAlertgroup(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                   @RequestParam(value = "groupName") String groupName,
-                                   @RequestParam(value = "description", required = false) String description,
-                                   @RequestParam(value = "alertInstanceIds") String alertInstanceIds) {
+    public Result<Void> createAlertgroup(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                      @RequestParam(value = "groupName") String groupName,
+                                      @RequestParam(value = "description", required = false) String description,
+                                      @RequestParam(value = "alertInstanceIds") String alertInstanceIds) {
         logger.info("loginUser user {}, create alert group, groupName: {}, desc: {},alertInstanceIds:{}",
                 RegexUtils.escapeNRT(loginUser.getUserName()), RegexUtils.escapeNRT(groupName),
                 RegexUtils.escapeNRT(description), RegexUtils.escapeNRT(alertInstanceIds));
-        Map<String, Object> result = alertGroupService.createAlertgroup(loginUser, groupName, description, alertInstanceIds);
-        return returnDataList(result);
+        return alertGroupService.createAlertgroup(loginUser, groupName, description, alertInstanceIds);
     }
 
     /**
@@ -104,11 +106,10 @@ public class AlertGroupController extends BaseController {
     @GetMapping(value = "/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_ALL_ALERTGROUP_ERROR)
-    public Result list(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<AlertGroup>> list(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login  user {}, query all alertGroup",
                 loginUser.getUserName());
-        Map<String, Object> result = alertGroupService.queryAlertgroup();
-        return returnDataList(result);
+        return alertGroupService.queryAlertgroup();
     }
 
     /**
@@ -129,20 +130,19 @@ public class AlertGroupController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(LIST_PAGING_ALERT_GROUP_ERROR)
-    public Result listPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                             @RequestParam(value = "searchVal", required = false) String searchVal,
-                             @RequestParam("pageNo") Integer pageNo,
-                             @RequestParam("pageSize") Integer pageSize) {
+    public Result<PageListVO<AlertGroup>> listPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                     @RequestParam(value = "searchVal", required = false) String searchVal,
+                                                     @RequestParam("pageNo") Integer pageNo,
+                                                     @RequestParam("pageSize") Integer pageSize) {
         logger.info("login  user {}, list paging, pageNo: {}, searchVal: {}, pageSize: {}",
                 loginUser.getUserName(), pageNo, searchVal, pageSize);
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult result = checkPageParams(pageNo, pageSize);
+        if (result.getStatus() != Status.SUCCESS) {
+            return error(result);
         }
 
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = alertGroupService.listPaging(loginUser, searchVal, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return alertGroupService.listPaging(loginUser, searchVal, pageNo, pageSize);
     }
 
     /**
@@ -164,17 +164,16 @@ public class AlertGroupController extends BaseController {
     @PostMapping(value = "/update")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_ALERT_GROUP_ERROR)
-    public Result updateAlertgroup(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                   @RequestParam(value = "id") int id,
-                                   @RequestParam(value = "groupName") String groupName,
-                                   @RequestParam(value = "description", required = false) String description,
-                                   @RequestParam(value = "alertInstanceIds") String alertInstanceIds) {
+    public Result<Void> updateAlertgroup(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                         @RequestParam(value = "id") int id,
+                                         @RequestParam(value = "groupName") String groupName,
+                                         @RequestParam(value = "description", required = false) String description,
+                                         @RequestParam(value = "alertInstanceIds") String alertInstanceIds) {
         logger.info("login  user {}, updateProcessInstance alert group, groupName: {},  desc: {}",
                 RegexUtils.escapeNRT(loginUser.getUserName()),
                 RegexUtils.escapeNRT(groupName),
                 RegexUtils.escapeNRT(description));
-        Map<String, Object> result = alertGroupService.updateAlertgroup(loginUser, id, groupName, description, alertInstanceIds);
-        return returnDataList(result);
+        return alertGroupService.updateAlertgroup(loginUser, id, groupName, description, alertInstanceIds);
     }
 
     /**
@@ -191,11 +190,10 @@ public class AlertGroupController extends BaseController {
     @PostMapping(value = "/delete")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_ALERT_GROUP_ERROR)
-    public Result delAlertgroupById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                    @RequestParam(value = "id") int id) {
+    public Result<Void> delAlertgroupById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                          @RequestParam(value = "id") int id) {
         logger.info("login user {}, delete AlertGroup, id: {},", loginUser.getUserName(), id);
-        Map<String, Object> result = alertGroupService.delAlertgroupById(loginUser, id);
-        return returnDataList(result);
+        return alertGroupService.delAlertgroupById(loginUser, id);
     }
 
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
@@ -24,15 +24,19 @@ import static org.apache.dolphinscheduler.api.enums.Status.LIST_PAGING_ALERT_PLU
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_ALL_ALERT_PLUGIN_INSTANCE_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_ALERT_PLUGIN_INSTANCE_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.AlertPluginInstanceService;
 import org.apache.dolphinscheduler.api.utils.RegexUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.AlertPluginInstanceVO;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.dao.entity.AlertPluginInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,15 +88,14 @@ public class AlertPluginInstanceController extends BaseController {
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result createAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> createAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                             @RequestParam(value = "pluginDefineId") int pluginDefineId,
                                             @RequestParam(value = "instanceName") String instanceName,
                                             @RequestParam(value = "pluginInstanceParams") String pluginInstanceParams) {
         logger.info("login user {},create alert plugin instance, instanceName:{} ",
                 RegexUtils.escapeNRT(loginUser.getUserName()),
                 RegexUtils.escapeNRT(instanceName));
-        Map<String, Object> result = alertPluginInstanceService.create(loginUser, pluginDefineId, instanceName, pluginInstanceParams);
-        return returnDataList(result);
+        return alertPluginInstanceService.create(loginUser, pluginDefineId, instanceName, pluginInstanceParams);
     }
 
     /**
@@ -113,13 +116,12 @@ public class AlertPluginInstanceController extends BaseController {
     @GetMapping(value = "/update")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result updateAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> updateAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                             @RequestParam(value = "alertPluginInstanceId") int alertPluginInstanceId,
                                             @RequestParam(value = "instanceName") String instanceName,
                                             @RequestParam(value = "pluginInstanceParams") String pluginInstanceParams) {
         logger.info("login user {},update alert plugin instance id {}", RegexUtils.escapeNRT(loginUser.getUserName()), alertPluginInstanceId);
-        Map<String, Object> result = alertPluginInstanceService.update(loginUser, alertPluginInstanceId, instanceName, pluginInstanceParams);
-        return returnDataList(result);
+        return alertPluginInstanceService.update(loginUser, alertPluginInstanceId, instanceName, pluginInstanceParams);
     }
 
     /**
@@ -136,12 +138,11 @@ public class AlertPluginInstanceController extends BaseController {
     @GetMapping(value = "/delete")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result deleteAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> deleteAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                             @RequestParam(value = "id") int id) {
         logger.info("login user {},delete alert plugin instance id {}", RegexUtils.escapeNRT(loginUser.getUserName()), id);
 
-        Map<String, Object> result = alertPluginInstanceService.delete(loginUser, id);
-        return returnDataList(result);
+        return alertPluginInstanceService.delete(loginUser, id);
     }
 
     /**
@@ -155,11 +156,10 @@ public class AlertPluginInstanceController extends BaseController {
     @PostMapping(value = "/get")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GET_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result getAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                         @RequestParam(value = "id") int id) {
+    public Result<AlertPluginInstance> getAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                              @RequestParam(value = "id") int id) {
         logger.info("login user {},get alert plugin instance, id {}", RegexUtils.escapeNRT(loginUser.getUserName()), id);
-        Map<String, Object> result = alertPluginInstanceService.get(loginUser, id);
-        return returnDataList(result);
+        return alertPluginInstanceService.get(loginUser, id);
     }
 
     /**
@@ -172,10 +172,9 @@ public class AlertPluginInstanceController extends BaseController {
     @PostMapping(value = "/queryAll")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_ALL_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result getAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<AlertPluginInstanceVO>> getAlertPluginInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user {}, query all alert plugin instance", RegexUtils.escapeNRT(loginUser.getUserName()));
-        Map<String, Object> result = alertPluginInstanceService.queryAll();
-        return returnDataList(result);
+        return alertPluginInstanceService.queryAll();
     }
 
     /**
@@ -224,17 +223,16 @@ public class AlertPluginInstanceController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(LIST_PAGING_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result listPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                             @RequestParam("pageNo") Integer pageNo,
-                             @RequestParam("pageSize") Integer pageSize) {
+    public Result<PageListVO<AlertPluginInstanceVO>> listPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                @RequestParam("pageNo") Integer pageNo,
+                                                                @RequestParam("pageSize") Integer pageSize) {
         logger.info("login user {}, list paging, pageNo: {}, pageSize: {}", RegexUtils.escapeNRT(loginUser.getUserName()), pageNo, pageSize);
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult result = checkPageParams(pageNo, pageSize);
+        if (result.getStatus() != Status.SUCCESS) {
+            return error(result);
         }
 
-        result = alertPluginInstanceService.queryPluginPage(pageNo, pageSize);
-        return returnDataListPaging(result);
+        return alertPluginInstanceService.queryPluginPage(pageNo, pageSize);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataAnalysisController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataAnalysisController.java
@@ -23,12 +23,16 @@ import static org.apache.dolphinscheduler.api.enums.Status.COUNT_PROCESS_INSTANC
 import static org.apache.dolphinscheduler.api.enums.Status.QUEUE_COUNT_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.TASK_INSTANCE_STATE_COUNT_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CommandStateCount;
+import org.apache.dolphinscheduler.api.dto.DefineUserDto;
+import org.apache.dolphinscheduler.api.dto.TaskCountDto;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.DataAnalysisService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -80,14 +84,13 @@ public class DataAnalysisController extends BaseController {
     @GetMapping(value = "/task-state-count")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(TASK_INSTANCE_STATE_COUNT_ERROR)
-    public Result countTaskState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<TaskCountDto> countTaskState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                  @RequestParam(value = "startDate", required = false) String startDate,
                                  @RequestParam(value = "endDate", required = false) String endDate,
                                  @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
         logger.info("count task state, user:{}, start date: {}, end date:{}, project id {}",
                 loginUser.getUserName(), startDate, endDate, projectId);
-        Map<String, Object> result = dataAnalysisService.countTaskStateByProject(loginUser, projectId, startDate, endDate);
-        return returnDataList(result);
+        return dataAnalysisService.countTaskStateByProject(loginUser, projectId, startDate, endDate);
     }
 
     /**
@@ -108,14 +111,13 @@ public class DataAnalysisController extends BaseController {
     @GetMapping(value = "/process-state-count")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(COUNT_PROCESS_INSTANCE_STATE_ERROR)
-    public Result countProcessInstanceState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                            @RequestParam(value = "startDate", required = false) String startDate,
-                                            @RequestParam(value = "endDate", required = false) String endDate,
-                                            @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
+    public Result<TaskCountDto> countProcessInstanceState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                          @RequestParam(value = "startDate", required = false) String startDate,
+                                                          @RequestParam(value = "endDate", required = false) String endDate,
+                                                          @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
         logger.info("count process instance state, user:{}, start date: {}, end date:{}, project id:{}",
                 loginUser.getUserName(), startDate, endDate, projectId);
-        Map<String, Object> result = dataAnalysisService.countProcessInstanceStateByProject(loginUser, projectId, startDate, endDate);
-        return returnDataList(result);
+        return dataAnalysisService.countProcessInstanceStateByProject(loginUser, projectId, startDate, endDate);
     }
 
     /**
@@ -132,12 +134,11 @@ public class DataAnalysisController extends BaseController {
     @GetMapping(value = "/define-user-count")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(COUNT_PROCESS_DEFINITION_USER_ERROR)
-    public Result countDefinitionByUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                        @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
+    public Result<DefineUserDto> countDefinitionByUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                       @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
         logger.info("count process definition , user:{}, project id:{}",
                 loginUser.getUserName(), projectId);
-        Map<String, Object> result = dataAnalysisService.countDefinitionByUser(loginUser, projectId);
-        return returnDataList(result);
+        return dataAnalysisService.countDefinitionByUser(loginUser, projectId);
     }
 
 
@@ -159,14 +160,13 @@ public class DataAnalysisController extends BaseController {
     @GetMapping(value = "/command-state-count")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(COMMAND_STATE_COUNT_ERROR)
-    public Result countCommandState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                    @RequestParam(value = "startDate", required = false) String startDate,
-                                    @RequestParam(value = "endDate", required = false) String endDate,
-                                    @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
+    public Result<List<CommandStateCount>> countCommandState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                             @RequestParam(value = "startDate", required = false) String startDate,
+                                                             @RequestParam(value = "endDate", required = false) String endDate,
+                                                             @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
         logger.info("count command state, user:{}, start date: {}, end date:{}, project id {}",
                 loginUser.getUserName(), startDate, endDate, projectId);
-        Map<String, Object> result = dataAnalysisService.countCommandState(loginUser, projectId, startDate, endDate);
-        return returnDataList(result);
+        return dataAnalysisService.countCommandState(loginUser, projectId, startDate, endDate);
     }
 
     /**
@@ -183,12 +183,11 @@ public class DataAnalysisController extends BaseController {
     @GetMapping(value = "/queue-count")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUEUE_COUNT_ERROR)
-    public Result countQueueState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Map<String, Integer>> countQueueState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                   @RequestParam(value = "projectId", required = false, defaultValue = "0") int projectId) {
         logger.info("count command state, user:{}, project id {}",
                 loginUser.getUserName(), projectId);
-        Map<String, Object> result = dataAnalysisService.countQueueState(loginUser, projectId);
-        return returnDataList(result);
+        return dataAnalysisService.countQueueState(loginUser, projectId);
     }
 
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
@@ -28,18 +28,21 @@ import static org.apache.dolphinscheduler.api.enums.Status.UNAUTHORIZED_DATASOUR
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_DATASOURCE_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_DATASOURCE_NAME_FAILURE;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.DataSourceService;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbConnectType;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.utils.CommonUtils;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -211,8 +214,7 @@ public class DataSourceController extends BaseController {
                                   @RequestParam("id") int id) {
         logger.info("login user {}, query datasource: {}",
                 loginUser.getUserName(), id);
-        Map<String, Object> result = dataSourceService.queryDataSource(id);
-        return returnDataList(result);
+        return dataSourceService.queryDataSource(id);
     }
 
     /**
@@ -229,10 +231,9 @@ public class DataSourceController extends BaseController {
     @GetMapping(value = "/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_DATASOURCE_ERROR)
-    public Result queryDataSourceList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<List<DataSource>> queryDataSourceList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                       @RequestParam("type") DbType type) {
-        Map<String, Object> result = dataSourceService.queryDataSourceList(loginUser, type.ordinal());
-        return returnDataList(result);
+        return dataSourceService.queryDataSourceList(loginUser, type.ordinal());
     }
 
     /**
@@ -253,17 +254,16 @@ public class DataSourceController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_DATASOURCE_ERROR)
-    public Result queryDataSourceListPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                            @RequestParam(value = "searchVal", required = false) String searchVal,
-                                            @RequestParam("pageNo") Integer pageNo,
-                                            @RequestParam("pageSize") Integer pageSize) {
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+    public Result<PageListVO<DataSource>> queryDataSourceListPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                    @RequestParam(value = "searchVal", required = false) String searchVal,
+                                                                    @RequestParam("pageNo") Integer pageNo,
+                                                                    @RequestParam("pageSize") Integer pageSize) {
+        CheckParamResult result = checkPageParams(pageNo, pageSize);
+        if (result.getStatus() != Status.SUCCESS) {
+            return error(result);
         }
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = dataSourceService.queryDataSourceListPaging(loginUser, searchVal, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return dataSourceService.queryDataSourceListPaging(loginUser, searchVal, pageNo, pageSize);
     }
 
     /**
@@ -402,12 +402,11 @@ public class DataSourceController extends BaseController {
     @GetMapping(value = "/unauth-datasource")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UNAUTHORIZED_DATASOURCE)
-    public Result unauthDatasource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                   @RequestParam("userId") Integer userId) {
+    public Result<List<DataSource>> unauthDatasource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                     @RequestParam("userId") Integer userId) {
         logger.info("unauthorized datasource, login user:{}, unauthorized userId:{}",
                 loginUser.getUserName(), userId);
-        Map<String, Object> result = dataSourceService.unauthDatasource(loginUser, userId);
-        return returnDataList(result);
+        return dataSourceService.unauthDatasource(loginUser, userId);
     }
 
 
@@ -425,12 +424,11 @@ public class DataSourceController extends BaseController {
     @GetMapping(value = "/authed-datasource")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(AUTHORIZED_DATA_SOURCE)
-    public Result authedDatasource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<List<DataSource>> authedDatasource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                    @RequestParam("userId") Integer userId) {
         logger.info("authorized data source, login user:{}, authorized useId:{}",
                 loginUser.getUserName(), userId);
-        Map<String, Object> result = dataSourceService.authedDatasource(loginUser, userId);
-        return returnDataList(result);
+        return dataSourceService.authedDatasource(loginUser, userId);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
@@ -106,7 +106,7 @@ public class ExecutorController extends BaseController {
     @PostMapping(value = "start-process-instance")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(START_PROCESS_INSTANCE_ERROR)
-    public Result startProcessInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> startProcessInstance(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                        @ApiParam(name = "projectName", value = "PROJECT_NAME", required = true) @PathVariable String projectName,
                                        @RequestParam(value = "processDefinitionId") int processDefinitionId,
                                        @RequestParam(value = "scheduleTime", required = false) String scheduleTime,
@@ -135,10 +135,9 @@ public class ExecutorController extends BaseController {
         if (startParams != null) {
             startParamMap = JSONUtils.toMap(startParams);
         }
-        Map<String, Object> result = execService.execProcessInstance(loginUser, projectName, processDefinitionId, scheduleTime, execType, failureStrategy,
+        return execService.execProcessInstance(loginUser, projectName, processDefinitionId, scheduleTime, execType, failureStrategy,
                 startNodeList, taskDependType, warningType,
                 warningGroupId, runMode, processInstancePriority, workerGroup, timeout, startParamMap);
-        return returnDataList(result);
     }
 
 
@@ -159,15 +158,14 @@ public class ExecutorController extends BaseController {
     @PostMapping(value = "/execute")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(EXECUTE_PROCESS_INSTANCE_ERROR)
-    public Result execute(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> execute(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                           @ApiParam(name = "projectName", value = "PROJECT_NAME", required = true) @PathVariable String projectName,
                           @RequestParam("processInstanceId") Integer processInstanceId,
                           @RequestParam("executeType") ExecuteType executeType
     ) {
         logger.info("execute command, login user: {}, project:{}, process instance id:{}, execute type:{}",
                 loginUser.getUserName(), projectName, processInstanceId, executeType);
-        Map<String, Object> result = execService.execute(loginUser, projectName, processInstanceId, executeType);
-        return returnDataList(result);
+        return execService.execute(loginUser, projectName, processInstanceId, executeType);
     }
 
     /**
@@ -184,10 +182,9 @@ public class ExecutorController extends BaseController {
     @PostMapping(value = "/start-check")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(CHECK_PROCESS_DEFINITION_ERROR)
-    public Result startCheckProcessDefinition(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> startCheckProcessDefinition(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                               @RequestParam(value = "processDefinitionId") int processDefinitionId) {
         logger.info("login user {}, check process definition {}", loginUser.getUserName(), processDefinitionId);
-        Map<String, Object> result = execService.startCheckByProcessDefinedId(processDefinitionId);
-        return returnDataList(result);
+        return execService.startCheckByProcessDefinedId(processDefinitionId);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
@@ -102,7 +102,7 @@ public class LoggerController extends BaseController {
     @GetMapping(value = "/download-log")
     @ResponseBody
     @ApiException(DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR)
-    public ResponseEntity downloadTaskLog(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public ResponseEntity<byte[]> downloadTaskLog(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                           @RequestParam(value = "taskInstanceId") int taskInstanceId) {
         byte[] logBytes = loggerService.getLogBytes(taskInstanceId);
         return ResponseEntity

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/MonitorController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/MonitorController.java
@@ -26,9 +26,14 @@ import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.MonitorService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.model.Server;
+import org.apache.dolphinscheduler.common.model.WorkerServerModel;
+import org.apache.dolphinscheduler.dao.entity.MonitorRecord;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.ZookeeperRecord;
 
-import java.util.Map;
+import java.util.Collection;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,11 +72,10 @@ public class MonitorController extends BaseController {
     @GetMapping(value = "/master/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(LIST_MASTERS_ERROR)
-    public Result listMaster(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<Server>> listMaster(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user: {}, query all master", loginUser.getUserName());
         logger.info("list master, user:{}", loginUser.getUserName());
-        Map<String, Object> result = monitorService.queryMaster(loginUser);
-        return returnDataList(result);
+        return monitorService.queryMaster(loginUser);
     }
 
     /**
@@ -84,10 +88,9 @@ public class MonitorController extends BaseController {
     @GetMapping(value = "/worker/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(LIST_WORKERS_ERROR)
-    public Result listWorker(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<Collection<WorkerServerModel>> listWorker(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user: {}, query all workers", loginUser.getUserName());
-        Map<String, Object> result = monitorService.queryWorker(loginUser);
-        return returnDataList(result);
+        return monitorService.queryWorker(loginUser);
     }
 
     /**
@@ -100,10 +103,9 @@ public class MonitorController extends BaseController {
     @GetMapping(value = "/database")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_DATABASE_STATE_ERROR)
-    public Result queryDatabaseState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<MonitorRecord>> queryDatabaseState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user: {}, query database state", loginUser.getUserName());
-        Map<String, Object> result = monitorService.queryDatabaseState(loginUser);
-        return returnDataList(result);
+        return monitorService.queryDatabaseState(loginUser);
     }
 
     /**
@@ -116,10 +118,9 @@ public class MonitorController extends BaseController {
     @GetMapping(value = "/zookeeper/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_ZOOKEEPER_STATE_ERROR)
-    public Result queryZookeeperState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<ZookeeperRecord>> queryZookeeperState(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user: {}, query zookeeper state", loginUser.getUserName());
-        Map<String, Object> result = monitorService.queryZookeeperState(loginUser);
-        return returnDataList(result);
+        return monitorService.queryZookeeperState(loginUser);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/QueueController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/QueueController.java
@@ -22,15 +22,17 @@ import static org.apache.dolphinscheduler.api.enums.Status.QUERY_QUEUE_LIST_ERRO
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_QUEUE_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_QUEUE_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.QueueService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.dao.entity.Queue;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,10 +76,9 @@ public class QueueController extends BaseController {
     @GetMapping(value = "/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_QUEUE_LIST_ERROR)
-    public Result queryList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<Queue>> queryList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user {}, query queue list", loginUser.getUserName());
-        Map<String, Object> result = queueService.queryList(loginUser);
-        return returnDataList(result);
+        return queueService.queryList(loginUser);
     }
 
     /**
@@ -103,14 +104,13 @@ public class QueueController extends BaseController {
                                        @RequestParam(value = "searchVal", required = false) String searchVal,
                                        @RequestParam("pageSize") Integer pageSize) {
         logger.info("login user {}, query queue list,search value:{}", loginUser.getUserName(), searchVal);
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult checkResult = checkPageParams(pageNo, pageSize);
+        if (!Status.SUCCESS.equals(checkResult.getStatus())) {
+            return Result.error(checkResult);
         }
 
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = queueService.queryList(loginUser, searchVal, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return queueService.queryList(loginUser, searchVal, pageNo, pageSize);
     }
 
     /**
@@ -129,13 +129,12 @@ public class QueueController extends BaseController {
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_QUEUE_ERROR)
-    public Result createQueue(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                              @RequestParam(value = "queue") String queue,
-                              @RequestParam(value = "queueName") String queueName) {
+    public Result<Void> createQueue(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                    @RequestParam(value = "queue") String queue,
+                                    @RequestParam(value = "queueName") String queueName) {
         logger.info("login user {}, create queue, queue: {}, queueName: {}",
                 loginUser.getUserName(), queue, queueName);
-        Map<String, Object> result = queueService.createQueue(loginUser, queue, queueName);
-        return returnDataList(result);
+        return queueService.createQueue(loginUser, queue, queueName);
     }
 
     /**
@@ -156,14 +155,13 @@ public class QueueController extends BaseController {
     @PostMapping(value = "/update")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(UPDATE_QUEUE_ERROR)
-    public Result updateQueue(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                              @RequestParam(value = "id") int id,
-                              @RequestParam(value = "queue") String queue,
-                              @RequestParam(value = "queueName") String queueName) {
+    public Result<Void> updateQueue(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                    @RequestParam(value = "id") int id,
+                                    @RequestParam(value = "queue") String queue,
+                                    @RequestParam(value = "queueName") String queueName) {
         logger.info("login user {}, update queue, id: {}, queue: {}, queueName: {}",
                 loginUser.getUserName(), id, queue, queueName);
-        Map<String, Object> result = queueService.updateQueue(loginUser, id, queue, queueName);
-        return returnDataList(result);
+        return queueService.updateQueue(loginUser, id, queue, queueName);
     }
 
     /**
@@ -183,9 +181,9 @@ public class QueueController extends BaseController {
     @PostMapping(value = "/verify-queue")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(VERIFY_QUEUE_ERROR)
-    public Result verifyQueue(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                              @RequestParam(value = "queue") String queue,
-                              @RequestParam(value = "queueName") String queueName
+    public Result<Void> verifyQueue(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                    @RequestParam(value = "queue") String queue,
+                                    @RequestParam(value = "queueName") String queueName
     ) {
 
         logger.info("login user {}, verfiy queue: {} queue name: {}",

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskRecordController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskRecordController.java
@@ -22,10 +22,10 @@ import static org.apache.dolphinscheduler.api.enums.Status.QUERY_TASK_RECORD_LIS
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.TaskRecordService;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.dao.entity.TaskRecord;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,22 +73,23 @@ public class TaskRecordController extends BaseController {
     @GetMapping("/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TASK_RECORD_LIST_PAGING_ERROR)
-    public Result queryTaskRecordListPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                            @RequestParam(value = "taskName", required = false) String taskName,
-                                            @RequestParam(value = "state", required = false) String state,
-                                            @RequestParam(value = "sourceTable", required = false) String sourceTable,
-                                            @RequestParam(value = "destTable", required = false) String destTable,
-                                            @RequestParam(value = "taskDate", required = false) String taskDate,
-                                            @RequestParam(value = "startDate", required = false) String startTime,
-                                            @RequestParam(value = "endDate", required = false) String endTime,
-                                            @RequestParam("pageNo") Integer pageNo,
-                                            @RequestParam("pageSize") Integer pageSize
+    public Result<PageListVO<TaskRecord>> queryTaskRecordListPaging(
+            @ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+            @RequestParam(value = "taskName", required = false) String taskName,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "sourceTable", required = false) String sourceTable,
+            @RequestParam(value = "destTable", required = false) String destTable,
+            @RequestParam(value = "taskDate", required = false) String taskDate,
+            @RequestParam(value = "startDate", required = false) String startTime,
+            @RequestParam(value = "endDate", required = false) String endTime,
+            @RequestParam("pageNo") Integer pageNo,
+            @RequestParam("pageSize") Integer pageSize
     ) {
 
         logger.info("query task record list, task name:{}, state :{}, taskDate: {}, start:{}, end:{}",
                 taskName, state, taskDate, startTime, endTime);
-        Map<String, Object> result = taskRecordService.queryTaskRecordListPaging(false, taskName, startTime, taskDate, sourceTable, destTable, endTime, state, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return taskRecordService.queryTaskRecordListPaging(false, taskName, startTime, taskDate, sourceTable,
+                destTable, endTime, state, pageNo, pageSize);
     }
 
     /**
@@ -109,22 +110,22 @@ public class TaskRecordController extends BaseController {
     @GetMapping("/history-list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TASK_RECORD_LIST_PAGING_ERROR)
-    public Result queryHistoryTaskRecordListPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                   @RequestParam(value = "taskName", required = false) String taskName,
-                                                   @RequestParam(value = "state", required = false) String state,
-                                                   @RequestParam(value = "sourceTable", required = false) String sourceTable,
-                                                   @RequestParam(value = "destTable", required = false) String destTable,
-                                                   @RequestParam(value = "taskDate", required = false) String taskDate,
-                                                   @RequestParam(value = "startDate", required = false) String startTime,
-                                                   @RequestParam(value = "endDate", required = false) String endTime,
-                                                   @RequestParam("pageNo") Integer pageNo,
-                                                   @RequestParam("pageSize") Integer pageSize
+    public Result<PageListVO<TaskRecord>> queryHistoryTaskRecordListPaging(
+            @ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+            @RequestParam(value = "taskName", required = false) String taskName,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "sourceTable", required = false) String sourceTable,
+            @RequestParam(value = "destTable", required = false) String destTable,
+            @RequestParam(value = "taskDate", required = false) String taskDate,
+            @RequestParam(value = "startDate", required = false) String startTime,
+            @RequestParam(value = "endDate", required = false) String endTime,
+            @RequestParam("pageNo") Integer pageNo,
+            @RequestParam("pageSize") Integer pageSize
     ) {
 
         logger.info("query hisotry task record list, task name:{}, state :{}, taskDate: {}, start:{}, end:{}",
                 taskName, state, taskDate, startTime, endTime);
-        Map<String, Object> result = taskRecordService.queryTaskRecordListPaging(true, taskName, startTime, taskDate, sourceTable, destTable, endTime, state, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return taskRecordService.queryTaskRecordListPaging(true, taskName, startTime, taskDate, sourceTable, destTable, endTime, state, pageNo, pageSize);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TenantController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TenantController.java
@@ -24,16 +24,19 @@ import static org.apache.dolphinscheduler.api.enums.Status.QUERY_TENANT_LIST_PAG
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_TENANT_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_OS_TENANT_CODE_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.TenantService;
 import org.apache.dolphinscheduler.api.utils.RegexUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,15 +88,14 @@ public class TenantController extends BaseController {
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_TENANT_ERROR)
-    public Result createTenant(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                               @RequestParam(value = "tenantCode") String tenantCode,
-                               @RequestParam(value = "queueId") int queueId,
-                               @RequestParam(value = "description", required = false) String description) throws Exception {
+    public Result<Void> createTenant(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                     @RequestParam(value = "tenantCode") String tenantCode,
+                                     @RequestParam(value = "queueId") int queueId,
+                                     @RequestParam(value = "description", required = false) String description) throws Exception {
         logger.info("login user {}, create tenant, tenantCode: {}, queueId: {}, desc: {}",
                 RegexUtils.escapeNRT(loginUser.getUserName()), RegexUtils.escapeNRT(tenantCode),
                 queueId, RegexUtils.escapeNRT(description));
-        Map<String, Object> result = tenantService.createTenant(loginUser, tenantCode, queueId, description);
-        return returnDataList(result);
+        return tenantService.createTenant(loginUser, tenantCode, queueId, description);
     }
 
     /**
@@ -114,19 +116,18 @@ public class TenantController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TENANT_LIST_PAGING_ERROR)
-    public Result queryTenantlistPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                        @RequestParam(value = "searchVal", required = false) String searchVal,
-                                        @RequestParam("pageNo") Integer pageNo,
-                                        @RequestParam("pageSize") Integer pageSize) {
+    public Result<PageListVO<Tenant>> queryTenantlistPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                            @RequestParam(value = "searchVal", required = false) String searchVal,
+                                                            @RequestParam("pageNo") Integer pageNo,
+                                                            @RequestParam("pageSize") Integer pageSize) {
         logger.info("login user {}, list paging, pageNo: {}, searchVal: {}, pageSize: {}",
                 loginUser.getUserName(), pageNo, searchVal, pageSize);
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult checkResult = checkPageParams(pageNo, pageSize);
+        if (checkResult.getStatus() != Status.SUCCESS) {
+            return Result.error(checkResult);
         }
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = tenantService.queryTenantList(loginUser, searchVal, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return tenantService.queryTenantList(loginUser, searchVal, pageNo, pageSize);
     }
 
 
@@ -140,10 +141,9 @@ public class TenantController extends BaseController {
     @GetMapping(value = "/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TENANT_LIST_ERROR)
-    public Result queryTenantlist(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<Tenant>> queryTenantlist(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user {}, query tenant list", loginUser.getUserName());
-        Map<String, Object> result = tenantService.queryTenantList(loginUser);
-        return returnDataList(result);
+        return tenantService.queryTenantList(loginUser);
     }
 
 
@@ -168,17 +168,16 @@ public class TenantController extends BaseController {
     @PostMapping(value = "/update")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_TENANT_ERROR)
-    public Result updateTenant(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                               @RequestParam(value = "id") int id,
-                               @RequestParam(value = "tenantCode") String tenantCode,
-                               @RequestParam(value = "queueId") int queueId,
-                               @RequestParam(value = "description", required = false) String description) throws Exception {
+    public Result<Void> updateTenant(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                     @RequestParam(value = "id") int id,
+                                     @RequestParam(value = "tenantCode") String tenantCode,
+                                     @RequestParam(value = "queueId") int queueId,
+                                     @RequestParam(value = "description", required = false) String description) throws Exception {
         String userReplace = RegexUtils.escapeNRT(loginUser.getUserName());
         String tenantCodeReplace = RegexUtils.escapeNRT(tenantCode);
         String descReplace = RegexUtils.escapeNRT(description);
         logger.info("login user {}, create tenant, tenantCode: {}, queueId: {}, desc: {}", userReplace, tenantCodeReplace, queueId, descReplace);
-        Map<String, Object> result = tenantService.updateTenant(loginUser, id, tenantCode, queueId, description);
-        return returnDataList(result);
+        return tenantService.updateTenant(loginUser, id, tenantCode, queueId, description);
     }
 
     /**
@@ -196,11 +195,10 @@ public class TenantController extends BaseController {
     @PostMapping(value = "/delete")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_TENANT_BY_ID_ERROR)
-    public Result deleteTenantById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                   @RequestParam(value = "id") int id) throws Exception {
+    public Result<Void> deleteTenantById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                         @RequestParam(value = "id") int id) throws Exception {
         logger.info("login user {}, delete tenant, tenantId: {},", loginUser.getUserName(), id);
-        Map<String, Object> result = tenantService.deleteTenantById(loginUser, id);
-        return returnDataList(result);
+        return tenantService.deleteTenantById(loginUser, id);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/UiPluginController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/UiPluginController.java
@@ -24,9 +24,10 @@ import org.apache.dolphinscheduler.api.service.UiPluginService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.PluginType;
+import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,12 +69,11 @@ public class UiPluginController extends BaseController {
     @PostMapping(value = "/queryUiPluginsByType")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(QUERY_PLUGINS_ERROR)
-    public Result queryUiPluginsByType(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestParam(value = "pluginType") PluginType pluginType) {
+    public Result<List<PluginDefine>> queryUiPluginsByType(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                           @RequestParam(value = "pluginType") PluginType pluginType) {
 
         logger.info("query plugins by type , pluginType: {}", pluginType);
-        Map<String, Object> result = uiPluginService.queryUiPluginsByType(pluginType);
-        return returnDataList(result);
+        return uiPluginService.queryUiPluginsByType(pluginType);
     }
 
     @ApiOperation(value = "queryUiPluginDetailById", notes = "QUERY_UI_PLUGIN_DETAIL_BY_ID")
@@ -83,11 +83,10 @@ public class UiPluginController extends BaseController {
     @PostMapping(value = "/queryUiPluginDetailById")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(QUERY_PLUGINS_ERROR)
-    public Result queryUiPluginDetailById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<PluginDefine> queryUiPluginDetailById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                           @RequestParam("pluginId") Integer pluginId) {
 
         logger.info("query plugin detail by id , pluginId: {}", pluginId);
-        Map<String, Object> result = uiPluginService.queryUiPluginDetailById(pluginId);
-        return returnDataList(result);
+        return uiPluginService.queryUiPluginDetailById(pluginId);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/UsersController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/UsersController.java
@@ -31,10 +31,12 @@ import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_USER_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.USER_LIST_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_USERNAME_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -100,7 +102,7 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_USER_ERROR)
-    public Result createUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> createUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                              @RequestParam(value = "userName") String userName,
                              @RequestParam(value = "userPassword") String userPassword,
                              @RequestParam(value = "tenantId") int tenantId,
@@ -110,8 +112,7 @@ public class UsersController extends BaseController {
                              @RequestParam(value = "state", required = false) int state) throws Exception {
         logger.info("login user {}, create user, userName: {}, email: {}, tenantId: {}, userPassword: {}, phone: {}, user queue: {}, state: {}",
                 loginUser.getUserName(), userName, email, tenantId, Constants.PASSWORD_DEFAULT, phone, queue, state);
-        Map<String, Object> result = usersService.createUser(loginUser, userName, userPassword, email, tenantId, phone, queue, state);
-        return returnDataList(result);
+        return usersService.createUser(loginUser, userName, userPassword, email, tenantId, phone, queue, state);
     }
 
     /**
@@ -132,19 +133,18 @@ public class UsersController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_USER_LIST_PAGING_ERROR)
-    public Result queryUserList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                @RequestParam("pageNo") Integer pageNo,
-                                @RequestParam("pageSize") Integer pageSize,
-                                @RequestParam(value = "searchVal", required = false) String searchVal) {
+    public Result<PageListVO<User>> queryUserList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                  @RequestParam("pageNo") Integer pageNo,
+                                                  @RequestParam("pageSize") Integer pageSize,
+                                                  @RequestParam(value = "searchVal", required = false) String searchVal) {
         logger.info("login user {}, list user paging, pageNo: {}, searchVal: {}, pageSize: {}",
                 loginUser.getUserName(), pageNo, searchVal, pageSize);
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult result = checkPageParams(pageNo, pageSize);
+        if (result.getStatus() != Status.SUCCESS) {
+            return error(result);
         }
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = usersService.queryUserList(loginUser, searchVal, pageNo, pageSize);
-        return returnDataListPaging(result);
+        return usersService.queryUserList(loginUser, searchVal, pageNo, pageSize);
     }
 
 
@@ -175,19 +175,18 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/update")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_USER_ERROR)
-    public Result updateUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                             @RequestParam(value = "id") int id,
-                             @RequestParam(value = "userName") String userName,
-                             @RequestParam(value = "userPassword") String userPassword,
-                             @RequestParam(value = "queue", required = false, defaultValue = "") String queue,
-                             @RequestParam(value = "email") String email,
-                             @RequestParam(value = "tenantId") int tenantId,
-                             @RequestParam(value = "phone", required = false) String phone,
-                             @RequestParam(value = "state", required = false) int state) throws Exception {
+    public Result<Void> updateUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                   @RequestParam(value = "id") int id,
+                                   @RequestParam(value = "userName") String userName,
+                                   @RequestParam(value = "userPassword") String userPassword,
+                                   @RequestParam(value = "queue", required = false, defaultValue = "") String queue,
+                                   @RequestParam(value = "email") String email,
+                                   @RequestParam(value = "tenantId") int tenantId,
+                                   @RequestParam(value = "phone", required = false) String phone,
+                                   @RequestParam(value = "state", required = false) int state) throws Exception {
         logger.info("login user {}, updateProcessInstance user, userName: {}, email: {}, tenantId: {}, userPassword: {}, phone: {}, user queue: {}, state: {}",
                 loginUser.getUserName(), userName, email, tenantId, Constants.PASSWORD_DEFAULT, phone, queue, state);
-        Map<String, Object> result = usersService.updateUser(loginUser, id, userName, userPassword, email, tenantId, phone, queue, state);
-        return returnDataList(result);
+        return usersService.updateUser(loginUser, id, userName, userPassword, email, tenantId, phone, queue, state);
     }
 
     /**
@@ -204,11 +203,10 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/delete")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_USER_BY_ID_ERROR)
-    public Result delUserById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                              @RequestParam(value = "id") int id) throws Exception {
+    public Result<Void> delUserById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                    @RequestParam(value = "id") int id) throws Exception {
         logger.info("login user {}, delete user, userId: {},", loginUser.getUserName(), id);
-        Map<String, Object> result = usersService.deleteUserById(loginUser, id);
-        return returnDataList(result);
+        return usersService.deleteUserById(loginUser, id);
     }
 
     /**
@@ -227,12 +225,11 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/grant-project")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GRANT_PROJECT_ERROR)
-    public Result grantProject(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                               @RequestParam(value = "userId") int userId,
-                               @RequestParam(value = "projectIds") String projectIds) {
+    public Result<Void> grantProject(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                     @RequestParam(value = "userId") int userId,
+                                     @RequestParam(value = "projectIds") String projectIds) {
         logger.info("login user {}, grant project, userId: {},projectIds : {}", loginUser.getUserName(), userId, projectIds);
-        Map<String, Object> result = usersService.grantProject(loginUser, userId, projectIds);
-        return returnDataList(result);
+        return usersService.grantProject(loginUser, userId, projectIds);
     }
 
     /**
@@ -251,12 +248,11 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/grant-file")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GRANT_RESOURCE_ERROR)
-    public Result grantResource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                @RequestParam(value = "userId") int userId,
-                                @RequestParam(value = "resourceIds") String resourceIds) {
+    public Result<Void> grantResource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                      @RequestParam(value = "userId") int userId,
+                                      @RequestParam(value = "resourceIds") String resourceIds) {
         logger.info("login user {}, grant project, userId: {},resourceIds : {}", loginUser.getUserName(), userId, resourceIds);
-        Map<String, Object> result = usersService.grantResources(loginUser, userId, resourceIds);
-        return returnDataList(result);
+        return usersService.grantResources(loginUser, userId, resourceIds);
     }
 
 
@@ -276,12 +272,11 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/grant-udf-func")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GRANT_UDF_FUNCTION_ERROR)
-    public Result grantUDFFunc(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> grantUDFFunc(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                @RequestParam(value = "userId") int userId,
                                @RequestParam(value = "udfIds") String udfIds) {
         logger.info("login user {}, grant project, userId: {},resourceIds : {}", loginUser.getUserName(), userId, udfIds);
-        Map<String, Object> result = usersService.grantUDFFunction(loginUser, userId, udfIds);
-        return returnDataList(result);
+        return usersService.grantUDFFunction(loginUser, userId, udfIds);
     }
 
 
@@ -301,12 +296,11 @@ public class UsersController extends BaseController {
     @PostMapping(value = "/grant-datasource")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GRANT_DATASOURCE_ERROR)
-    public Result grantDataSource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> grantDataSource(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                   @RequestParam(value = "userId") int userId,
                                   @RequestParam(value = "datasourceIds") String datasourceIds) {
         logger.info("login user {}, grant project, userId: {},projectIds : {}", loginUser.getUserName(), userId, datasourceIds);
-        Map<String, Object> result = usersService.grantDataSource(loginUser, userId, datasourceIds);
-        return returnDataList(result);
+        return usersService.grantDataSource(loginUser, userId, datasourceIds);
     }
 
 
@@ -320,10 +314,9 @@ public class UsersController extends BaseController {
     @GetMapping(value = "/get-user-info")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GET_USER_INFO_ERROR)
-    public Result getUserInfo(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<User> getUserInfo(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user {},get user info", loginUser.getUserName());
-        Map<String, Object> result = usersService.getUserInfo(loginUser);
-        return returnDataList(result);
+        return usersService.getUserInfo(loginUser);
     }
 
     /**
@@ -336,10 +329,9 @@ public class UsersController extends BaseController {
     @GetMapping(value = "/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(USER_LIST_ERROR)
-    public Result listUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<User>> listUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user {}, user list", loginUser.getUserName());
-        Map<String, Object> result = usersService.queryAllGeneralUsers(loginUser);
-        return returnDataList(result);
+        return usersService.queryAllGeneralUsers(loginUser);
     }
 
 
@@ -352,10 +344,9 @@ public class UsersController extends BaseController {
     @GetMapping(value = "/list-all")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(USER_LIST_ERROR)
-    public Result listAll(@RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<User>> listAll(@RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("login user {}, user list", loginUser.getUserName());
-        Map<String, Object> result = usersService.queryUserList(loginUser);
-        return returnDataList(result);
+        return usersService.queryUserList(loginUser);
     }
 
 
@@ -396,12 +387,11 @@ public class UsersController extends BaseController {
     @GetMapping(value = "/unauth-user")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UNAUTHORIZED_USER_ERROR)
-    public Result unauthorizedUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<List<User>> unauthorizedUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                    @RequestParam("alertgroupId") Integer alertgroupId) {
         logger.info("unauthorized user, login user:{}, alert group id:{}",
                 loginUser.getUserName(), alertgroupId);
-        Map<String, Object> result = usersService.unauthorizedUser(loginUser, alertgroupId);
-        return returnDataList(result);
+        return usersService.unauthorizedUser(loginUser, alertgroupId);
     }
 
 
@@ -419,16 +409,15 @@ public class UsersController extends BaseController {
     @GetMapping(value = "/authed-user")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(AUTHORIZED_USER_ERROR)
-    public Result authorizedUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<List<User>> authorizedUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                  @RequestParam("alertgroupId") Integer alertgroupId) {
         try {
             logger.info("authorized user , login user:{}, alert group id:{}",
                     loginUser.getUserName(), alertgroupId);
-            Map<String, Object> result = usersService.authorizedUser(loginUser, alertgroupId);
-            return returnDataList(result);
+            return usersService.authorizedUser(loginUser, alertgroupId);
         } catch (Exception e) {
             logger.error(Status.AUTHORIZED_USER_ERROR.getMsg(), e);
-            return error(Status.AUTHORIZED_USER_ERROR.getCode(), Status.AUTHORIZED_USER_ERROR.getMsg());
+            return Result.error(Status.AUTHORIZED_USER_ERROR);
         }
     }
 
@@ -440,7 +429,7 @@ public class UsersController extends BaseController {
      * @param repeatPassword repeat password
      * @param email          user email
      */
-    @ApiOperation(value="registerUser",notes = "REGISTER_USER_NOTES")
+    @ApiOperation(value = "registerUser", notes = "REGISTER_USER_NOTES")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "userName", value = "USER_NAME", type = "String"),
             @ApiImplicitParam(name = "userPassword", value = "USER_PASSWORD", type = "String"),
@@ -450,18 +439,17 @@ public class UsersController extends BaseController {
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(CREATE_USER_ERROR)
-    public Result<Object> registerUser(@RequestParam(value = "userName") String userName,
-                               @RequestParam(value = "userPassword") String userPassword,
-                               @RequestParam(value = "repeatPassword") String repeatPassword,
-                               @RequestParam(value = "email") String email) throws Exception {
+    public Result<User> registerUser(@RequestParam(value = "userName") String userName,
+                                     @RequestParam(value = "userPassword") String userPassword,
+                                     @RequestParam(value = "repeatPassword") String repeatPassword,
+                                     @RequestParam(value = "email") String email) throws Exception {
         userName = ParameterUtils.handleEscapes(userName);
         userPassword = ParameterUtils.handleEscapes(userPassword);
         repeatPassword = ParameterUtils.handleEscapes(repeatPassword);
         email = ParameterUtils.handleEscapes(email);
         logger.info("user self-register, userName: {}, userPassword {}, repeatPassword {}, eamil {}",
                 userName, Constants.PASSWORD_DEFAULT, Constants.PASSWORD_DEFAULT, email);
-        Map<String, Object> result = usersService.registerUser(userName, userPassword, repeatPassword, email);
-        return returnDataList(result);
+        return usersService.registerUser(userName, userPassword, repeatPassword, email);
     }
 
     /**
@@ -469,20 +457,19 @@ public class UsersController extends BaseController {
      *
      * @param userName       user name
      */
-    @ApiOperation(value="activateUser",notes = "ACTIVATE_USER_NOTES")
+    @ApiOperation(value = "activateUser", notes = "ACTIVATE_USER_NOTES")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "userName", value = "USER_NAME", type = "String"),
     })
     @PostMapping("/activate")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_USER_ERROR)
-    public Result<Object> activateUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestParam(value = "userName") String userName) {
+    public Result<User> activateUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                     @RequestParam(value = "userName") String userName) {
         userName = ParameterUtils.handleEscapes(userName);
         logger.info("login user {}, activate user, userName: {}",
                 loginUser.getUserName(), userName);
-        Map<String, Object> result = usersService.activateUser(loginUser, userName);
-        return returnDataList(result);
+        return usersService.activateUser(loginUser, userName);
     }
 
     /**
@@ -490,18 +477,17 @@ public class UsersController extends BaseController {
      *
      * @param  userNames       user names
      */
-    @ApiOperation(value = "batchActivateUser",notes = "BATCH_ACTIVATE_USER_NOTES")
+    @ApiOperation(value = "batchActivateUser", notes = "BATCH_ACTIVATE_USER_NOTES")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "userNames", value = "USER_NAMES", type = "String"),
     })
     @PostMapping("/batch/activate")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_USER_ERROR)
-    public Result<Object> batchActivateUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestBody List<String> userNames) {
+    public Result<Map<String, Object>> batchActivateUser(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                         @RequestBody List<String> userNames) {
         List<String> formatUserNames = userNames.stream().map(ParameterUtils::handleEscapes).collect(Collectors.toList());
         logger.info(" activate userNames: {}", formatUserNames);
-        Map<String, Object> result = usersService.batchActivateUser(loginUser, formatUserNames);
-        return returnDataList(result);
+        return usersService.batchActivateUser(loginUser, formatUserNames);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkFlowLineageController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkFlowLineageController.java
@@ -66,11 +66,10 @@ public class WorkFlowLineageController extends BaseController {
                                                                     @ApiIgnore @RequestParam(value = "searchVal", required = false) String searchVal) {
         try {
             searchVal = ParameterUtils.handleEscapes(searchVal);
-            Map<String, Object> result = workFlowLineageService.queryWorkFlowLineageByName(searchVal,projectId);
-            return returnDataList(result);
+            return workFlowLineageService.queryWorkFlowLineageByName(searchVal, projectId);
         } catch (Exception e) {
             logger.error(QUERY_WORKFLOW_LINEAGE_ERROR.getMsg(),e);
-            return error(QUERY_WORKFLOW_LINEAGE_ERROR.getCode(), QUERY_WORKFLOW_LINEAGE_ERROR.getMsg());
+            return Result.error(QUERY_WORKFLOW_LINEAGE_ERROR);
         }
     }
 
@@ -89,11 +88,10 @@ public class WorkFlowLineageController extends BaseController {
                 }
             }
 
-            Map<String, Object> result = workFlowLineageService.queryWorkFlowLineageByIds(idsSet, projectId);
-            return returnDataList(result);
+            return workFlowLineageService.queryWorkFlowLineageByIds(idsSet, projectId);
         } catch (Exception e) {
             logger.error(QUERY_WORKFLOW_LINEAGE_ERROR.getMsg(),e);
-            return error(QUERY_WORKFLOW_LINEAGE_ERROR.getCode(), QUERY_WORKFLOW_LINEAGE_ERROR.getMsg());
+            return Result.error(QUERY_WORKFLOW_LINEAGE_ERROR);
         }
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkerGroupController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkerGroupController.java
@@ -22,16 +22,19 @@ import static org.apache.dolphinscheduler.api.enums.Status.QUERY_WORKER_ADDRESS_
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_WORKER_GROUP_FAIL;
 import static org.apache.dolphinscheduler.api.enums.Status.SAVE_ERROR;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.WorkerGroupService;
 import org.apache.dolphinscheduler.api.utils.RegexUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 
-import java.util.Map;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,15 +85,14 @@ public class WorkerGroupController extends BaseController {
     @PostMapping(value = "/save")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(SAVE_ERROR)
-    public Result saveWorkerGroup(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> saveWorkerGroup(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                   @RequestParam(value = "id", required = false, defaultValue = "0") int id,
                                   @RequestParam(value = "name") String name,
                                   @RequestParam(value = "addrList") String addrList
     ) {
         logger.info("save worker group: login user {}, id:{}, name: {}, addrList: {} ",
                 RegexUtils.escapeNRT(loginUser.getUserName()), id, RegexUtils.escapeNRT(name), RegexUtils.escapeNRT(addrList));
-        Map<String, Object> result = workerGroupService.saveWorkerGroup(loginUser, id, name, addrList);
-        return returnDataList(result);
+        return workerGroupService.saveWorkerGroup(loginUser, id, name, addrList);
     }
 
     /**
@@ -111,20 +113,19 @@ public class WorkerGroupController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKER_GROUP_FAIL)
-    public Result queryAllWorkerGroupsPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<PageListVO<WorkerGroup>> queryAllWorkerGroupsPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                              @RequestParam("pageNo") Integer pageNo,
                                              @RequestParam("pageSize") Integer pageSize,
                                              @RequestParam(value = "searchVal", required = false) String searchVal
     ) {
         logger.info("query all worker group paging: login user {}, pageNo:{}, pageSize:{}, searchVal:{}",
                 RegexUtils.escapeNRT(loginUser.getUserName()), pageNo, pageSize, searchVal);
-        Map<String, Object> result = checkPageParams(pageNo, pageSize);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataListPaging(result);
+        CheckParamResult checkParamResult = checkPageParams(pageNo, pageSize);
+        if (checkParamResult.getStatus() != Status.SUCCESS) {
+            return error(checkParamResult);
         }
         searchVal = ParameterUtils.handleEscapes(searchVal);
-        result = workerGroupService.queryAllGroupPaging(loginUser, pageNo, pageSize, searchVal);
-        return returnDataListPaging(result);
+        return workerGroupService.queryAllGroupPaging(loginUser, pageNo, pageSize, searchVal);
     }
 
     /**
@@ -137,10 +138,9 @@ public class WorkerGroupController extends BaseController {
     @GetMapping(value = "/all-groups")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKER_GROUP_FAIL)
-    public Result queryAllWorkerGroups(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<String>> queryAllWorkerGroups(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("query all worker group: login user {}", RegexUtils.escapeNRT(loginUser.getUserName()));
-        Map<String, Object> result = workerGroupService.queryAllGroup();
-        return returnDataList(result);
+        return workerGroupService.queryAllGroup();
     }
 
     /**
@@ -157,12 +157,11 @@ public class WorkerGroupController extends BaseController {
     @PostMapping(value = "/delete-by-id")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_WORKER_GROUP_FAIL)
-    public Result deleteById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+    public Result<Void> deleteById(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                              @RequestParam("id") Integer id
     ) {
         logger.info("delete worker group: login user {}, id:{} ", RegexUtils.escapeNRT(loginUser.getUserName()), id);
-        Map<String, Object> result = workerGroupService.deleteWorkerGroupById(loginUser, id);
-        return returnDataList(result);
+        return workerGroupService.deleteWorkerGroupById(loginUser, id);
     }
 
     /**
@@ -175,10 +174,9 @@ public class WorkerGroupController extends BaseController {
     @GetMapping(value = "/worker-address-list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKER_ADDRESS_LIST_FAIL)
-    public Result queryWorkerAddressList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
+    public Result<List<String>> queryWorkerAddressList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
         logger.info("query worker address list: login user {}", RegexUtils.escapeNRT(loginUser.getUserName()));
-        Map<String, Object> result = workerGroupService.getWorkerAddressList();
-        return returnDataList(result);
+        return workerGroupService.getWorkerAddressList();
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/CheckParamResult.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/CheckParamResult.java
@@ -15,21 +15,46 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.service;
+package org.apache.dolphinscheduler.api.dto;
 
-import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.enums.PluginType;
-import org.apache.dolphinscheduler.dao.entity.PluginDefine;
+import org.apache.dolphinscheduler.api.enums.Status;
 
-import java.util.List;
+import java.io.Serializable;
 
-/**
- * ui plugin service
- */
-public interface UiPluginService {
+public class CheckParamResult implements Serializable {
 
-    Result<List<PluginDefine>> queryUiPluginsByType(PluginType pluginType);
+    private Status status;
 
-    Result<PluginDefine> queryUiPluginDetailById(int id);
+    private String msg;
+
+    public CheckParamResult() {
+
+    }
+
+    public CheckParamResult(Status status) {
+        this.status = status;
+        this.msg = status.getMsg();
+    }
+
+    public CheckParamResult(Status status, String mes) {
+        this.status = status;
+        this.msg = mes;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/CheckParamResultWithInfo.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/CheckParamResultWithInfo.java
@@ -15,21 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.service;
+package org.apache.dolphinscheduler.api.dto;
 
-import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.enums.PluginType;
-import org.apache.dolphinscheduler.dao.entity.PluginDefine;
+import java.io.Serializable;
 
-import java.util.List;
+public class CheckParamResultWithInfo<T> extends CheckParamResult implements Serializable {
+    private T info;
 
-/**
- * ui plugin service
- */
-public interface UiPluginService {
+    public void setInfo(T info) {
+        this.info = info;
+    }
 
-    Result<List<PluginDefine>> queryUiPluginsByType(PluginType pluginType);
-
-    Result<PluginDefine> queryUiPluginDetailById(int id);
-
+    public T getInfo() {
+        return info;
+    }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AccessTokenService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AccessTokenService.java
@@ -17,9 +17,10 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
+import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.Map;
 
 /**
  * access token service
@@ -35,7 +36,7 @@ public interface AccessTokenService {
      * @param pageSize page size
      * @return token list for page number and page size
      */
-    Map<String, Object> queryAccessTokenList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<AccessToken>> queryAccessTokenList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * create token
@@ -45,7 +46,7 @@ public interface AccessTokenService {
      * @param token token string
      * @return create result code
      */
-    Map<String, Object> createToken(User loginUser, int userId, String expireTime, String token);
+    Result<Void> createToken(User loginUser, int userId, String expireTime, String token);
 
 
     /**
@@ -55,7 +56,7 @@ public interface AccessTokenService {
      * @param expireTime token expire time
      * @return token string
      */
-    Map<String, Object> generateToken(User loginUser, int userId, String expireTime);
+    Result<String> generateToken(User loginUser, int userId, String expireTime);
 
     /**
      * delete access token
@@ -64,7 +65,7 @@ public interface AccessTokenService {
      * @param id token id
      * @return delete result code
      */
-    Map<String, Object> delAccessTokenById(User loginUser, int id);
+    Result<Void> delAccessTokenById(User loginUser, int id);
 
     /**
      * update token by id
@@ -75,5 +76,5 @@ public interface AccessTokenService {
      * @param token token string
      * @return update result code
      */
-    Map<String, Object> updateToken(User loginUser, int id, int userId, String expireTime, String token);
+    Result<Void> updateToken(User loginUser, int id, int userId, String expireTime, String token);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertGroupService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertGroupService.java
@@ -17,9 +17,12 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
+import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * alert group service
@@ -31,7 +34,7 @@ public interface AlertGroupService {
      *
      * @return alert group list
      */
-    Map<String, Object> queryAlertgroup();
+    Result<List<AlertGroup>> queryAlertgroup();
 
     /**
      * paging query alarm group list
@@ -42,7 +45,7 @@ public interface AlertGroupService {
      * @param pageSize page size
      * @return alert group list page
      */
-    Map<String, Object> listPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<AlertGroup>> listPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * create alert group
@@ -53,7 +56,7 @@ public interface AlertGroupService {
      * @param alertInstanceIds alertInstanceIds
      * @return create result code
      */
-    Map<String, Object> createAlertgroup(User loginUser, String groupName, String desc, String alertInstanceIds);
+    Result<Void> createAlertgroup(User loginUser, String groupName, String desc, String alertInstanceIds);
 
     /**
      * updateProcessInstance alert group
@@ -65,7 +68,7 @@ public interface AlertGroupService {
      * @param alertInstanceIds alertInstanceIds
      * @return update result code
      */
-    Map<String, Object> updateAlertgroup(User loginUser, int id, String groupName, String desc, String alertInstanceIds);
+    Result<Void> updateAlertgroup(User loginUser, int id, String groupName, String desc, String alertInstanceIds);
 
     /**
      * delete alert group by id
@@ -74,7 +77,7 @@ public interface AlertGroupService {
      * @param id alert group id
      * @return delete result code
      */
-    Map<String, Object> delAlertgroupById(User loginUser, int id);
+    Result<Void> delAlertgroupById(User loginUser, int id);
 
     /**
      * verify group name exists

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceService.java
@@ -17,9 +17,13 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.AlertPluginInstanceVO;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
+import org.apache.dolphinscheduler.dao.entity.AlertPluginInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * alert plugin instance service
@@ -35,7 +39,7 @@ public interface AlertPluginInstanceService {
      * @param pluginInstanceParams plugin instance params
      * @return result
      */
-    Map<String, Object> create(User loginUser,int pluginDefineId,String instanceName,String pluginInstanceParams);
+    Result<Void> create(User loginUser,int pluginDefineId,String instanceName,String pluginInstanceParams);
 
     /**
      * update
@@ -45,7 +49,7 @@ public interface AlertPluginInstanceService {
      * @param pluginInstanceParams plugin instance params
      * @return result
      */
-    Map<String, Object> update(User loginUser, int alertPluginInstanceId,String instanceName,String pluginInstanceParams);
+    Result<Void> update(User loginUser, int alertPluginInstanceId,String instanceName,String pluginInstanceParams);
 
     /**
      * delete alert plugin instance
@@ -54,7 +58,7 @@ public interface AlertPluginInstanceService {
      * @param id id
      * @return result
      */
-    Map<String, Object> delete(User loginUser, int id);
+    Result<Void> delete(User loginUser, int id);
 
     /**
      * get alert plugin instance
@@ -63,14 +67,14 @@ public interface AlertPluginInstanceService {
      * @param id get id
      * @return alert plugin
      */
-    Map<String, Object> get(User loginUser, int id);
+    Result<AlertPluginInstance> get(User loginUser, int id);
 
     /**
      * queryAll
      *
      * @return alert plugins
      */
-    Map<String, Object> queryAll();
+    Result<List<AlertPluginInstanceVO>> queryAll();
 
     /**
      * checkExistPluginInstanceName
@@ -81,9 +85,10 @@ public interface AlertPluginInstanceService {
 
     /**
      * queryPluginPage
+     *
      * @param pageIndex page index
-     * @param pageSize  page size
+     * @param pageSize page size
      * @return plugins
      */
-    Map<String, Object> queryPluginPage(int pageIndex,int pageSize);
+    Result<PageListVO<AlertPluginInstanceVO>> queryPluginPage(int pageIndex, int pageSize);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/BaseService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/BaseService.java
@@ -17,11 +17,14 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
+import org.apache.dolphinscheduler.api.dto.CheckParamResultWithInfo;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -41,19 +44,18 @@ public interface BaseService {
      * isNotAdmin
      *
      * @param loginUser login user
-     * @param result result code
      * @return true if not administrator, otherwise false
      */
-    boolean isNotAdmin(User loginUser, Map<String, Object> result);
+    boolean isNotAdmin(User loginUser);
 
     /**
      * put message to map
      *
-     * @param result result code
+     * @param checkParamResult result code
      * @param status status
      * @param statusParams status message
      */
-    void putMsg(Map<String, Object> result, Status status, Object... statusParams);
+    void putMsg(CheckParamResult checkParamResult, Status status, Object... statusParams);
 
     /**
      * put message to result object
@@ -95,7 +97,7 @@ public interface BaseService {
      *
      * @param startDateStr start date string
      * @param endDateStr end date string
-     * @return map<status,startDate,endDate>
+     * @return map<status, startDate, endDate>
      */
-    Map<String, Object> checkAndParseDateParameters(String startDateStr, String endDateStr);
+    CheckParamResultWithInfo<Map<String, Date>> checkAndParseDateParameters(String startDateStr, String endDateStr);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataAnalysisService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataAnalysisService.java
@@ -17,8 +17,13 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.CommandStateCount;
+import org.apache.dolphinscheduler.api.dto.DefineUserDto;
+import org.apache.dolphinscheduler.api.dto.TaskCountDto;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,7 +40,7 @@ public interface DataAnalysisService {
      * @param endDate end date
      * @return task state count data
      */
-    Map<String, Object> countTaskStateByProject(User loginUser, int projectId, String startDate, String endDate);
+    Result<TaskCountDto> countTaskStateByProject(User loginUser, int projectId, String startDate, String endDate);
 
     /**
      * statistical process instance status data
@@ -46,7 +51,7 @@ public interface DataAnalysisService {
      * @param endDate end date
      * @return process instance state count data
      */
-    Map<String, Object> countProcessInstanceStateByProject(User loginUser, int projectId, String startDate, String endDate);
+    Result<TaskCountDto> countProcessInstanceStateByProject(User loginUser, int projectId, String startDate, String endDate);
 
     /**
      * statistics the process definition quantities of certain person
@@ -55,7 +60,7 @@ public interface DataAnalysisService {
      * @param projectId project id
      * @return definition count data
      */
-    Map<String, Object> countDefinitionByUser(User loginUser, int projectId);
+    Result<DefineUserDto> countDefinitionByUser(User loginUser, int projectId);
 
     /**
      * statistical command status data
@@ -66,7 +71,7 @@ public interface DataAnalysisService {
      * @param endDate end date
      * @return command state count data
      */
-    Map<String, Object> countCommandState(User loginUser, int projectId, String startDate, String endDate);
+    Result<List<CommandStateCount>> countCommandState(User loginUser, int projectId, String startDate, String endDate);
 
     /**
      * count queue state
@@ -75,6 +80,6 @@ public interface DataAnalysisService {
      * @param projectId project id
      * @return queue state count data
      */
-    Map<String, Object> countQueueState(User loginUser, int projectId);
+    Result<Map<String, Integer>> countQueueState(User loginUser, int projectId);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
@@ -18,10 +18,13 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.DbConnectType;
 import org.apache.dolphinscheduler.common.enums.DbType;
+import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,13 +36,13 @@ public interface DataSourceService {
      * create data source
      *
      * @param loginUser login user
-     * @param name      data source name
-     * @param desc      data source description
-     * @param type      data source type
+     * @param name data source name
+     * @param desc data source description
+     * @param type data source type
      * @param parameter datasource parameters
      * @return create result code
      */
-    Result<Object> createDataSource(User loginUser, String name, String desc, DbType type, String parameter);
+    Result<Void> createDataSource(User loginUser, String name, String desc, DbType type, String parameter);
 
     /**
      * updateProcessInstance datasource
@@ -52,7 +55,7 @@ public interface DataSourceService {
      * @param id        data source id
      * @return update result code
      */
-    Result<Object> updateDataSource(int id, User loginUser, String name, String desc, DbType type, String parameter);
+    Result<Void> updateDataSource(int id, User loginUser, String name, String desc, DbType type, String parameter);
 
     /**
      * updateProcessInstance datasource
@@ -60,27 +63,27 @@ public interface DataSourceService {
      * @param id datasource id
      * @return data source detail
      */
-    Map<String, Object> queryDataSource(int id);
+    Result<Map<String, Object>> queryDataSource(int id);
 
     /**
      * query datasource list by keyword
      *
      * @param loginUser login user
      * @param searchVal search value
-     * @param pageNo    page number
-     * @param pageSize  page size
+     * @param pageNo page number
+     * @param pageSize page size
      * @return data source list page
      */
-    Map<String, Object> queryDataSourceListPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<DataSource>> queryDataSourceListPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * query data resource list
      *
      * @param loginUser login user
-     * @param type      data source type
+     * @param type data source type
      * @return data source list page
      */
-    Map<String, Object> queryDataSourceList(User loginUser, Integer type);
+    Result<List<DataSource>> queryDataSourceList(User loginUser, Integer type);
 
     /**
      * verify datasource exists
@@ -97,7 +100,7 @@ public interface DataSourceService {
      * @param parameter data source parameters
      * @return true if connect successfully, otherwise false
      */
-    Result<Object> checkConnection(DbType type, String parameter);
+    Result<Void> checkConnection(DbType type, String parameter);
 
     /**
      * test connection
@@ -105,7 +108,7 @@ public interface DataSourceService {
      * @param id datasource id
      * @return connect result code
      */
-    Result<Object> connectionTest(int id);
+    Result<Void> connectionTest(int id);
 
     /**
      * build paramters
@@ -141,7 +144,7 @@ public interface DataSourceService {
      * @param userId    user id
      * @return unauthed data source result code
      */
-    Map<String, Object> unauthDatasource(User loginUser, Integer userId);
+    Result<List<DataSource>> unauthDatasource(User loginUser, Integer userId);
 
     /**
      * authorized datasource
@@ -150,5 +153,5 @@ public interface DataSourceService {
      * @param userId    user id
      * @return authorized result code
      */
-    Map<String, Object> authedDatasource(User loginUser, Integer userId);
+    Result<List<DataSource>> authedDatasource(User loginUser, Integer userId);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.ExecuteType;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Priority;
@@ -54,13 +55,13 @@ public interface ExecutorService {
      * @param startParams the global param values which pass to new process instance
      * @return execute process instance code
      */
-    Map<String, Object> execProcessInstance(User loginUser, String projectName,
-                                            int processDefinitionId, String cronTime, CommandType commandType,
-                                            FailureStrategy failureStrategy, String startNodeList,
-                                            TaskDependType taskDependType, WarningType warningType, int warningGroupId,
-                                            RunMode runMode,
-                                            Priority processInstancePriority, String workerGroup, Integer timeout,
-                                            Map<String, String> startParams);
+    Result<Void> execProcessInstance(User loginUser, String projectName,
+                                     int processDefinitionId, String cronTime, CommandType commandType,
+                                     FailureStrategy failureStrategy, String startNodeList,
+                                     TaskDependType taskDependType, WarningType warningType, int warningGroupId,
+                                     RunMode runMode,
+                                     Priority processInstancePriority, String workerGroup, Integer timeout,
+                                     Map<String, String> startParams);
 
     /**
      * check whether the process definition can be executed
@@ -69,7 +70,7 @@ public interface ExecutorService {
      * @param processDefineId process definition id
      * @return check result code
      */
-    Map<String, Object> checkProcessDefinitionValid(ProcessDefinition processDefinition, int processDefineId);
+    Result<Void> checkProcessDefinitionValid(ProcessDefinition processDefinition, int processDefineId);
 
     /**
      * do action to process instance：pause, stop, repeat, recover from pause, recover from stop
@@ -80,7 +81,7 @@ public interface ExecutorService {
      * @param executeType execute type
      * @return execute result code
      */
-    Map<String, Object> execute(User loginUser, String projectName, Integer processInstanceId, ExecuteType executeType);
+    Result<Void> execute(User loginUser, String projectName, Integer processInstanceId, ExecuteType executeType);
 
     /**
      * check if sub processes are offline before starting process definition
@@ -88,5 +89,5 @@ public interface ExecutorService {
      * @param processDefineId process definition id
      * @return check result code
      */
-    Map<String, Object> startCheckByProcessDefinedId(int processDefineId);
+    Result<Void> startCheckByProcessDefinedId(int processDefineId);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/MonitorService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/MonitorService.java
@@ -17,11 +17,15 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.model.Server;
+import org.apache.dolphinscheduler.common.model.WorkerServerModel;
+import org.apache.dolphinscheduler.dao.entity.MonitorRecord;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.ZookeeperRecord;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 /**
  * monitor service
@@ -34,31 +38,31 @@ public interface MonitorService {
      * @param loginUser login user
      * @return data base state
      */
-    Map<String,Object> queryDatabaseState(User loginUser);
-    
+    Result<List<MonitorRecord>> queryDatabaseState(User loginUser);
+
     /**
      * query master list
      *
      * @param loginUser login user
      * @return master information list
      */
-    Map<String,Object> queryMaster(User loginUser);
-    
+    Result<List<Server>> queryMaster(User loginUser);
+
     /**
      * query zookeeper state
      *
      * @param loginUser login user
      * @return zookeeper information list
      */
-    Map<String,Object> queryZookeeperState(User loginUser);
-    
+    Result<List<ZookeeperRecord>> queryZookeeperState(User loginUser);
+
     /**
      * query worker list
      *
      * @param loginUser login user
      * @return worker information list
      */
-    Map<String,Object> queryWorker(User loginUser);
-    
+    Result<Collection<WorkerServerModel>> queryWorker(User loginUser);
+
     List<Server> getServerListFromZK(boolean isMaster);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionService.java
@@ -17,10 +17,17 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
+import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
+import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.dao.entity.ProcessData;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
@@ -47,13 +54,13 @@ public interface ProcessDefinitionService {
      * @return create result code
      * @throws JsonProcessingException JsonProcessingException
      */
-    Map<String, Object> createProcessDefinition(User loginUser,
-                                                String projectName,
-                                                String name,
-                                                String processDefinitionJson,
-                                                String desc,
-                                                String locations,
-                                                String connects) throws JsonProcessingException;
+    Result<Integer> createProcessDefinition(User loginUser,
+                                            String projectName,
+                                            String name,
+                                            String processDefinitionJson,
+                                            String desc,
+                                            String locations,
+                                            String connects) throws JsonProcessingException;
 
     /**
      * query process definition list
@@ -62,8 +69,8 @@ public interface ProcessDefinitionService {
      * @param projectName project name
      * @return definition list
      */
-    Map<String, Object> queryProcessDefinitionList(User loginUser,
-                                                   String projectName);
+    Result<List<ProcessDefinition>> queryProcessDefinitionList(User loginUser,
+                                                               String projectName);
 
     /**
      * query process definition list paging
@@ -76,12 +83,12 @@ public interface ProcessDefinitionService {
      * @param userId user id
      * @return process definition page
      */
-    Map<String, Object> queryProcessDefinitionListPaging(User loginUser,
-                                                         String projectName,
-                                                         String searchVal,
-                                                         Integer pageNo,
-                                                         Integer pageSize,
-                                                         Integer userId);
+    Result<PageListVO<ProcessDefinition>> queryProcessDefinitionListPaging(User loginUser,
+                                                                           String projectName,
+                                                                           String searchVal,
+                                                                           Integer pageNo,
+                                                                           Integer pageSize,
+                                                                           Integer userId);
 
     /**
      * query datail of process definition
@@ -92,9 +99,9 @@ public interface ProcessDefinitionService {
      * @return process definition detail
      */
 
-    Map<String, Object> queryProcessDefinitionById(User loginUser,
-                                                   String projectName,
-                                                   Integer processId);
+    Result<ProcessDefinition> queryProcessDefinitionById(User loginUser,
+                                                         String projectName,
+                                                         Integer processId);
 
     /**
      * query datail of process definition
@@ -105,9 +112,9 @@ public interface ProcessDefinitionService {
      * @return process definition detail
      */
 
-    Map<String, Object> queryProcessDefinitionByName(User loginUser,
-                                                   String projectName,
-                                                   String processDefinitionName);
+    Result<ProcessDefinition> queryProcessDefinitionByName(User loginUser,
+                                                           String projectName,
+                                                           String processDefinitionName);
 
     /**
      * batch copy process definition
@@ -117,7 +124,7 @@ public interface ProcessDefinitionService {
      * @param processDefinitionIds processDefinitionIds
      * @param targetProjectId targetProjectId
      */
-    Map<String, Object> batchCopyProcessDefinition(User loginUser,
+    Result<Void> batchCopyProcessDefinition(User loginUser,
                                                    String projectName,
                                                    String processDefinitionIds,
                                                    int targetProjectId);
@@ -130,7 +137,7 @@ public interface ProcessDefinitionService {
      * @param processDefinitionIds processDefinitionIds
      * @param targetProjectId targetProjectId
      */
-    Map<String, Object> batchMoveProcessDefinition(User loginUser,
+    Result<Void> batchMoveProcessDefinition(User loginUser,
                                                    String projectName,
                                                    String processDefinitionIds,
                                                    int targetProjectId);
@@ -148,12 +155,12 @@ public interface ProcessDefinitionService {
      * @param connects connects for nodes
      * @return update result code
      */
-    Map<String, Object> updateProcessDefinition(User loginUser,
-                                                String projectName,
-                                                int id,
-                                                String name,
-                                                String processDefinitionJson, String desc,
-                                                String locations, String connects);
+    Result<ProcessDefinition> updateProcessDefinition(User loginUser,
+                                                      String projectName,
+                                                      int id,
+                                                      String name,
+                                                      String processDefinitionJson, String desc,
+                                                      String locations, String connects);
 
     /**
      * verify process definition name unique
@@ -163,9 +170,9 @@ public interface ProcessDefinitionService {
      * @param name name
      * @return true if process definition name not exists, otherwise false
      */
-    Map<String, Object> verifyProcessDefinitionName(User loginUser,
-                                                    String projectName,
-                                                    String name);
+    CheckParamResult verifyProcessDefinitionName(User loginUser,
+                                                 String projectName,
+                                                 String name);
 
     /**
      * delete process definition by id
@@ -175,7 +182,7 @@ public interface ProcessDefinitionService {
      * @param processDefinitionId process definition id
      * @return delete result code
      */
-    Map<String, Object> deleteProcessDefinitionById(User loginUser,
+    Result<Void> deleteProcessDefinitionById(User loginUser,
                                                     String projectName,
                                                     Integer processDefinitionId);
 
@@ -188,10 +195,10 @@ public interface ProcessDefinitionService {
      * @param releaseState release state
      * @return release result code
      */
-    Map<String, Object> releaseProcessDefinition(User loginUser,
-                                                 String projectName,
-                                                 int id,
-                                                 ReleaseState releaseState);
+    Result<ProcessDefinition> releaseProcessDefinition(User loginUser,
+                                                       String projectName,
+                                                       int id,
+                                                       ReleaseState releaseState);
 
     /**
      * batch export process definition by ids
@@ -214,7 +221,7 @@ public interface ProcessDefinitionService {
      * @param currentProjectName current project name
      * @return import process
      */
-    Map<String, Object> importProcessDefinition(User loginUser,
+    Result<Void> importProcessDefinition(User loginUser,
                                                 MultipartFile file,
                                                 String currentProjectName);
 
@@ -225,8 +232,8 @@ public interface ProcessDefinitionService {
      * @param processDefinitionJson process definition json
      * @return check result code
      */
-    Map<String, Object> checkProcessNodeList(ProcessData processData,
-                                             String processDefinitionJson);
+    CheckParamResult checkProcessNodeList(ProcessData processData,
+                                          String processDefinitionJson);
 
     /**
      * get task node details based on process definition
@@ -234,7 +241,7 @@ public interface ProcessDefinitionService {
      * @param defineId define id
      * @return task node list
      */
-    Map<String, Object> getTaskNodeListByDefinitionId(Integer defineId);
+    Result<List<TaskNode>> getTaskNodeListByDefinitionId(Integer defineId);
 
     /**
      * get task node details based on process definition
@@ -242,7 +249,7 @@ public interface ProcessDefinitionService {
      * @param defineIdList define id list
      * @return task node list
      */
-    Map<String, Object> getTaskNodeListByDefinitionIdList(String defineIdList);
+    Result<Map<Integer, List<TaskNode>>> getTaskNodeListByDefinitionIdList(String defineIdList);
 
     /**
      * query process definition all by project id
@@ -250,7 +257,7 @@ public interface ProcessDefinitionService {
      * @param projectId project id
      * @return process definitions in the project
      */
-    Map<String, Object> queryProcessDefinitionAllByProjectId(Integer projectId);
+    Result<List<ProcessDefinition>> queryProcessDefinitionAllByProjectId(Integer projectId);
 
     /**
      * Encapsulates the TreeView structure
@@ -260,7 +267,7 @@ public interface ProcessDefinitionService {
      * @return tree view json data
      * @throws Exception exception
      */
-    Map<String, Object> viewTree(Integer processId,
+    Result<TreeViewDto> viewTree(Integer processId,
                                  Integer limit) throws Exception;
 
     /**
@@ -272,7 +279,7 @@ public interface ProcessDefinitionService {
      * @param version the version user want to switch
      * @return switch process definition version result code
      */
-    Map<String, Object> switchProcessDefinitionVersion(User loginUser, String projectName
+    Result<Void> switchProcessDefinitionVersion(User loginUser, String projectName
             , int processDefinitionId, long version);
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionVersionService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionVersionService.java
@@ -17,11 +17,12 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionVersion;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
 
 /**
  * process definition version service
@@ -46,8 +47,8 @@ public interface ProcessDefinitionVersionService {
      * @param processDefinitionId process definition id
      * @return the pagination process definition versions info of the certain process definition
      */
-    Map<String, Object> queryProcessDefinitionVersions(User loginUser, String projectName,
-                                                       int pageNo, int pageSize, int processDefinitionId);
+    Result<PageListVO<ProcessDefinitionVersion>> queryProcessDefinitionVersions(User loginUser, String projectName,
+                                                                                int pageNo, int pageSize, int processDefinitionId);
 
     /**
      * query one certain process definition version by version number and process definition id
@@ -68,6 +69,6 @@ public interface ProcessDefinitionVersionService {
      * @param version version number
      * @return delele result code
      */
-    Map<String, Object> deleteByProcessDefinitionIdAndVersion(User loginUser, String projectName,
-                                                              int processDefinitionId, long version);
+    Result<Void> deleteByProcessDefinitionIdAndVersion(User loginUser, String projectName,
+                                                       int processDefinitionId, long version);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessInstanceService.java
@@ -17,6 +17,9 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.gantt.GanttDto;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.DependResult;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.enums.Flag;
@@ -36,7 +39,7 @@ public interface ProcessInstanceService {
     /**
      * return top n SUCCESS process instance order by running time which started between startTime and endTime
      */
-    Map<String, Object> queryTopNLongestRunningProcessInstance(User loginUser, String projectName, int size, String startTime, String endTime);
+    Result<List<ProcessInstance>> queryTopNLongestRunningProcessInstance(User loginUser, String projectName, int size, String startTime, String endTime);
 
     /**
      * query process instance by id
@@ -46,7 +49,7 @@ public interface ProcessInstanceService {
      * @param processId process instance id
      * @return process instance detail
      */
-    Map<String, Object> queryProcessInstanceById(User loginUser, String projectName, Integer processId);
+    Result<ProcessInstance> queryProcessInstanceById(User loginUser, String projectName, Integer processId);
 
     /**
      * paging query process instance list, filtering according to project, process definition, time range, keyword, process status
@@ -63,10 +66,10 @@ public interface ProcessInstanceService {
      * @param endDate end time
      * @return process instance list
      */
-    Map<String, Object> queryProcessInstanceList(User loginUser, String projectName, Integer processDefineId,
-                                                 String startDate, String endDate,
-                                                 String searchVal, String executorName, ExecutionStatus stateType, String host,
-                                                 Integer pageNo, Integer pageSize);
+    Result<PageListVO<ProcessInstance>> queryProcessInstanceList(User loginUser, String projectName, Integer processDefineId,
+                                                                 String startDate, String endDate,
+                                                                 String searchVal, String executorName, ExecutionStatus stateType, String host,
+                                                                 Integer pageNo, Integer pageSize);
 
     /**
      * query task list by process instance id
@@ -77,7 +80,7 @@ public interface ProcessInstanceService {
      * @return task list for the process instance
      * @throws IOException io exception
      */
-    Map<String, Object> queryTaskListByProcessId(User loginUser, String projectName, Integer processId) throws IOException;
+    Result<Map<String, Object>> queryTaskListByProcessId(User loginUser, String projectName, Integer processId) throws IOException;
 
     Map<String, DependResult> parseLogForDependentResult(String log) throws IOException;
 
@@ -89,7 +92,7 @@ public interface ProcessInstanceService {
      * @param taskId task id
      * @return sub process instance detail
      */
-    Map<String, Object> querySubProcessInstanceByTaskId(User loginUser, String projectName, Integer taskId);
+    Result<Map<String, Object>> querySubProcessInstanceByTaskId(User loginUser, String projectName, Integer taskId);
 
     /**
      * update process instance
@@ -106,7 +109,7 @@ public interface ProcessInstanceService {
      * @return update result code
      * @throws ParseException parse exception for json parse
      */
-    Map<String, Object> updateProcessInstance(User loginUser, String projectName, Integer processInstanceId,
+    Result<Void> updateProcessInstance(User loginUser, String projectName, Integer processInstanceId,
                                               String processInstanceJson, String scheduleTime, Boolean syncDefine,
                                               Flag flag, String locations, String connects) throws ParseException;
 
@@ -118,7 +121,7 @@ public interface ProcessInstanceService {
      * @param subId sub process id
      * @return parent instance detail
      */
-    Map<String, Object> queryParentInstanceBySubId(User loginUser, String projectName, Integer subId);
+    Result<Map<String, Object>> queryParentInstanceBySubId(User loginUser, String projectName, Integer subId);
 
     /**
      * delete process instance by id, at the same time，delete task instance and their mapping relation data
@@ -128,7 +131,7 @@ public interface ProcessInstanceService {
      * @param processInstanceId process instance id
      * @return delete result code
      */
-    Map<String, Object> deleteProcessInstanceById(User loginUser, String projectName, Integer processInstanceId);
+    Result<Void> deleteProcessInstanceById(User loginUser, String projectName, Integer processInstanceId);
 
     /**
      * view process instance variables
@@ -136,7 +139,7 @@ public interface ProcessInstanceService {
      * @param processInstanceId process instance id
      * @return variables data
      */
-    Map<String, Object> viewVariables(Integer processInstanceId);
+    Result<Map<String, Object>> viewVariables(Integer processInstanceId);
 
     /**
      * encapsulation gantt structure
@@ -145,7 +148,7 @@ public interface ProcessInstanceService {
      * @return gantt tree data
      * @throws Exception exception when json parse
      */
-    Map<String, Object> viewGantt(Integer processInstanceId) throws Exception;
+    Result<GanttDto> viewGantt(Integer processInstanceId) throws Exception;
 
     /**
      * query process instance by processDefinitionId and stateArray

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
@@ -17,10 +17,13 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * project service
@@ -35,7 +38,7 @@ public interface ProjectService {
      * @param desc description
      * @return returns an error if it exists
      */
-    Map<String, Object> createProject(User loginUser, String name, String desc);
+    Result<Integer> createProject(User loginUser, String name, String desc);
 
     /**
      * query project details by id
@@ -43,7 +46,7 @@ public interface ProjectService {
      * @param projectId project id
      * @return project detail information
      */
-    Map<String, Object> queryById(Integer projectId);
+    Result<Project> queryById(Integer projectId);
 
     /**
      * check project and authorization
@@ -53,9 +56,9 @@ public interface ProjectService {
      * @param projectName project name
      * @return true if the login user have permission to see the project
      */
-    Map<String, Object> checkProjectAndAuth(User loginUser, Project project, String projectName);
+    CheckParamResult checkProjectAndAuth(User loginUser, Project project, String projectName);
 
-    boolean hasProjectAndPerm(User loginUser, Project project, Map<String, Object> result);
+    CheckParamResult hasProjectAndPerm(User loginUser, Project project);
 
     /**
      * admin can view all projects
@@ -66,7 +69,7 @@ public interface ProjectService {
      * @param pageNo page number
      * @return project list which the login user have permission to see
      */
-    Map<String, Object> queryProjectListPaging(User loginUser, Integer pageSize, Integer pageNo, String searchVal);
+    Result<PageListVO<Project>> queryProjectListPaging(User loginUser, Integer pageSize, Integer pageNo, String searchVal);
 
     /**
      * delete project by id
@@ -75,7 +78,7 @@ public interface ProjectService {
      * @param projectId project id
      * @return delete result code
      */
-    Map<String, Object> deleteProject(User loginUser, Integer projectId);
+    Result<Void> deleteProject(User loginUser, Integer projectId);
 
     /**
      * updateProcessInstance project
@@ -86,7 +89,7 @@ public interface ProjectService {
      * @param desc description
      * @return update result code
      */
-    Map<String, Object> update(User loginUser, Integer projectId, String projectName, String desc);
+    Result<Void> update(User loginUser, Integer projectId, String projectName, String desc);
 
     /**
      * query unauthorized project
@@ -95,7 +98,7 @@ public interface ProjectService {
      * @param userId user id
      * @return the projects which user have not permission to see
      */
-    Map<String, Object> queryUnauthorizedProject(User loginUser, Integer userId);
+    Result<List<Project>> queryUnauthorizedProject(User loginUser, Integer userId);
 
     /**
      * query authorized project
@@ -104,7 +107,7 @@ public interface ProjectService {
      * @param userId user id
      * @return projects which the user have permission to see, Except for items created by this user
      */
-    Map<String, Object> queryAuthorizedProject(User loginUser, Integer userId);
+    Result<List<Project>> queryAuthorizedProject(User loginUser, Integer userId);
 
     /**
      * query authorized project
@@ -112,20 +115,20 @@ public interface ProjectService {
      * @param loginUser login user
      * @return projects which the user have permission to see, Except for items created by this user
      */
-    Map<String, Object> queryProjectCreatedByUser(User loginUser);
+    Result<List<Project>> queryProjectCreatedByUser(User loginUser);
 
     /**
      * query all project list that have one or more process definitions.
      *
      * @return project list
      */
-    Map<String, Object> queryAllProjectList();
+    Result<List<Project>> queryAllProjectList();
 
     /**
      * query authorized and user create project list by user id
      * @param loginUser
      * @return
      */
-    Map<String, Object> queryProjectCreatedAndAuthorizedByUser(User loginUser);
+    Result<List<Project>> queryProjectCreatedAndAuthorizedByUser(User loginUser);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/QueueService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/QueueService.java
@@ -18,9 +18,11 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
+import org.apache.dolphinscheduler.dao.entity.Queue;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * queue service
@@ -33,7 +35,7 @@ public interface QueueService {
      * @param loginUser login user
      * @return queue list
      */
-    Map<String, Object> queryList(User loginUser);
+    Result<List<Queue>> queryList(User loginUser);
 
     /**
      * query queue list paging
@@ -44,7 +46,7 @@ public interface QueueService {
      * @param pageSize page size
      * @return queue list
      */
-    Map<String, Object> queryList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<Queue>> queryList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * create queue
@@ -54,7 +56,7 @@ public interface QueueService {
      * @param queueName queue name
      * @return create result
      */
-    Map<String, Object> createQueue(User loginUser, String queue, String queueName);
+    Result<Void> createQueue(User loginUser, String queue, String queueName);
 
     /**
      * update queue
@@ -65,15 +67,15 @@ public interface QueueService {
      * @param queueName queue name
      * @return update result code
      */
-    Map<String, Object> updateQueue(User loginUser, int id, String queue, String queueName);
+    Result<Void> updateQueue(User loginUser, int id, String queue, String queueName);
 
     /**
      * verify queue and queueName
      *
-     * @param queue     queue
+     * @param queue queue
      * @param queueName queue name
      * @return true if the queue name not exists, otherwise return false
      */
-    Result<Object> verifyQueue(String queue, String queueName);
+    Result<Void> verifyQueue(String queue, String queueName);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -17,13 +17,17 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.resources.ResourceComponent;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.ProgramType;
 import org.apache.dolphinscheduler.common.enums.ResourceType;
+import org.apache.dolphinscheduler.dao.entity.Resource;
+import org.apache.dolphinscheduler.dao.entity.UdfFunc;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -97,7 +101,7 @@ public interface ResourcesService {
      * @param pageSize page size
      * @return resource list page
      */
-    Map<String, Object> queryResourceListPaging(User loginUser, int directoryId, ResourceType type, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<Resource>> queryResourceListPaging(User loginUser, int directoryId, ResourceType type, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * query resource list
@@ -106,7 +110,7 @@ public interface ResourcesService {
      * @param type resource type
      * @return resource list
      */
-    Map<String, Object> queryResourceList(User loginUser, ResourceType type);
+    Result<List<ResourceComponent>> queryResourceList(User loginUser, ResourceType type);
 
     /**
      * query resource list by program type
@@ -115,7 +119,7 @@ public interface ResourcesService {
      * @param type resource type
      * @return resource list
      */
-    Map<String, Object> queryResourceByProgramType(User loginUser, ResourceType type, ProgramType programType);
+    Result<List<ResourceComponent>> queryResourceByProgramType(User loginUser, ResourceType type, ProgramType programType);
 
     /**
      * delete resource
@@ -193,7 +197,7 @@ public interface ResourcesService {
      * @param userId user id
      * @return unauthorized result code
      */
-    Map<String, Object> authorizeResourceTree(User loginUser, Integer userId);
+    Result<List<ResourceComponent>> authorizeResourceTree(User loginUser, Integer userId);
 
     /**
      * unauthorized file
@@ -202,7 +206,7 @@ public interface ResourcesService {
      * @param userId user id
      * @return unauthorized result code
      */
-    Map<String, Object> unauthorizedFile(User loginUser, Integer userId);
+    Result<List<ResourceComponent>> unauthorizedFile(User loginUser, Integer userId);
 
     /**
      * unauthorized udf function
@@ -211,7 +215,7 @@ public interface ResourcesService {
      * @param userId user id
      * @return unauthorized result code
      */
-    Map<String, Object> unauthorizedUDFFunction(User loginUser, Integer userId);
+    Result<List<UdfFunc>> unauthorizedUDFFunction(User loginUser, Integer userId);
 
     /**
      * authorized udf function
@@ -220,7 +224,7 @@ public interface ResourcesService {
      * @param userId user id
      * @return authorized result code
      */
-    Map<String, Object> authorizedUDFFunction(User loginUser, Integer userId);
+    Result<List<UdfFunc>> authorizedUDFFunction(User loginUser, Integer userId);
 
     /**
      * authorized file
@@ -229,6 +233,6 @@ public interface ResourcesService {
      * @param userId user id
      * @return authorized result
      */
-    Map<String, Object> authorizedFile(User loginUser, Integer userId);
+    Result<List<ResourceComponent>> authorizedFile(User loginUser, Integer userId);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/SchedulerService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/SchedulerService.java
@@ -17,13 +17,16 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Priority;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
 import org.apache.dolphinscheduler.common.enums.WarningType;
+import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * scheduler service
@@ -44,14 +47,14 @@ public interface SchedulerService {
      * @param workerGroup worker group
      * @return create result code
      */
-    Map<String, Object> insertSchedule(User loginUser, String projectName,
-                                       Integer processDefineId,
-                                       String schedule,
-                                       WarningType warningType,
-                                       int warningGroupId,
-                                       FailureStrategy failureStrategy,
-                                       Priority processInstancePriority,
-                                       String workerGroup);
+    Result<Schedule> insertSchedule(User loginUser, String projectName,
+                                    Integer processDefineId,
+                                    String schedule,
+                                    WarningType warningType,
+                                    int warningGroupId,
+                                    FailureStrategy failureStrategy,
+                                    Priority processInstancePriority,
+                                    String workerGroup);
 
     /**
      * updateProcessInstance schedule
@@ -68,7 +71,7 @@ public interface SchedulerService {
      * @param scheduleStatus schedule status
      * @return update result code
      */
-    Map<String, Object> updateSchedule(User loginUser,
+    Result<Void> updateSchedule(User loginUser,
                                        String projectName,
                                        Integer id,
                                        String scheduleExpression,
@@ -89,7 +92,7 @@ public interface SchedulerService {
      * @param scheduleStatus schedule status
      * @return publish result code
      */
-    Map<String, Object> setScheduleState(User loginUser,
+    Result<Void> setScheduleState(User loginUser,
                                          String projectName,
                                          Integer id,
                                          ReleaseState scheduleStatus);
@@ -105,7 +108,7 @@ public interface SchedulerService {
      * @param searchVal search value
      * @return schedule list page
      */
-    Map<String, Object> querySchedule(User loginUser, String projectName, Integer processDefineId, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<Schedule>> querySchedule(User loginUser, String projectName, Integer processDefineId, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * query schedule list
@@ -114,7 +117,7 @@ public interface SchedulerService {
      * @param projectName project name
      * @return schedule list
      */
-    Map<String, Object> queryScheduleList(User loginUser, String projectName);
+    Result<List<Schedule>> queryScheduleList(User loginUser, String projectName);
 
     /**
      * delete schedule
@@ -133,7 +136,7 @@ public interface SchedulerService {
      * @param scheduleId scheule id
      * @return delete result code
      */
-    Map<String, Object> deleteScheduleById(User loginUser, String projectName, Integer scheduleId);
+    Result<Void> deleteScheduleById(User loginUser, String projectName, Integer scheduleId);
 
     /**
      * preview schedule
@@ -143,5 +146,5 @@ public interface SchedulerService {
      * @param schedule schedule expression
      * @return the next five fire time
      */
-    Map<String, Object> previewSchedule(User loginUser, String projectName, String schedule);
+    Result<List<String>> previewSchedule(User loginUser, String projectName, String schedule);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskInstanceService.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.User;
 
@@ -43,10 +45,10 @@ public interface TaskInstanceService {
      * @param pageSize page size
      * @return task list page
      */
-    Map<String, Object> queryTaskListPaging(User loginUser, String projectName,
-                                            Integer processInstanceId, String processInstanceName, String taskName, String executorName, String startDate,
-                                            String endDate, String searchVal, ExecutionStatus stateType, String host,
-                                            Integer pageNo, Integer pageSize);
+    Result<PageListVO<Map<String, Object>>> queryTaskListPaging(User loginUser, String projectName,
+                                                         Integer processInstanceId, String processInstanceName, String taskName, String executorName, String startDate,
+                                                         String endDate, String searchVal, ExecutionStatus stateType, String host,
+                                                         Integer pageNo, Integer pageSize);
 
     /**
      * change one task instance's state from failure to forced success
@@ -56,6 +58,6 @@ public interface TaskInstanceService {
      * @param taskInstanceId task instance id
      * @return the result code and msg
      */
-    Map<String, Object> forceTaskSuccess(User loginUser, String projectName, Integer taskInstanceId);
+    Result<Void> forceTaskSuccess(User loginUser, String projectName, Integer taskInstanceId);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskRecordService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskRecordService.java
@@ -17,7 +17,10 @@
 
 package org.apache.dolphinscheduler.api.service;
 
-import java.util.Map;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
+import org.apache.dolphinscheduler.dao.entity.TaskRecord;
+
 
 /**
  * task record service
@@ -39,8 +42,8 @@ public interface TaskRecordService {
      * @param isHistory is history
      * @return task record list
      */
-    Map<String,Object> queryTaskRecordListPaging(boolean isHistory, String taskName, String startDate,
-                                                 String taskDate, String sourceTable,
-                                                 String destTable, String endDate,
-                                                 String state, Integer pageNo, Integer pageSize);
+    Result<PageListVO<TaskRecord>> queryTaskRecordListPaging(boolean isHistory, String taskName, String startDate,
+                                                             String taskDate, String sourceTable,
+                                                             String destTable, String endDate,
+                                                             String state, Integer pageNo, Integer pageSize);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TenantService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TenantService.java
@@ -18,9 +18,11 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
+import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * tenant service
@@ -37,10 +39,10 @@ public interface TenantService {
      * @return create result code
      * @throws Exception exception
      */
-    Map<String, Object> createTenant(User loginUser,
-                                     String tenantCode,
-                                     int queueId,
-                                     String desc) throws Exception;
+    Result<Void> createTenant(User loginUser,
+                              String tenantCode,
+                              int queueId,
+                              String desc) throws Exception;
 
     /**
      * query tenant list paging
@@ -51,7 +53,7 @@ public interface TenantService {
      * @param pageSize page size
      * @return tenant list page
      */
-    Map<String, Object> queryTenantList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<Tenant>> queryTenantList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * updateProcessInstance tenant
@@ -64,7 +66,7 @@ public interface TenantService {
      * @return update result code
      * @throws Exception exception
      */
-    Map<String, Object> updateTenant(User loginUser, int id, String tenantCode, int queueId,
+    Result<Void> updateTenant(User loginUser, int id, String tenantCode, int queueId,
             String desc) throws Exception;
 
     /**
@@ -75,7 +77,7 @@ public interface TenantService {
      * @return delete result code
      * @throws Exception exception
      */
-    Map<String, Object> deleteTenantById(User loginUser, int id) throws Exception;
+    Result<Void> deleteTenantById(User loginUser, int id) throws Exception;
 
     /**
      * query tenant list
@@ -83,7 +85,7 @@ public interface TenantService {
      * @param loginUser login user
      * @return tenant list
      */
-    Map<String, Object> queryTenantList(User loginUser);
+    Result<List<Tenant>> queryTenantList(User loginUser);
 
     /**
      * verify tenant code
@@ -91,5 +93,5 @@ public interface TenantService {
      * @param tenantCode tenant code
      * @return true if tenant code can user, otherwise return false
      */
-    Result verifyTenantCode(String tenantCode);
+    Result<Void> verifyTenantCode(String tenantCode);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UdfFuncService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UdfFuncService.java
@@ -18,10 +18,12 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.UdfType;
+import org.apache.dolphinscheduler.dao.entity.UdfFunc;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * udf func service
@@ -56,7 +58,7 @@ public interface UdfFuncService {
      * @param id  udf function id
      * @return udf function detail
      */
-    Map<String, Object> queryUdfFuncDetail(int id);
+    Result<UdfFunc> queryUdfFuncDetail(int id);
 
     /**
      * updateProcessInstance udf function
@@ -71,7 +73,7 @@ public interface UdfFuncService {
      * @param className class name
      * @return update result code
      */
-    Map<String, Object> updateUdfFunc(int udfFuncId,
+    Result<Void> updateUdfFunc(int udfFuncId,
                                       String funcName,
                                       String className,
                                       String argTypes,
@@ -89,7 +91,7 @@ public interface UdfFuncService {
      * @param searchVal search value
      * @return udf function list page
      */
-    Map<String, Object> queryUdfFuncListPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<UdfFunc>> queryUdfFuncListPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * query udf list
@@ -98,7 +100,7 @@ public interface UdfFuncService {
      * @param type  udf type
      * @return udf func list
      */
-    Map<String, Object> queryUdfFuncList(User loginUser, Integer type);
+    Result<List<UdfFunc>> queryUdfFuncList(User loginUser, Integer type);
 
     /**
      * delete udf function
@@ -106,7 +108,7 @@ public interface UdfFuncService {
      * @param id udf function id
      * @return delete result code
      */
-    Result<Object> delete(int id);
+    Result<Void> delete(int id);
 
     /**
      * verify udf function by name
@@ -114,6 +116,6 @@ public interface UdfFuncService {
      * @param name name
      * @return true if the name can user, otherwise return false
      */
-    Result<Object> verifyUdfFuncByName(String name);
+    Result<Void> verifyUdfFuncByName(String name);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UsersService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UsersService.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.User;
 
@@ -43,8 +44,8 @@ public interface UsersService {
      * @return create result code
      * @throws Exception exception
      */
-    Map<String, Object> createUser(User loginUser, String userName, String userPassword, String email,
-                                   int tenantId, String phone, String queue, int state) throws IOException;
+    Result<Void> createUser(User loginUser, String userName, String userPassword, String email,
+                            int tenantId, String phone, String queue, int state) throws IOException;
 
     User createUser(String userName, String userPassword, String email,
                     int tenantId, String phone, String queue, int state);
@@ -112,7 +113,7 @@ public interface UsersService {
      * @param pageSize page size
      * @return user list page
      */
-    Map<String, Object> queryUserList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
+    Result<PageListVO<User>> queryUserList(User loginUser, String searchVal, Integer pageNo, Integer pageSize);
 
     /**
      * updateProcessInstance user
@@ -129,7 +130,7 @@ public interface UsersService {
      * @return update result code
      * @throws Exception exception
      */
-    Map<String, Object> updateUser(User loginUser, int userId, String userName, String userPassword, String email,
+    Result<Void> updateUser(User loginUser, int userId, String userName, String userPassword, String email,
                                    int tenantId, String phone, String queue, int state) throws IOException;
 
     /**
@@ -140,7 +141,7 @@ public interface UsersService {
      * @return delete result code
      * @throws Exception exception when operate hdfs
      */
-    Map<String, Object> deleteUserById(User loginUser, int id) throws IOException;
+    Result<Void> deleteUserById(User loginUser, int id) throws IOException;
 
     /**
      * grant project
@@ -150,7 +151,7 @@ public interface UsersService {
      * @param projectIds project id array
      * @return grant result code
      */
-    Map<String, Object> grantProject(User loginUser, int userId, String projectIds);
+    Result<Void> grantProject(User loginUser, int userId, String projectIds);
 
 
     /**
@@ -161,7 +162,7 @@ public interface UsersService {
      * @param resourceIds resource id array
      * @return grant result code
      */
-    Map<String, Object> grantResources(User loginUser, int userId, String resourceIds);
+    Result<Void> grantResources(User loginUser, int userId, String resourceIds);
 
 
     /**
@@ -172,7 +173,7 @@ public interface UsersService {
      * @param udfIds udf id array
      * @return grant result code
      */
-    Map<String, Object> grantUDFFunction(User loginUser, int userId, String udfIds);
+    Result<Void> grantUDFFunction(User loginUser, int userId, String udfIds);
 
 
     /**
@@ -183,7 +184,7 @@ public interface UsersService {
      * @param datasourceIds data source id array
      * @return grant result code
      */
-    Map<String, Object> grantDataSource(User loginUser, int userId, String datasourceIds);
+    Result<Void> grantDataSource(User loginUser, int userId, String datasourceIds);
 
     /**
      * query user info
@@ -191,7 +192,7 @@ public interface UsersService {
      * @param loginUser login user
      * @return user info
      */
-    Map<String, Object> getUserInfo(User loginUser);
+    Result<User> getUserInfo(User loginUser);
 
     /**
      * query user list
@@ -199,7 +200,7 @@ public interface UsersService {
      * @param loginUser login user
      * @return user list
      */
-    Map<String, Object> queryAllGeneralUsers(User loginUser);
+    Result<List<User>> queryAllGeneralUsers(User loginUser);
 
 
     /**
@@ -208,7 +209,7 @@ public interface UsersService {
      * @param loginUser login user
      * @return user list
      */
-    Map<String, Object> queryUserList(User loginUser);
+    Result<List<User>> queryUserList(User loginUser);
 
     /**
      * verify user name exists
@@ -226,7 +227,7 @@ public interface UsersService {
      * @param alertgroupId alert group id
      * @return unauthorize result code
      */
-    Map<String, Object> unauthorizedUser(User loginUser, Integer alertgroupId);
+    Result<List<User>> unauthorizedUser(User loginUser, Integer alertgroupId);
 
 
     /**
@@ -236,7 +237,7 @@ public interface UsersService {
      * @param alertgroupId alert group id
      * @return authorized result code
      */
-    Map<String, Object> authorizedUser(User loginUser, Integer alertgroupId);
+    Result<List<User>> authorizedUser(User loginUser, Integer alertgroupId);
 
     /**
      * register user, default state is 0, default tenant_id is 1, no phone, no queue
@@ -248,7 +249,7 @@ public interface UsersService {
      * @return register result code
      * @throws Exception exception
      */
-    Map<String, Object> registerUser(String userName, String userPassword, String repeatPassword, String email);
+    Result<User> registerUser(String userName, String userPassword, String repeatPassword, String email);
 
     /**
      * activate user, only system admin have permission, change user state code 0 to 1
@@ -257,7 +258,7 @@ public interface UsersService {
      * @param userName user name
      * @return create result code
      */
-    Map<String, Object> activateUser(User loginUser, String userName);
+    Result<User> activateUser(User loginUser, String userName);
 
     /**
      * activate user, only system admin have permission, change users state code 0 to 1
@@ -266,5 +267,5 @@ public interface UsersService {
      * @param userNames user name
      * @return create result code
      */
-    Map<String, Object> batchActivateUser(User loginUser, List<String> userNames);
+    Result<Map<String, Object>> batchActivateUser(User loginUser, List<String> userNames);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkFlowLineageService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkFlowLineageService.java
@@ -17,6 +17,10 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.dao.entity.WorkFlowLineage;
+
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,8 +29,8 @@ import java.util.Set;
  */
 public interface WorkFlowLineageService {
 
-    Map<String, Object> queryWorkFlowLineageByName(String workFlowName, int projectId);
+    Result<List<WorkFlowLineage>> queryWorkFlowLineageByName(String workFlowName, int projectId);
 
-    Map<String, Object> queryWorkFlowLineageByIds(Set<Integer> ids,int projectId);
+    Result<Map<String, Object>> queryWorkFlowLineageByIds(Set<Integer> ids, int projectId);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkerGroupService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkerGroupService.java
@@ -17,9 +17,12 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * worker group service
@@ -35,7 +38,7 @@ public interface WorkerGroupService {
      * @param addrList addr list
      * @return create or update result code
      */
-    Map<String, Object> saveWorkerGroup(User loginUser, int id, String name, String addrList);
+    Result<Void> saveWorkerGroup(User loginUser, int id, String name, String addrList);
 
     /**
      * query worker group paging
@@ -46,27 +49,27 @@ public interface WorkerGroupService {
      * @param pageSize page size
      * @return worker group list page
      */
-    Map<String, Object> queryAllGroupPaging(User loginUser, Integer pageNo, Integer pageSize, String searchVal);
+    Result<PageListVO<WorkerGroup>> queryAllGroupPaging(User loginUser, Integer pageNo, Integer pageSize, String searchVal);
 
     /**
      * query all worker group
      *
      * @return all worker group list
      */
-    Map<String, Object> queryAllGroup();
+    Result<List<String>> queryAllGroup();
 
     /**
      * delete worker group by id
      * @param id worker group id
      * @return delete result code
      */
-    Map<String, Object> deleteWorkerGroupById(User loginUser, Integer id);
+    Result<Void> deleteWorkerGroupById(User loginUser, Integer id);
 
     /**
      * query all worker address list
      *
      * @return all worker address list
      */
-    Map<String, Object> getWorkerAddressList();
+    Result<List<String>> getWorkerAddressList();
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/MonitorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/MonitorServiceImpl.java
@@ -19,10 +19,9 @@ package org.apache.dolphinscheduler.api.service.impl;
 
 import static org.apache.dolphinscheduler.common.utils.Preconditions.checkNotNull;
 
-import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.MonitorService;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.api.utils.ZookeeperMonitor;
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ZKNodeType;
 import org.apache.dolphinscheduler.common.model.Server;
 import org.apache.dolphinscheduler.common.model.WorkerServerModel;
@@ -31,7 +30,7 @@ import org.apache.dolphinscheduler.dao.entity.MonitorRecord;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.ZookeeperRecord;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -61,15 +60,11 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
      * @return data base state
      */
     @Override
-    public Map<String,Object> queryDatabaseState(User loginUser) {
-        Map<String, Object> result = new HashMap<>();
+    public Result<List<MonitorRecord>> queryDatabaseState(User loginUser) {
 
         List<MonitorRecord> monitorRecordList = monitorDBDao.queryDatabaseState();
 
-        result.put(Constants.DATA_LIST, monitorRecordList);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
+        return Result.success(monitorRecordList);
 
     }
 
@@ -80,15 +75,11 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
      * @return master information list
      */
     @Override
-    public Map<String,Object> queryMaster(User loginUser) {
-
-        Map<String, Object> result = new HashMap<>();
+    public Result<List<Server>> queryMaster(User loginUser) {
 
         List<Server> masterServers = getServerListFromZK(true);
-        result.put(Constants.DATA_LIST, masterServers);
-        putMsg(result,Status.SUCCESS);
 
-        return result;
+        return Result.success(masterServers);
     }
 
     /**
@@ -98,15 +89,11 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
      * @return zookeeper information list
      */
     @Override
-    public Map<String,Object> queryZookeeperState(User loginUser) {
-        Map<String, Object> result = new HashMap<>();
+    public Result<List<ZookeeperRecord>> queryZookeeperState(User loginUser) {
 
         List<ZookeeperRecord> zookeeperRecordList = zookeeperMonitor.zookeeperInfoList();
 
-        result.put(Constants.DATA_LIST, zookeeperRecordList);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
+        return Result.success(zookeeperRecordList);
 
     }
 
@@ -117,9 +104,8 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
      * @return worker information list
      */
     @Override
-    public Map<String,Object> queryWorker(User loginUser) {
+    public Result<Collection<WorkerServerModel>> queryWorker(User loginUser) {
 
-        Map<String, Object> result = new HashMap<>();
         List<WorkerServerModel> workerServers = getServerListFromZK(false)
                 .stream()
                 .map((Server server) -> {
@@ -148,10 +134,7 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
                         return oldOne;
                     }));
 
-        result.put(Constants.DATA_LIST, workerHostPortServerMapping.values());
-        putMsg(result,Status.SUCCESS);
-
-        return result;
+        return Result.success(workerHostPortServerMapping.values());
     }
 
     @Override

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskRecordServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskRecordServiceImpl.java
@@ -20,10 +20,10 @@ package org.apache.dolphinscheduler.api.service.impl;
 import static org.apache.dolphinscheduler.common.Constants.TASK_RECORD_TABLE_HISTORY_HIVE_LOG;
 import static org.apache.dolphinscheduler.common.Constants.TASK_RECORD_TABLE_HIVE_LOG;
 
-import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.TaskRecordService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.dao.TaskRecordDao;
 import org.apache.dolphinscheduler.dao.entity.TaskRecord;
 
@@ -55,11 +55,10 @@ public class TaskRecordServiceImpl extends BaseServiceImpl implements TaskRecord
      * @return task record list
      */
     @Override
-    public Map<String,Object> queryTaskRecordListPaging(boolean isHistory, String taskName, String startDate,
+    public Result<PageListVO<TaskRecord>> queryTaskRecordListPaging(boolean isHistory, String taskName, String startDate,
                                                         String taskDate, String sourceTable,
                                                         String destTable, String endDate,
                                                         String state, Integer pageNo, Integer pageSize) {
-        Map<String, Object> result = new HashMap<>();
         PageInfo<TaskRecord> pageInfo = new PageInfo<>(pageNo, pageSize);
 
         Map<String, String> map = new HashMap<>();
@@ -78,9 +77,7 @@ public class TaskRecordServiceImpl extends BaseServiceImpl implements TaskRecord
         List<TaskRecord> recordList = TaskRecordDao.queryAllTaskRecord(map, table);
         pageInfo.setTotalCount(count);
         pageInfo.setLists(recordList);
-        result.put(Constants.DATA_LIST, pageInfo);
-        putMsg(result, Status.SUCCESS);
 
-        return result;
+        return Result.success(new PageListVO<>(pageInfo));
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UiPluginServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UiPluginServiceImpl.java
@@ -19,15 +19,13 @@ package org.apache.dolphinscheduler.api.service.impl;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.UiPluginService;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.PluginType;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.mapper.PluginDefineMapper;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -42,37 +40,28 @@ public class UiPluginServiceImpl extends BaseServiceImpl implements UiPluginServ
     PluginDefineMapper pluginDefineMapper;
 
     @Override
-    public Map<String, Object> queryUiPluginsByType(PluginType pluginType) {
-        Map<String, Object> result = new HashMap<>();
+    public Result<List<PluginDefine>> queryUiPluginsByType(PluginType pluginType) {
         if (!pluginType.getHasUi()) {
-            putMsg(result, Status.PLUGIN_NOT_A_UI_COMPONENT);
-            return result;
+            return Result.error(Status.PLUGIN_NOT_A_UI_COMPONENT);
         }
         List<PluginDefine> pluginDefines = pluginDefineMapper.queryByPluginType(pluginType.getDesc());
 
         if (CollectionUtils.isEmpty(pluginDefines)) {
-            putMsg(result, Status.QUERY_PLUGINS_RESULT_IS_NULL);
-            return result;
+            return Result.error(Status.QUERY_PLUGINS_RESULT_IS_NULL);
         }
         // pluginDefines=buildPluginParams(pluginDefines);
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, pluginDefines);
-        return result;
+        return Result.success(pluginDefines);
     }
 
     @Override
-    public Map<String, Object> queryUiPluginDetailById(int id) {
-        Map<String, Object> result = new HashMap<>();
+    public Result<PluginDefine> queryUiPluginDetailById(int id) {
         PluginDefine pluginDefine = pluginDefineMapper.queryDetailById(id);
         if (null == pluginDefine) {
-            putMsg(result, Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL);
-            return result;
+            return Result.error(Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL);
         }
         // String params=pluginDefine.getPluginParams();
         // pluginDefine.setPluginParams(parseParams(params));
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, pluginDefine);
-        return result;
+        return Result.success(pluginDefine);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkFlowLineageServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkFlowLineageServiceImpl.java
@@ -17,8 +17,8 @@
 
 package org.apache.dolphinscheduler.api.service.impl;
 
-import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.WorkFlowLineageService;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
 import org.apache.dolphinscheduler.dao.entity.WorkFlowLineage;
@@ -45,12 +45,9 @@ public class WorkFlowLineageServiceImpl extends BaseServiceImpl implements WorkF
     private WorkFlowLineageMapper workFlowLineageMapper;
 
     @Override
-    public Map<String, Object> queryWorkFlowLineageByName(String workFlowName, int projectId) {
-        Map<String, Object> result = new HashMap<>();
+    public Result<List<WorkFlowLineage>> queryWorkFlowLineageByName(String workFlowName, int projectId) {
         List<WorkFlowLineage> workFlowLineageList = workFlowLineageMapper.queryByName(workFlowName, projectId);
-        result.put(Constants.DATA_LIST, workFlowLineageList);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return Result.success(workFlowLineageList);
     }
 
     private void getWorkFlowRelationRecursion(Set<Integer> ids, List<WorkFlowRelation> workFlowRelations, Set<Integer> sourceIds) {
@@ -71,13 +68,12 @@ public class WorkFlowLineageServiceImpl extends BaseServiceImpl implements WorkF
     }
 
     @Override
-    public Map<String, Object> queryWorkFlowLineageByIds(Set<Integer> ids, int projectId) {
-        Map<String, Object> result = new HashMap<>();
+    public Result<Map<String, Object>> queryWorkFlowLineageByIds(Set<Integer> ids, int projectId) {
         List<WorkFlowLineage> workFlowLineageList = workFlowLineageMapper.queryByIds(ids, projectId);
         Map<String, Object> workFlowLists = new HashMap<>();
         Set<Integer> idsV = new HashSet<>();
         if (ids == null || ids.isEmpty()) {
-            for (WorkFlowLineage workFlowLineage:workFlowLineageList) {
+            for (WorkFlowLineage workFlowLineage : workFlowLineageList) {
                 idsV.add(workFlowLineage.getWorkFlowId());
             }
         } else {
@@ -103,9 +99,7 @@ public class WorkFlowLineageServiceImpl extends BaseServiceImpl implements WorkF
 
         workFlowLists.put(Constants.WORKFLOW_LIST, workFlowLineageList);
         workFlowLists.put(Constants.WORKFLOW_RELATION_LIST, workFlowRelations);
-        result.put(Constants.DATA_LIST, workFlowLists);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return Result.success(workFlowLists);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/CheckUtils.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/CheckUtils.java
@@ -14,19 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.api.utils;
 
-
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
-import org.apache.dolphinscheduler.common.utils.*;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.StringUtils;
 import org.apache.dolphinscheduler.common.utils.TaskParametersUtils;
 
 import java.text.MessageFormat;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 
@@ -35,18 +34,19 @@ import java.util.regex.Pattern;
  */
 public class CheckUtils {
 
-  private CheckUtils() {
-    throw new IllegalStateException("CheckUtils class");
-  }
+    private CheckUtils() {
+        throw new IllegalStateException("CheckUtils class");
+    }
+
   /**
    * check username
    *
    * @param userName user name
    * @return true if user name regex valid,otherwise return false
    */
-  public static boolean checkUserName(String userName) {
-    return regexChecks(userName, Constants.REGEX_USER_NAME);
-  }
+    public static boolean checkUserName(String userName) {
+        return regexChecks(userName, Constants.REGEX_USER_NAME);
+    }
 
   /**
    * check email
@@ -54,13 +54,13 @@ public class CheckUtils {
    * @param email email
    * @return true if email regex valid, otherwise return false
    */
-  public static boolean checkEmail(String email) {
-    if (StringUtils.isEmpty(email)){
-      return false;
-    }
+    public static boolean checkEmail(String email) {
+        if (StringUtils.isEmpty(email)) {
+            return false;
+        }
 
-    return email.length() > 5 && email.length() <= 40 && regexChecks(email, Constants.REGEX_MAIL_NAME) ;
-  }
+        return email.length() > 5 && email.length() <= 40 && regexChecks(email, Constants.REGEX_MAIL_NAME);
+    }
 
   /**
    * check project description
@@ -68,16 +68,16 @@ public class CheckUtils {
    * @param desc desc
    * @return true if description regex valid, otherwise return false
    */
-  public static Map<String, Object> checkDesc(String desc) {
-    Map<String, Object> result = new HashMap<>();
-    if (StringUtils.isNotEmpty(desc) && desc.length() > 200) {
-        result.put(Constants.STATUS, Status.REQUEST_PARAMS_NOT_VALID_ERROR);
-        result.put(Constants.MSG, MessageFormat.format(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getMsg(), "desc length"));
-    }else{
-      result.put(Constants.STATUS, Status.SUCCESS);
+    public static CheckParamResult checkDesc(String desc) {
+        CheckParamResult descCheckResult = new CheckParamResult();
+        if (StringUtils.isNotEmpty(desc) && desc.length() > 200) {
+            descCheckResult.setStatus(Status.REQUEST_PARAMS_NOT_VALID_ERROR);
+            descCheckResult.setMsg(MessageFormat.format(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getMsg(), "desc length"));
+        } else {
+            descCheckResult.setStatus(Status.SUCCESS);
+        }
+        return descCheckResult;
     }
-    return result;
-  }
 
   /**
    * check extra info
@@ -85,9 +85,9 @@ public class CheckUtils {
    * @param otherParams other parames
    * @return true if other parameters are valid, otherwise return false
    */
-  public static boolean checkOtherParams(String otherParams) {
-    return StringUtils.isNotEmpty(otherParams) && !JSONUtils.checkJsonValid(otherParams);
-  }
+    public static boolean checkOtherParams(String otherParams) {
+        return StringUtils.isNotEmpty(otherParams) && !JSONUtils.checkJsonValid(otherParams);
+    }
 
   /**
    * check password
@@ -95,9 +95,9 @@ public class CheckUtils {
    * @param password password
    * @return true if password regex valid, otherwise return false
    */
-  public static boolean checkPassword(String password) {
-    return StringUtils.isNotEmpty(password) && password.length() >= 2 && password.length() <= 20;
-  }
+    public static boolean checkPassword(String password) {
+        return StringUtils.isNotEmpty(password) && password.length() >= 2 && password.length() <= 20;
+    }
 
   /**
    * check phone
@@ -105,9 +105,9 @@ public class CheckUtils {
    * @param phone phone
    * @return true if phone regex valid, otherwise return false
    */
-  public static boolean checkPhone(String phone) {
-    return StringUtils.isEmpty(phone) || phone.length() == 11;
-  }
+    public static boolean checkPhone(String phone) {
+        return StringUtils.isEmpty(phone) || phone.length() == 11;
+    }
 
 
   /**
@@ -117,15 +117,15 @@ public class CheckUtils {
    * @param taskType task type
    * @return true if task node parameters are valid, otherwise return false
    */
-  public static boolean checkTaskNodeParameters(String parameter, String taskType) {
-    AbstractParameters abstractParameters = TaskParametersUtils.getParameters(taskType, parameter);
+    public static boolean checkTaskNodeParameters(String parameter, String taskType) {
+        AbstractParameters abstractParameters = TaskParametersUtils.getParameters(taskType, parameter);
 
-    if (abstractParameters != null) {
-      return abstractParameters.checkParameters();
+        if (abstractParameters != null) {
+            return abstractParameters.checkParameters();
+        }
+
+        return false;
     }
-
-    return false;
-  }
 
   /**
    * check params
@@ -135,12 +135,12 @@ public class CheckUtils {
    * @param phone phone
    * @return true if user parameters are valid, other return false
    */
-  public static boolean checkUserParams(String userName, String password, String email, String phone){
-    return CheckUtils.checkUserName(userName) &&
-            CheckUtils.checkEmail(email) &&
-            CheckUtils.checkPassword(password) &&
-            CheckUtils.checkPhone(phone);
-  }
+    public static boolean checkUserParams(String userName, String password, String email, String phone) {
+        return CheckUtils.checkUserName(userName)
+                && CheckUtils.checkEmail(email)
+                && CheckUtils.checkPassword(password)
+                && CheckUtils.checkPhone(phone);
+    }
 
   /**
    * regex check
@@ -149,11 +149,11 @@ public class CheckUtils {
    * @param pattern regex pattern
    * @return true if regex pattern is right, otherwise return false
    */
-  private static boolean regexChecks(String str, Pattern pattern) {
-    if (StringUtils.isEmpty(str)) {
-      return false;
-    }
+    private static boolean regexChecks(String str, Pattern pattern) {
+        if (StringUtils.isEmpty(str)) {
+            return false;
+        }
 
-    return pattern.matcher(str).matches();
-  }
+        return pattern.matcher(str).matches();
+    }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/Result.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/Result.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dolphinscheduler.api.utils;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 
 import java.text.MessageFormat;
@@ -49,11 +50,6 @@ public class Result<T> {
         this.msg = msg;
     }
 
-    private Result(T data) {
-        this.code  = 0;
-        this.data = data;
-    }
-
     private Result(Status status) {
         if (status != null) {
             this.code = status.getCode();
@@ -69,17 +65,26 @@ public class Result<T> {
      * @return resule
      */
     public static <T> Result<T> success(T data) {
-        return new Result<>(data);
+        Result<T> result = new Result<>(Status.SUCCESS);
+        result.setData(data);
+        return result;
     }
 
     /**
      * Call this function if there is any error
      *
-     * @param status status
+     * @param errorStatus errorStatus
      * @return result
      */
-    public static Result error(Status status) {
-        return new Result(status);
+    public static <T> Result<T> error(Status errorStatus) {
+        return new Result<>(errorStatus);
+    }
+
+    public static <T> Result<T> error(CheckParamResult checkParamResult) {
+        Result<T> result = new Result<>();
+        result.setCode(checkParamResult.getStatus().getCode());
+        result.setMsg(checkParamResult.getMsg());
+        return result;
     }
 
     /**
@@ -89,8 +94,8 @@ public class Result<T> {
      * @param args args
      * @return result
      */
-    public static Result errorWithArgs(Status status, Object... args) {
-        return new Result(status.getCode(), MessageFormat.format(status.getMsg(), args));
+    public static <T> Result<T> errorWithArgs(Status status, Object... args) {
+        return new Result<>(status.getCode(), MessageFormat.format(status.getMsg(), args));
     }
 
     public Integer getCode() {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/vo/PageListVO.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/vo/PageListVO.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.vo;
+
+import org.apache.dolphinscheduler.api.utils.PageInfo;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class PageListVO<T> implements Serializable {
+    private List<T> totalList;
+    private Integer currentPage;
+    private Integer totalPage;
+    private Integer total;
+
+    public PageListVO(PageInfo<T> pageInfo) {
+        this.totalList = pageInfo.getLists();
+        this.currentPage = pageInfo.getCurrentPage();
+        this.totalPage = pageInfo.getTotalPage();
+        this.total = pageInfo.getTotalCount();
+    }
+
+    public PageListVO() {
+
+    }
+
+    public List<T> getTotalList() {
+        return totalList;
+    }
+
+    public void setTotalList(List<T> totalList) {
+        this.totalList = totalList;
+    }
+
+    public Integer getCurrentPage() {
+        return currentPage;
+    }
+
+    public void setCurrentPage(Integer currentPage) {
+        this.currentPage = currentPage;
+    }
+
+    public Integer getTotalPage() {
+        return totalPage;
+    }
+
+    public void setTotalPage(Integer totalPage) {
+        this.totalPage = totalPage;
+    }
+
+    public Integer getTotal() {
+        return total;
+    }
+
+    public void setTotal(Integer total) {
+        this.total = total;
+    }
+
+    @Override
+    public String toString() {
+        return "PageListVO{"
+                + "totalList=" + totalList
+                + ", currentPage=" + currentPage
+                + ", totalPage=" + totalPage
+                + ", total=" + total + '}';
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/HttpClientTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/HttpClientTest.java
@@ -26,20 +26,21 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HttpClientTest {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpClientTest.class);
 
     @Test
-    public  void doPOSTParam()throws Exception{
+    public void doPOSTParam() throws Exception {
         // create HttpClient
         CloseableHttpClient httpclient = HttpClients.createDefault();
 
@@ -74,15 +75,14 @@ public class HttpClientTest {
 
     /**
      * do get param path variables chinese
-     * @throws Exception
      */
     @Test
-    public  void doGETParamPathVariableAndChinese()throws Exception{
+    public void doGETParamPathVariableAndChinese() throws Exception {
         // create HttpClient
         CloseableHttpClient httpclient = HttpClients.createDefault();
 
         List<NameValuePair> parameters = new ArrayList<NameValuePair>();
-       // parameters.add(new BasicNameValuePair("pageSize", "10"));
+        // parameters.add(new BasicNameValuePair("pageSize", "10"));
 
         // define the parameters of the request
         URI uri = new URIBuilder("http://localhost:12345/dolphinscheduler/projects/%E5%85%A8%E9%83%A8%E6%B5%81%E7%A8%8B%E6%B5%8B%E8%AF%95/process/list")
@@ -112,12 +112,10 @@ public class HttpClientTest {
     }
 
     /**
-     *
      * do get param
-     * @throws Exception
      */
     @Test
-    public  void doGETParam()throws Exception{
+    public void doGETParam() throws Exception {
         // create HttpClient
         CloseableHttpClient httpclient = HttpClients.createDefault();
 
@@ -128,7 +126,7 @@ public class HttpClientTest {
 
         // define the parameters of the request
         URI uri = new URIBuilder("http://localhost:12345/dolphinscheduler/projects/analysis/queue-count")
-                 .setParameters(parameters)
+                .setParameters(parameters)
                 .build();
 
         // create http GET request

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessDefinitionControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessDefinitionControllerTest.java
@@ -17,22 +17,23 @@
 
 package org.apache.dolphinscheduler.api.controller;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
+import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.ProcessDefinitionVersionService;
 import org.apache.dolphinscheduler.api.service.impl.ProcessDefinitionServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
 import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionVersion;
-import org.apache.dolphinscheduler.dao.entity.Resource;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -92,9 +93,7 @@ public class ProcessDefinitionControllerTest {
         String name = "dag_test";
         String description = "desc test";
         String connects = "[]";
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, 1);
+        Result<Integer> result = Result.success(1);
 
         Mockito.when(processDefinitionService.createProcessDefinition(user, projectName, name, json,
                 description, locations, connects)).thenReturn(result);
@@ -104,19 +103,19 @@ public class ProcessDefinitionControllerTest {
         Assert.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }
 
-    private void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
-        result.put(Constants.STATUS, status);
+    private void putMsg(CheckParamResult result, Status status, Object... statusParams) {
+        result.setStatus(status);
         if (statusParams != null && statusParams.length > 0) {
-            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
+            result.setMsg(MessageFormat.format(status.getMsg(), statusParams));
         } else {
-            result.put(Constants.MSG, status.getMsg());
+            result.setMsg(status.getMsg());
         }
     }
 
     @Test
     public void testVerifyProcessDefinitionName() throws Exception {
 
-        Map<String, Object> result = new HashMap<>();
+        CheckParamResult result = new CheckParamResult();
         putMsg(result, Status.PROCESS_DEFINITION_NAME_EXIST);
         String projectName = "test";
         String name = "dag_test";
@@ -142,10 +141,8 @@ public class ProcessDefinitionControllerTest {
         String description = "desc test";
         String connects = "[]";
         int id = 1;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put("processDefinitionId", 1);
 
+        Result<ProcessDefinition> result = Result.success(new ProcessDefinition());
         Mockito.when(processDefinitionService.updateProcessDefinition(user, projectName, id, name, json,
                 description, locations, connects)).thenReturn(result);
 
@@ -158,8 +155,7 @@ public class ProcessDefinitionControllerTest {
     public void testReleaseProcessDefinition() throws Exception {
         String projectName = "test";
         int id = 1;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        Result<ProcessDefinition> result = Result.success(null);
 
         Mockito.when(processDefinitionService.releaseProcessDefinition(user, projectName, id, ReleaseState.OFFLINE)).thenReturn(result);
         Result response = processDefinitionController.releaseProcessDefinition(user, projectName, id, ReleaseState.OFFLINE);
@@ -190,12 +186,10 @@ public class ProcessDefinitionControllerTest {
         processDefinition.setName(name);
         processDefinition.setProcessDefinitionJson(json);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, processDefinition);
+        Result<ProcessDefinition> result = Result.success(processDefinition);
 
         Mockito.when(processDefinitionService.queryProcessDefinitionById(user, projectName, id)).thenReturn(result);
-        Result response = processDefinitionController.queryProcessDefinitionById(user, projectName, id);
+        Result<ProcessDefinition> response = processDefinitionController.queryProcessDefinitionById(user, projectName, id);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }
@@ -207,8 +201,7 @@ public class ProcessDefinitionControllerTest {
         int targetProjectId = 2;
         String id = "1";
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        Result<Void> result = Result.success(null);
 
         Mockito.when(processDefinitionService.batchCopyProcessDefinition(user, projectName, id, targetProjectId)).thenReturn(result);
         Result response = processDefinitionController.copyProcessDefinition(user, projectName, id, targetProjectId);
@@ -223,8 +216,7 @@ public class ProcessDefinitionControllerTest {
         int targetProjectId = 2;
         String id = "1";
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        Result<Void> result = Result.success(null);
 
         Mockito.when(processDefinitionService.batchMoveProcessDefinition(user, projectName, id, targetProjectId)).thenReturn(result);
         Result response = processDefinitionController.moveProcessDefinition(user, projectName, id, targetProjectId);
@@ -238,9 +230,7 @@ public class ProcessDefinitionControllerTest {
         String projectName = "test";
         List<ProcessDefinition> resourceList = getDefinitionList();
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, resourceList);
+        Result<List<ProcessDefinition>> result = Result.success(resourceList);
 
         Mockito.when(processDefinitionService.queryProcessDefinitionList(user, projectName)).thenReturn(result);
         Result response = processDefinitionController.queryProcessDefinitionList(user, projectName);
@@ -296,11 +286,9 @@ public class ProcessDefinitionControllerTest {
         String projectName = "test";
         int id = 1;
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-
+        Result<Void> result = Result.success(null);
         Mockito.when(processDefinitionService.deleteProcessDefinitionById(user, projectName, id)).thenReturn(result);
-        Result response = processDefinitionController.deleteProcessDefinitionById(user, projectName, id);
+        Result<Void> response = processDefinitionController.deleteProcessDefinitionById(user, projectName, id);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }
@@ -310,8 +298,7 @@ public class ProcessDefinitionControllerTest {
         String projectName = "test";
         int id = 1;
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        Result<List<TaskNode>> result = Result.success(null);
 
         Mockito.when(processDefinitionService.getTaskNodeListByDefinitionId(id)).thenReturn(result);
         Result response = processDefinitionController.getNodeListByDefinitionId(user, projectName, id);
@@ -324,8 +311,7 @@ public class ProcessDefinitionControllerTest {
         String projectName = "test";
         String idList = "1,2,3";
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        Result<Map<Integer, List<TaskNode>>> result = Result.success(null);
 
         Mockito.when(processDefinitionService.getTaskNodeListByDefinitionIdList(idList)).thenReturn(result);
         Result response = processDefinitionController.getNodeListByDefinitionIdList(user, projectName, idList);
@@ -336,8 +322,7 @@ public class ProcessDefinitionControllerTest {
     @Test
     public void testQueryProcessDefinitionAllByProjectId() throws Exception {
         int projectId = 1;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        Result<List<ProcessDefinition>> result = Result.success(null);
 
         Mockito.when(processDefinitionService.queryProcessDefinitionAllByProjectId(projectId)).thenReturn(result);
         Result response = processDefinitionController.queryProcessDefinitionAllByProjectId(user, projectId);
@@ -350,9 +335,8 @@ public class ProcessDefinitionControllerTest {
         String projectName = "test";
         int processId = 1;
         int limit = 2;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
 
+        Result<TreeViewDto> result = Result.success(null);
         Mockito.when(processDefinitionService.viewTree(processId, limit)).thenReturn(result);
         Result response = processDefinitionController.viewTree(user, projectName, processId, limit);
 
@@ -367,12 +351,10 @@ public class ProcessDefinitionControllerTest {
         String searchVal = "";
         int userId = 1;
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, new PageInfo<Resource>(1, 10));
+        Result<PageListVO<ProcessDefinition>> result = Result.success(new PageListVO<>(new PageInfo<>(1, 10)));
 
         Mockito.when(processDefinitionService.queryProcessDefinitionListPaging(user, projectName, searchVal, pageNo, pageSize, userId)).thenReturn(result);
-        Result response = processDefinitionController.queryProcessDefinitionListPaging(user, projectName, pageNo, searchVal, userId, pageSize);
+        Result<PageListVO<ProcessDefinition>> response = processDefinitionController.queryProcessDefinitionListPaging(user, projectName, pageNo, searchVal, userId, pageSize);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }
@@ -391,16 +373,14 @@ public class ProcessDefinitionControllerTest {
     public void testQueryProcessDefinitionVersions() {
         String projectName = "test";
 
-        Result result = processDefinitionController.queryProcessDefinitionVersions(user, projectName, 1, -10, 1);
+        Result<PageListVO<ProcessDefinitionVersion>> result = processDefinitionController.queryProcessDefinitionVersions(user, projectName, 1, -10, 1);
         Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), result.getCode().intValue());
 
         result = processDefinitionController.queryProcessDefinitionVersions(user, projectName, -1, 10, 1);
         Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), result.getCode().intValue());
 
-        Map<String, Object> resultMap = new HashMap<>();
-        putMsg(resultMap, Status.SUCCESS);
-        resultMap.put(Constants.DATA_LIST, new PageInfo<ProcessDefinitionVersion>(1, 10));
-        Mockito.when(processDefinitionVersionService.queryProcessDefinitionVersions(user, projectName, 1, 10, 1)).thenReturn(resultMap);
+        PageListVO<ProcessDefinitionVersion> pageListVO = new PageListVO<>();
+        Mockito.when(processDefinitionVersionService.queryProcessDefinitionVersions(user, projectName, 1, 10, 1)).thenReturn(Result.success(pageListVO));
         result = processDefinitionController.queryProcessDefinitionVersions(user, projectName, 1, 10, 1);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
@@ -409,10 +389,8 @@ public class ProcessDefinitionControllerTest {
     @Test
     public void testSwitchProcessDefinitionVersion() {
         String projectName = "test";
-        Map<String, Object> resultMap = new HashMap<>();
-        putMsg(resultMap, Status.SUCCESS);
-        Mockito.when(processDefinitionService.switchProcessDefinitionVersion(user, projectName, 1, 10)).thenReturn(resultMap);
-        Result result = processDefinitionController.switchProcessDefinitionVersion(user, projectName, 1, 10);
+        Mockito.when(processDefinitionService.switchProcessDefinitionVersion(user, projectName, 1, 10)).thenReturn(Result.success(null));
+        Result<Void> result = processDefinitionController.switchProcessDefinitionVersion(user, projectName, 1, 10);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
@@ -420,10 +398,8 @@ public class ProcessDefinitionControllerTest {
     @Test
     public void testDeleteProcessDefinitionVersion() {
         String projectName = "test";
-        Map<String, Object> resultMap = new HashMap<>();
-        putMsg(resultMap, Status.SUCCESS);
-        Mockito.when(processDefinitionVersionService.deleteByProcessDefinitionIdAndVersion(user, projectName, 1, 10)).thenReturn(resultMap);
-        Result result = processDefinitionController.deleteProcessDefinitionVersion(user, projectName, 1, 10);
+        Mockito.when(processDefinitionVersionService.deleteByProcessDefinitionIdAndVersion(user, projectName, 1, 10)).thenReturn(Result.success(null));
+        Result<Void> result = processDefinitionController.deleteProcessDefinitionVersion(user, projectName, 1, 10);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TaskInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TaskInstanceControllerTest.java
@@ -30,13 +30,11 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.TaskInstanceService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -64,18 +62,16 @@ public class TaskInstanceControllerTest extends AbstractControllerTest {
     @Test
     public void testQueryTaskListPaging() {
 
-        Map<String,Object> result = new HashMap<>();
         Integer pageNo = 1;
         Integer pageSize = 20;
-        PageInfo pageInfo = new PageInfo<TaskInstance>(pageNo, pageSize);
-        result.put(Constants.DATA_LIST, pageInfo);
-        result.put(Constants.STATUS, Status.SUCCESS);
+        PageInfo<Map<String, Object>> pageInfo = new PageInfo<>(pageNo, pageSize);
+        Result<PageListVO<Map<String, Object>>> result = Result.success(new PageListVO<>(pageInfo));
 
-        when(taskInstanceService.queryTaskListPaging(any(), eq(""),  eq(1), eq(""), eq(""), eq(""),any(), any(),
+        when(taskInstanceService.queryTaskListPaging(any(), eq(""), eq(1), eq(""), eq(""), eq(""), any(), any(),
                 eq(""), Mockito.any(), eq("192.168.xx.xx"), any(), any())).thenReturn(result);
-        Result taskResult = taskInstanceController.queryTaskListPaging(null, "", 1, "", "",
-                "", "", ExecutionStatus.SUCCESS,"192.168.xx.xx", "2020-01-01 00:00:00", "2020-01-02 00:00:00",pageNo, pageSize);
-        Assert.assertEquals(Integer.valueOf(Status.SUCCESS.getCode()), taskResult.getCode());
+        result = taskInstanceController.queryTaskListPaging(null, "", 1, "", "",
+                "", "", ExecutionStatus.SUCCESS, "192.168.xx.xx", "2020-01-01 00:00:00", "2020-01-02 00:00:00", pageNo, pageSize);
+        Assert.assertEquals(Integer.valueOf(Status.SUCCESS.getCode()), result.getCode());
     }
 
     @Ignore
@@ -84,9 +80,7 @@ public class TaskInstanceControllerTest extends AbstractControllerTest {
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         paramsMap.add("taskInstanceId", "104");
 
-        Map<String, Object> mockResult = new HashMap<>(5);
-        mockResult.put(Constants.STATUS, Status.SUCCESS);
-        mockResult.put(Constants.MSG, Status.SUCCESS.getMsg());
+        Result<Void> mockResult = Result.success(null);
         when(taskInstanceService.forceTaskSuccess(any(User.class), anyString(), anyInt())).thenReturn(mockResult);
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectName}/task-instance/force-success", "cxc_1113")

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AccessTokenServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AccessTokenServiceTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.AccessTokenServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
@@ -73,29 +75,29 @@ public class AccessTokenServiceTest {
         when(accessTokenMapper.selectAccessTokenPage(any(Page.class), eq("zhangsan"), eq(0))).thenReturn(tokenPage);
 
         User user = new User();
-        Map<String, Object> result = accessTokenService.queryAccessTokenList(user, "zhangsan", 1, 10);
+        Result<PageListVO<AccessToken>> result = accessTokenService.queryAccessTokenList(user, "zhangsan", 1, 10);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        PageInfo<AccessToken> pageInfo = (PageInfo<AccessToken>) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(pageInfo.getTotalCount() > 0);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        PageListVO<AccessToken> tokenPageListVO = result.getData();
+        Assert.assertTrue(tokenPageListVO.getTotal() > 0);
     }
 
     @Test
     public void testCreateToken() {
 
         when(accessTokenMapper.insert(any(AccessToken.class))).thenReturn(2);
-        Map<String, Object> result = accessTokenService.createToken(getLoginUser(), 1, getDate(), "AccessTokenServiceTest");
+        Result<Void> result = accessTokenService.createToken(getLoginUser(), 1, getDate(), "AccessTokenServiceTest");
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
     public void testGenerateToken() {
 
-        Map<String, Object> result = accessTokenService.generateToken(getLoginUser(), Integer.MAX_VALUE,getDate());
+        Result<String> result = accessTokenService.generateToken(getLoginUser(), Integer.MAX_VALUE, getDate());
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        String token = (String) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        String token = result.getData();
         Assert.assertNotNull(token);
     }
 
@@ -105,32 +107,32 @@ public class AccessTokenServiceTest {
         when(accessTokenMapper.selectById(1)).thenReturn(getEntity());
         User userLogin = new User();
         // not exist
-        Map<String, Object> result = accessTokenService.delAccessTokenById(userLogin, 0);
+        Result<Void> result = accessTokenService.delAccessTokenById(userLogin, 0);
         logger.info(result.toString());
-        Assert.assertEquals(Status.ACCESS_TOKEN_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.ACCESS_TOKEN_NOT_EXIST.getCode(), (int) result.getCode());
         // no operate
         result = accessTokenService.delAccessTokenById(userLogin, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //success
         userLogin.setId(1);
         userLogin.setUserType(UserType.ADMIN_USER);
         result = accessTokenService.delAccessTokenById(userLogin, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
     public void testUpdateToken() {
 
         when(accessTokenMapper.selectById(1)).thenReturn(getEntity());
-        Map<String, Object> result = accessTokenService.updateToken(getLoginUser(), 1,Integer.MAX_VALUE,getDate(),"token");
+        Result<Void> result = accessTokenService.updateToken(getLoginUser(), 1, Integer.MAX_VALUE, getDate(), "token");
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         // not exist
         result = accessTokenService.updateToken(getLoginUser(), 2,Integer.MAX_VALUE,getDate(),"token");
         logger.info(result.toString());
-        Assert.assertEquals(Status.ACCESS_TOKEN_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.ACCESS_TOKEN_NOT_EXIST.getCode(), (int) result.getCode());
 
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertGroupServiceTest.java
@@ -22,8 +22,8 @@ import static org.mockito.ArgumentMatchers.eq;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.AlertGroupServiceImpl;
-import org.apache.dolphinscheduler.api.utils.PageInfo;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
 import org.apache.dolphinscheduler.dao.entity.AlertGroup;
@@ -32,7 +32,6 @@ import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,9 +66,9 @@ public class AlertGroupServiceTest {
     public void testQueryAlertGroup() {
 
         Mockito.when(alertGroupMapper.queryAllGroupList()).thenReturn(getList());
-        Map<String, Object> result = alertGroupService.queryAlertgroup();
+        Result<List<AlertGroup>> result = alertGroupService.queryAlertgroup();
         logger.info(result.toString());
-        List<AlertGroup> alertGroups = (List<AlertGroup>) result.get(Constants.DATA_LIST);
+        List<AlertGroup> alertGroups = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(alertGroups));
     }
 
@@ -81,15 +80,15 @@ public class AlertGroupServiceTest {
         Mockito.when(alertGroupMapper.queryAlertGroupPage(any(Page.class), eq(groupName))).thenReturn(page);
         User user = new User();
         // no operate
-        Map<String, Object> result = alertGroupService.listPaging(user, groupName, 1, 10);
-        logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Result<PageListVO<AlertGroup>> pageListVOResult = alertGroupService.listPaging(user, groupName, 1, 10);
+        logger.info(pageListVOResult.toString());
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) pageListVOResult.getCode());
         //success
         user.setUserType(UserType.ADMIN_USER);
-        result = alertGroupService.listPaging(user, groupName, 1, 10);
-        logger.info(result.toString());
-        PageInfo<AlertGroup> pageInfo = (PageInfo<AlertGroup>) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getLists()));
+        pageListVOResult = alertGroupService.listPaging(user, groupName, 1, 10);
+        logger.info(pageListVOResult.toString());
+        PageListVO<AlertGroup> alertGroupPageListVO = pageListVOResult.getData();
+        Assert.assertTrue(CollectionUtils.isNotEmpty(alertGroupPageListVO.getTotalList()));
 
     }
 
@@ -99,14 +98,14 @@ public class AlertGroupServiceTest {
         Mockito.when(alertGroupMapper.insert(any(AlertGroup.class))).thenReturn(2);
         User user = new User();
         //no operate
-        Map<String, Object> result = alertGroupService.createAlertgroup(user, groupName, groupName, null);
+        Result<?> result = alertGroupService.createAlertgroup(user, groupName, groupName, null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         user.setUserType(UserType.ADMIN_USER);
         //success
         result = alertGroupService.createAlertgroup(user, groupName, groupName, null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
@@ -114,19 +113,19 @@ public class AlertGroupServiceTest {
 
         User user = new User();
         // no operate
-        Map<String, Object> result = alertGroupService.updateAlertgroup(user, 1, groupName, groupName, null);
+        Result<Void> result = alertGroupService.updateAlertgroup(user, 1, groupName, groupName, null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         user.setUserType(UserType.ADMIN_USER);
         // not exist
         result = alertGroupService.updateAlertgroup(user, 1, groupName, groupName, null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.ALERT_GROUP_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.ALERT_GROUP_NOT_EXIST.getCode(), (int) result.getCode());
         //success
         Mockito.when(alertGroupMapper.selectById(2)).thenReturn(getEntity());
         result = alertGroupService.updateAlertgroup(user, 2, groupName, groupName, null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 
@@ -135,19 +134,19 @@ public class AlertGroupServiceTest {
 
         User user = new User();
         // no operate
-        Map<String, Object> result = alertGroupService.delAlertgroupById(user, 1);
+        Result<Void> result = alertGroupService.delAlertgroupById(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         user.setUserType(UserType.ADMIN_USER);
         // not exist
         result = alertGroupService.delAlertgroupById(user, 2);
         logger.info(result.toString());
-        Assert.assertEquals(Status.ALERT_GROUP_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.ALERT_GROUP_NOT_EXIST.getCode(), (int) result.getCode());
         //success
         Mockito.when(alertGroupMapper.selectById(2)).thenReturn(getEntity());
         result = alertGroupService.delAlertgroupById(user, 2);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceServiceTest.java
@@ -19,7 +19,8 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.AlertPluginInstanceServiceImpl;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.AlertPluginInstanceVO;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.AlertPluginInstance;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
@@ -158,33 +159,33 @@ public class AlertPluginInstanceServiceTest {
     @Test
     public void testCreate() {
         Mockito.when(alertPluginInstanceMapper.existInstanceName("test")).thenReturn(true);
-        Map<String, Object> result = alertPluginInstanceService.create(user, 1, "test", uiParams);
-        Assert.assertEquals(Status.PLUGIN_INSTANCE_ALREADY_EXIT, result.get(Constants.STATUS));
+        Result<Void> result = alertPluginInstanceService.create(user, 1, "test", uiParams);
+        Assert.assertEquals(Status.PLUGIN_INSTANCE_ALREADY_EXIT.getCode(), (int) result.getCode());
         Mockito.when(alertPluginInstanceMapper.insert(Mockito.any())).thenReturn(1);
         result = alertPluginInstanceService.create(user, 1, "test1", uiParams);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
     public void testDelete() {
         List<String> ids = Arrays.asList("11,2,3", null, "98,1");
         Mockito.when(alertGroupMapper.queryInstanceIdsList()).thenReturn(ids);
-        Map<String, Object> result = alertPluginInstanceService.delete(user, 1);
-        Assert.assertEquals(Status.DELETE_ALERT_PLUGIN_INSTANCE_ERROR_HAS_ALERT_GROUP_ASSOCIATED, result.get(Constants.STATUS));
+        Result<Void> result = alertPluginInstanceService.delete(user, 1);
+        Assert.assertEquals(Status.DELETE_ALERT_PLUGIN_INSTANCE_ERROR_HAS_ALERT_GROUP_ASSOCIATED.getCode(), (int) result.getCode());
         Mockito.when(alertPluginInstanceMapper.deleteById(9)).thenReturn(1);
         result = alertPluginInstanceService.delete(user, 9);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 
     @Test
     public void testUpdate() {
         Mockito.when(alertPluginInstanceMapper.updateById(Mockito.any())).thenReturn(0);
-        Map<String, Object> result = alertPluginInstanceService.update(user, 1, "testUpdate", uiParams);
-        Assert.assertEquals(Status.SAVE_ERROR, result.get(Constants.STATUS));
+        Result<Void> result = alertPluginInstanceService.update(user, 1, "testUpdate", uiParams);
+        Assert.assertEquals(Status.SAVE_ERROR.getCode(), (int) result.getCode());
         Mockito.when(alertPluginInstanceMapper.updateById(Mockito.any())).thenReturn(1);
         result = alertPluginInstanceService.update(user, 1, "testUpdate", uiParams);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
@@ -200,8 +201,8 @@ public class AlertPluginInstanceServiceTest {
         List<AlertPluginInstance> pluginInstanceList = Collections.singletonList(alertPluginInstance);
         Mockito.when(alertPluginInstanceMapper.queryAllAlertPluginInstanceList()).thenReturn(pluginInstanceList);
         Mockito.when(pluginDefineMapper.queryAllPluginDefineList()).thenReturn(pluginDefines);
-        Map<String, Object> result = alertPluginInstanceService.queryAll();
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Result<List<AlertPluginInstanceVO>> result = alertPluginInstanceService.queryAll();
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/BaseServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/BaseServiceTest.java
@@ -17,16 +17,13 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.HadoopUtils;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -76,28 +73,29 @@ public class BaseServiceTest {
     }
 
 
-
     @Test
-    public void testPutMsg(){
+    public void testPutMsg() {
 
-        Map<String, Object> result = new HashMap<>();
+        CheckParamResult result = new CheckParamResult();
         baseService.putMsg(result, Status.SUCCESS);
-        Assert.assertEquals(Status.SUCCESS,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS, result.getStatus());
         //has params
-        baseService.putMsg(result, Status.PROJECT_NOT_FOUNT,"test");
+        baseService.putMsg(result, Status.PROJECT_NOT_FOUNT, "test");
 
     }
+
     @Test
-    public void testPutMsgTwo(){
+    public void testPutMsgTwo() {
 
         Result result = new Result();
         baseService.putMsg(result, Status.SUCCESS);
-        Assert.assertEquals(Status.SUCCESS.getMsg(),result.getMsg());
+        Assert.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
         //has params
-        baseService.putMsg(result,Status.PROJECT_NOT_FOUNT,"test");
+        baseService.putMsg(result, Status.PROJECT_NOT_FOUNT, "test");
     }
+
     @Test
-    public void testCreateTenantDirIfNotExists(){
+    public void testCreateTenantDirIfNotExists() {
 
         PowerMockito.mockStatic(HadoopUtils.class);
         PowerMockito.when(HadoopUtils.getInstance()).thenReturn(hadoopUtils);
@@ -106,7 +104,7 @@ public class BaseServiceTest {
             baseService.createTenantDirIfNotExists("test");
         } catch (Exception e) {
             Assert.assertTrue(false);
-            logger.error("CreateTenantDirIfNotExists error ",e);
+            logger.error("CreateTenantDirIfNotExists error ", e);
             e.printStackTrace();
         }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.api.service;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.DataSourceServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbConnectType;
 import org.apache.dolphinscheduler.common.enums.DbType;
@@ -162,8 +163,8 @@ public class DataSourceServiceTest {
         String searchVal = "";
         int pageNo = 1;
         int pageSize = 10;
-        Map<String, Object> success = dataSourceService.queryDataSourceListPaging(loginUser, searchVal, pageNo, pageSize);
-        Assert.assertEquals(Status.SUCCESS, success.get(Constants.STATUS));
+        Result<PageListVO<DataSource>> pageListVOResult = dataSourceService.queryDataSourceListPaging(loginUser, searchVal, pageNo, pageSize);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) pageListVOResult.getCode());
     }
 
     @Test
@@ -206,13 +207,13 @@ public class DataSourceServiceTest {
         int userId = -1;
 
         //user no operation perm
-        Map<String, Object> noOperationPerm = dataSourceService.unauthDatasource(loginUser, userId);
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, noOperationPerm.get(Constants.STATUS));
+        Result<List<DataSource>> result = dataSourceService.unauthDatasource(loginUser, userId);
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
         //success
         loginUser.setUserType(UserType.ADMIN_USER);
-        Map<String, Object> success = dataSourceService.unauthDatasource(loginUser, userId);
-        Assert.assertEquals(Status.SUCCESS, success.get(Constants.STATUS));
+        Result<List<DataSource>> success = dataSourceService.unauthDatasource(loginUser, userId);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) success.getCode());
     }
 
     @Test
@@ -221,21 +222,21 @@ public class DataSourceServiceTest {
         int userId = -1;
 
         //user no operation perm
-        Map<String, Object> noOperationPerm = dataSourceService.authedDatasource(loginUser, userId);
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, noOperationPerm.get(Constants.STATUS));
+        Result<List<DataSource>> noOperationPerm = dataSourceService.authedDatasource(loginUser, userId);
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) noOperationPerm.getCode());
 
         //success
         loginUser.setUserType(UserType.ADMIN_USER);
-        Map<String, Object> success = dataSourceService.authedDatasource(loginUser, userId);
-        Assert.assertEquals(Status.SUCCESS, success.get(Constants.STATUS));
+        Result<List<DataSource>> success = dataSourceService.authedDatasource(loginUser, userId);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) success.getCode());
     }
 
     @Test
     public void queryDataSourceListTest() {
         User loginUser = new User();
         loginUser.setUserType(UserType.GENERAL_USER);
-        Map<String, Object> map = dataSourceService.queryDataSourceList(loginUser, DbType.MYSQL.ordinal());
-        Assert.assertEquals(Status.SUCCESS, map.get(Constants.STATUS));
+        Result<List<DataSource>> result = dataSourceService.queryDataSourceList(loginUser, DbType.MYSQL.ordinal());
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
@@ -251,12 +252,12 @@ public class DataSourceServiceTest {
     @Test
     public void queryDataSourceTest() {
         PowerMockito.when(dataSourceMapper.selectById(Mockito.anyInt())).thenReturn(null);
-        Map<String, Object> result = dataSourceService.queryDataSource(Mockito.anyInt());
-        Assert.assertEquals(((Status) result.get(Constants.STATUS)).getCode(), Status.RESOURCE_NOT_EXIST.getCode());
+        Result<Map<String, Object>> result = dataSourceService.queryDataSource(Mockito.anyInt());
+        Assert.assertEquals(Status.RESOURCE_NOT_EXIST.getCode(), (int) result.getCode());
 
         PowerMockito.when(dataSourceMapper.selectById(Mockito.anyInt())).thenReturn(getOracleDataSource());
         result = dataSourceService.queryDataSource(Mockito.anyInt());
-        Assert.assertEquals(((Status) result.get(Constants.STATUS)).getCode(), Status.SUCCESS.getCode());
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     private List<DataSource> getDataSourceList() {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorService2Test.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorService2Test.java
@@ -21,10 +21,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.ExecuteType;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.ExecutorServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
@@ -46,10 +48,8 @@ import org.apache.dolphinscheduler.service.process.ProcessService;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -146,13 +146,13 @@ public class ExecutorService2Test {
     public void testNoComplement() throws ParseException {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, cronTime, CommandType.START_PROCESS,
                 null, null,
                 null, null, 0,
                 RunMode.RUN_MODE_SERIAL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         verify(processService, times(1)).createCommand(any(Command.class));
 
     }
@@ -164,13 +164,13 @@ public class ExecutorService2Test {
     public void testComplementWithStartNodeList() throws ParseException {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, cronTime, CommandType.START_PROCESS,
                 null, "n1,n2",
                 null, null, 0,
                 RunMode.RUN_MODE_SERIAL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         verify(processService, times(1)).createCommand(any(Command.class));
 
     }
@@ -183,13 +183,13 @@ public class ExecutorService2Test {
     public void testDateError() throws ParseException {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, "2020-01-31 23:00:00,2020-01-01 00:00:00", CommandType.COMPLEMENT_DATA,
                 null, null,
                 null, null, 0,
                 RunMode.RUN_MODE_SERIAL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(Status.START_PROCESS_INSTANCE_ERROR, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.START_PROCESS_INSTANCE_ERROR.getCode(), (int) result.getCode());
         verify(processService, times(0)).createCommand(any(Command.class));
     }
 
@@ -200,13 +200,13 @@ public class ExecutorService2Test {
     public void testSerial() throws ParseException {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
                 null, null,
                 null, null, 0,
                 RunMode.RUN_MODE_SERIAL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         verify(processService, times(1)).createCommand(any(Command.class));
 
     }
@@ -218,13 +218,13 @@ public class ExecutorService2Test {
     public void testParallelWithOutSchedule() throws ParseException {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
                 null, null,
                 null, null, 0,
                 RunMode.RUN_MODE_PARALLEL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         verify(processService, times(31)).createCommand(any(Command.class));
 
     }
@@ -236,13 +236,13 @@ public class ExecutorService2Test {
     public void testParallelWithSchedule() throws ParseException {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(oneSchedulerList());
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
                 null, null,
                 null, null, 0,
                 RunMode.RUN_MODE_PARALLEL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         verify(processService, times(15)).createCommand(any(Command.class));
 
     }
@@ -251,22 +251,22 @@ public class ExecutorService2Test {
     public void testNoMsterServers() throws ParseException {
         Mockito.when(monitorService.getServerListFromZK(true)).thenReturn(new ArrayList<>());
 
-        Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+        Result<Void> result = executorService.execProcessInstance(loginUser, projectName,
                 processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
                 null, null,
                 null, null, 0,
                 RunMode.RUN_MODE_PARALLEL,
                 Priority.LOW, Constants.DEFAULT_WORKER_GROUP, 110, null);
-        Assert.assertEquals(result.get(Constants.STATUS), Status.MASTER_NOT_EXISTS);
+        Assert.assertEquals(Status.MASTER_NOT_EXISTS.getCode(), (int) result.getCode());
 
     }
 
     @Test
     public void testExecuteRepeatRunning() throws Exception {
         Mockito.when(processService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
-        
-        Map<String, Object> result = executorService.execute(loginUser, projectName, processInstanceId, ExecuteType.REPEAT_RUNNING);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+
+        Result<Void> result = executorService.execute(loginUser, projectName, processInstanceId, ExecuteType.REPEAT_RUNNING);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     private List<Server> getMasterServersList() {
@@ -299,9 +299,7 @@ public class ExecutorService2Test {
         return schedulerList;
     }
 
-    private Map<String, Object> checkProjectAndAuth() {
-        Map<String, Object> result = new HashMap<>();
-        result.put(Constants.STATUS, Status.SUCCESS);
-        return result;
+    private CheckParamResult checkProjectAndAuth() {
+        return new CheckParamResult(Status.SUCCESS);
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorServiceTest.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.api.service;
 import org.apache.dolphinscheduler.api.ApiApplicationServer;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.ExecutorServiceImpl;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 
 import java.text.MessageFormat;
@@ -51,8 +52,8 @@ public class ExecutorServiceTest {
     @Ignore
     @Test
     public void startCheckByProcessDefinedId(){
-        Map<String, Object> map = executorService.startCheckByProcessDefinedId(1234);
-        Assert.assertNull(map);
+        Result<Void> result = executorService.startCheckByProcessDefinedId(1234);
+        Assert.assertNull(result.getData());
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/MonitorServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/MonitorServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.MonitorServiceImpl;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.model.Server;
@@ -58,10 +59,10 @@ public class MonitorServiceTest {
     public  void testQueryDatabaseState(){
 
         Mockito.when(monitorDBDao.queryDatabaseState()).thenReturn(getList());
-        Map<String,Object> result = monitorService.queryDatabaseState(null);
+        Result<List<MonitorRecord>> result = monitorService.queryDatabaseState(null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS,result.get(Constants.STATUS));
-        List<MonitorRecord> monitorRecordList = (List<MonitorRecord>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<MonitorRecord> monitorRecordList = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(monitorRecordList));
     }
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
@@ -21,10 +21,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.dto.ProcessMeta;
+import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.ProcessDefinitionServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
@@ -64,7 +68,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -262,22 +265,22 @@ public class ProcessDefinitionServiceTest {
         loginUser.setId(-1);
         loginUser.setUserType(UserType.GENERAL_USER);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
 
         //project not found
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.queryProcessDefinitionList(loginUser, "project_test1");
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<List<ProcessDefinition>> result = processDefinitionService.queryProcessDefinitionList(loginUser, "project_test1");
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result.getCode());
 
         //project check auth success
-        putMsg(result, Status.SUCCESS, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
         List<ProcessDefinition> resourceList = new ArrayList<>();
         resourceList.add(getProcessDefinition());
         Mockito.when(processDefineMapper.queryAllDefinitionList(project.getId())).thenReturn(resourceList);
-        Map<String, Object> checkSuccessRes = processDefinitionService.queryProcessDefinitionList(loginUser, "project_test1");
-        Assert.assertEquals(Status.SUCCESS, checkSuccessRes.get(Constants.STATUS));
+        Result<List<ProcessDefinition>> successResult = processDefinitionService.queryProcessDefinitionList(loginUser, "project_test1");
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) successResult.getCode());
     }
 
     @Test
@@ -292,17 +295,17 @@ public class ProcessDefinitionServiceTest {
         loginUser.setId(-1);
         loginUser.setUserType(UserType.GENERAL_USER);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
 
         //project not found
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.queryProcessDefinitionListPaging(loginUser, "project_test1", "", 1, 5, 0);
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<PageListVO<ProcessDefinition>> result = processDefinitionService.queryProcessDefinitionListPaging(loginUser, "project_test1", "", 1, 5, 0);
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result.getCode());
 
-        putMsg(result, Status.SUCCESS, projectName);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
         loginUser.setId(1);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
         Page<ProcessDefinition> page = new Page<>(1, 10);
         page.setTotal(30);
         Mockito.when(processDefineMapper.queryDefineListPaging(
@@ -312,10 +315,10 @@ public class ProcessDefinitionServiceTest {
                 , Mockito.eq(project.getId())
                 , Mockito.anyBoolean())).thenReturn(page);
 
-        Map<String, Object> map1 = processDefinitionService.queryProcessDefinitionListPaging(
+        Result<PageListVO<ProcessDefinition>> pageListVOResult = processDefinitionService.queryProcessDefinitionListPaging(
                 loginUser, projectName, "", 1, 10, loginUser.getId());
 
-        Assert.assertEquals(Status.SUCCESS, map1.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) pageListVOResult.getCode());
     }
 
     @Test
@@ -329,28 +332,28 @@ public class ProcessDefinitionServiceTest {
         loginUser.setId(-1);
         loginUser.setUserType(UserType.GENERAL_USER);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
 
         //project check auth fail
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.queryProcessDefinitionById(loginUser,
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<ProcessDefinition> result = processDefinitionService.queryProcessDefinitionById(loginUser,
                 "project_test1", 1);
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result.getCode());
 
         //project check auth success, instance not exist
-        putMsg(result, Status.SUCCESS, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
         Mockito.when(processDefineMapper.selectById(1)).thenReturn(null);
-        Map<String, Object> instanceNotexitRes = processDefinitionService.queryProcessDefinitionById(loginUser,
+        Result<ProcessDefinition> instanceNotexitRes = processDefinitionService.queryProcessDefinitionById(loginUser,
                 "project_test1", 1);
-        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, instanceNotexitRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST.getCode(), (int) instanceNotexitRes.getCode());
 
         //instance exit
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(getProcessDefinition());
-        Map<String, Object> successRes = processDefinitionService.queryProcessDefinitionById(loginUser,
+        Result<ProcessDefinition> successRes = processDefinitionService.queryProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
     }
 
     @Test
@@ -364,28 +367,28 @@ public class ProcessDefinitionServiceTest {
         loginUser.setId(-1);
         loginUser.setUserType(UserType.GENERAL_USER);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
 
         //project check auth fail
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.queryProcessDefinitionByName(loginUser,
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<ProcessDefinition> result = processDefinitionService.queryProcessDefinitionByName(loginUser,
                 "project_test1", "test_def");
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result.getCode());
 
         //project check auth success, instance not exist
-        putMsg(result, Status.SUCCESS, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Mockito.when(processDefineMapper.queryByDefineName(project.getId(),"test_def")).thenReturn(null);
-        Map<String, Object> instanceNotexitRes = processDefinitionService.queryProcessDefinitionByName(loginUser,
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Mockito.when(processDefineMapper.queryByDefineName(project.getId(), "test_def")).thenReturn(null);
+        Result<ProcessDefinition> instanceNotexitRes = processDefinitionService.queryProcessDefinitionByName(loginUser,
                 "project_test1", "test_def");
-        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, instanceNotexitRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST.getCode(), (int) instanceNotexitRes.getCode());
 
         //instance exit
-        Mockito.when(processDefineMapper.queryByDefineName(project.getId(),"test")).thenReturn(getProcessDefinition());
-        Map<String, Object> successRes = processDefinitionService.queryProcessDefinitionByName(loginUser,
+        Mockito.when(processDefineMapper.queryByDefineName(project.getId(), "test")).thenReturn(getProcessDefinition());
+        Result<ProcessDefinition> successRes = processDefinitionService.queryProcessDefinitionByName(loginUser,
                 "project_test1", "test");
-        Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
     }
 
     @Test
@@ -399,38 +402,38 @@ public class ProcessDefinitionServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
 
         // copy project definition ids empty test
-        Map<String, Object> map = processDefinitionService.batchCopyProcessDefinition(loginUser, projectName, StringUtils.EMPTY, 0);
-        Assert.assertEquals(Status.PROCESS_DEFINITION_IDS_IS_EMPTY, map.get(Constants.STATUS));
+        Result<Void> result = processDefinitionService.batchCopyProcessDefinition(loginUser, projectName, StringUtils.EMPTY, 0);
+        Assert.assertEquals(Status.PROCESS_DEFINITION_IDS_IS_EMPTY.getCode(), (int) result.getCode());
 
-        Map<String, Object> result = new HashMap<>();
+        CheckParamResult checkParamResult = new CheckParamResult();
 
         // project check auth fail
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map1 = processDefinitionService.batchCopyProcessDefinition(
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<Void> result1 = processDefinitionService.batchCopyProcessDefinition(
                 loginUser, projectName, String.valueOf(project.getId()), 0);
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map1.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result1.getCode());
 
         // project check auth success, target project is null
-        putMsg(result, Status.SUCCESS, projectName);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
         Mockito.when(projectMapper.queryDetailById(0)).thenReturn(null);
-        Map<String, Object> map2 = processDefinitionService.batchCopyProcessDefinition(
+        Result<Void> result2 = processDefinitionService.batchCopyProcessDefinition(
                 loginUser, projectName, String.valueOf(project.getId()), 0);
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map2.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result2.getCode());
 
         // project check auth success, target project name not equal project name, check auth target project fail
         Project project1 = getProject(projectName);
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(project1);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
 
-        putMsg(result, Status.SUCCESS, projectName);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
         String projectName2 = "project_test2";
         Project project2 = getProject(projectName2);
         Mockito.when(projectMapper.queryByName(projectName2)).thenReturn(project2);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project2, projectName2)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project2, projectName2)).thenReturn(checkParamResult);
         Mockito.when(projectMapper.queryDetailById(1)).thenReturn(project2);
         // instance exit
         ProcessDefinition definition = getProcessDefinition();
@@ -444,9 +447,9 @@ public class ProcessDefinitionServiceTest {
 
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(definition);
 
-        Map<String, Object> map3 = processDefinitionService.batchCopyProcessDefinition(
+        Result<Void> result3 = processDefinitionService.batchCopyProcessDefinition(
                 loginUser, projectName, "46", 1);
-        Assert.assertEquals(Status.SUCCESS, map3.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result3.getCode());
 
     }
 
@@ -470,14 +473,14 @@ public class ProcessDefinitionServiceTest {
         loginUser.setId(-1);
         loginUser.setUserType(UserType.GENERAL_USER);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, projectName);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
 
-        Map<String, Object> result2 = new HashMap<>();
-        putMsg(result2, Status.SUCCESS, targetProject.getName());
+        CheckParamResult checkParamResult1 = new CheckParamResult();
+        putMsg(checkParamResult1, Status.SUCCESS, targetProject.getName());
 
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project2, projectName2)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project2, projectName2)).thenReturn(checkParamResult1);
 
         ProcessDefinition definition = getProcessDefinition();
         definition.setLocations("{\"tasks-36196\":{\"name\":\"ssh_test1\",\"targetarr\":\"\",\"x\":141,\"y\":70}}");
@@ -489,15 +492,10 @@ public class ProcessDefinitionServiceTest {
         definition.setConnects("[]");
 
         // check target project result == null
-        Mockito.when(processDefineMapper.updateById(definition)).thenReturn(46);
-        Mockito.when(processDefineMapper.selectById(46)).thenReturn(definition);
-
-        putMsg(result, Status.SUCCESS);
-
-        Map<String, Object> successRes = processDefinitionService.batchMoveProcessDefinition(
+        Result<Void> successRes = processDefinitionService.batchMoveProcessDefinition(
                 loginUser, "project_test1", "46", 2);
 
-        Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
     }
 
     @Test
@@ -511,35 +509,35 @@ public class ProcessDefinitionServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
 
         //project check auth fail
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.deleteProcessDefinitionById(loginUser, "project_test1", 6);
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<Void> result = processDefinitionService.deleteProcessDefinitionById(loginUser, "project_test1", 6);
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result.getCode());
 
         //project check auth success, instance not exist
-        putMsg(result, Status.SUCCESS, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
         Mockito.when(processDefineMapper.selectById(1)).thenReturn(null);
-        Map<String, Object> instanceNotexitRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> instanceNotexitRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 1);
-        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, instanceNotexitRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST.getCode(), (int) instanceNotexitRes.getCode());
 
         ProcessDefinition processDefinition = getProcessDefinition();
         //user no auth
         loginUser.setUserType(UserType.GENERAL_USER);
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition);
-        Map<String, Object> userNoAuthRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> userNoAuthRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, userNoAuthRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) userNoAuthRes.getCode());
 
         //process definition online
         loginUser.setUserType(UserType.ADMIN_USER);
         processDefinition.setReleaseState(ReleaseState.ONLINE);
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition);
-        Map<String, Object> dfOnlineRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> dfOnlineRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.PROCESS_DEFINE_STATE_ONLINE, dfOnlineRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROCESS_DEFINE_STATE_ONLINE.getCode(), (int) dfOnlineRes.getCode());
 
         //scheduler list elements > 1
         processDefinition.setReleaseState(ReleaseState.OFFLINE);
@@ -548,9 +546,9 @@ public class ProcessDefinitionServiceTest {
         schedules.add(getSchedule());
         schedules.add(getSchedule());
         Mockito.when(scheduleMapper.queryByProcessDefinitionId(46)).thenReturn(schedules);
-        Map<String, Object> schedulerGreaterThanOneRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> schedulerGreaterThanOneRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.DELETE_PROCESS_DEFINE_BY_ID_ERROR, schedulerGreaterThanOneRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.DELETE_PROCESS_DEFINE_BY_ID_ERROR.getCode(), (int) schedulerGreaterThanOneRes.getCode());
 
         //scheduler online
         schedules.clear();
@@ -558,9 +556,9 @@ public class ProcessDefinitionServiceTest {
         schedule.setReleaseState(ReleaseState.ONLINE);
         schedules.add(schedule);
         Mockito.when(scheduleMapper.queryByProcessDefinitionId(46)).thenReturn(schedules);
-        Map<String, Object> schedulerOnlineRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> schedulerOnlineRes = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.SCHEDULE_CRON_STATE_ONLINE, schedulerOnlineRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SCHEDULE_CRON_STATE_ONLINE.getCode(), (int) schedulerOnlineRes.getCode());
 
         //delete fail
         schedules.clear();
@@ -568,15 +566,15 @@ public class ProcessDefinitionServiceTest {
         schedules.add(schedule);
         Mockito.when(scheduleMapper.queryByProcessDefinitionId(46)).thenReturn(schedules);
         Mockito.when(processDefineMapper.deleteById(46)).thenReturn(0);
-        Map<String, Object> deleteFail = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> deleteFail = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.DELETE_PROCESS_DEFINE_BY_ID_ERROR, deleteFail.get(Constants.STATUS));
+        Assert.assertEquals(Status.DELETE_PROCESS_DEFINE_BY_ID_ERROR.getCode(), (int) deleteFail.getCode());
 
         //delete success
         Mockito.when(processDefineMapper.deleteById(46)).thenReturn(1);
-        Map<String, Object> deleteSuccess = processDefinitionService.deleteProcessDefinitionById(loginUser,
+        Result<Void> deleteSuccess = processDefinitionService.deleteProcessDefinitionById(loginUser,
                 "project_test1", 46);
-        Assert.assertEquals(Status.SUCCESS, deleteSuccess.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) deleteSuccess.getCode());
     }
 
     @Test
@@ -591,33 +589,33 @@ public class ProcessDefinitionServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
 
         //project check auth fail
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.releaseProcessDefinition(loginUser, "project_test1",
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        Result<ProcessDefinition> result = processDefinitionService.releaseProcessDefinition(loginUser, "project_test1",
                 6, ReleaseState.OFFLINE);
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT.getCode(), (int) result.getCode());
 
         // project check auth success, processs definition online
-        putMsg(result, Status.SUCCESS, projectName);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(getProcessDefinition());
-        Map<String, Object> onlineRes = processDefinitionService.releaseProcessDefinition(
+        Result<ProcessDefinition> onlineRes = processDefinitionService.releaseProcessDefinition(
                 loginUser, "project_test1", 46, ReleaseState.ONLINE);
-        Assert.assertEquals(Status.SUCCESS, onlineRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) onlineRes.getCode());
 
         // project check auth success, processs definition online
         ProcessDefinition processDefinition1 = getProcessDefinition();
         processDefinition1.setResourceIds("1,2");
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition1);
         Mockito.when(processService.getUserById(1)).thenReturn(loginUser);
-        Map<String, Object> onlineWithResourceRes = processDefinitionService.releaseProcessDefinition(
+        Result<ProcessDefinition> onlineWithResourceRes = processDefinitionService.releaseProcessDefinition(
                 loginUser, "project_test1", 46, ReleaseState.ONLINE);
-        Assert.assertEquals(Status.SUCCESS, onlineWithResourceRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) onlineWithResourceRes.getCode());
 
         // release error code
-        Map<String, Object> failRes = processDefinitionService.releaseProcessDefinition(
+        Result<ProcessDefinition> failRes = processDefinitionService.releaseProcessDefinition(
                 loginUser, "project_test1", 46, ReleaseState.getEnum(2));
-        Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, failRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) failRes.getCode());
 
         //FIXME has function exit code 1 when exception
         //process definition offline
@@ -642,76 +640,76 @@ public class ProcessDefinitionServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
 
         //project check auth fail
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
-        Map<String, Object> map = processDefinitionService.verifyProcessDefinitionName(loginUser,
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
+        checkParamResult = processDefinitionService.verifyProcessDefinitionName(loginUser,
                 "project_test1", "test_pdf");
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, checkParamResult.getStatus());
 
         //project check auth success, process not exist
-        putMsg(result, Status.SUCCESS, projectName);
+        putMsg(checkParamResult, Status.SUCCESS, projectName);
         Mockito.when(processDefineMapper.verifyByDefineName(project.getId(), "test_pdf")).thenReturn(null);
-        Map<String, Object> processNotExistRes = processDefinitionService.verifyProcessDefinitionName(loginUser,
+        CheckParamResult processNotExistRes = processDefinitionService.verifyProcessDefinitionName(loginUser,
                 "project_test1", "test_pdf");
-        Assert.assertEquals(Status.SUCCESS, processNotExistRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS, processNotExistRes.getStatus());
 
         //process exist
         Mockito.when(processDefineMapper.verifyByDefineName(project.getId(), "test_pdf")).thenReturn(getProcessDefinition());
-        Map<String, Object> processExistRes = processDefinitionService.verifyProcessDefinitionName(loginUser,
+        CheckParamResult processExistRes = processDefinitionService.verifyProcessDefinitionName(loginUser,
                 "project_test1", "test_pdf");
-        Assert.assertEquals(Status.PROCESS_DEFINITION_NAME_EXIST, processExistRes.get(Constants.STATUS));
+        Assert.assertEquals(Status.PROCESS_DEFINITION_NAME_EXIST, processExistRes.getStatus());
     }
 
     @Test
     public void testCheckProcessNodeList() {
 
-        Map<String, Object> dataNotValidRes = processDefinitionService.checkProcessNodeList(null, "");
-        Assert.assertEquals(Status.DATA_IS_NOT_VALID, dataNotValidRes.get(Constants.STATUS));
+        CheckParamResult checkParamResult = processDefinitionService.checkProcessNodeList(null, "");
+        Assert.assertEquals(Status.DATA_IS_NOT_VALID, checkParamResult.getStatus());
 
         // task not empty
         String processDefinitionJson = SHELL_JSON;
         ProcessData processData = JSONUtils.parseObject(processDefinitionJson, ProcessData.class);
         Assert.assertNotNull(processData);
-        Map<String, Object> taskEmptyRes = processDefinitionService.checkProcessNodeList(processData, processDefinitionJson);
-        Assert.assertEquals(Status.SUCCESS, taskEmptyRes.get(Constants.STATUS));
+        CheckParamResult taskEmptyResult = processDefinitionService.checkProcessNodeList(processData, processDefinitionJson);
+        Assert.assertEquals(Status.SUCCESS, taskEmptyResult.getStatus());
 
         // task empty
         processData.setTasks(null);
-        Map<String, Object> taskNotEmptyRes = processDefinitionService.checkProcessNodeList(processData, processDefinitionJson);
-        Assert.assertEquals(Status.PROCESS_DAG_IS_EMPTY, taskNotEmptyRes.get(Constants.STATUS));
+        CheckParamResult taskNoEmptyResult = processDefinitionService.checkProcessNodeList(processData, processDefinitionJson);
+        Assert.assertEquals(Status.PROCESS_DAG_IS_EMPTY, taskNoEmptyResult.getStatus());
 
         // task cycle
         String processDefinitionJsonCycle = CYCLE_SHELL_JSON;
         ProcessData processDataCycle = JSONUtils.parseObject(processDefinitionJsonCycle, ProcessData.class);
-        Map<String, Object> taskCycleRes = processDefinitionService.checkProcessNodeList(processDataCycle, processDefinitionJsonCycle);
-        Assert.assertEquals(Status.PROCESS_NODE_HAS_CYCLE, taskCycleRes.get(Constants.STATUS));
+        CheckParamResult taskCycleResult = processDefinitionService.checkProcessNodeList(processDataCycle, processDefinitionJsonCycle);
+        Assert.assertEquals(Status.PROCESS_NODE_HAS_CYCLE, taskCycleResult.getStatus());
 
         //json abnormal
         String abnormalJson = processDefinitionJson.replaceAll("SHELL", "");
         processData = JSONUtils.parseObject(abnormalJson, ProcessData.class);
-        Map<String, Object> abnormalTaskRes = processDefinitionService.checkProcessNodeList(processData, abnormalJson);
-        Assert.assertEquals(Status.PROCESS_NODE_S_PARAMETER_INVALID, abnormalTaskRes.get(Constants.STATUS));
+        CheckParamResult abnormalTaskResult = processDefinitionService.checkProcessNodeList(processData, abnormalJson);
+        Assert.assertEquals(Status.PROCESS_NODE_S_PARAMETER_INVALID, abnormalTaskResult.getStatus());
     }
 
     @Test
     public void testGetTaskNodeListByDefinitionId() {
         //process definition not exist
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(null);
-        Map<String, Object> processDefinitionNullRes = processDefinitionService.getTaskNodeListByDefinitionId(46);
-        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, processDefinitionNullRes.get(Constants.STATUS));
+        Result<List<TaskNode>> processDefinitionNullRes = processDefinitionService.getTaskNodeListByDefinitionId(46);
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST.getCode(), (int) processDefinitionNullRes.getCode());
 
         //process data null
         ProcessDefinition processDefinition = getProcessDefinition();
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition);
-        Map<String, Object> successRes = processDefinitionService.getTaskNodeListByDefinitionId(46);
-        Assert.assertEquals(Status.DATA_IS_NOT_VALID, successRes.get(Constants.STATUS));
+        Result<List<TaskNode>> successRes = processDefinitionService.getTaskNodeListByDefinitionId(46);
+        Assert.assertEquals(Status.DATA_IS_NOT_VALID.getCode(), (int) successRes.getCode());
 
         //success
         processDefinition.setProcessDefinitionJson(SHELL_JSON);
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition);
-        Map<String, Object> dataNotValidRes = processDefinitionService.getTaskNodeListByDefinitionId(46);
-        Assert.assertEquals(Status.SUCCESS, dataNotValidRes.get(Constants.STATUS));
+        Result<List<TaskNode>> dataNotValidRes = processDefinitionService.getTaskNodeListByDefinitionId(46);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) dataNotValidRes.getCode());
     }
 
     @Test
@@ -720,8 +718,8 @@ public class ProcessDefinitionServiceTest {
         String defineIdList = "46";
         Integer[] idArray = {46};
         Mockito.when(processDefineMapper.queryDefinitionListByIdList(idArray)).thenReturn(null);
-        Map<String, Object> processNotExistRes = processDefinitionService.getTaskNodeListByDefinitionIdList(defineIdList);
-        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, processNotExistRes.get(Constants.STATUS));
+        Result<Map<Integer, List<TaskNode>>> processNotExistRes = processDefinitionService.getTaskNodeListByDefinitionIdList(defineIdList);
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST.getCode(), (int) processNotExistRes.getCode());
 
         //process definition exist
         ProcessDefinition processDefinition = getProcessDefinition();
@@ -729,8 +727,8 @@ public class ProcessDefinitionServiceTest {
         List<ProcessDefinition> processDefinitionList = new ArrayList<>();
         processDefinitionList.add(processDefinition);
         Mockito.when(processDefineMapper.queryDefinitionListByIdList(idArray)).thenReturn(processDefinitionList);
-        Map<String, Object> successRes = processDefinitionService.getTaskNodeListByDefinitionIdList(defineIdList);
-        Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Result<Map<Integer, List<TaskNode>>> successRes = processDefinitionService.getTaskNodeListByDefinitionIdList(defineIdList);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
     }
 
     @Test
@@ -741,8 +739,8 @@ public class ProcessDefinitionServiceTest {
         List<ProcessDefinition> processDefinitionList = new ArrayList<>();
         processDefinitionList.add(processDefinition);
         Mockito.when(processDefineMapper.queryAllDefinitionList(projectId)).thenReturn(processDefinitionList);
-        Map<String, Object> successRes = processDefinitionService.queryProcessDefinitionAllByProjectId(projectId);
-        Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Result<List<ProcessDefinition>> successRes = processDefinitionService.queryProcessDefinitionAllByProjectId(projectId);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
     }
 
     @Test
@@ -751,8 +749,8 @@ public class ProcessDefinitionServiceTest {
         ProcessDefinition processDefinition = getProcessDefinition();
         processDefinition.setProcessDefinitionJson(SHELL_JSON);
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(null);
-        Map<String, Object> processDefinitionNullRes = processDefinitionService.viewTree(46, 10);
-        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, processDefinitionNullRes.get(Constants.STATUS));
+        Result<TreeViewDto> processDefinitionNullRes = processDefinitionService.viewTree(46, 10);
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST.getCode(), (int) processDefinitionNullRes.getCode());
 
         List<ProcessInstance> processInstanceList = new ArrayList<>();
         ProcessInstance processInstance = new ProcessInstance();
@@ -777,13 +775,13 @@ public class ProcessDefinitionServiceTest {
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition);
         Mockito.when(processInstanceService.queryByProcessDefineId(46, 10)).thenReturn(processInstanceList);
         Mockito.when(taskInstanceMapper.queryByInstanceIdAndName(processInstance.getId(), "shell-1")).thenReturn(null);
-        Map<String, Object> taskNullRes = processDefinitionService.viewTree(46, 10);
-        Assert.assertEquals(Status.SUCCESS, taskNullRes.get(Constants.STATUS));
+        Result<TreeViewDto> taskNullRes = processDefinitionService.viewTree(46, 10);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) taskNullRes.getCode());
 
         //task instance exist
         Mockito.when(taskInstanceMapper.queryByInstanceIdAndName(processInstance.getId(), "shell-1")).thenReturn(taskInstance);
-        Map<String, Object> taskNotNuLLRes = processDefinitionService.viewTree(46, 10);
-        Assert.assertEquals(Status.SUCCESS, taskNotNuLLRes.get(Constants.STATUS));
+        Result<TreeViewDto> taskNotNuLLRes = processDefinitionService.viewTree(46, 10);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) taskNotNuLLRes.getCode());
 
     }
 
@@ -845,8 +843,8 @@ public class ProcessDefinitionServiceTest {
         Mockito.when(processDefineMapper.selectById(46)).thenReturn(processDefinition);
         Mockito.when(processInstanceService.queryByProcessDefineId(46, 10)).thenReturn(processInstanceList);
         Mockito.when(taskInstanceMapper.queryByInstanceIdAndName(processInstance.getId(), "shell-1")).thenReturn(taskInstance);
-        Map<String, Object> taskNotNuLLRes = processDefinitionService.viewTree(46, 10);
-        Assert.assertEquals(Status.SUCCESS, taskNotNuLLRes.get(Constants.STATUS));
+        Result<TreeViewDto> taskNotNuLLRes = processDefinitionService.viewTree(46, 10);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) taskNotNuLLRes.getCode());
 
     }
 
@@ -933,8 +931,8 @@ public class ProcessDefinitionServiceTest {
         loginUser.setUserType(UserType.ADMIN_USER);
 
         String currentProjectName = "testProject";
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, currentProjectName);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.SUCCESS, currentProjectName);
 
         ProcessDefinition shellDefinition2 = new ProcessDefinition();
         shellDefinition2.setId(46);
@@ -943,12 +941,12 @@ public class ProcessDefinitionServiceTest {
         shellDefinition2.setProcessDefinitionJson(subProcessJson);
 
         Mockito.when(projectMapper.queryByName(currentProjectName)).thenReturn(getProject(currentProjectName));
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, getProject(currentProjectName), currentProjectName)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, getProject(currentProjectName), currentProjectName)).thenReturn(checkParamResult);
         Mockito.when(processDefineMapper.queryByDefineId(46)).thenReturn(shellDefinition2);
 
-        Map<String, Object> importProcessResult = processDefinitionService.importProcessDefinition(loginUser, multipartFile, currentProjectName);
+        Result<Void> result = processDefinitionService.importProcessDefinition(loginUser, multipartFile, currentProjectName);
 
-        Assert.assertEquals(Status.SUCCESS, importProcessResult.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
         boolean delete = file.delete();
 
@@ -961,8 +959,8 @@ public class ProcessDefinitionServiceTest {
         loginUser.setId(1);
         loginUser.setUserType(UserType.ADMIN_USER);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.SUCCESS);
 
         String projectName = "project_test1";
         Project project = getProject(projectName);
@@ -970,7 +968,7 @@ public class ProcessDefinitionServiceTest {
         ProcessDefinition processDefinition = getProcessDefinition();
 
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult);
         Mockito.when(processService.findProcessDefineById(1)).thenReturn(processDefinition);
         Mockito.when(processDefinitionVersionService.addProcessDefinitionVersion(processDefinition)).thenReturn(1L);
 
@@ -1063,10 +1061,10 @@ public class ProcessDefinitionServiceTest {
                 + "    \"tenantId\": 1,\n"
                 + "    \"timeout\": 0\n"
                 + "}";
-        Map<String, Object> updateResult = processDefinitionService.updateProcessDefinition(loginUser, projectName, 1, "test",
+        Result<ProcessDefinition> updateResult = processDefinitionService.updateProcessDefinition(loginUser, projectName, 1, "test",
                 sqlDependentJson, "", "", "");
 
-        Assert.assertEquals(Status.UPDATE_PROCESS_DEFINITION_ERROR, updateResult.get(Constants.STATUS));
+        Assert.assertEquals(Status.UPDATE_PROCESS_DEFINITION_ERROR.getCode(), (int) updateResult.getCode());
     }
 
     @Test
@@ -1081,10 +1079,11 @@ public class ProcessDefinitionServiceTest {
         String projectName = "project_test1";
         Project project = getProject(projectName);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT);
+        CheckParamResult checkParamResult = new CheckParamResult();
+        putMsg(checkParamResult, Status.PROJECT_NOT_FOUNT);
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName))
+                .thenReturn(checkParamResult);
 
         processDefinitionService.batchExportProcessDefinitionByIds(
                 loginUser, projectName, "1", null);
@@ -1098,10 +1097,9 @@ public class ProcessDefinitionServiceTest {
                 + ",\"preTasks\":[],\"retryInterval\":\"1\",\"runFlag\":\"NORMAL\",\"taskInstancePriority\":\"MEDIUM\""
                 + ",\"timeout\":{\"enable\":false,\"interval\":null,\"strategy\":\"\"},\"type\":\"SHELL\""
                 + ",\"waitStartTimeout\":{},\"workerGroup\":\"default\"}],\"tenantId\":4,\"timeout\":0}");
-        Map<String, Object> checkResult = new HashMap<>();
-        checkResult.put(Constants.STATUS, Status.SUCCESS);
+        CheckParamResult checkParamResult1 = new CheckParamResult(Status.SUCCESS);
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(project);
-        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkResult);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkParamResult1);
         Mockito.when(processDefineMapper.queryByDefineId(1)).thenReturn(processDefinition);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
@@ -1293,12 +1291,12 @@ public class ProcessDefinitionServiceTest {
         return scheduleList;
     }
 
-    private void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
-        result.put(Constants.STATUS, status);
+    private void putMsg(CheckParamResult checkParamResult, Status status, Object... statusParams) {
+        checkParamResult.setStatus(status);
         if (statusParams != null && statusParams.length > 0) {
-            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
+            checkParamResult.setMsg(MessageFormat.format(status.getMsg(), statusParams));
         } else {
-            result.put(Constants.MSG, status.getMsg());
+            checkParamResult.setMsg(status.getMsg());
         }
     }
 
@@ -1326,8 +1324,6 @@ public class ProcessDefinitionServiceTest {
         Integer processDefinitionId = 111;
         String processDefinitionName = "testProcessDefinition";
         String projectName = "project_test1";
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUNT);
         ProcessMeta processMeta = new ProcessMeta();
         Assert.assertEquals(0, processDefinitionService.importProcessSchedule(loginUser, projectName, processMeta, processDefinitionName, processDefinitionId));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/QueueServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/QueueServiceTest.java
@@ -21,6 +21,7 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.QueueServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
@@ -79,39 +80,40 @@ public class QueueServiceTest {
     public void testQueryList() {
 
         Mockito.when(queueMapper.selectList(null)).thenReturn(getQueueList());
-        Map<String, Object> result = queueService.queryList(getLoginUser());
+        Result<List<Queue>> result = queueService.queryList(getLoginUser());
         logger.info(result.toString());
-        List<Queue> queueList  = (List<Queue>) result.get(Constants.DATA_LIST);
+        List<Queue> queueList = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(queueList));
 
     }
+
     @Test
     public void testQueryListPage() {
 
-        IPage<Queue> page = new Page<>(1,10);
+        IPage<Queue> page = new Page<>(1, 10);
         page.setTotal(1L);
         page.setRecords(getQueueList());
         Mockito.when(queueMapper.queryQueuePaging(Mockito.any(Page.class), Mockito.eq(queueName))).thenReturn(page);
-        Map<String, Object> result = queueService.queryList(getLoginUser(),queueName,1,10);
+        Result<PageListVO<Queue>> result = queueService.queryList(getLoginUser(), queueName, 1, 10);
         logger.info(result.toString());
-        PageInfo<Queue>  pageInfo = (PageInfo<Queue>) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getLists()));
+        PageListVO<Queue> pageInfo = result.getData();
+        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getTotalList()));
     }
     @Test
     public void testCreateQueue() {
 
         // queue is null
-        Map<String, Object> result = queueService.createQueue(getLoginUser(),null,queueName);
+        Result<Void> result = queueService.createQueue(getLoginUser(), null, queueName);
         logger.info(result.toString());
-        Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
         // queueName is null
         result = queueService.createQueue(getLoginUser(),queueName,null);
         logger.info(result.toString());
-        Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
         // correct
         result = queueService.createQueue(getLoginUser(),queueName,queueName);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 
@@ -123,25 +125,25 @@ public class QueueServiceTest {
         Mockito.when(queueMapper.existQueue(null, "test")).thenReturn(true);
 
         // not exist
-        Map<String, Object> result = queueService.updateQueue(getLoginUser(),0,"queue",queueName);
+        Result<Void> result = queueService.updateQueue(getLoginUser(), 0, "queue", queueName);
         logger.info(result.toString());
-        Assert.assertEquals(Status.QUEUE_NOT_EXIST.getCode(),((Status)result.get(Constants.STATUS)).getCode());
+        Assert.assertEquals(Status.QUEUE_NOT_EXIST.getCode(), (int) result.getCode());
         //no need update
         result = queueService.updateQueue(getLoginUser(),1,queueName,queueName);
         logger.info(result.toString());
-        Assert.assertEquals(Status.NEED_NOT_UPDATE_QUEUE.getCode(),((Status)result.get(Constants.STATUS)).getCode());
+        Assert.assertEquals(Status.NEED_NOT_UPDATE_QUEUE.getCode(), (int) result.getCode());
         //queue exist
         result = queueService.updateQueue(getLoginUser(),1,"test",queueName);
         logger.info(result.toString());
-        Assert.assertEquals(Status.QUEUE_VALUE_EXIST.getCode(),((Status)result.get(Constants.STATUS)).getCode());
+        Assert.assertEquals(Status.QUEUE_VALUE_EXIST.getCode(), (int) result.getCode());
         // queueName exist
         result = queueService.updateQueue(getLoginUser(),1,"test1","test");
         logger.info(result.toString());
-        Assert.assertEquals(Status.QUEUE_NAME_EXIST.getCode(),((Status)result.get(Constants.STATUS)).getCode());
+        Assert.assertEquals(Status.QUEUE_NAME_EXIST.getCode(), (int) result.getCode());
         //success
         result = queueService.updateQueue(getLoginUser(),1,"test1","test1");
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS.getCode(),((Status)result.get(Constants.STATUS)).getCode());
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -17,10 +17,12 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.resources.ResourceComponent;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.ResourcesServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ResourceType;
 import org.apache.dolphinscheduler.common.enums.UserType;
@@ -269,11 +271,11 @@ public class ResourcesServiceTest {
 
         Mockito.when(resourcesMapper.queryResourcePaging(Mockito.any(Page.class),
                 Mockito.eq(0), Mockito.eq(-1), Mockito.eq(0), Mockito.eq("test"), Mockito.any())).thenReturn(resourcePage);
-        Map<String, Object> result = resourcesService.queryResourceListPaging(loginUser, -1, ResourceType.FILE, "test", 1, 10);
+        Result<PageListVO<Resource>> result = resourcesService.queryResourceListPaging(loginUser, -1, ResourceType.FILE, "test", 1, 10);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        PageInfo pageInfo = (PageInfo) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getLists()));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        PageListVO<Resource> pageListVO = result.getData();
+        Assert.assertTrue(CollectionUtils.isNotEmpty(pageListVO.getTotalList()));
 
     }
 
@@ -283,10 +285,10 @@ public class ResourcesServiceTest {
         loginUser.setId(0);
         loginUser.setUserType(UserType.ADMIN_USER);
         Mockito.when(resourcesMapper.queryResourceListAuthored(0, 0)).thenReturn(getResourceList());
-        Map<String, Object> result = resourcesService.queryResourceList(loginUser, ResourceType.FILE);
+        Result<List<ResourceComponent>> result = resourcesService.queryResourceList(loginUser, ResourceType.FILE);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<Resource> resourceList = (List<Resource>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<ResourceComponent> resourceList = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(resourceList));
     }
 
@@ -555,17 +557,17 @@ public class ResourcesServiceTest {
     public void testUnauthorizedFile() {
         User user = getUser();
         //USER_NO_OPERATION_PERM
-        Map<String, Object> result = resourcesService.unauthorizedFile(user, 1);
+        Result<List<ResourceComponent>> result = resourcesService.unauthorizedFile(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
         //SUCCESS
         user.setUserType(UserType.ADMIN_USER);
         Mockito.when(resourcesMapper.queryResourceExceptUserId(1)).thenReturn(getResourceList());
         result = resourcesService.unauthorizedFile(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<Resource> resources = (List<Resource>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<ResourceComponent> resources = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(resources));
 
     }
@@ -575,17 +577,17 @@ public class ResourcesServiceTest {
 
         User user = getUser();
         //USER_NO_OPERATION_PERM
-        Map<String, Object> result = resourcesService.unauthorizedUDFFunction(user, 1);
+        Result<List<UdfFunc>> result = resourcesService.unauthorizedUDFFunction(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
         //SUCCESS
         user.setUserType(UserType.ADMIN_USER);
         Mockito.when(udfFunctionMapper.queryUdfFuncExceptUserId(1)).thenReturn(getUdfFuncList());
         result = resourcesService.unauthorizedUDFFunction(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<UdfFunc> udfFuncs = (List<UdfFunc>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<UdfFunc> udfFuncs = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(udfFuncs));
     }
 
@@ -593,16 +595,16 @@ public class ResourcesServiceTest {
     public void testAuthorizedUDFFunction() {
         User user = getUser();
         //USER_NO_OPERATION_PERM
-        Map<String, Object> result = resourcesService.authorizedUDFFunction(user, 1);
+        Result<List<UdfFunc>> result = resourcesService.authorizedUDFFunction(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //SUCCESS
         user.setUserType(UserType.ADMIN_USER);
         Mockito.when(udfFunctionMapper.queryAuthedUdfFunc(1)).thenReturn(getUdfFuncList());
         result = resourcesService.authorizedUDFFunction(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<UdfFunc> udfFuncs = (List<UdfFunc>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<UdfFunc> udfFuncs = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(udfFuncs));
     }
 
@@ -611,9 +613,9 @@ public class ResourcesServiceTest {
 
         User user = getUser();
         //USER_NO_OPERATION_PERM
-        Map<String, Object> result = resourcesService.authorizedFile(user, 1);
+        Result<List<ResourceComponent>> result = resourcesService.authorizedFile(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //SUCCESS
         user.setUserType(UserType.ADMIN_USER);
 
@@ -623,8 +625,8 @@ public class ResourcesServiceTest {
         Mockito.when(resourcesMapper.queryResourceListById(Mockito.any())).thenReturn(getResourceList());
         result = resourcesService.authorizedFile(user, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<Resource> resources = (List<Resource>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<ResourceComponent> resources = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(resources));
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
@@ -19,8 +19,8 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.TenantServiceImpl;
-import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
@@ -35,7 +35,6 @@ import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -82,20 +81,20 @@ public class TenantServiceTest {
         Mockito.when(tenantMapper.existTenant(tenantCode)).thenReturn(true);
         try {
             //check tenantCode
-            Map<String, Object> result =
-                tenantService.createTenant(getLoginUser(), "%!1111", 1, "TenantServiceTest");
+
+            Result<Void> result = tenantService.createTenant(getLoginUser(), "%!1111", 1, "TenantServiceTest");
             logger.info(result.toString());
-            Assert.assertEquals(Status.CHECK_OS_TENANT_CODE_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.VERIFY_OS_TENANT_CODE_ERROR.getCode(), (int) result.getCode());
 
             //check exist
             result = tenantService.createTenant(loginUser, tenantCode, 1, "TenantServiceTest");
             logger.info(result.toString());
-            Assert.assertEquals(Status.OS_TENANT_CODE_EXIST, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             // success
             result = tenantService.createTenant(loginUser, "test", 1, "TenantServiceTest");
             logger.info(result.toString());
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
         } catch (Exception e) {
             logger.error("create tenant error", e);
@@ -111,11 +110,11 @@ public class TenantServiceTest {
         page.setRecords(getList());
         page.setTotal(1L);
         Mockito.when(tenantMapper.queryTenantPaging(Mockito.any(Page.class), Mockito.eq("TenantServiceTest")))
-            .thenReturn(page);
-        Map<String, Object> result = tenantService.queryTenantList(getLoginUser(), "TenantServiceTest", 1, 10);
+                .thenReturn(page);
+        Result<PageListVO<Tenant>> result = tenantService.queryTenantList(getLoginUser(), "TenantServiceTest", 1, 10);
         logger.info(result.toString());
-        PageInfo<Tenant> pageInfo = (PageInfo<Tenant>) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getLists()));
+        PageListVO<Tenant> pageInfo = result.getData();
+        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getTotalList()));
 
     }
 
@@ -125,14 +124,14 @@ public class TenantServiceTest {
         Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
         try {
             // id not exist
-            Map<String, Object> result =
-                tenantService.updateTenant(getLoginUser(), 912222, tenantCode, 1, "desc");
+
+            Result<Void> result = tenantService.updateTenant(getLoginUser(), 912222, tenantCode, 1, "desc");
             logger.info(result.toString());
             // success
-            Assert.assertEquals(Status.TENANT_NOT_EXIST, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.TENANT_NOT_EXIST.getCode(), (int) result.getCode());
             result = tenantService.updateTenant(getLoginUser(), 1, tenantCode, 1, "desc");
             logger.info(result.toString());
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         } catch (Exception e) {
             logger.error("update tenant error", e);
             Assert.fail();
@@ -151,32 +150,32 @@ public class TenantServiceTest {
 
         try {
             //TENANT_NOT_EXIST
-            Map<String, Object> result = tenantService.deleteTenantById(getLoginUser(), 12);
+            Result<Void> result = tenantService.deleteTenantById(getLoginUser(), 12);
             logger.info(result.toString());
-            Assert.assertEquals(Status.TENANT_NOT_EXIST, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.TENANT_NOT_EXIST.getCode(), (int) result.getCode());
 
             //DELETE_TENANT_BY_ID_FAIL
             result = tenantService.deleteTenantById(getLoginUser(), 1);
             logger.info(result.toString());
-            Assert.assertEquals(Status.DELETE_TENANT_BY_ID_FAIL, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.DELETE_TENANT_BY_ID_FAIL.getCode(), (int) result.getCode());
 
             //DELETE_TENANT_BY_ID_FAIL_DEFINES
             Mockito.when(tenantMapper.queryById(2)).thenReturn(getTenant(2));
             result = tenantService.deleteTenantById(getLoginUser(), 2);
             logger.info(result.toString());
-            Assert.assertEquals(Status.DELETE_TENANT_BY_ID_FAIL_DEFINES, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.DELETE_TENANT_BY_ID_FAIL_DEFINES.getCode(), (int) result.getCode());
 
             //DELETE_TENANT_BY_ID_FAIL_USERS
             Mockito.when(tenantMapper.queryById(3)).thenReturn(getTenant(3));
             result = tenantService.deleteTenantById(getLoginUser(), 3);
             logger.info(result.toString());
-            Assert.assertEquals(Status.DELETE_TENANT_BY_ID_FAIL_USERS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.DELETE_TENANT_BY_ID_FAIL_USERS.getCode(), (int) result.getCode());
 
             // success
             Mockito.when(tenantMapper.queryById(4)).thenReturn(getTenant(4));
             result = tenantService.deleteTenantById(getLoginUser(), 4);
             logger.info(result.toString());
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         } catch (Exception e) {
             logger.error("delete tenant error", e);
             Assert.fail();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
@@ -84,7 +84,7 @@ public class TenantServiceTest {
 
             Result<Void> result = tenantService.createTenant(getLoginUser(), "%!1111", 1, "TenantServiceTest");
             logger.info(result.toString());
-            Assert.assertEquals(Status.VERIFY_OS_TENANT_CODE_ERROR.getCode(), (int) result.getCode());
+            Assert.assertEquals(Status.CHECK_OS_TENANT_CODE_ERROR.getCode(), (int) result.getCode());
 
             //check exist
             result = tenantService.createTenant(loginUser, tenantCode, 1, "TenantServiceTest");

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UdfFuncServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UdfFuncServiceTest.java
@@ -21,6 +21,7 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.UdfFuncServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UdfType;
 import org.apache.dolphinscheduler.common.enums.UserType;
@@ -101,72 +102,74 @@ public class UdfFuncServiceTest {
     }
 
     @Test
-    public  void testQueryUdfFuncDetail(){
-
+    public void testQueryUdfFuncDetail() {
         PowerMockito.when(udfFuncMapper.selectById(1)).thenReturn(getUdfFunc());
         //resource not exist
-        Map<String, Object> result = udfFuncService.queryUdfFuncDetail(2);
+        Result<UdfFunc> result = udfFuncService.queryUdfFuncDetail(2);
         logger.info(result.toString());
-        Assert.assertEquals(Status.RESOURCE_NOT_EXIST,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.RESOURCE_NOT_EXIST.getCode(), (int) result.getCode());
         // success
         result = udfFuncService.queryUdfFuncDetail(1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
-    public  void testUpdateUdfFunc(){
+    public void testUpdateUdfFunc() {
 
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(false);
         PowerMockito.when(udfFuncMapper.selectUdfById(1)).thenReturn(getUdfFunc());
         PowerMockito.when(resourceMapper.selectById(1)).thenReturn(getResource());
 
         //UDF_FUNCTION_NOT_EXIST
-        Map<String, Object> result = udfFuncService.updateUdfFunc(12, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest", "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 1);
+        Result<Void> result = udfFuncService.updateUdfFunc(12, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest",
+                "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.UDF_FUNCTION_NOT_EXIST,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.UDF_FUNCTION_NOT_EXIST.getCode(), (int) result.getCode());
 
         //HDFS_NOT_STARTUP
-        result = udfFuncService.updateUdfFunc(1, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest", "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 1);
+        result = udfFuncService.updateUdfFunc(1, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest",
+                "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.HDFS_NOT_STARTUP,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.HDFS_NOT_STARTUP.getCode(), (int) result.getCode());
 
         //RESOURCE_NOT_EXIST
         PowerMockito.when(udfFuncMapper.selectUdfById(11)).thenReturn(getUdfFunc());
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
-        result = udfFuncService.updateUdfFunc(11, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest", "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 12);
+        result = udfFuncService.updateUdfFunc(11, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest",
+                "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 12);
         logger.info(result.toString());
-        Assert.assertEquals(Status.RESOURCE_NOT_EXIST,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.RESOURCE_NOT_EXIST.getCode(), (int) result.getCode());
 
         //success
         result = udfFuncService.updateUdfFunc(11, "UdfFuncServiceTest", "org.apache.dolphinscheduler.api.service.UdfFuncServiceTest", "String", "UdfFuncServiceTest", "UdfFuncServiceTest", UdfType.HIVE, 1);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS,result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 
     @Test
-    public  void testQueryUdfFuncListPaging(){
+    public void testQueryUdfFuncListPaging() {
 
-        IPage<UdfFunc> page = new Page<>(1,10);
+        IPage<UdfFunc> page = new Page<>(1, 10);
         page.setTotal(1L);
         page.setRecords(getList());
-        Mockito.when(udfFuncMapper.queryUdfFuncPaging(Mockito.any(Page.class), Mockito.eq(0),Mockito.eq("test"))).thenReturn(page);
-        Map<String, Object> result = udfFuncService.queryUdfFuncListPaging(getLoginUser(),"test",1,10);
+        Mockito.when(udfFuncMapper.queryUdfFuncPaging(Mockito.any(Page.class), Mockito.eq(0), Mockito.eq("test"))).thenReturn(page);
+        Result<PageListVO<UdfFunc>> result = udfFuncService.queryUdfFuncListPaging(getLoginUser(), "test", 1, 10);
         logger.info(result.toString());
-        PageInfo pageInfo = (PageInfo) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getLists()));
+        PageListVO<UdfFunc> pageListVO = result.getData();
+        Assert.assertTrue(CollectionUtils.isNotEmpty(pageListVO.getTotalList()));
     }
 
     @Test
-    public  void testQueryUdfFuncList(){
+    public void testQueryUdfFuncList() {
         User user = getLoginUser();
         user.setUserType(UserType.GENERAL_USER);
         Mockito.when(udfFuncMapper.getUdfFuncByType(user.getId(), UdfType.HIVE.ordinal())).thenReturn(getList());
-        Map<String, Object> result = udfFuncService.queryUdfFuncList(user,UdfType.HIVE.ordinal());
+        Result<List<UdfFunc>> result = udfFuncService.queryUdfFuncList(user, UdfType.HIVE.ordinal());
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS,result.get(Constants.STATUS));
-        List<UdfFunc> udfFuncList = (List<UdfFunc>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<UdfFunc> udfFuncList = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(udfFuncList));
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UiPluginServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UiPluginServiceTest.java
@@ -19,11 +19,13 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.UiPluginServiceImpl;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.PluginType;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.mapper.PluginDefineMapper;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -57,30 +59,30 @@ public class UiPluginServiceTest {
 
     @Test
     public void testQueryPlugins1() {
-        Map<String, Object> result = uiPluginService.queryUiPluginsByType(PluginType.REGISTER);
-        Assert.assertEquals(Status.PLUGIN_NOT_A_UI_COMPONENT, result.get("status"));
+        Result<List<PluginDefine>> result = uiPluginService.queryUiPluginsByType(PluginType.REGISTER);
+        Assert.assertEquals(Status.PLUGIN_NOT_A_UI_COMPONENT.getCode(), (int) result.getCode());
     }
 
     @Test
     public void testQueryPlugins2() {
-        Map<String, Object> result = uiPluginService.queryUiPluginsByType(PluginType.ALERT);
+        Result<List<PluginDefine>> result = uiPluginService.queryUiPluginsByType(PluginType.ALERT);
         Mockito.when(pluginDefineMapper.queryByPluginType(PluginType.ALERT.getDesc())).thenReturn(null);
-        Assert.assertEquals(Status.QUERY_PLUGINS_RESULT_IS_NULL, result.get("status"));
+        Assert.assertEquals(Status.QUERY_PLUGINS_RESULT_IS_NULL.getCode(), (int) result.getCode());
 
         Mockito.when(pluginDefineMapper.queryByPluginType(PluginType.ALERT.getDesc())).thenReturn(Collections.singletonList(pluginDefine));
         result = uiPluginService.queryUiPluginsByType(PluginType.ALERT);
-        Assert.assertEquals(Status.SUCCESS, result.get("status"));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
     public void testQueryPluginDetailById() {
         Mockito.when(pluginDefineMapper.queryDetailById(1)).thenReturn(null);
-        Map<String, Object> result = uiPluginService.queryUiPluginDetailById(1);
-        Assert.assertEquals(Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL, result.get("status"));
+        Result<PluginDefine> result = uiPluginService.queryUiPluginDetailById(1);
+        Assert.assertEquals(Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL.getCode(), (int) result.getCode());
 
         Mockito.when(pluginDefineMapper.queryDetailById(1)).thenReturn(pluginDefine);
         result = uiPluginService.queryUiPluginDetailById(1);
-        Assert.assertEquals(Status.SUCCESS, result.get("status"));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.UsersServiceImpl;
-import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ResourceType;
 import org.apache.dolphinscheduler.common.enums.UserType;
@@ -128,41 +128,41 @@ public class UsersServiceTest {
         int state = 1;
         try {
             //userName error
-            Map<String, Object> result = usersService.createUser(user, userName, userPassword, email, tenantId, phone, queueName, state);
+            Result<Void> result = usersService.createUser(user, userName, userPassword, email, tenantId, phone, queueName, state);
             logger.info(result.toString());
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             userName = "userTest0001";
             userPassword = "userTest000111111111111111";
             //password error
             result = usersService.createUser(user, userName, userPassword, email, tenantId, phone, queueName, state);
             logger.info(result.toString());
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             userPassword = "userTest0001";
             email = "1q.com";
             //email error
             result = usersService.createUser(user, userName, userPassword, email, tenantId, phone, queueName, state);
             logger.info(result.toString());
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             email = "122222@qq.com";
             phone = "2233";
             //phone error
             result = usersService.createUser(user, userName, userPassword, email, tenantId, phone, queueName, state);
             logger.info(result.toString());
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             phone = "13456432345";
             //tenantId not exists
             result = usersService.createUser(user, userName, userPassword, email, tenantId, phone, queueName, state);
             logger.info(result.toString());
-            Assert.assertEquals(Status.TENANT_NOT_EXIST, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.TENANT_NOT_EXIST.getCode(), (int) result.getCode());
             //success
             Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
             result = usersService.createUser(user, userName, userPassword, email, 1, phone, queueName, state);
             logger.info(result.toString());
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
         } catch (Exception e) {
             logger.error(Status.CREATE_USER_ERROR.getMsg(), e);
@@ -221,15 +221,15 @@ public class UsersServiceTest {
         User user = new User();
 
         //no operate
-        Map<String, Object> result = usersService.queryUserList(user);
+        Result<List<User>> result = usersService.queryUserList(user);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
         //success
         user.setUserType(UserType.ADMIN_USER);
         when(userMapper.selectList(null)).thenReturn(getUserList());
         result = usersService.queryUserList(user);
-        List<User> userList = (List<User>) result.get(Constants.DATA_LIST);
+        List<User> userList = result.getData();
         Assert.assertTrue(userList.size() > 0);
     }
 
@@ -241,16 +241,16 @@ public class UsersServiceTest {
         when(userMapper.queryUserPaging(any(Page.class), eq("userTest"))).thenReturn(page);
 
         //no operate
-        Map<String, Object> result = usersService.queryUserList(user, "userTest", 1, 10);
-        logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Result<PageListVO<User>> pageListResult = usersService.queryUserList(user, "userTest", 1, 10);
+        logger.info(pageListResult.toString());
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) pageListResult.getCode());
 
         //success
         user.setUserType(UserType.ADMIN_USER);
-        result = usersService.queryUserList(user, "userTest", 1, 10);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        PageInfo<User> pageInfo = (PageInfo<User>) result.get(Constants.DATA_LIST);
-        Assert.assertTrue(pageInfo.getLists().size() > 0);
+        pageListResult = usersService.queryUserList(user, "userTest", 1, 10);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) pageListResult.getCode());
+        PageListVO<User> userPageListVO = pageListResult.getData();
+        Assert.assertTrue(userPageListVO.getTotalList().size() > 0);
     }
 
     @Test
@@ -259,15 +259,15 @@ public class UsersServiceTest {
         String userPassword = "userTest0001";
         try {
             //user not exist
-            Map<String, Object> result = usersService.updateUser(getLoginUser(), 0,userName,userPassword,"3443@qq.com",1,"13457864543","queue", 1);
-            Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+            Result<Void> result = usersService.updateUser(getLoginUser(), 0, userName, userPassword, "3443@qq.com", 1, "13457864543", "queue", 1);
+            Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
             logger.info(result.toString());
 
             //success
             when(userMapper.selectById(1)).thenReturn(getUser());
-            result = usersService.updateUser(getLoginUser(), 1,userName,userPassword,"32222s@qq.com",1,"13457864543","queue", 1);
+            result = usersService.updateUser(getLoginUser(), 1, userName, userPassword, "32222s@qq.com", 1, "13457864543", "queue", 1);
             logger.info(result.toString());
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         } catch (Exception e) {
             logger.error("update user error", e);
             Assert.assertTrue(false);
@@ -282,20 +282,20 @@ public class UsersServiceTest {
             when(userMapper.selectById(1)).thenReturn(getUser());
 
             //no operate
-            Map<String, Object> result = usersService.deleteUserById(loginUser, 3);
+            Result<Void> result = usersService.deleteUserById(loginUser, 3);
             logger.info(result.toString());
-            Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
             // user not exist
             loginUser.setUserType(UserType.ADMIN_USER);
             result = usersService.deleteUserById(loginUser, 3);
             logger.info(result.toString());
-            Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
 
             //success
             result = usersService.deleteUserById(loginUser, 1);
             logger.info(result.toString());
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         } catch (Exception e) {
             logger.error("delete user error", e);
             Assert.assertTrue(false);
@@ -309,19 +309,19 @@ public class UsersServiceTest {
         when(userMapper.selectById(1)).thenReturn(getUser());
         User loginUser = new User();
         String projectIds = "100000,120000";
-        Map<String, Object> result = usersService.grantProject(loginUser, 1, projectIds);
+        Result<Void> result = usersService.grantProject(loginUser, 1, projectIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //user not exist
         loginUser.setUserType(UserType.ADMIN_USER);
         result = usersService.grantProject(loginUser, 2, projectIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
         //success
         when(projectUserMapper.deleteProjectRelation(Mockito.anyInt(), Mockito.anyInt())).thenReturn(1);
         result = usersService.grantProject(loginUser, 1, projectIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
@@ -329,20 +329,20 @@ public class UsersServiceTest {
         String resourceIds = "100000,120000";
         when(userMapper.selectById(1)).thenReturn(getUser());
         User loginUser = new User();
-        Map<String, Object> result = usersService.grantResources(loginUser, 1, resourceIds);
+        Result<Void> result = usersService.grantResources(loginUser, 1, resourceIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //user not exist
         loginUser.setUserType(UserType.ADMIN_USER);
         result = usersService.grantResources(loginUser, 2, resourceIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
         //success
         when(resourceMapper.selectById(Mockito.anyInt())).thenReturn(getResource());
         when(resourceUserMapper.deleteResourceUser(1, 0)).thenReturn(1);
         result = usersService.grantResources(loginUser, 1, resourceIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 
@@ -352,19 +352,19 @@ public class UsersServiceTest {
         String udfIds = "100000,120000";
         when(userMapper.selectById(1)).thenReturn(getUser());
         User loginUser = new User();
-        Map<String, Object> result = usersService.grantUDFFunction(loginUser, 1, udfIds);
+        Result<Void> result = usersService.grantUDFFunction(loginUser, 1, udfIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //user not exist
         loginUser.setUserType(UserType.ADMIN_USER);
         result = usersService.grantUDFFunction(loginUser, 2, udfIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
         //success
         when(udfUserMapper.deleteByUserId(1)).thenReturn(1);
         result = usersService.grantUDFFunction(loginUser, 1, udfIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
     @Test
@@ -372,19 +372,19 @@ public class UsersServiceTest {
         String datasourceIds = "100000,120000";
         when(userMapper.selectById(1)).thenReturn(getUser());
         User loginUser = new User();
-        Map<String, Object> result = usersService.grantDataSource(loginUser, 1, datasourceIds);
+        Result<Void> result = usersService.grantDataSource(loginUser, 1, datasourceIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //user not exist
         loginUser.setUserType(UserType.ADMIN_USER);
         result = usersService.grantDataSource(loginUser, 2, datasourceIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
         //success
         when(datasourceUserMapper.deleteByUserId(Mockito.anyInt())).thenReturn(1);
         result = usersService.grantDataSource(loginUser, 1, datasourceIds);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
     }
 
@@ -401,10 +401,10 @@ public class UsersServiceTest {
         loginUser.setUserName("admin");
         loginUser.setUserType(UserType.ADMIN_USER);
         // get admin user
-        Map<String, Object> result = usersService.getUserInfo(loginUser);
+        Result<User> result = usersService.getUserInfo(loginUser);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        User tempUser = (User) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        User tempUser = result.getData();
         //check userName
         Assert.assertEquals("admin", tempUser.getUserName());
 
@@ -415,8 +415,8 @@ public class UsersServiceTest {
         when(alertGroupMapper.queryByUserId(1)).thenReturn(getAlertGroups());
         result = usersService.getUserInfo(loginUser);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        tempUser = (User) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        tempUser = result.getData();
         //check userName
         Assert.assertEquals("userTest0001", tempUser.getUserName());
     }
@@ -426,16 +426,16 @@ public class UsersServiceTest {
     public void testQueryAllGeneralUsers() {
         User loginUser = new User();
         //no operate
-        Map<String, Object> result = usersService.queryAllGeneralUsers(loginUser);
+        Result<List<User>> result = usersService.queryAllGeneralUsers(loginUser);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //success
         loginUser.setUserType(UserType.ADMIN_USER);
         when(userMapper.queryAllGeneralUser()).thenReturn(getUserList());
         result = usersService.queryAllGeneralUsers(loginUser);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<User> userList = (List<User>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<User> userList = result.getData();
         Assert.assertTrue(CollectionUtils.isNotEmpty(userList));
     }
 
@@ -458,14 +458,14 @@ public class UsersServiceTest {
         when(userMapper.selectList(null)).thenReturn(getUserList());
         when(userMapper.queryUserListByAlertGroupId(2)).thenReturn(getUserList());
         //no operate
-        Map<String, Object> result = usersService.unauthorizedUser(loginUser, 2);
+        Result<List<User>> result = usersService.unauthorizedUser(loginUser, 2);
         logger.info(result.toString());
         loginUser.setUserType(UserType.ADMIN_USER);
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //success
         result = usersService.unauthorizedUser(loginUser, 2);
         logger.info(result.toString());
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }
 
 
@@ -474,14 +474,14 @@ public class UsersServiceTest {
         User loginUser = new User();
         when(userMapper.queryUserListByAlertGroupId(2)).thenReturn(getUserList());
         //no operate
-        Map<String, Object> result = usersService.authorizedUser(loginUser, 2);
+        Result<List<User>> result = usersService.authorizedUser(loginUser, 2);
         logger.info(result.toString());
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
         //success
         loginUser.setUserType(UserType.ADMIN_USER);
         result = usersService.authorizedUser(loginUser, 2);
-        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        List<User> userList = (List<User>) result.get(Constants.DATA_LIST);
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+        List<User> userList = result.getData();
         logger.info(result.toString());
         Assert.assertTrue(CollectionUtils.isNotEmpty(userList));
     }
@@ -494,31 +494,31 @@ public class UsersServiceTest {
         String email = "123@qq.com";
         try {
             //userName error
-            Map<String, Object> result = usersService.registerUser(userName, userPassword, repeatPassword, email);
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Result<User> result = usersService.registerUser(userName, userPassword, repeatPassword, email);
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             userName = "userTest0002";
             userPassword = "userTest000111111111111111";
             //password error
             result = usersService.registerUser(userName, userPassword, repeatPassword, email);
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             userPassword = "userTest0002";
             email = "1q.com";
             //email error
             result = usersService.registerUser(userName, userPassword, repeatPassword, email);
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             //repeatPassword error
             email = "7400@qq.com";
             repeatPassword = "userPassword";
             result = usersService.registerUser(userName, userPassword, repeatPassword, email);
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             //success
             repeatPassword = "userTest0002";
             result = usersService.registerUser(userName, userPassword, repeatPassword, email);
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
 
         } catch (Exception e) {
             Assert.assertTrue(false);
@@ -533,29 +533,29 @@ public class UsersServiceTest {
         String userName = "userTest0002~";
         try {
             //not admin
-            Map<String, Object> result = usersService.activateUser(user, userName);
-            Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+            Result<User> result = usersService.activateUser(user, userName);
+            Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
             //userName error
             user.setUserType(UserType.ADMIN_USER);
             result = usersService.activateUser(user, userName);
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) result.getCode());
 
             //user not exist
             userName = "userTest10013";
             result = usersService.activateUser(user, userName);
-            Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.USER_NOT_EXIST.getCode(), (int) result.getCode());
 
             //user state error
             userName = "userTest0001";
             when(userMapper.queryByUserNameAccurately(userName)).thenReturn(getUser());
             result = usersService.activateUser(user, userName);
-            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), (int) (result.getCode()));
 
             //success
             when(userMapper.queryByUserNameAccurately(userName)).thenReturn(getDisabledUser());
             result = usersService.activateUser(user, userName);
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         } catch (Exception e) {
             Assert.assertTrue(false);
         }
@@ -573,15 +573,15 @@ public class UsersServiceTest {
 
         try {
             //not admin
-            Map<String, Object> result = usersService.batchActivateUser(user, userNames);
-            Assert.assertEquals(Status.USER_NO_OPERATION_PERM, result.get(Constants.STATUS));
+            Result<Map<String, Object>> result = usersService.batchActivateUser(user, userNames);
+            Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getCode(), (int) result.getCode());
 
             //batch activate user names
             user.setUserType(UserType.ADMIN_USER);
             when(userMapper.queryByUserNameAccurately("userTest0001")).thenReturn(getUser());
             when(userMapper.queryByUserNameAccurately("userTest0002")).thenReturn(getDisabledUser());
             result = usersService.batchActivateUser(user, userNames);
-            Map<String, Object> responseData = (Map<String, Object>) result.get(Constants.DATA_LIST);
+            Map<String, Object> responseData = result.getData();
             Map<String, Object> successData = (Map<String, Object>) responseData.get("success");
             int totalSuccess = (Integer) successData.get("sum");
 
@@ -590,7 +590,7 @@ public class UsersServiceTest {
 
             Assert.assertEquals(1, totalSuccess);
             Assert.assertEquals(3, totalFailed);
-            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         } catch (Exception e) {
             Assert.assertTrue(false);
         }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkFlowLineageServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkFlowLineageServiceTest.java
@@ -20,7 +20,7 @@ package org.apache.dolphinscheduler.api.service;
 import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.service.impl.WorkFlowLineageServiceImpl;
-import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.WorkFlowLineage;
 import org.apache.dolphinscheduler.dao.entity.WorkFlowRelation;
 import org.apache.dolphinscheduler.dao.mapper.WorkFlowLineageMapper;
@@ -54,9 +54,9 @@ public class WorkFlowLineageServiceTest {
     public void testQueryWorkFlowLineageByName() {
         String searchVal = "test";
         when(workFlowLineageMapper.queryByName(searchVal, 1)).thenReturn(getWorkFlowLineages());
-        Map<String, Object> result = workFlowLineageService.queryWorkFlowLineageByName(searchVal,1);
-        List<WorkFlowLineage> workFlowLineageList = (List<WorkFlowLineage>)result.get(Constants.DATA_LIST);
-        Assert.assertTrue(workFlowLineageList.size()>0);
+        Result<List<WorkFlowLineage>> result = workFlowLineageService.queryWorkFlowLineageByName(searchVal, 1);
+        List<WorkFlowLineage> workFlowLineageList = result.getData();
+        Assert.assertTrue(workFlowLineageList.size() > 0);
     }
 
     @Test
@@ -68,12 +68,12 @@ public class WorkFlowLineageServiceTest {
 
         when(workFlowLineageMapper.queryByIds(ids, 1)).thenReturn(getWorkFlowLineages());
         when(workFlowLineageMapper.querySourceTarget(1)).thenReturn(getWorkFlowRelation());
-        Map<String, Object> result = workFlowLineageService.queryWorkFlowLineageByIds(ids,1);
-        Map<String, Object> workFlowLists = (Map<String, Object>)result.get(Constants.DATA_LIST);
-        List<WorkFlowLineage> workFlowLineages = (List<WorkFlowLineage>)workFlowLists.get("workFlowList");
-        List<WorkFlowRelation> workFlowRelations = (List<WorkFlowRelation>)workFlowLists.get("workFlowRelationList");
-        Assert.assertTrue(workFlowLineages.size()>0);
-        Assert.assertTrue(workFlowRelations.size()>0);
+        Result<Map<String, Object>> result = workFlowLineageService.queryWorkFlowLineageByIds(ids, 1);
+        Map<String, Object> workFlowLists = result.getData();
+        List<WorkFlowLineage> workFlowLineages = (List<WorkFlowLineage>) workFlowLists.get("workFlowList");
+        List<WorkFlowRelation> workFlowRelations = (List<WorkFlowRelation>) workFlowLists.get("workFlowRelationList");
+        Assert.assertTrue(workFlowLineages.size() > 0);
+        Assert.assertTrue(workFlowRelations.size() > 0);
     }
 
     private List<WorkFlowLineage> getWorkFlowLineages() {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -19,8 +19,9 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.WorkerGroupServiceImpl;
-import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.api.utils.ZookeeperMonitor;
+import org.apache.dolphinscheduler.api.vo.PageListVO;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.enums.ZKNodeType;
@@ -104,18 +105,18 @@ public class WorkerGroupServiceTest {
         User user = new User();
         // general user add
         user.setUserType(UserType.GENERAL_USER);
-        Map<String, Object> result = workerGroupService.saveWorkerGroup(user, 0, groupName, "127.0.0.1:1234");
-        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getMsg(), result.get(Constants.MSG));
+        Result<Void> result = workerGroupService.saveWorkerGroup(user, 0, groupName, "127.0.0.1:1234");
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM.getMsg(), result.getMsg());
 
         // success
         user.setUserType(UserType.ADMIN_USER);
         result = workerGroupService.saveWorkerGroup(user, 0, groupName, "127.0.0.1:1234");
-        Assert.assertEquals(Status.SUCCESS.getMsg(), result.get(Constants.MSG));
+        Assert.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
         // group name exist
         Mockito.when(workerGroupMapper.selectById(2)).thenReturn(getWorkerGroup(2));
         Mockito.when(workerGroupMapper.queryWorkerGroupByName(groupName)).thenReturn(getList());
         result = workerGroupService.saveWorkerGroup(user, 2, groupName, "127.0.0.1:1234");
-        Assert.assertEquals(Status.NAME_EXIST, result.get(Constants.STATUS));
+        Assert.assertEquals(Status.NAME_EXIST.getCode(), (int) result.getCode());
     }
 
     /**
@@ -126,15 +127,15 @@ public class WorkerGroupServiceTest {
         User user = new User();
         // general user add
         user.setUserType(UserType.ADMIN_USER);
-        Map<String, Object> result = workerGroupService.queryAllGroupPaging(user, 1, 10, null);
-        PageInfo<WorkerGroup> pageInfo = (PageInfo) result.get(Constants.DATA_LIST);
-        Assert.assertEquals(pageInfo.getLists().size(), 1);
+        Result<PageListVO<WorkerGroup>> result = workerGroupService.queryAllGroupPaging(user, 1, 10, null);
+        PageListVO<WorkerGroup> pageInfo = result.getData();
+        Assert.assertEquals(pageInfo.getTotalList().size(), 1);
     }
 
     @Test
     public void testQueryAllGroup() {
-        Map<String, Object> result = workerGroupService.queryAllGroup();
-        List<String> workerGroups = (List<String>) result.get(Constants.DATA_LIST);
+        Result<List<String>> result = workerGroupService.queryAllGroup();
+        List<String> workerGroups = result.getData();
         Assert.assertEquals(workerGroups.size(), 1);
     }
 
@@ -148,16 +149,16 @@ public class WorkerGroupServiceTest {
         WorkerGroup wg2 = getWorkerGroup(2);
         Mockito.when(workerGroupMapper.selectById(2)).thenReturn(wg2);
         Mockito.when(processInstanceMapper.queryByWorkerGroupNameAndStatus(wg2.getName(), Constants.NOT_TERMINATED_STATES)).thenReturn(getProcessInstanceList());
-        Map<String, Object> result = workerGroupService.deleteWorkerGroupById(user, 1);
-        Assert.assertEquals(Status.DELETE_WORKER_GROUP_NOT_EXIST.getCode(), ((Status) result.get(Constants.STATUS)).getCode());
+        Result<Void> result = workerGroupService.deleteWorkerGroupById(user, 1);
+        Assert.assertEquals(Status.DELETE_WORKER_GROUP_NOT_EXIST.getCode(), (int) result.getCode());
         result = workerGroupService.deleteWorkerGroupById(user, 2);
-        Assert.assertEquals(Status.DELETE_WORKER_GROUP_BY_ID_FAIL.getCode(), ((Status) result.get(Constants.STATUS)).getCode());
+        Assert.assertEquals(Status.DELETE_WORKER_GROUP_BY_ID_FAIL.getCode(), (int) result.getCode());
         // correct
         WorkerGroup wg3 = getWorkerGroup(3);
         Mockito.when(workerGroupMapper.selectById(3)).thenReturn(wg3);
         Mockito.when(processInstanceMapper.queryByWorkerGroupNameAndStatus(wg3.getName(), Constants.NOT_TERMINATED_STATES)).thenReturn(new ArrayList<>());
         result = workerGroupService.deleteWorkerGroupById(user, 3);
-        Assert.assertEquals(Status.SUCCESS.getMsg(), result.get(Constants.MSG));
+        Assert.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
     }
 
     /**
@@ -171,8 +172,8 @@ public class WorkerGroupServiceTest {
 
     @Test
     public void testQueryAllGroupWithDefault() {
-        Map<String, Object> result = workerGroupService.queryAllGroup();
-        List<String> workerGroups = (List<String>) result.get(Constants.DATA_LIST);
+        Result<List<String>> result = workerGroupService.queryAllGroup();
+        List<String> workerGroups = result.getData();
         Assert.assertEquals(1, workerGroups.size());
         Assert.assertEquals("default", workerGroups.toArray()[0]);
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/CheckUtilsTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/CheckUtilsTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.dolphinscheduler.api.dto.CheckParamResult;
 import org.apache.dolphinscheduler.api.enums.Status;
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ProgramType;
 import org.apache.dolphinscheduler.common.enums.TaskType;
 import org.apache.dolphinscheduler.common.process.ResourceInfo;
@@ -38,8 +38,6 @@ import org.apache.dolphinscheduler.common.task.spark.SparkParameters;
 import org.apache.dolphinscheduler.common.task.sql.SqlParameters;
 import org.apache.dolphinscheduler.common.task.subprocess.SubProcessParameters;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-
-import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -89,10 +87,10 @@ public class CheckUtilsTest {
     @Test
     public void testCheckDesc() {
 
-        Map<String, Object> objectMap = CheckUtils.checkDesc("I am desc");
-        Status status = (Status) objectMap.get(Constants.STATUS);
+        CheckParamResult checkResult = CheckUtils.checkDesc("I am desc");
+        Status status = checkResult.getStatus();
 
-        assertEquals(status.getCode(),Status.SUCCESS.getCode());
+        assertEquals(status.getCode(), Status.SUCCESS.getCode());
 
     }
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CollectionUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CollectionUtilsTest.java
@@ -17,11 +17,15 @@
 package org.apache.dolphinscheduler.common.utils;
 
 import org.apache.dolphinscheduler.common.Constants;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.*;
-
 
 public class CollectionUtilsTest {
 


### PR DESCRIPTION
  * Refactor the Api code to make the method return typed parameters

## Purpose of the pull request

Most methods in the current API module do not have a clear return value, but return Object or Map<String, Object>. These makes it difficult to develop a new feature and maintain old code. It is strongly recommended using a specific type class as the return value of method, rather than Object or Map<String, Object>.

This closes #5015

## Brief change log

Change the method return value of API model.


## Verify this pull request

This pull request is already covered by existing tests.

