### PR TITLE
[Fix][Api] add mysql-connector rely to dolphinscheduler-api module

### DIFF
--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -230,6 +230,12 @@
         </dependency>
 
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Purpose of the pull request

Add mysql-connector rely to dolphinscheduler-api module.

## Brief change log
 
Add mysql-connector-java to dolphinscheduler-api pom.xml.

## Verify this pull request

Actually, I don’t know if this is an error. If I waste your time, I'm really sorry. When I used mysql to store data during secondary development,  the file of the controller package under the dolphinscheduler-api test module will reporte an error that com.mysql.jdbc.Driver could not be found. You need to re-add this dependency under the dependency of this module to test successfully, because the test relys on dolphinscheduler-dao module.