### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ You are very welcome to communicate with the developers and users of Dolphin Sch
 1. Join the Slack channel by [this invitation link](https://join.slack.com/t/asf-dolphinscheduler/shared_invite/zt-omtdhuio-_JISsxYhiVsltmC5h38yfw).
 2. Follow the [Twitter account of Dolphin Scheduler](https://twitter.com/dolphinschedule) and get the latest news on time.
 
+### Contributor over time
+  
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/dolphinscheduler)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/dolphinscheduler)
+
 ## How to Contribute
 
 The community welcomes everyone to contribute, please refer to this page to find out more: [How to contribute](https://dolphinscheduler.apache.org/en-us/community/development/contribute.html).


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
Hi community!

We're the maintainers of [Apache APISIX](https://github.com/apache/apisix). To better present how our community grows, we develop a tool to show contributors growing history on https://github.com/api7/contributor-graph. Since we found it helpful, we think maybe if it could help some other community.

**WHAT IT IS**

Basically, it just shows the contributors growth over time, just like the stargazers overtime on the README. It would be the same with starcc that we would update the graph each day, so the link would always present the real-time data. There is some other stuff to [play around](https://www.apiseven.com/en/contributor-graph) if you would like to give it a try~

![image](https://user-images.githubusercontent.com/34589752/119030672-3452fc80-b978-11eb-90ec-4bf3d8bbab1f.png)

**HOW IT WORKS**

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.


Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻 


## Brief change log

  - *add contributor over time graph to README*

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.