### PR TITLE
fix: Remove duplicate "registryClient.close" method calls

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManager.java
@@ -378,7 +378,6 @@ public class ServerNodeManager implements InitializingBean {
     @PreDestroy
     public void destroy() {
         executorService.shutdownNow();
-        registryClient.close();
     }
 
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

The master server or worker server is started, When the server is shut down, 
log error : 
```
org.apache.dolphinscheduler.spi.register.RegistryException: zookeeper remove error
	at org.apache.dolphinscheduler.plugin.registry.zookeeper.ZookeeperRegistry.remove(ZookeeperRegistry.java:202) ~[na:na]
	at org.apache.dolphinscheduler.service.registry.RegistryCenter.remove(RegistryCenter.java:156) ~[classes/:na]
	at org.apache.dolphinscheduler.server.master.registry.MasterRegistryClient.unRegistry(MasterRegistryClient.java:374) ~[classes/:na]
	at org.apache.dolphinscheduler.server.master.registry.MasterRegistryClient.closeRegistry(MasterRegistryClient.java:135) ~[classes/:na]
	at org.apache.dolphinscheduler.server.master.MasterServer.close(MasterServer.java:178) [classes/:na]
	at org.apache.dolphinscheduler.server.master.MasterServer.lambda$run$0(MasterServer.java:145) [classes/:na]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_112]
Caused by: java.lang.IllegalStateException: Expected state [STARTED] was [STOPPED]
	at org.apache.curator.shaded.com.google.common.base.Preconditions.checkState(Preconditions.java:823) ~[na:na]
	at org.apache.curator.framework.imps.CuratorFrameworkImpl.checkState(CuratorFrameworkImpl.java:432) ~[curator-framework-4.3.0.jar:4.3.0]
	at org.apache.curator.framework.imps.CuratorFrameworkImpl.delete(CuratorFrameworkImpl.java:452) ~[curator-framework-4.3.0.jar:4.3.0]
	at org.apache.dolphinscheduler.plugin.registry.zookeeper.ZookeeperRegistry.remove(ZookeeperRegistry.java:200) ~[na:na]
	... 6 common frames omitted
```

Reason:
The "registry center close" logic already exists in the master server.
```
            // close
            this.masterSchedulerService.close();
            this.nettyRemotingServer.close();
            this.masterRegistryClient.closeRegistry();
```

The "registry center close" logic also exists in the ServerNodeManager class.
```
    /**
     * destroy
     */
    @PreDestroy
    public void destroy() {
        executorService.shutdownNow();
        registryClient.close();
    }
```

So, Need to remove "registryClient.close();" in the ServerNodeManager class.

## Brief change log

Remove "registryClient.close();" in the ServerNodeManager class.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is already covered by existing tests, such as *(please describe tests)*.

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
