### PR TITLE
[Fix-5477][api] when start a process manually, its local parameter  which references ${system.datetime} does not get runtime value

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -624,7 +624,7 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
         Date scheduleTime = processInstance.getScheduleTime();
         Map<String, String> timeParams = BusinessTimeUtils
                 .getBusinessTime(processInstance.getCmdTypeIfComplement(),
-                        scheduleTime !=null ? scheduleTime : processInstance.getStartTime());
+                        scheduleTime != null ? scheduleTime : processInstance.getStartTime());
         String userDefinedParams = processInstance.getGlobalParams();
         // global params
         List<Property> globalParams = new ArrayList<>();

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -629,6 +629,9 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
         // global params
         List<Property> globalParams = new ArrayList<>();
 
+        if (userDefinedParams != null && userDefinedParams.length() > 0) {
+            globalParams = JSONUtils.toList(userDefinedParams, Property.class);
+        }
         // global param string
         String globalParamStr = ParameterUtils.convertParameterPlaceholders(JSONUtils.toJsonString(globalParams), timeParams);
         globalParams = JSONUtils.toList(globalParamStr, Property.class);
@@ -636,9 +639,6 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
             timeParams.put(property.getProp(), property.getValue());
         }
 
-        if (userDefinedParams != null && userDefinedParams.length() > 0) {
-            globalParams = JSONUtils.toList(userDefinedParams, Property.class);
-        }
 
         Map<String, Map<String, Object>> localUserDefParams = getLocalParams(processInstance, timeParams);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -621,9 +621,10 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
             throw new RuntimeException("workflow instance is null");
         }
 
+        Date scheduleTime = processInstance.getScheduleTime();
         Map<String, String> timeParams = BusinessTimeUtils
                 .getBusinessTime(processInstance.getCmdTypeIfComplement(),
-                        processInstance.getScheduleTime());
+                        scheduleTime !=null ? scheduleTime : processInstance.getStartTime());
         String userDefinedParams = processInstance.getGlobalParams();
         // global params
         List<Property> globalParams = new ArrayList<>();
@@ -661,8 +662,8 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
             TaskDefinitionLog taskDefinitionLog = taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                     taskInstance.getTaskCode(), taskInstance.getTaskDefinitionVersion());
             String parameter = taskDefinitionLog.getTaskParams();
-            Map<String, String> map = JSONUtils.toMap(parameter);
-            String localParams = map.get(LOCAL_PARAMS);
+            Map<String, Object> map = JSONUtils.toMap(parameter,String.class,Object.class);
+            String localParams = JSONUtils.toJsonString(map.get(LOCAL_PARAMS));
             if (localParams != null && !localParams.isEmpty()) {
                 localParams = ParameterUtils.convertParameterPlaceholders(localParams, timeParams);
                 List<Property> localParamsList = JSONUtils.toList(localParams, Property.class);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -662,7 +662,7 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
             TaskDefinitionLog taskDefinitionLog = taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                     taskInstance.getTaskCode(), taskInstance.getTaskDefinitionVersion());
             String parameter = taskDefinitionLog.getTaskParams();
-            Map<String, Object> map = JSONUtils.toMap(parameter,String.class,Object.class);
+            Map<String, Object> map = JSONUtils.toMap(parameter, String.class, Object.class);
             String localParams = JSONUtils.toJsonString(map.get(LOCAL_PARAMS));
             if (localParams != null && !localParams.isEmpty()) {
                 localParams = ParameterUtils.convertParameterPlaceholders(localParams, timeParams);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
@@ -35,29 +35,15 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.graph.DAG;
 import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.common.model.TaskNodeRelation;
+import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionLog;
-import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
-import org.apache.dolphinscheduler.dao.entity.Project;
-import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.dao.entity.Tenant;
-import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
-import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.entity.*;
+import org.apache.dolphinscheduler.dao.mapper.*;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -101,6 +87,9 @@ public class ProcessInstanceServiceTest {
 
     @Mock
     TaskInstanceMapper taskInstanceMapper;
+
+    @Mock
+    TaskDefinitionLogMapper taskDefinitionLogMapper;
 
     @Mock
     LoggerServiceImpl loggerService;
@@ -493,6 +482,45 @@ public class ProcessInstanceServiceTest {
         Map<String, Object> successRes = processInstanceService.viewVariables(1);
         Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
     }
+
+    @Test
+    public void testViewVariablesNotSchedule() throws Exception {
+        String shellJson2 = "{\"globalParams\":[],\"tasks\":[{\"type\":\"SHELL\",\"id\":\"tasks-9527\",\"name\":\"shell-1\"," +
+                "\"params\":{\"resourceList\":[],\"localParams\":[{\"prop\":\"BATCH_TIME\",\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}," +
+                "\"description\":\"\",\"runFlag\":\"NORMAL\",\"dependence\":{},\"maxRetryTimes\":\"0\",\"retryInterval\":\"1\"," +
+                "\"timeout\":{\"strategy\":\"\",\"interval\":1,\"enable\":false},\"taskInstancePriority\":\"MEDIUM\"," +
+                "\"workerGroupId\":-1,\"preTasks\":[]}],\"tenantId\":1,\"timeout\":0}";
+
+
+        //process instance not null
+        ProcessInstance processInstance = getProcessInstance();
+        processInstance.setCommandType(CommandType.SCHEDULER);
+        processInstance.setScheduleTime(null);
+        processInstance.setProcessInstanceJson(shellJson2);
+        processInstance.setGlobalParams("");
+        processInstance.setStartTime(DateUtils.stringToDate("2021-05-15 22:50:00"));
+        when(processInstanceMapper.queryDetailById(1)).thenReturn(processInstance);
+
+        TaskInstance taskInstance = getTaskInstance();
+        TaskDefinitionLog taskDefinitionLog = new TaskDefinitionLog();
+        taskDefinitionLog.setName("shell-1");
+        taskDefinitionLog.setTaskParams("{\"resourceList\":[],\"localParams\":[{\"prop\":\"BATCH_TIME\",\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}");
+
+
+        when(taskInstanceMapper.findValidTaskListByProcessId(processInstance.getId(),Flag.YES)).thenReturn(Arrays.asList(taskInstance));
+
+//        when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(taskCode, version))
+//                .thenReturn(new TaskDefinitionLog());
+
+        when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
+                taskInstance.getTaskCode(), taskInstance.getTaskDefinitionVersion())).thenReturn(taskDefinitionLog);
+
+        Map<String, Object> successRes = processInstanceService.viewVariables(1);
+        Property property = ((ArrayList<Property>)((HashMap) ((HashMap) ((HashMap) successRes.get("data")).get("localParams")).get("shell-1")).get("localParamsList")).get(0);
+        Assert.assertEquals("BATCH_TIME", property.getProp());
+        Assert.assertEquals("20210515225000", property.getValue());
+    }
+
 
     @Test
     public void testViewGantt() throws Exception {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
@@ -509,9 +509,6 @@ public class ProcessInstanceServiceTest {
 
         when(taskInstanceMapper.findValidTaskListByProcessId(processInstance.getId(),Flag.YES)).thenReturn(Arrays.asList(taskInstance));
 
-//        when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(taskCode, version))
-//                .thenReturn(new TaskDefinitionLog());
-
         when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                 taskInstance.getTaskCode(), taskInstance.getTaskDefinitionVersion())).thenReturn(taskDefinitionLog);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
@@ -50,8 +50,8 @@ import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
+import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
 import java.io.IOException;
@@ -527,14 +527,14 @@ public class ProcessInstanceServiceTest {
                 + "\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],"
                 + "\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}");
 
-        when(taskInstanceMapper.findValidTaskListByProcessId(processInstance.getId(),Flag.YES))
+        when(taskInstanceMapper.findValidTaskListByProcessId(processInstance.getId(), Flag.YES))
                 .thenReturn(Arrays.asList(taskInstance));
 
         when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                 taskInstance.getTaskCode(), taskInstance.getTaskDefinitionVersion())).thenReturn(taskDefinitionLog);
 
         Map<String, Object> successRes = processInstanceService.viewVariables(1);
-        Property property = ((ArrayList<Property>)((HashMap) ((HashMap) ((HashMap) successRes.get("data"))
+        Property property = ((ArrayList<Property>) ((HashMap) ((HashMap) ((HashMap) successRes.get("data"))
                 .get("localParams")).get("shell-1")).get("localParamsList")).get(0);
         Assert.assertEquals("BATCH_TIME", property.getProp());
         Assert.assertEquals("20210515225000", property.getValue());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
@@ -37,13 +37,31 @@ import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.common.model.TaskNodeRelation;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
-import org.apache.dolphinscheduler.dao.entity.*;
-import org.apache.dolphinscheduler.dao.mapper.*;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionLog;
+import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.dao.entity.Tenant;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
+import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionLogMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -485,12 +503,13 @@ public class ProcessInstanceServiceTest {
 
     @Test
     public void testViewVariablesNotSchedule() throws Exception {
-        String shellJson2 = "{\"globalParams\":[],\"tasks\":[{\"type\":\"SHELL\",\"id\":\"tasks-9527\",\"name\":\"shell-1\"," +
-                "\"params\":{\"resourceList\":[],\"localParams\":[{\"prop\":\"BATCH_TIME\",\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}," +
-                "\"description\":\"\",\"runFlag\":\"NORMAL\",\"dependence\":{},\"maxRetryTimes\":\"0\",\"retryInterval\":\"1\"," +
-                "\"timeout\":{\"strategy\":\"\",\"interval\":1,\"enable\":false},\"taskInstancePriority\":\"MEDIUM\"," +
-                "\"workerGroupId\":-1,\"preTasks\":[]}],\"tenantId\":1,\"timeout\":0}";
-
+        String shellJson2 = "{\"globalParams\":[],\"tasks\":[{\"type\":\"SHELL\",\"id\":\"tasks-9527\","
+                + "\"name\":\"shell-1\",\"params\":{\"resourceList\":[],\"localParams\":[{\"prop\":\"BATCH_TIME\","
+                + "\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],"
+                + "\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"},\"description\":\"\","
+                + "\"runFlag\":\"NORMAL\",\"dependence\":{},\"maxRetryTimes\":\"0\",\"retryInterval\":\"1\","
+                + "\"timeout\":{\"strategy\":\"\",\"interval\":1,\"enable\":false},\"taskInstancePriority\":\"MEDIUM\","
+                + "\"workerGroupId\":-1,\"preTasks\":[]}],\"tenantId\":1,\"timeout\":0}";
 
         //process instance not null
         ProcessInstance processInstance = getProcessInstance();
@@ -504,20 +523,22 @@ public class ProcessInstanceServiceTest {
         TaskInstance taskInstance = getTaskInstance();
         TaskDefinitionLog taskDefinitionLog = new TaskDefinitionLog();
         taskDefinitionLog.setName("shell-1");
-        taskDefinitionLog.setTaskParams("{\"resourceList\":[],\"localParams\":[{\"prop\":\"BATCH_TIME\",\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}");
+        taskDefinitionLog.setTaskParams("{\"resourceList\":[],\"localParams\":[{\"prop\":\"BATCH_TIME\","
+                + "\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"${system.datetime}\"}],"
+                + "\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}");
 
-
-        when(taskInstanceMapper.findValidTaskListByProcessId(processInstance.getId(),Flag.YES)).thenReturn(Arrays.asList(taskInstance));
+        when(taskInstanceMapper.findValidTaskListByProcessId(processInstance.getId(),Flag.YES))
+                .thenReturn(Arrays.asList(taskInstance));
 
         when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                 taskInstance.getTaskCode(), taskInstance.getTaskDefinitionVersion())).thenReturn(taskDefinitionLog);
 
         Map<String, Object> successRes = processInstanceService.viewVariables(1);
-        Property property = ((ArrayList<Property>)((HashMap) ((HashMap) ((HashMap) successRes.get("data")).get("localParams")).get("shell-1")).get("localParamsList")).get(0);
+        Property property = ((ArrayList<Property>)((HashMap) ((HashMap) ((HashMap) successRes.get("data"))
+                .get("localParams")).get("shell-1")).get("localParamsList")).get(0);
         Assert.assertEquals("BATCH_TIME", property.getProp());
         Assert.assertEquals("20210515225000", property.getValue());
     }
-
 
     @Test
     public void testViewGantt() throws Exception {


### PR DESCRIPTION
## Purpose of the pull request

closes #5477 

## Brief change log

## Verify this pull request

This change added tests and can be verified as follows:

  - Added testViewVariablesNotSchedule() in org.apache.dolphinscheduler.api.service.ProcessInstanceServiceTest.
  - Manually verified the change by testing locally.
