### PR TITLE
docker-compose wrong env

### DIFF
--- a/docker/build/conf/dolphinscheduler/registry.properties.tpl
+++ b/docker/build/conf/dolphinscheduler/registry.properties.tpl
@@ -17,7 +17,7 @@
 
 registry.plugin.name=${REGISTRY_PLUGIN_NAME}
 registry.plugin.dir=${REGISTRY_PLUGIN_DIR}
-registry.plugin.binding=registry
+#registry.plugin.binding=registry
 registry.servers=${REGISTRY_SERVERS}
 
 

--- a/docker/docker-swarm/config.env.sh
+++ b/docker/docker-swarm/config.env.sh
@@ -40,7 +40,7 @@ DATABASE_PARAMS=characterEncoding=utf8
 # ZooKeeper
 #============================================================================
 
-REGISTRY_PLUGIN_DIR=lib/plugin/registry/zookeeper
+REGISTRY_PLUGIN_DIR=lib/plugin/registry
 REGISTRY_PLUGIN_NAME=zookeeper
 REGISTRY_SERVERS=dolphinscheduler-zookeeper:2181
 


### PR DESCRIPTION
fix docker-compose run error

wrong log：

...
INFO] 2021-06-19 18:07:52.059 org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader:[93] -  DolphinPluginLoader.loadPlugins() configPlugins.plugin= (registry)
[INFO] 2021-06-19 18:07:52.060 org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader:[100] - -- Loading plugin registry --
[INFO] 2021-06-19 18:07:52.060 org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader:[123] -  DolphinPluginLoader.buildPluginClassLoader(registry)
[INFO] 2021-06-19 18:07:52.061 org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader:[124] -  DolphinPluginLoader.buildPluginClassLoader, file.getAbsolutePath() (**/opt/apache-dolphinscheduler-1.3.6-SNAPSHOT-bin/registry**)
18:07:52.131 [Master-Server] ERROR org.springframework.boot.SpringApplication - Application run failed
....
Caused by: java.lang.IllegalArgumentException: **plugin must be a pom file or directory registry .**
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.buildPluginClassLoader(DolphinPluginLoader.java:131)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugin(DolphinPluginLoader.java:101)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugins(DolphinPluginLoader.java:94)
	at org.apache.dolphinscheduler.service.registry.RegistryCenter.installRegistryPlugin(RegistryCenter.java:138)



