### PR TITLE
[Fix-5702][APIServer] When update the existing alarm plug-in instance, the api should use POST instead of GET

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
@@ -108,7 +108,7 @@ public class AlertPluginInstanceController extends BaseController {
             @ApiImplicitParam(name = "instanceName", value = "ALERT_PLUGIN_INSTANCE_NAME", required = true, dataType = "String", example = "DING TALK"),
             @ApiImplicitParam(name = "pluginInstanceParams", value = "ALERT_PLUGIN_INSTANCE_PARAMS", required = true, dataType = "String", example = "ALERT_PLUGIN_INSTANCE_PARAMS")
     })
-    @GetMapping(value = "/update")
+    @PostMapping(value = "/update")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_ALERT_PLUGIN_INSTANCE_ERROR)
     @AccessLogAnnotation(ignoreRequestArgs = "loginUser")

--- a/dolphinscheduler-ui/src/js/conf/home/store/security/actions.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/security/actions.js
@@ -446,7 +446,7 @@ export default {
    */
   updateAlertPluginInstance ({ state }, payload) {
     return new Promise((resolve, reject) => {
-      io.get('alert-plugin-instance/update', payload, res => {
+      io.post('alert-plugin-instance/update', payload, res => {
         resolve(res)
       }).catch(e => {
         reject(e)


### PR DESCRIPTION

## Purpose of the pull request
fix #5702 

## Brief change log

pdate the existing alarm plug-in instance, the front-end and back-end interaction should use POST method


## Verify this pull request
Using Existing UTS and munutal test works well

![image](https://user-images.githubusercontent.com/52202080/123517065-cd8cd580-d6d1-11eb-966f-758c300b872a.png)

