### PR TITLE
[Fix-5738][UI] The cancel button in the pop-up dialog of `batch copy` and `batch move`  doesn't work.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/relatedItems.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/relatedItems.vue
@@ -19,6 +19,7 @@
           ref="popup"
           :ok-text="$t('Confirm')"
           :nameText="$t('Related items')"
+          @close="_close"
           @ok="_ok">
     <template slot="content">
       <div class="create-tenement-model">
@@ -58,6 +59,9 @@
       tmp: Boolean
     },
     methods: {
+      _close() {
+        this.$emit('closeRelatedItems')
+      },
       _ok () {
         if (this._verification()) {
           if (this.tmp) {

--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/relatedItems.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/relatedItems.vue
@@ -59,7 +59,7 @@
       tmp: Boolean
     },
     methods: {
-      _close() {
+      _close () {
         this.$emit('closeRelatedItems')
       },
       _ok () {


### PR DESCRIPTION
## Purpose of the pull request
Fix the issue: #5738
this PR close #5738
## Brief change log
add a method to support the cancel event.

## Verify this pull request
 Manually verified the change by testing locally.

