### PR TITLE
[Improvement] The newly introduced spi pugin support work in windows os.

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -36,6 +36,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.ClassReader;
@@ -49,8 +50,15 @@ import com.google.common.io.ByteStreams;
  * The role of this class is to load the plugin class during development
  */
 final class DolphinPluginDiscovery {
+    // Windows: \target\classes, Unix-like: /target/classes
+    private static final String ARTIFACT_DIR = new StringJoiner(File.separator, File.separator, "")
+            .add("target").add("classes").toString();
     private static final String JAVA_CLASS_FILE_SUFFIX = ".class";
-    private static final String PLUGIN_SERVICES_FILE = "META-INF/services/" + DolphinSchedulerPlugin.class.getName();
+
+    // Windows: "META-INF\services\" + DolphinSchedulerPlugin.class.getName()
+    // Unix-like: "META-INF/services/" + DolphinSchedulerPlugin.class.getName()
+    private static final String PLUGIN_SERVICES_FILE = String.join(File.separator, "META-INF",
+            "services", DolphinSchedulerPlugin.class.getName());
 
     private DolphinPluginDiscovery() {
     }
@@ -62,7 +70,7 @@ final class DolphinPluginDiscovery {
         }
 
         File file = artifact.getFile();
-        if (!file.getPath().endsWith("/target/classes")) {
+        if (!file.getPath().endsWith(ARTIFACT_DIR)) {
             throw new RuntimeException("Unexpected file for main artifact: " + file);
         }
         if (!file.isDirectory()) {


### PR DESCRIPTION
**The newly introduced spi (#5562) can't work in windows os, it leads to the project can't be launched in windows.**

## Purpose of the pull request
git clone the latest branch of dev in windows, and try to run the entire project in windows os, but it would throws exception like below:
```markdown
Caused by: java.lang.RuntimeException: Unexpected file for main artifact: E:\workspaces\dolphinscheduler\.\dolphinscheduler-registry-plugin\dolphinscheduler-registry-zookeeper\target\classes**
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginDiscovery.discoverPluginsFromArtifact(DolphinPluginDiscovery.java:73)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.buildPluginClassLoaderFromPom(DolphinPluginLoader.java:136)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.buildPluginClassLoader(DolphinPluginLoader.java:121)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugin(DolphinPluginLoader.java:97)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugins(DolphinPluginLoader.java:90)
	at org.apache.dolphinscheduler.service.registry.RegistryCenter.installRegistryPlugin(RegistryCenter.java:138)
	... 38 more
Disconnected from the target VM, address: '127.0.0.1:11392', transport: 'socket'
```

The code in `DolphinPluginDiscovery.java` uses hard code to test whether the dir is ok:
```java
 if (!file.getPath().endsWith("/target/classes")) {
            throw new RuntimeException("Unexpected file for main artifact: " + file);
 }
```
**but it does't consider the sperator in  windows OS is different in unix-like OS. The static vriables in `DolphinPluginDiscovery.java` also have the same problems.**

## Brief change log
Use the File.sperator to repleace the hardcode :"/"
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

anually verified the change by testing locally
