### PR TITLE
[Fix-5701]When deleting a user, the accessToken associated with the user should also be deleted

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -486,6 +486,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
      * @throws Exception exception when operate hdfs
      */
     @Override
+    @Transactional(rollbackFor = RuntimeException.class)
     public Map<String, Object> deleteUserById(User loginUser, int id) throws IOException {
         Map<String, Object> result = new HashMap<>();
         //only admin can operate

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -519,7 +519,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         accessTokenMapper.deleteAccessTokenByUserId(id);
-		
+        
         userMapper.deleteById(id);
         putMsg(result, Status.SUCCESS);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -43,6 +43,7 @@ import org.apache.dolphinscheduler.dao.entity.ResourcesUser;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.UDFUser;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
@@ -82,6 +83,9 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
 
     private static final Logger logger = LoggerFactory.getLogger(UsersServiceImpl.class);
+
+    @Autowired
+    private AccessTokenMapper accessTokenMapper;
 
     @Autowired
     private UserMapper userMapper;
@@ -514,6 +518,8 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             }
         }
 
+        accessTokenMapper.deleteAccessTokenByUserId(id);
+		
         userMapper.deleteById(id);
         putMsg(result, Status.SUCCESS);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -35,6 +35,7 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.Resource;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
@@ -78,6 +79,9 @@ public class UsersServiceTest {
 
     @Mock
     private UserMapper userMapper;
+
+    @Mock
+    private AccessTokenMapper accessTokenMapper;
 
     @Mock
     private TenantMapper tenantMapper;
@@ -221,7 +225,6 @@ public class UsersServiceTest {
         Assert.assertEquals(user.getId(), userExistId);
     }
 
-
     @Test
     public void testQueryUserList() {
         User user = new User();
@@ -265,13 +268,13 @@ public class UsersServiceTest {
         String userPassword = "userTest0001";
         try {
             //user not exist
-            Map<String, Object> result = usersService.updateUser(getLoginUser(), 0,userName,userPassword,"3443@qq.com",1,"13457864543","queue", 1);
+            Map<String, Object> result = usersService.updateUser(getLoginUser(), 0, userName, userPassword, "3443@qq.com", 1, "13457864543", "queue", 1);
             Assert.assertEquals(Status.USER_NOT_EXIST, result.get(Constants.STATUS));
             logger.info(result.toString());
 
             //success
             when(userMapper.selectById(1)).thenReturn(getUser());
-            result = usersService.updateUser(getLoginUser(), 1,userName,userPassword,"32222s@qq.com",1,"13457864543","queue", 1);
+            result = usersService.updateUser(getLoginUser(), 1, userName, userPassword, "32222s@qq.com", 1, "13457864543", "queue", 1);
             logger.info(result.toString());
             Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         } catch (Exception e) {
@@ -286,7 +289,7 @@ public class UsersServiceTest {
         try {
             when(userMapper.queryTenantCodeByUserId(1)).thenReturn(getUser());
             when(userMapper.selectById(1)).thenReturn(getUser());
-
+            when(accessTokenMapper.deleteAccessTokenByUserId(1)).thenReturn(0);
             //no operate
             Map<String, Object> result = usersService.deleteUserById(loginUser, 3);
             logger.info(result.toString());
@@ -356,7 +359,6 @@ public class UsersServiceTest {
 
     }
 
-
     @Test
     public void testGrantUDFFunction() {
         String udfIds = "100000,120000";
@@ -398,7 +400,7 @@ public class UsersServiceTest {
 
     }
 
-    private User getLoginUser(){
+    private User getLoginUser() {
         User loginUser = new User();
         loginUser.setId(1);
         loginUser.setUserType(UserType.ADMIN_USER);
@@ -430,7 +432,6 @@ public class UsersServiceTest {
         //check userName
         Assert.assertEquals("userTest0001", tempUser.getUserName());
     }
-
 
     @Test
     public void testQueryAllGeneralUsers() {
@@ -477,7 +478,6 @@ public class UsersServiceTest {
         logger.info(result.toString());
         Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
     }
-
 
     @Test
     public void testAuthorizedUser() {
@@ -534,7 +534,6 @@ public class UsersServiceTest {
             Assert.assertTrue(false);
         }
     }
-
 
     @Test
     public void testActivateUser() {
@@ -617,7 +616,6 @@ public class UsersServiceTest {
         user.setState(0);
         return user;
     }
-
 
     /**
      * get user

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.java
@@ -14,13 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.dao.mapper;
 
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
+
+import org.apache.ibatis.annotations.Param;
+
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
-import org.apache.ibatis.annotations.Param;
 
 /**
  * accesstoken mapper interface
@@ -30,6 +33,7 @@ public interface AccessTokenMapper extends BaseMapper<AccessToken> {
 
     /**
      * access token page
+     *
      * @param page page
      * @param userName userName
      * @param userId userId
@@ -39,4 +43,12 @@ public interface AccessTokenMapper extends BaseMapper<AccessToken> {
                                              @Param("userName") String userName,
                                              @Param("userId") int userId
     );
+
+    /**
+     * delete by userId
+     *
+     * @param userId userId
+     * @return delete result
+     */
+    int deleteAccessTokenByUserId(@Param("userId") int userId);
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
@@ -31,4 +31,8 @@
         </if>
         order by t.update_time desc
     </select>
+    <delete id="deleteAccessTokenByUserId">
+        delete from t_ds_access_token
+        where user_id = #{userId}
+    </delete>
 </mapper>

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
@@ -16,12 +16,22 @@
  */
 package org.apache.dolphinscheduler.dao.mapper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
-import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.dolphinscheduler.dao.entity.User;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,14 +41,8 @@ import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.annotation.Resource;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 /**
  * AccessToken mapper test
@@ -57,8 +61,6 @@ public class AccessTokenMapperTest {
 
     /**
      * test insert
-     *
-     * @throws Exception
      */
     @Test
     public void testInsert() throws Exception {
@@ -66,6 +68,27 @@ public class AccessTokenMapperTest {
 
         AccessToken accessToken = createAccessToken(userId);
         assertThat(accessToken.getId(), greaterThan(0));
+    }
+
+    /**
+     * test delete AccessToken By UserId
+     */
+    @Test
+    public void testDeleteAccessTokenByUserId() throws Exception {
+        Integer userId = 1;
+        int insertCount = 0;
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                createAccessToken(userId);
+                insertCount++;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        int deleteCount = accessTokenMapper.deleteAccessTokenByUserId(userId);
+        Assert.assertEquals(insertCount, deleteCount);
     }
 
 


### PR DESCRIPTION
## Purpose of the pull request

Fix issue: #5701 

## Brief change log
When deleting  an userl, I add a new method to delete the releated accessTokens(if exists)
## Verify this pull request
+ Manually verified the change by testing locally
+ add a new UT.


## What's more
In addition to the problems mentioned above, I have another question:  
Assume the following scenario:  
if a user has an accessToken, and it hasn't  expired. At this time, I disable the user:
**1. Does it necessary to update the expire time of the relealted accessToken ?
---已经禁用的用户对应的未失效token是否应该更新下失效时间表明该token其实已经无效？
2. Is it necessary for disabled users to appear in the drop-down list of users allowed to create accessToken?
---已经禁用的用户是否不应该出现在创建新的AccessToken时可选的用户下拉列表中?**