### PR TITLE
yarn application state check  add a Retrial mechanism

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -424,7 +424,7 @@ public abstract class AbstractCommandExecutor {
                                 break;
                             }
                         }
-                       //Judge the state again
+                        //Judge the state again
                         if (applicationStatus.equals(ExecutionStatus.FAILURE)
                             || applicationStatus.equals(ExecutionStatus.KILL)) {
                             return false;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -434,8 +434,8 @@ public abstract class AbstractCommandExecutor {
             result = false;
         }
         return result;
-
     }
+    
     /**
      *
      * @param appId

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -415,15 +415,7 @@ public abstract class AbstractCommandExecutor {
                     if (applicationStatus.equals(ExecutionStatus.FAILURE)
                         || applicationStatus.equals(ExecutionStatus.KILL)) {
                         //Try again 10 times every 15 seconds
-                        for (int i = 0; i < 10; i++) {
-                            applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
-                            if (applicationStatus.equals(ExecutionStatus.FAILURE)
-                                 || applicationStatus.equals(ExecutionStatus.KILL)) {
-                                ThreadUtils.sleep(15000);
-                            } else {
-                                break;
-                            }
-                        }
+                        applicationStatus = retryExecutionStatus(appId);
                         //Judge the state again
                         if (applicationStatus.equals(ExecutionStatus.FAILURE)
                             || applicationStatus.equals(ExecutionStatus.KILL)) {
@@ -444,7 +436,26 @@ public abstract class AbstractCommandExecutor {
         return result;
 
     }
-
+    /**
+     *
+     * @param appId
+     * @return appId ExecutionStatus
+     * @throws Exception
+     */
+    private ExecutionStatus retryExecutionStatus(String appId) throws Exception {
+        ExecutionStatus applicationStatus = null;
+        for (int i = 0; i < 10; i++) {
+            applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
+            if (applicationStatus.equals(ExecutionStatus.FAILURE)
+                    || applicationStatus.equals(ExecutionStatus.KILL)) {
+                ThreadUtils.sleep(10000);
+            } else {
+                break;
+            }
+        }
+        return applicationStatus;
+    }
+    
     public int getProcessId() {
         return getProcessId(process);
     }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -425,8 +425,8 @@ public abstract class AbstractCommandExecutor {
                             }
                         }
                         //Judge the state again
-                        if (applicationStatus.equals(ExecutionStatus.FAILURE) ||
-                                applicationStatus.equals(ExecutionStatus.KILL)) {
+                       if (applicationStatus.equals(ExecutionStatus.FAILURE)
+                            || applicationStatus.equals(ExecutionStatus.KILL)) {
                             return false;
                         }
                     }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -417,10 +417,10 @@ public abstract class AbstractCommandExecutor {
                         //Try again 10 times every 15 seconds
                         for (int i = 0; i < 10; i++) {
                             applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
-                            if (applicationStatus.equals(ExecutionStatus.FAILURE) ||
-                                    applicationStatus.equals(ExecutionStatus.KILL)) {
+                             if (applicationStatus.equals(ExecutionStatus.FAILURE)
+                                || applicationStatus.equals(ExecutionStatus.KILL)) {
                                 ThreadUtils.sleep(15000);
-                            }else{
+                            } else {
                                 break;
                             }
                         }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -415,7 +415,7 @@ public abstract class AbstractCommandExecutor {
                     if (applicationStatus.equals(ExecutionStatus.FAILURE)
                         || applicationStatus.equals(ExecutionStatus.KILL)) {
                         //Try again 10 times every 15 seconds
-                        applicationStatus = retryExecutionStatus(appId);
+                        applicationStatus = retryExecutionStatus(appId,applicationStatus);
                         //Judge the state again
                         if (applicationStatus.equals(ExecutionStatus.FAILURE)
                             || applicationStatus.equals(ExecutionStatus.KILL)) {
@@ -442,8 +442,7 @@ public abstract class AbstractCommandExecutor {
      * @return appId ExecutionStatus
      * @throws Exception
      */
-    private ExecutionStatus retryExecutionStatus(String appId) throws Exception {
-        ExecutionStatus applicationStatus = null;
+    private ExecutionStatus retryExecutionStatus(String appId,ExecutionStatus applicationStatus) throws Exception {
         for (int i = 0; i < 10; i++) {
             applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
             if (applicationStatus.equals(ExecutionStatus.FAILURE)

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -417,15 +417,15 @@ public abstract class AbstractCommandExecutor {
                         //Try again 10 times every 15 seconds
                         for (int i = 0; i < 10; i++) {
                             applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
-                             if (applicationStatus.equals(ExecutionStatus.FAILURE)
-                                || applicationStatus.equals(ExecutionStatus.KILL)) {
+                            if (applicationStatus.equals(ExecutionStatus.FAILURE)
+                                 || applicationStatus.equals(ExecutionStatus.KILL)) {
                                 ThreadUtils.sleep(15000);
                             } else {
                                 break;
                             }
                         }
-                        //Judge the state again
-                       if (applicationStatus.equals(ExecutionStatus.FAILURE)
+                       //Judge the state again
+                        if (applicationStatus.equals(ExecutionStatus.FAILURE)
                             || applicationStatus.equals(ExecutionStatus.KILL)) {
                             return false;
                         }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -414,7 +414,21 @@ public abstract class AbstractCommandExecutor {
                     }
                     if (applicationStatus.equals(ExecutionStatus.FAILURE)
                         || applicationStatus.equals(ExecutionStatus.KILL)) {
-                        return false;
+                        //Try again 10 times every 15 seconds
+                        for (int i = 0; i < 10; i++) {
+                            applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
+                            if (applicationStatus.equals(ExecutionStatus.FAILURE) ||
+                                    applicationStatus.equals(ExecutionStatus.KILL)) {
+                                ThreadUtils.sleep(15000);
+                            }else{
+                                break;
+                            }
+                        }
+                        //Judge the state again
+                        if (applicationStatus.equals(ExecutionStatus.FAILURE) ||
+                                applicationStatus.equals(ExecutionStatus.KILL)) {
+                            return false;
+                        }
                     }
 
                     if (applicationStatus.equals(ExecutionStatus.SUCCESS)) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -412,15 +412,12 @@ public abstract class AbstractCommandExecutor {
                     if (logger.isDebugEnabled()) {
                         logger.debug("check yarn application status, appId:{}, final state:{}", appId, applicationStatus.name());
                     }
+                    //Try again 10 times every 15 seconds
+                    applicationStatus = retryExecutionStatus(appId,applicationStatus);
+                    //Judge the state again
                     if (applicationStatus.equals(ExecutionStatus.FAILURE)
                         || applicationStatus.equals(ExecutionStatus.KILL)) {
-                        //Try again 10 times every 15 seconds
-                        applicationStatus = retryExecutionStatus(appId,applicationStatus);
-                        //Judge the state again
-                        if (applicationStatus.equals(ExecutionStatus.FAILURE)
-                            || applicationStatus.equals(ExecutionStatus.KILL)) {
-                            return false;
-                        }
+                        return false;
                     }
 
                     if (applicationStatus.equals(ExecutionStatus.SUCCESS)) {


### PR DESCRIPTION
Because the yarn application is always highly available, and the application has its own retrial mechanism, it will be given some opportunities to try again during detection; In this way, we can prevent the task from recovering itself while we show that the task has failed; Of course, the detection interval and times can be specified;

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
