### PR TITLE
[Improvement][Worker] Throw operation not permitted exception when kill shell task 

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
@@ -409,7 +409,7 @@ public class ProcessUtils {
      * @throws Exception exception
      */
     public static String getPidsStr(int processId) throws Exception {
-        StringBuilder sb = new StringBuilder();
+        List<String> pidList = new ArrayList<>();
         Matcher mat = null;
         // pstree pid get sub pids
         if (OSUtils.isMacOS()) {
@@ -424,11 +424,14 @@ public class ProcessUtils {
 
         if (null != mat) {
             while (mat.find()) {
-                sb.append(mat.group(1)).append(" ");
+                pidList.add(mat.group(1));
             }
         }
 
-        return sb.toString().trim();
+        if (CommonUtils.isSudoEnable() && !pidList.isEmpty()) {
+            pidList = pidList.subList(1, pidList.size());
+        }
+        return String.join(" ", pidList).trim();
     }
 
     /**


### PR DESCRIPTION
## Purpose of the pull request
When sudo config is set true in worker `sudo.enable=true`, the command task will use sudo -u to run the task, detail code in `AbstractCommandExecutor`. 
When the task start, the parent task processor belongs to root, when we kill the parent process, it will throw an exception `Operation not permitted`. And it seems that we needn't kill the parent process, we should only kill the sub processes.
this closes #5199 
