### PR TITLE
[Improvement][UI] Update the update time after the user information is successfully modified

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
@@ -110,8 +110,9 @@
           email: param.email,
           phone: param.phone
         })
-        this.createUserDialog = false
-        this.getUserInfo()
+                this.getUserInfo().finally(() => {
+                    this.createUserDialog = false
+                })
       },
 
       close () {

--- a/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
@@ -110,9 +110,9 @@
           email: param.email,
           phone: param.phone
         })
-                this.getUserInfo().finally(() => {
-                    this.createUserDialog = false
-                })
+        this.getUserInfo().finally(() => {
+          this.createUserDialog = false
+        })
       },
 
       close () {

--- a/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
@@ -95,7 +95,7 @@
     props: {},
     methods: {
       ...mapMutations('user', ['setUserInfo']),
-            ...mapActions('user', ['getUserInfo']),
+      ...mapActions('user', ['getUserInfo']),
       /**
        * edit
        */

--- a/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
@@ -95,6 +95,7 @@
     props: {},
     methods: {
       ...mapMutations('user', ['setUserInfo']),
+            ...mapActions('user', ['getUserInfo']),
       /**
        * edit
        */
@@ -110,6 +111,7 @@
           phone: param.phone
         })
         this.createUserDialog = false
+        this.getUserInfo()
       },
 
       close () {

--- a/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/user/pages/account/_source/info.vue
@@ -80,7 +80,7 @@
   </div>
 </template>
 <script>
-  import { mapState, mapMutations } from 'vuex'
+  import { mapActions, mapState, mapMutations } from 'vuex'
   import mListBoxF from '@/module/components/listBoxF/listBoxF'
   import mCreateUser from '@/conf/home/pages/security/pages/users/_source/createUser'
 


### PR DESCRIPTION
## Purpose of the pull request
After the user's personal information page is successfully modified, the update time of the page is still old and not very friendly.

shows as flows, it should display 2021-05-23 XX:XX
![image](https://user-images.githubusercontent.com/52202080/122969049-cd819280-d3be-11eb-87fe-8d6c90a15c04.png)

## Brief change log
After the modification is successful, query once and update the lastUpdateTime

## Verify this pull request
Manually verified the change by testing locally