### PR TITLE
fix bug:when shell task raw script has $[${day} - 1],throw java.lang.…

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/ParameterUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/ParameterUtils.java
@@ -45,7 +45,7 @@ public class ParameterUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ParameterUtils.class);
 
-    private static final String DATE_PARSE_PATTERN = "\\$\\[([^\\]]+)]";
+    private static final String DATE_PARSE_PATTERN = "\\$\\[([^\\$\\]]+)]";
 
     private static final String DATE_START_PATTERN = "^[0-9]";
 


### PR DESCRIPTION
…IllegalArgumentException::Pattern includes reserved character:'{'

