### PR TITLE
Improved shell task execution result log information, adding process.…

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -207,8 +207,8 @@ public abstract class AbstractCommandExecutor {
         // waiting for the run to finish
         boolean status = process.waitFor(remainTime, TimeUnit.SECONDS);
 
-        logger.info("process has exited, execute path:{}, processId:{} ,exitStatusCode:{}",
-            taskExecutionContext.getExecutePath(), processId, result.getExitStatusCode());
+        logger.info("process has exited, execute path:{}, processId:{} ,exitStatusCode:{} ,processWaitForStatus:{} ,processExitValue:{}",
+            taskExecutionContext.getExecutePath(), processId, result.getExitStatusCode(), status, process.exitValue());
 
         // if SHELL task exit
         if (status) {
@@ -224,7 +224,8 @@ public abstract class AbstractCommandExecutor {
                 result.setExitStatusCode(isSuccessOfYarnState(appIds) ? EXIT_CODE_SUCCESS : EXIT_CODE_FAILURE);
             }
         } else {
-            logger.error("process has failure , exitStatusCode : {} , ready to kill ...", result.getExitStatusCode());
+            logger.error("process has failure , exitStatusCode:{}, processExitValue:{}, ready to kill ...",
+                 result.getExitStatusCode(), process.exitValue());
             ProcessUtils.kill(taskExecutionContext);
             result.setExitStatusCode(EXIT_CODE_FAILURE);
         }


### PR DESCRIPTION
…waitFor() and process.exitValue() information to the original log

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

this closes #5469

 improved for issuse-5469。
其中对于log.error, 
status = process.waitFor(), 已经为false的时候，即status状态确定，才打印log.error的日志
logger.error("process has failure , exitStatusCode:{}, processExitValue:{}, ready to kill ..."， 所以没有增加process.waitFor的返回庄家。

## Brief change log
 Improved shell task execution result log information, 

## Verify this pull request
 This pull request is code cleanup without any test coverage.
 


