### PR TITLE
[Improvement][Service]edit datasource select Spark, data parameters lost

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -235,6 +235,8 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
         switch (dataSource.getType()) {
             case HIVE:
+           //edit datasource select spark, data parameters lost
+            case SPARK:
             case SQLSERVER:
                 separator = ";";
                 break;

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/_source/selectTenant.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/_source/selectTenant.vue
@@ -1,86 +1,103 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 <template>
-  <el-select
-          :disabled="isDetails"
-          @change="_onChange"
-          v-model="selectedValue"
-          size="small"
-          style="width: 180px">
-    <el-option
-            v-for="item in itemList"
-            :key="item.id"
-            :value="item.id"
-            :label="item.tenantCode">
-    </el-option>
-  </el-select>
+  <x-select
+      :disabled="isDetails"
+      @on-change="_onChange"
+      v-model="value"
+      style="width: 180px">
+    <x-option
+        v-for="item in itemList"
+        :key="item.id"
+        :value="item.id"
+        :disabled="item.disabled"
+        :label="item.tenantName">
+    </x-option>
+  </x-select>
 </template>
 <script>
-  import disabledState from '@/module/mixin/disabledState'
-  export default {
-    name: 'form-tenant',
-    data () {
-      return {
-        selectedValue: this.value,
-        itemList: []
+import disabledState from '@/module/mixin/disabledState'
+export default {
+  name: 'form-tenant',
+  data () {
+    return {
+      itemList: [],currentUserInfo:[]
+    }
+  },
+  mixins: [disabledState],
+  props: {
+    value: {
+      type: String,
+      default: 'default'
+    }
+  },
+  model: {
+    prop: 'value',
+    event: 'tenantSelectEvent'
+  },
+  mounted() {
+    let result = this.itemList.some(item=>{
+      if(item.id == this.value) {
+        return true
       }
-    },
-    mixins: [disabledState],
-    props: {
-      value: {
-        type: String,
-        default: 'default'
+    })
+    if(!result) {
+      this.value = 'default'
+    }
+  },
+  methods: {
+    _onChange (o) {
+      this.value = o.value
+      this.$emit('tenantSelectEvent', o.value)
+    }
+  },
+  watch: {
+  },
+  created () {
+    let stateTenantAllList = this.store.state.security.tenantAllList || []
+    let currentUserInfo = this.store.state.user.userInfo || [] ;
+    if (stateTenantAllList.length) {
+      this.itemList = stateTenantAllList
+      if(currentUserInfo && currentUserInfo.tenantId ===0 ){
+        this.itemList.forEach(function(ele) {
+          ele.disabled=false
+        });
+      }else{
+        this.itemList.forEach(function(ele) {
+          ele.id === currentUserInfo.tenantId ? ele.disabled=false :ele.disabled =true
+        });
       }
-    },
-    model: {
-      prop: 'value',
-      event: 'tenantSelectEvent'
-    },
-    mounted () {
-      let result = this.itemList.some(item => {
-        if (item.id === this.value) {
-          return true
-        }
-      })
-      if (!result) {
-        this.selectedValue = 'default'
-      }
-    },
-    methods: {
-      _onChange (o) {
-        this.$emit('tenantSelectEvent', o)
-      }
-    },
-    watch: {
-      value (val) {
-        this.selectedValue = val
-      }
-    },
-    created () {
-      let stateTenantAllList = this.store.state.security.tenantAllList || []
-      if (stateTenantAllList.length) {
-        this.itemList = stateTenantAllList
-      } else {
-        this.store.dispatch('security/getTenantList').then(res => {
-          this.$nextTick(() => {
-            this.itemList = res
-          })
+    } else {
+      this.store.dispatch('security/getTenantList').then(res => {
+        this.$nextTick(() => {
+          this.itemList = res
+
+          if(currentUserInfo && currentUserInfo.tenantId ===0 ){
+            this.itemList.forEach(function(ele) {
+              ele.disabled=false
+            });
+          }else{
+            this.itemList.forEach(function(ele) {
+              ele.id === currentUserInfo.tenantId ? ele.disabled=false :ele.disabled =true
+            });
+          }
         })
-      }
+      })
     }
   }
+}
 </script>


### PR DESCRIPTION
1:(Fixed) edit datasource select Spark, data parameters lost.
    for example: CreateDatasource ,select spark "jdbc connect parameters": {serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=spark_hiveserver2}  after clicking submit, 
edit again  jdbc connect parameters:{"serviceDiscoveryMode":"zooKeeper;zooKeeperNamespace"}
    

2:Modify ordinary users tenants
    scene：The administrator creates a common user and associates tenants. After the user logs in, the new process can also select other tenants.
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: 
  1: fixed edit datasource select Spark).
  2: add  common user cannot select other tenants to create a workflow
-->

## Brief change log

 