### PR TITLE
fix

### DIFF
--- a/dolphinscheduler-api/src/main/resources/logback-api.xml
+++ b/dolphinscheduler-api/src/main/resources/logback-api.xml
@@ -59,6 +59,7 @@
 
 
     <root level="INFO">
+<!--        <appender-ref ref="STDOUT"/>-->
         <appender-ref ref="APILOGFILE"/>
         <appender-ref ref="SKYWALKING-LOG"/>
     </root>

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -699,8 +699,10 @@ public final class Constants {
     /**
      * application regex
      */
-    public static final String APPLICATION_REGEX = "application_\\d+_\\d+";
+//    public static final String APPLICATION_REGEX = "application_\\d+_\\d+";
+    public static final String APPLICATION_REGEX = "http://([\\w-]+\\.*)+[\\w-]+(/[\\w-.*/?%&=]*)?:(\\d*)/(\\w*)/application_\\d+_\\d+";
     public static final String PID = OSUtils.isWindows() ? "handle" : "pid";
+
     /**
      * month_begin
      */

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LoggerUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LoggerUtilsTest.java
@@ -36,8 +36,8 @@ public class LoggerUtilsTest {
 
     @Test
     public void getAppIds() {
-       List<String> appIdList =  LoggerUtils.getAppIds("Running job: application_1_1",logger);
-       Assert.assertEquals("application_1_1", appIdList.get(0));
+        List<String> appIdList = LoggerUtils.getAppIds("The url to track the job: http://AzaAaa123s456:8088/proxy/application_1624948206873_0693", logger);
+        Assert.assertEquals("http://AzaAaa123s456:8088/proxy/application_1624948206873_0693", appIdList.get(0));
 
     }
 }

--- a/dolphinscheduler-dao/src/main/resources/datasource.properties
+++ b/dolphinscheduler-dao/src/main/resources/datasource.properties
@@ -14,18 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 # postgresql
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/dolphinscheduler
-spring.datasource.username=test
-spring.datasource.password=test
-
+#spring.datasource.driver-class-name=org.postgresql.Driver
+#spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/dolphinscheduler
+#spring.datasource.username=test
+#spring.datasource.password=test
 # mysql
-#spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
-#spring.datasource.username=xxxx
-#spring.datasource.password=xxxx
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=123456
 
 # connection configuration
 #spring.datasource.initialSize=5

--- a/dolphinscheduler-server/src/main/resources/logback-master.xml
+++ b/dolphinscheduler-server/src/main/resources/logback-master.xml
@@ -78,6 +78,7 @@
     <!-- skywalking log reporter end-->
 
     <root level="INFO">
+<!--        <appender-ref ref="STDOUT"/>-->
         <appender-ref ref="TASKLOGFILE"/>
         <appender-ref ref="MASTERLOGFILE"/>
         <appender-ref ref="SKYWALKING-LOG"/>

--- a/dolphinscheduler-server/src/main/resources/logback-worker.xml
+++ b/dolphinscheduler-server/src/main/resources/logback-worker.xml
@@ -78,6 +78,7 @@
     <!-- skywalking log reporter end-->
 
     <root level="INFO">
+<!--        <appender-ref ref="STDOUT"/>-->
         <appender-ref ref="TASKLOGFILE"/>
         <appender-ref ref="WORKERLOGFILE"/>
         <appender-ref ref="SKYWALKING-LOG"/>

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/datasource.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/datasource.vue
@@ -30,6 +30,7 @@
       </x-select>
       <x-select :placeholder="$t('Please select the datasource')"
                 v-model="datasource"
+                filterable
                 style="width: 288px;"
                 :disabled="isDetails">
         <x-option

--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/taskInstance/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/taskInstance/_source/list.vue
@@ -47,18 +47,23 @@
             <span>{{$t('End Time')}}</span>
           </th>
           <th scope="col" style="min-width: 250px">
-            <span>{{$t('host')}}</span>
+            <span>{{ $t('host') }}</span>
           </th>
           <th scope="col" style="min-width: 70px">
-            <span>{{$t('Duration')}}</span>
+            <span>{{ $t('Duration') }}</span>
           </th>
           <th scope="col" style="min-width: 60px">
             <div style="width: 50px">
-              <span>{{$t('Retry Count')}}</span>
+              <span>{{ $t('Retry Count') }}</span>
+            </div>
+          </th>
+          <th scope="col" style="min-width: 100px">
+            <div style="width: 50px">
+              <span>{{ $t('AppId') }}</span>
             </div>
           </th>
           <th scope="col" style="min-width: 60px">
-            <span>{{$t('Operation')}}</span>
+            <span>{{ $t('Operation') }}</span>
           </th>
         </tr>
         <tr v-for="(item, $index) in list" :key="item.id">
@@ -90,6 +95,7 @@
           <td style="min-width: 250px"><span style="padding-right: 10px">{{item.host || '-'}}</span></td>
           <td><span>{{item.duration || '-'}}</span></td>
           <td><span>{{item.retryTimes}}</span></td>
+          <td><span @click="handleJump(item)" class="ellipsis links jump" :title="item.appLink">{{ getAppid(item) }}</span></td>
           <td>
             <x-button
                     type="info"
@@ -127,11 +133,20 @@
       pageSize: Number
     },
     methods: {
-      _rtState (code) {
+      getAppid(item) {
+        //  http://cdh02.vision.com:8088/proxy/application_1624948206873_0693/
+        const appLink = item.appLink.split('/')[4]
+        return appLink
+      },
+      handleJump(item) {
+        const url = item.appLink
+        window.open(url)
+      },
+      _rtState(code) {
         let o = tasksState[code]
         return `<em class="${o.icoUnicode} ${o.isSpin ? 'as as-spin' : ''}" style="color:${o.color}" data-toggle="tooltip" data-container="body" title="${o.desc}"></em>`
       },
-      _refreshLog (item) {
+      _refreshLog(item) {
         let self = this
         let instance = this.$modal.dialog({
           closable: false,
@@ -139,12 +154,12 @@
           escClose: true,
           className: 'v-modal-custom',
           transitionName: 'opacityp',
-          render (h) {
+          render(h) {
             return h(mLog, {
               on: {
-                ok () {
+                ok() {
                 },
-                close () {
+                close() {
                   instance.remove()
                 }
               },
@@ -169,11 +184,16 @@
         })
       }
     },
-    created () {
+    created() {
     },
-    mounted () {
+    mounted() {
       this.list = this.taskInstanceList
     },
-    components: { }
+    components: {}
   }
 </script>
+<style lang="scss" rel="stylesheet/scss">
+.jump {
+  cursor: pointer;
+}
+</style>

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
@@ -290,6 +290,7 @@ export default {
   'Submit Time': 'Submit Time',
   Duration: 'Duration',
   'Retry Count': 'Retry Count',
+  'AppId': 'Application Id',
   'Task Name': 'Task Name',
   'Task Date': 'Task Date',
   'Source Table': 'Source Table',

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -290,6 +290,7 @@ export default {
   'Submit Time': '提交时间',
   Duration: '运行时长',
   'Retry Count': '重试次数',
+  'AppId': '应用程序执行ID',
   'Task Name': '任务名称',
   'Task Date': '任务日期',
   'Source Table': '源表',

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,7 @@
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.connector.version}</version>
                 <scope>test</scope>
+<!--                <scope>compile</scope>-->
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
1. 更改 Constants 常量类的匹配application id 的正则 APPLICATION_REGEX , 使之获取到log中完整的yarn执行applicationID ,存储到数据表中
example: http://HSaaHHScnjdnc21dbj113:8088/proxy/application_1223232_2121/
前端:
1.增加 任务实例 列表中的栏位 AppId , 显示application_1223232_2121
2.增加跳转至此执行applicationID 方法 , 实现可跳转至yarn 执行 application 的URL
3.修改使用 选择数据源 时 , 支持搜索 快速定位关键字

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
