### PR TITLE
[Improvement]  Can't get zookeeper server list in the monitor web page.

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryCenter.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryCenter.java
@@ -30,6 +30,7 @@ import org.apache.dolphinscheduler.spi.register.RegistryException;
 import org.apache.dolphinscheduler.spi.register.RegistryPluginManager;
 import org.apache.dolphinscheduler.spi.register.SubscribeListener;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -87,6 +88,8 @@ public class RegistryCenter {
 
     private static final String REGISTRY_CONFIG_FILE_PATH = "/registry.properties";
 
+    private static Map<String, String> REGISTRY_PROPERTIES;
+
     /**
      * init node persist
      */
@@ -98,6 +101,7 @@ public class RegistryCenter {
             if (null == registryConfig || registryConfig.isEmpty()) {
                 throw new RegistryException("registry config param is null");
             }
+            REGISTRY_PROPERTIES = Collections.unmodifiableMap(registryConfig);
             if (null == registryPluginManager) {
                 installRegistryPlugin(registryConfig.get(REGISTRY_PLUGIN_NAME));
                 registry = registryPluginManager.getRegistry();
@@ -139,6 +143,10 @@ public class RegistryCenter {
         } catch (Exception e) {
             throw new RuntimeException("Load registry Plugin Failed !", e);
         }
+    }
+
+    public static Map<String, String> getRegistryProperties() {
+        return REGISTRY_PROPERTIES;
     }
 
     /**


### PR DESCRIPTION

## Purpose of the pull request
Make sure the server info of zookeeper can be sent to the front.
git clone the latest branch of dev try to run the entire project in windows os, the rest api would always returns null：
Request URL: http://localhost:8888/dolphinscheduler/monitor/zookeeper/list?_t=0.6361127216024349
Response: {"code":0,"msg":"success","data":null}

## Brief change log
an enancement to the pr  #5562, try to add an Unmodified Map to store the `registry.` properties  in `RegistryCenter`  to make sure we can get registry.servers in `RegistryMonitor`.


## Verify this pull request
Manually verified the change by testing locally
