### PR TITLE
[Fix-5719][K8s] Fix Ingress tls: got map expected array On TLS enabled On Kubernetes

### DIFF
--- a/docker/kubernetes/dolphinscheduler/templates/ingress.yaml
+++ b/docker/kubernetes/dolphinscheduler/templates/ingress.yaml
@@ -49,8 +49,8 @@ spec:
           {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
-    hosts:
+    - hosts:
       - {{ .Values.ingress.host }}
-    secretName: {{ .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
*[Fix-5719][K8s] Fix Ingress tls: got map expected array On TLS enabled On Kubernetes*

This closes #5719