### PR TITLE
[Improvement] Fix a potential problem when editing an existing mysql data source

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -158,7 +158,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
         Result<Object> isConnection = checkConnection(dataSource.getType(), connectionParam);
         if (Status.SUCCESS.getCode() != isConnection.getCode()) {
-            return result;
+            return isConnection;
         }
 
         Date now = new Date();


### PR DESCRIPTION

## Purpose of the pull request
Fix a potential problem that editing an existing mysql data source may cause the backend to return null data.
reproduce step:
1. Create a normal MySQL data source
2. Modify the IP of the data source created in the step 1, by modify ip to a non-existent IP, and then directly click the edit button (skip the test connection), then we'll seen an error message tip with no content


![image (2)](https://user-images.githubusercontent.com/52202080/122748532-de4adf00-d2be-11eb-88c1-bbd2364dcff8.png)

Request URL: http://localhost:8888/dolphinscheduler/datasources/update
response {"code":null,"msg":null,"data":null}


## Brief change log

fix a special case in edit an existing datasource.
```java
Result<Object> isConnection = checkConnection(dataSource.getType(), connectionParam);
        if (Status.SUCCESS.getCode() != isConnection.getCode()) {
            return result;
        }
```
The result instance does not have a certain code and msg value, which results in the content returned to the front end shows as `nul`l. In this case, just return isConnection directly.

## Verify this pull request
Using Existed UTs.
Alse munutal test works well