### PR TITLE
[Fix-5653][API] Caused by: org.postgresql.util.PSQLException: ERROR: operator does not exist: ` character varying

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationLogMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationLogMapper.xml
@@ -19,7 +19,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="org.apache.dolphinscheduler.dao.mapper.ProcessTaskRelationLogMapper">
     <sql id="baseSql">
-        id, `name`, process_definition_version, project_code, process_definition_code, pre_task_code, pre_task_version,
+        id, name, process_definition_version, project_code, process_definition_code, pre_task_code, pre_task_version,
         post_task_code, post_task_version, condition_type, condition_params, operator, operate_time, create_time, update_time
     </sql>
     <select id="queryByProcessCodeAndVersion" resultType="org.apache.dolphinscheduler.dao.entity.ProcessTaskRelationLog">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationMapper.xml
@@ -19,7 +19,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="org.apache.dolphinscheduler.dao.mapper.ProcessTaskRelationMapper">
     <sql id="baseSql">
-        id, `name`, process_definition_version, project_code, process_definition_code, pre_task_code, pre_task_version,
+        id, name, process_definition_version, project_code, process_definition_code, pre_task_code, pre_task_version,
         post_task_code, post_task_version, condition_type, condition_params, create_time, update_time
     </sql>
     <select id="queryByProcessCode" resultType="org.apache.dolphinscheduler.dao.entity.ProcessTaskRelation">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionLogMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionLogMapper.xml
@@ -19,7 +19,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper">
     <sql id="baseSql">
-        id, code, `name`, version, description, project_code, user_id, task_type, task_params, flag, task_priority,
+        id, code, name, version, description, project_code, user_id, task_type, task_params, flag, task_priority,
         worker_group, fail_retry_times, fail_retry_interval, timeout_flag, timeout_notify_strategy, timeout, delay_time,
         resource_ids, operator, operate_time, create_time, update_time
     </sql>

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionMapper.xml
@@ -19,7 +19,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper">
     <sql id="baseSql">
-        id, code, `name`, version, description, project_code, user_id, task_type, task_params, flag, task_priority,
+        id, code, name, version, description, project_code, user_id, task_type, task_params, flag, task_priority,
         worker_group, fail_retry_times, fail_retry_interval, timeout_flag, timeout_notify_strategy, timeout, delay_time,
         resource_ids, create_time, update_time
     </sql>
@@ -28,7 +28,7 @@
         <include refid="baseSql"/>
         from t_ds_task_definition
         WHERE project_code = #{projectCode}
-        and `name` = #{taskDefinitionName}
+        and name = #{taskDefinitionName}
     </select>
     <select id="queryAllDefinitionList" resultType="org.apache.dolphinscheduler.dao.entity.TaskDefinition">
         select


### PR DESCRIPTION
## Purpose of the pull request
this pr close #5653
Caused by: org.postgresql.util.PSQLException: ERROR: operator does not exist: ` character varying

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 

MySQL:
![image](https://user-images.githubusercontent.com/37063904/122358151-f6e98b00-cf86-11eb-8f49-c9f8ad5aeb05.png)

postgresql:
![image](https://user-images.githubusercontent.com/37063904/122358471-3fa14400-cf87-11eb-97f7-99b4934aa64f.png)

