### PR TITLE
[Improvement][Worker] Do not verify the status of yarn in ShellCommandExecutor 

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractYarnTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractYarnTask.java
@@ -28,7 +28,11 @@ import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.slf4j.Logger;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,8 +108,8 @@ public abstract class AbstractYarnTask extends AbstractTask {
                 while (Stopper.isRunning()) {
                     ExecutionStatus applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
                     logger.info("appId:{}, final state:{}", appId, applicationStatus.name());
-                    if (ExecutionStatus.FAILURE.equals(applicationStatus) ||
-                            ExecutionStatus.KILL.equals(applicationStatus)) {
+                    if (ExecutionStatus.FAILURE.equals(applicationStatus)
+                            || ExecutionStatus.KILL.equals(applicationStatus)) {
                         return false;
                     }
                     if (ExecutionStatus.SUCCESS.equals(applicationStatus)) {
@@ -122,9 +126,8 @@ public abstract class AbstractYarnTask extends AbstractTask {
 
     }
 
-
     /**
-     * get app links
+     * parse yarn app id list from log
      *
      * @param logPath log path
      * @return app id list

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractYarnTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractYarnTask.java
@@ -16,18 +16,6 @@
  */
 package org.apache.dolphinscheduler.server.worker.task;
 
-import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
-import org.apache.dolphinscheduler.common.thread.Stopper;
-import org.apache.dolphinscheduler.common.utils.HadoopUtils;
-import org.apache.dolphinscheduler.common.utils.StringUtils;
-import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
-import org.apache.dolphinscheduler.server.utils.ProcessUtils;
-import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
-import org.apache.dolphinscheduler.service.process.ProcessService;
-import org.slf4j.Logger;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,6 +26,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
+import org.apache.dolphinscheduler.common.thread.Stopper;
+import org.apache.dolphinscheduler.common.utils.HadoopUtils;
+import org.apache.dolphinscheduler.common.utils.StringUtils;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
+import org.apache.dolphinscheduler.server.utils.ProcessUtils;
+import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
+import org.apache.dolphinscheduler.service.process.ProcessService;
+
+import org.slf4j.Logger;
 
 
 /**
@@ -64,7 +65,7 @@ public abstract class AbstractYarnTask extends AbstractTask {
      * Abstract Yarn Task
      *
      * @param taskExecutionContext taskExecutionContext
-     * @param logger               logger
+     * @param logger logger
      */
     public AbstractYarnTask(TaskExecutionContext taskExecutionContext, Logger logger) {
         super(taskExecutionContext, logger);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractYarnTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractYarnTask.java
@@ -16,6 +16,11 @@
  */
 package org.apache.dolphinscheduler.server.worker.task;
 
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
+import org.apache.dolphinscheduler.common.thread.Stopper;
+import org.apache.dolphinscheduler.common.utils.HadoopUtils;
+import org.apache.dolphinscheduler.common.utils.StringUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.utils.ProcessUtils;
@@ -23,10 +28,25 @@ import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.slf4j.Logger;
 
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.dolphinscheduler.common.Constants.EXIT_CODE_FAILURE;
+import static org.apache.dolphinscheduler.common.Constants.EXIT_CODE_SUCCESS;
+
 /**
  *  abstract yarn task
  */
 public abstract class AbstractYarnTask extends AbstractTask {
+  /**
+   * rules for extracting application ID
+   */
+  protected static final Pattern APPLICATION_REGEX = Pattern.compile(Constants.APPLICATION_REGEX);
+
   /**
    *  process task
    */
@@ -55,14 +75,123 @@ public abstract class AbstractYarnTask extends AbstractTask {
     try {
       // SHELL task exit code
       CommandExecuteResult commandExecuteResult = shellCommandExecutor.run(buildCommand());
+      // get appIds from log
+      List<String> appIds = getAppIds(taskExecutionContext.getLogPath());
       setExitStatusCode(commandExecuteResult.getExitStatusCode());
-      setAppIds(commandExecuteResult.getAppIds());
+      // if yarn task , yarn state is final state
+      if (commandExecuteResult.getExitStatusCode() == EXIT_CODE_SUCCESS){
+        setExitStatusCode(isSuccessOfYarnState(appIds) ? EXIT_CODE_SUCCESS : EXIT_CODE_FAILURE);
+      }
+      setAppIds(String.join(Constants.COMMA, appIds));
       setProcessId(commandExecuteResult.getProcessId());
     } catch (Exception e) {
       logger.error("yarn process failure", e);
       exitStatusCode = -1;
       throw e;
     }
+  }
+
+  /**
+   * check yarn state
+   *
+   * @param appIds application id list
+   * @return is success of yarn task state
+   */
+  public boolean isSuccessOfYarnState(List<String> appIds) {
+    boolean result = true;
+    try {
+      for (String appId : appIds) {
+        while(Stopper.isRunning()){
+          ExecutionStatus applicationStatus = HadoopUtils.getInstance().getApplicationStatus(appId);
+          logger.info("appId:{}, final state:{}",appId,applicationStatus.name());
+          if (ExecutionStatus.FAILURE.equals(applicationStatus) ||
+                  ExecutionStatus.KILL.equals(applicationStatus)) {
+            return false;
+          }
+          if (ExecutionStatus.SUCCESS.equals(applicationStatus)){
+            break;
+          }
+          Thread.sleep(Constants.SLEEP_TIME_MILLIS);
+        }
+      }
+    } catch (Exception e) {
+      logger.error(String.format("yarn applications: %s  status failed ", appIds.toString()),e);
+      result = false;
+    }
+    return result;
+
+  }
+
+
+  /**
+   * get app links
+   *
+   * @param logPath log path
+   * @return app id list
+   */
+  private List<String> getAppIds(String logPath) {
+    List<String> logs = convertFile2List(logPath);
+
+    List<String> appIds = new ArrayList<>();
+    /**
+     * analysis log?get submited yarn application id
+     */
+    for (String log : logs) {
+      String appId = findAppId(log);
+      if (StringUtils.isNotEmpty(appId) && !appIds.contains(appId)) {
+        logger.info("find app id: {}", appId);
+        appIds.add(appId);
+      }
+    }
+    return appIds;
+  }
+
+  /**
+   * convert file to list
+   * @param filename file name
+   * @return line list
+   */
+  private List<String> convertFile2List(String filename) {
+    List lineList = new ArrayList<String>(100);
+    File file=new File(filename);
+
+    if (!file.exists()){
+      return lineList;
+    }
+
+    BufferedReader br = null;
+    try {
+      br = new BufferedReader(new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8));
+      String line = null;
+      while ((line = br.readLine()) != null) {
+        lineList.add(line);
+      }
+    } catch (Exception e) {
+      logger.error(String.format("read file: %s failed : ",filename),e);
+    } finally {
+      if(br != null){
+        try {
+          br.close();
+        } catch (IOException e) {
+          logger.error(e.getMessage(),e);
+        }
+      }
+
+    }
+    return lineList;
+  }
+
+  /**
+   * find app id
+   * @param line line
+   * @return appid
+   */
+  private String findAppId(String line) {
+    Matcher matcher = APPLICATION_REGEX.matcher(line);
+    if (matcher.find()) {
+      return matcher.group();
+    }
+    return null;
   }
 
   /**

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/CommandExecuteResult.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/CommandExecuteResult.java
@@ -27,10 +27,6 @@ public class CommandExecuteResult {
      */
     private Integer exitStatusCode;
 
-    /**
-     *  appIds
-     */
-    private String appIds;
 
     /**
      * process id
@@ -51,13 +47,6 @@ public class CommandExecuteResult {
         this.exitStatusCode = exitStatusCode;
     }
 
-    public String getAppIds() {
-        return appIds;
-    }
-
-    public void setAppIds(String appIds) {
-        this.appIds = appIds;
-    }
 
     public Integer getProcessId() {
         return processId;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/datax/DataxTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/datax/DataxTask.java
@@ -166,9 +166,7 @@ public class DataxTask extends AbstractTask {
             String jsonFilePath = buildDataxJsonFile(paramsMap);
             String shellCommandFilePath = buildShellCommandFile(jsonFilePath, paramsMap);
             CommandExecuteResult commandExecuteResult = shellCommandExecutor.run(shellCommandFilePath);
-
             setExitStatusCode(commandExecuteResult.getExitStatusCode());
-            setAppIds(commandExecuteResult.getAppIds());
             setProcessId(commandExecuteResult.getProcessId());
         } catch (Exception e) {
             setExitStatusCode(Constants.EXIT_CODE_FAILURE);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/python/PythonTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/python/PythonTask.java
@@ -90,7 +90,6 @@ public class PythonTask extends AbstractTask {
             CommandExecuteResult commandExecuteResult = pythonCommandExecutor.run(buildCommand());
 
             setExitStatusCode(commandExecuteResult.getExitStatusCode());
-            setAppIds(commandExecuteResult.getAppIds());
             setProcessId(commandExecuteResult.getProcessId());
             pythonParameters.dealOutParam(pythonCommandExecutor.getVarPool());
         }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
@@ -103,7 +103,6 @@ public class ShellTask extends AbstractTask {
             // construct process
             CommandExecuteResult commandExecuteResult = shellCommandExecutor.run(buildCommand());
             setExitStatusCode(commandExecuteResult.getExitStatusCode());
-            setAppIds(commandExecuteResult.getAppIds());
             setProcessId(commandExecuteResult.getProcessId());
             shellParameters.dealOutParam(shellCommandExecutor.getVarPool());
         } catch (Exception e) {

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/ShellTaskReturnTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/ShellTaskReturnTest.java
@@ -96,7 +96,7 @@ public class ShellTaskReturnTest {
         PowerMockito.mockStatic(Files.class);
         PowerMockito.when(Files.exists(Paths.get(anyString()))).thenReturn(true);
         commandExecuteResult = new CommandExecuteResult();
-        commandExecuteResult.setAppIds("appId");
+
         commandExecuteResult.setExitStatusCode(0);
         commandExecuteResult.setProcessId(1);
     }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTaskTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTaskTest.java
@@ -29,7 +29,6 @@ import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.DriverManager;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -96,7 +95,7 @@ public class ShellTaskTest {
         PowerMockito.mockStatic(Files.class);
         PowerMockito.when(Files.exists(Paths.get(anyString()))).thenReturn(true);
         commandExecuteResult = new CommandExecuteResult();
-        commandExecuteResult.setAppIds("appId");
+
         commandExecuteResult.setExitStatusCode(0);
         commandExecuteResult.setProcessId(1);
     }
@@ -106,8 +105,6 @@ public class ShellTaskTest {
         shellTask = new ShellTask(taskExecutionContext, logger);
         shellTask.init();
         shellTask.getParameters().setVarPool(taskExecutionContext.getVarPool());
-        shellCommandExecutor.isSuccessOfYarnState(new ArrayList<>());
-        shellCommandExecutor.isSuccessOfYarnState(null);
         PowerMockito.when(shellCommandExecutor.run(anyString())).thenReturn(commandExecuteResult);
         shellTask.handle();
     }


### PR DESCRIPTION
Do not verify the status of yarn in ShellCommandExecutor  (#5564)


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix #5564 
Move the code that  verify the status of yarn in ShellCommandExecutor  to  AbstractYarnTask . 
My shell command ouput log contains text that match the pattern APPLICATION_REGEX = "application_\\d+_\\d+"  but that task is not a yarn task. These yarn related code cause my shell command task failure.

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.
