### PR TITLE
[Bug][Master] remove check with executePath when kill yarn job

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
@@ -449,6 +449,14 @@ public class ProcessUtils {
                         taskExecutionContext.getLogPath());
             }
             if (StringUtils.isNotEmpty(log)) {
+                if (StringUtils.isEmpty(taskExecutionContext.getExecutePath())) {
+                    taskExecutionContext.setExecutePath(FileUtils.getProcessExecDir(taskExecutionContext.getProjectCode(),
+                            taskExecutionContext.getProcessDefineCode(),
+                            taskExecutionContext.getProcessDefineVersion(),
+                            taskExecutionContext.getProcessInstanceId(),
+                            taskExecutionContext.getTaskInstanceId()));
+                    FileUtils.createWorkDirIfAbsent(taskExecutionContext.getExecutePath());
+                }
                 List<String> appIds = LoggerUtils.getAppIds(log, logger);
                 if (CollectionUtils.isNotEmpty(appIds)) {
                     cancelApplication(appIds, logger, taskExecutionContext.getTenantCode(), taskExecutionContext.getExecutePath());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
@@ -450,11 +450,6 @@ public class ProcessUtils {
             }
             if (StringUtils.isNotEmpty(log)) {
                 List<String> appIds = LoggerUtils.getAppIds(log, logger);
-                String workerDir = taskExecutionContext.getExecutePath();
-                if (StringUtils.isEmpty(workerDir)) {
-                    logger.error("task instance work dir is empty");
-                    throw new RuntimeException("task instance work dir is empty");
-                }
                 if (CollectionUtils.isNotEmpty(appIds)) {
                     cancelApplication(appIds, logger, taskExecutionContext.getTenantCode(), taskExecutionContext.getExecutePath());
                     return appIds;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
@@ -455,8 +455,8 @@ public class ProcessUtils {
                             taskExecutionContext.getProcessDefineVersion(),
                             taskExecutionContext.getProcessInstanceId(),
                             taskExecutionContext.getTaskInstanceId()));
-                    FileUtils.createWorkDirIfAbsent(taskExecutionContext.getExecutePath());
                 }
+                FileUtils.createWorkDirIfAbsent(taskExecutionContext.getExecutePath());
                 List<String> appIds = LoggerUtils.getAppIds(log, logger);
                 if (CollectionUtils.isNotEmpty(appIds)) {
                     cancelApplication(appIds, logger, taskExecutionContext.getTenantCode(), taskExecutionContext.getExecutePath());


### PR DESCRIPTION
## Purpose of the pull request
when worker is down, a master trigger worker tolerance,
when handle a yarn task tolerance, it first kill the yarn job by yarn rest api and make the task state to NEED_FAULT_TOLERANCE,
so the task can scheduler by master.

## bug detail 
the check make the yarn job not killed, but re submit by another worker。　
it will make the yarn running  duplicated  biz application.



## change
This change added tests and can be verified as follows:

so remove the check code.
just get the applocationId and kill it ,no need to check the executePath.

issue link to #5550