### PR TITLE
[FIX-#5266][server-api] If start a process instance form fail node or stop node ,the param will be init

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -711,14 +711,6 @@ public class ProcessService {
                 if (commandTypeIfComplement == CommandType.REPEAT_RUNNING) {
                     setGlobalParamIfCommanded(processDefinition, cmdParam);
                 }
-
-                // Recalculate global parameters after rerun.
-
-                processInstance.setGlobalParams(ParameterUtils.curingGlobalParams(
-                    processDefinition.getGlobalParamMap(),
-                    processDefinition.getGlobalParamList(),
-                    commandTypeIfComplement,
-                    processInstance.getScheduleTime()));
             }
             processDefinition = processDefineMapper.selectById(processInstance.getProcessDefinitionId());
             processInstance.setProcessDefinition(processDefinition);


### PR DESCRIPTION
[FIX-#5266][server-api] If start a process instance form fail node or stop node ,the param will be init
when we start a process instance from fail node or stop mode ,the param that is already modify may be inited.