### PR TITLE
[Bug][Master] Fix when the master or worker down, the alert cann't insert to Db, due to the datasource close

### DIFF
--- a/dolphinscheduler-registry-plugin/dolphinscheduler-registry-zookeeper/src/test/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryTest.java
+++ b/dolphinscheduler-registry-plugin/dolphinscheduler-registry-zookeeper/src/test/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryTest.java
@@ -118,6 +118,12 @@ public class ZookeeperRegistryTest {
         public void notify(String path, DataChangeEvent dataChangeEvent) {
             logger.info("I'm test listener");
         }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
+
     }
 
     @After

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryClient.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryClient.java
@@ -119,7 +119,7 @@ public class MasterRegistryClient {
                 removeNodePath(null, NodeType.MASTER, true);
                 removeNodePath(null, NodeType.WORKER, true);
             }
-            registryClient.subscribe(REGISTRY_DOLPHINSCHEDULER_NODE, new MasterRegistryDataListener());
+            registryClient.subscribe(REGISTRY_DOLPHINSCHEDULER_NODE, new MasterRegistryDataListener(this));
         } catch (Exception e) {
             logger.error("master start up exception", e);
         } finally {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryDataListener.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryDataListener.java
@@ -22,7 +22,6 @@ import static org.apache.dolphinscheduler.common.Constants.REGISTRY_DOLPHINSCHED
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.NodeType;
-import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.spi.register.DataChangeEvent;
 import org.apache.dolphinscheduler.spi.register.SubscribeListener;
 
@@ -33,10 +32,17 @@ public class MasterRegistryDataListener implements SubscribeListener {
 
     private static final Logger logger = LoggerFactory.getLogger(MasterRegistryDataListener.class);
 
-    private MasterRegistryClient masterRegistryClient;
+    private final MasterRegistryClient masterRegistryClient;
 
-    public MasterRegistryDataListener() {
-        masterRegistryClient = SpringApplicationContext.getBean(MasterRegistryClient.class);
+    private final int order;
+
+    public MasterRegistryDataListener(MasterRegistryClient masterRegistryClient) {
+        this(masterRegistryClient, 0);
+    }
+
+    public MasterRegistryDataListener(MasterRegistryClient masterRegistryClient, int order) {
+        this.masterRegistryClient = masterRegistryClient;
+        this.order = order;
     }
 
 
@@ -49,6 +55,11 @@ public class MasterRegistryDataListener implements SubscribeListener {
             //monitor worker
             handleWorkerEvent(event, path);
         }
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
     }
 
     /**

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryDataListener.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryDataListener.java
@@ -45,7 +45,6 @@ public class MasterRegistryDataListener implements SubscribeListener {
         this.order = order;
     }
 
-
     @Override
     public void notify(String path, DataChangeEvent event) {
         //monitor master

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryDataListenerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryDataListenerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.master.registry;
+
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.spi.register.DataChangeEvent;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class MasterRegistryDataListenerTest {
+
+    @Test
+    public void testNotify() {
+        MasterRegistryClient mockRegistryClient = Mockito.mock(MasterRegistryClient.class);
+        MasterRegistryDataListener listener = new MasterRegistryDataListener(mockRegistryClient);
+        // Master
+        listener.notify(Constants.REGISTRY_DOLPHINSCHEDULER_MASTERS + Constants.SINGLE_SLASH + "xx", DataChangeEvent.ADD);
+        // Worker
+        listener.notify(Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SINGLE_SLASH + "xx", DataChangeEvent.ADD);
+        // if no exception, assert true
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void getOrder() {
+        MasterRegistryDataListener listener = new MasterRegistryDataListener(null);
+        Assert.assertEquals(0, listener.getOrder());
+    }
+
+    @Test
+    public void handleMasterEvent() {
+        MasterRegistryClient mockRegistryClient = Mockito.mock(MasterRegistryClient.class);
+
+        MasterRegistryDataListener listener = new MasterRegistryDataListener(mockRegistryClient);
+        listener.handleMasterEvent(DataChangeEvent.ADD, "");
+        listener.handleMasterEvent(DataChangeEvent.REMOVE, "");
+        // if no exception, assert true
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void handleWorkerEvent() {
+        MasterRegistryClient mockRegistryClient = Mockito.mock(MasterRegistryClient.class);
+
+        MasterRegistryDataListener listener = new MasterRegistryDataListener(mockRegistryClient);
+        listener.handleWorkerEvent(DataChangeEvent.ADD, "");
+        listener.handleWorkerEvent(DataChangeEvent.REMOVE, "");
+        // if no exception, assert true
+        Assert.assertTrue(true);
+    }
+}

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/register/ListenerManager.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/register/ListenerManager.java
@@ -43,8 +43,8 @@ public class ListenerManager {
     /**
      * add listener(A node can only be monitored by one listener)
      */
-    public static void addListener(String path, SubscribeListener listener) {
-        List<SubscribeListener> subscribeListeners = listeners.computeIfAbsent(path, k -> new ArrayList<>());
+    public static void addListener(String key, SubscribeListener listener) {
+        List<SubscribeListener> subscribeListeners = listeners.computeIfAbsent(key, k -> new ArrayList<>());
         subscribeListeners.add(listener);
         subscribeListeners.sort(Comparator.reverseOrder());
     }

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/register/Registry.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/register/Registry.java
@@ -35,7 +35,7 @@ public interface Registry {
     void close();
 
     /**
-     * subscribe registry data change, a path can only be monitored by one listener
+     * subscribe registry data change
      */
     boolean subscribe(String path, SubscribeListener subscribeListener);
 

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/register/SubscribeListener.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/register/SubscribeListener.java
@@ -20,11 +20,24 @@ package org.apache.dolphinscheduler.spi.register;
 /**
  * Registration center subscription. All listeners must implement this interface
  */
-public interface SubscribeListener {
+public interface SubscribeListener extends Comparable<SubscribeListener> {
 
     /**
      * Processing logic when the subscription node changes
      */
     void notify(String path, DataChangeEvent dataChangeEvent);
 
+    /**
+     * When multiple listeners listen to one event, the high order will be execute first.
+     * The default order is 0
+     *
+     * @return order
+     */
+    default int getOrder() {
+        return 0;
+    }
+
+    default int compareTo(SubscribeListener subscribeListener) {
+        return this.getOrder() - subscribeListener.getOrder();
+    }
 }

--- a/dolphinscheduler-spi/src/test/java/org/apache/dolphinscheduler/spi/register/ListenerManagerTest.java
+++ b/dolphinscheduler-spi/src/test/java/org/apache/dolphinscheduler/spi/register/ListenerManagerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.spi.register;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ListenerManagerTest {
+
+    private Logger logger = LoggerFactory.getLogger(ListenerManagerTest.class);
+
+    @Test
+    public void checkHasListeners() {
+        Assert.assertFalse(ListenerManager.checkHasListeners("/"));
+    }
+
+    @Test
+    public void addListener() {
+        ListenerManager.addListener("/", new MockListener());
+        ListenerManager.addListener("/", new MockListener());
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void removeListener() {
+        ListenerManager.removeListener("/xxx");
+    }
+
+    @Test
+    public void dataChange() {
+        ListenerManager.dataChange("key", "/", DataChangeEvent.ADD);
+        ListenerManager.addListener("key", new MockListener());
+        ListenerManager.dataChange("key", "/", DataChangeEvent.ADD);
+        Assert.assertTrue(true);
+    }
+
+    class MockListener implements SubscribeListener {
+
+        @Override
+        public void notify(String path, DataChangeEvent dataChangeEvent) {
+            logger.info("notify: path: {}, event: {}", path, dataChangeEvent);
+        }
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -975,6 +975,7 @@
                         <include>**/server/master/dispatch/host/assign/RoundRobinSelectorTest.java</include>
                         <include>**/server/master/dispatch/host/assign/HostWorkerTest.java</include>
                         <include>**/server/master/registry/MasterRegistryClientTest.java</include>
+                        <include>**/server/master/registry/MasterRegistryDataListenerTest.java</include>
                         <include>**/server/master/registry/ServerNodeManagerTest.java</include>
                         <include>**/server/master/dispatch/host/assign/RoundRobinHostManagerTest.java</include>
                         <include>**/server/master/MasterCommandTest.java</include>
@@ -1073,6 +1074,7 @@
                         <include>**/plugin/alert/slack/SlackAlertPluginTest.java</include>
                         <include>**/plugin/alert/slack/SlackSenderTest.java</include>
                         <include>**/spi/params/PluginParamsTransferTest.java</include>
+                        <include>**/spi/register/ListenerManagerTest.java</include>
                         <include>**/spi/plugin/DolphinSchedulerPluginLoaderTest.java</include>
                         <include>**/alert/plugin/EmailAlertPluginTest.java</include>
                         <include>**/alert/plugin/AlertPluginManagerTest.java</include>


### PR DESCRIPTION
close #5491, close #5578

When an instance receives a `Node_REMOVE` event from zookeeper,  it will trigger the listener to response for the change. 
One listener will remove the node to dead path. Another will insert an alert data to database.  
But the listener trigger has no order, because `TreeCache` use a map to store the listener.

This change save the listener in an ordered list. 
