### PR TITLE
[Improvement] Update the maven repository url in pluginManager

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginManagerConfig.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginManagerConfig.java
@@ -47,7 +47,7 @@ public class DolphinPluginManagerConfig {
      * Development, When AlertServer is running on IDE, AlertPluginLoad can load Alert Plugin from local Repository.
      */
     private String mavenLocalRepository = System.getProperty("user.home") + "/.m2/repository";
-    private List<String> mavenRemoteRepository = ImmutableList.of("http://repo1.maven.org/maven2/");
+    private List<String> mavenRemoteRepository = ImmutableList.of("https://repo1.maven.org/maven2/");
 
     File getInstalledPluginsDir() {
         return installedPluginsDir;


### PR DESCRIPTION

## Purpose of the pull request
Update the maven repository url in pluginManager.

## Brief change log
```shell
[root@localserver ~]# curl http://repo1.maven.org/maven2/
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```
The latest branch uses the wrong maven url in `DolphinPluginManagerConfig.java` would cause the alertServer plugin cannot be started.
## Verify this pull request
Munual test works well.
