### PR TITLE
[BUG-5349]fix bug:  work flow would running if task is killed by manual.

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/DependResult.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/DependResult.java
@@ -26,6 +26,7 @@ public enum DependResult {
      * 0 success
      * 1 waiting
      * 2 failed
+     * 3 non execution
      */
-    SUCCESS, WAITING, FAILED
+    SUCCESS, WAITING, FAILED, NON_EXEC
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
@@ -617,7 +617,7 @@ public class MasterExecThread implements Runnable {
             }
             ExecutionStatus depTaskState = completeTaskList.get(depsNode).getState();
             if (depTaskState.typeIsPause() || depTaskState.typeIsCancel()) {
-                return DependResult.WAITING;
+                return DependResult.NON_EXEC;
             }
             // ignore task state if current task is condition
             if (taskNode.isConditionsTask()) {
@@ -1148,6 +1148,10 @@ public class MasterExecThread implements Runnable {
                     dependFailedTask.put(task.getName(), task);
                     removeTaskFromStandbyList(task);
                     logger.info("task {},id:{} depend result : {}", task.getName(), task.getId(), dependResult);
+                } else if (DependResult.NON_EXEC == dependResult) {
+                    // for some reasons(depend task pause/stop) this task would not be submit
+                    removeTaskFromStandbyList(task);
+                    logger.info("remove task {},id:{} , because depend result : {}", task.getName(), task.getId(), dependResult);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
fix  #5349  work flow would running if task is killed by manual.

add depend result enum NON_EXEC for the task that would not be submit .