### PR TITLE
[Improvement] the automatically generated spi service name in alert-plugin is wrong

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -83,6 +83,7 @@ final class DolphinPluginDiscovery {
 
         return listClasses(file.toPath()).stream()
                 .filter(name -> classInterfaces(name, classLoader).contains(DolphinSchedulerPlugin.class.getName()))
+                .map(plugin -> plugin.replace(File.separatorChar, '.'))
                 .collect(Collectors.toSet());
     }
 
@@ -141,7 +142,7 @@ final class DolphinPluginDiscovery {
     }
 
     private static String javaName(String binaryName) {
-        return binaryName.replace('/', '.').replace('\\', '.');
+        return binaryName.replace('/', '.');
     }
 }
 

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -83,7 +83,6 @@ final class DolphinPluginDiscovery {
 
         return listClasses(file.toPath()).stream()
                 .filter(name -> classInterfaces(name, classLoader).contains(DolphinSchedulerPlugin.class.getName()))
-                .map(plugin -> plugin.replace(File.separatorChar, '.'))
                 .collect(Collectors.toSet());
     }
 

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -83,7 +83,6 @@ final class DolphinPluginDiscovery {
 
         return listClasses(file.toPath()).stream()
                 .filter(name -> classInterfaces(name, classLoader).contains(DolphinSchedulerPlugin.class.getName()))
-                .map(plugin -> plugin.replace(File.separatorChar, '.'))
                 .collect(Collectors.toSet());
     }
 
@@ -106,7 +105,7 @@ final class DolphinPluginDiscovery {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
                 if (file.getFileName().toString().endsWith(JAVA_CLASS_FILE_SUFFIX)) {
                     String name = file.subpath(base.getNameCount(), file.getNameCount()).toString();
-                    list.add(javaName(name.substring(0, name.length() - JAVA_CLASS_FILE_SUFFIX.length())));
+                    list.add(convertClassName(name.substring(0, name.length() - JAVA_CLASS_FILE_SUFFIX.length())));
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -144,5 +143,8 @@ final class DolphinPluginDiscovery {
     private static String javaName(String binaryName) {
         return binaryName.replace('/', '.');
     }
-}
 
+    private static String convertClassName(String pathName) {
+        return pathName.replace(File.separatorChar, '.');
+    }
+}

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -142,7 +142,7 @@ final class DolphinPluginDiscovery {
     }
 
     private static String javaName(String binaryName) {
-        return binaryName.replace('/', '.');
+        return binaryName.replace('/', '.').replace('\\', '.');
     }
 }
 

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -145,3 +145,4 @@ final class DolphinPluginDiscovery {
         return binaryName.replace('/', '.');
     }
 }
+

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginDiscovery.java
@@ -83,6 +83,7 @@ final class DolphinPluginDiscovery {
 
         return listClasses(file.toPath()).stream()
                 .filter(name -> classInterfaces(name, classLoader).contains(DolphinSchedulerPlugin.class.getName()))
+                .map(plugin -> plugin.replace(File.separatorChar, '.'))
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
## Purpose of the pull request
In the newly implemented alert-plugin, the automatically generated spi service name is wrong：
![image](https://user-images.githubusercontent.com/52202080/122869972-a051c780-d35f-11eb-92d9-37a9e4c65648.png)

reproduce step(Use feishu-plugin as an example):
1. remove the file if exist:  `dolphinscheduler-alert-plugin\dolphinscheduler-alert-feishu\target\classes\META-INF\services\org.apache.dolphinscheduler.spi.DolphinSchedulerPlugin` (if we build the project by ` mvn -U clean package -Prelease -Dmaven.test.skip=true`, then the file would exists)
2. config the `alert.properties` in `dolphinscheduler-alert`, then run the `AlertServer`, you would see exceptions like below:
```java
Exception in thread "main" java.util.ServiceConfigurationError: org.apache.dolphinscheduler.spi.DolphinSchedulerPlugin: file:/E:/workspaces/dolphinscheduler/dolphinscheduler-alert-plugin/dolphinscheduler-alert-feishu/target/classes/META-INF/services/org.apache.dolphinscheduler.spi.DolphinSchedulerPlugin:1: Illegal provider-class name: org\apache\dolphinscheduler\plugin\alert\feishu\FeiShuAlertPlugin
	at java.util.ServiceLoader.fail(ServiceLoader.java:239)
	at java.util.ServiceLoader.fail(ServiceLoader.java:245)
	at java.util.ServiceLoader.parseLine(ServiceLoader.java:272)
	at java.util.ServiceLoader.parse(ServiceLoader.java:307)
	at java.util.ServiceLoader.access$200(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.hasNextService(ServiceLoader.java:357)
	at java.util.ServiceLoader$LazyIterator.hasNext(ServiceLoader.java:393)
	at java.util.ServiceLoader$1.hasNext(ServiceLoader.java:474)
	at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:270)
	at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:234)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugin(DolphinPluginLoader.java:106)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugin(DolphinPluginLoader.java:99)
	at org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader.loadPlugins(DolphinPluginLoader.java:90)
	at org.apache.dolphinscheduler.alert.AlertServer.initPlugin(AlertServer.java:114)
	at org.apache.dolphinscheduler.alert.AlertServer.start(AlertServer.java:158)
	at org.apache.dolphinscheduler.alert.AlertServer.main(AlertServer.java:174)
Disconnected from the target VM, address: '127.0.0.1:13662', transport: 'socket'
```

## Brief change log
Ensure the auto-generated spi service classname is right by replace `File.seperator` to '.'
## Verify this pull request
Manual test works well, the spi service file can be auto-generated to the right format as expected.
