### PR TITLE
[Improvement][Api Module] refactor registry client, remove spring annotation

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/MonitorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/MonitorServiceImpl.java
@@ -17,27 +17,22 @@
 
 package org.apache.dolphinscheduler.api.service.impl;
 
-import static org.apache.dolphinscheduler.common.utils.Preconditions.checkNotNull;
-
-import org.apache.dolphinscheduler.api.enums.Status;
-import org.apache.dolphinscheduler.api.service.MonitorService;
-import org.apache.dolphinscheduler.api.utils.RegistryMonitor;
-import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.NodeType;
-import org.apache.dolphinscheduler.common.model.Server;
-import org.apache.dolphinscheduler.common.model.WorkerServerModel;
-import org.apache.dolphinscheduler.dao.MonitorDBDao;
-import org.apache.dolphinscheduler.dao.entity.MonitorRecord;
-import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.entity.ZookeeperRecord;
-import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.service.MonitorService;
+import org.apache.dolphinscheduler.api.utils.RegistryCenterUtils;
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.model.Server;
+import org.apache.dolphinscheduler.common.model.WorkerServerModel;
+import org.apache.dolphinscheduler.dao.MonitorDBDao;
+import org.apache.dolphinscheduler.dao.entity.MonitorRecord;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.ZookeeperRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -48,12 +43,6 @@ import com.google.common.collect.Sets;
  */
 @Service
 public class MonitorServiceImpl extends BaseServiceImpl implements MonitorService {
-
-    @Autowired
-    private RegistryMonitor registryMonitor;
-
-    @Autowired
-    private RegistryClient registryClient;
 
     @Autowired
     private MonitorDBDao monitorDBDao;
@@ -105,7 +94,7 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
     public Map<String,Object> queryZookeeperState(User loginUser) {
         Map<String, Object> result = new HashMap<>();
 
-        List<ZookeeperRecord> zookeeperRecordList = registryMonitor.zookeeperInfoList();
+        List<ZookeeperRecord> zookeeperRecordList = RegistryCenterUtils.zookeeperInfoList();
 
         result.put(Constants.DATA_LIST, zookeeperRecordList);
         putMsg(result, Status.SUCCESS);
@@ -160,10 +149,7 @@ public class MonitorServiceImpl extends BaseServiceImpl implements MonitorServic
 
     @Override
     public List<Server> getServerListFromRegistry(boolean isMaster) {
-
-        checkNotNull(registryMonitor);
-        NodeType nodeType = isMaster ? NodeType.MASTER : NodeType.WORKER;
-        return registryClient.getServerList(nodeType);
+        return isMaster ? RegistryCenterUtils.getMasterServers() : RegistryCenterUtils.getWorkerServers();
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -20,7 +20,7 @@ package org.apache.dolphinscheduler.api.service.impl;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.WorkerGroupService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
-import org.apache.dolphinscheduler.api.utils.RegistryMonitor;
+import org.apache.dolphinscheduler.api.utils.RegistryCenterUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.NodeType;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
@@ -31,7 +31,6 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
-import org.apache.dolphinscheduler.service.registry.RegistryClient;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -39,8 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import javax.annotation.Resource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,15 +58,8 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
     @Autowired
     WorkerGroupMapper workerGroupMapper;
 
-
-    @Autowired
-    private RegistryMonitor registryMonitor;
-
     @Autowired
     ProcessInstanceMapper processInstanceMapper;
-
-    @Resource
-    RegistryClient registryClient;
 
     /**
      * create or update a worker group
@@ -147,7 +137,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         }
         // check zookeeper
         String workerGroupPath = Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SLASH + workerGroup.getName();
-        return registryClient.isExisted(workerGroupPath);
+        return RegistryCenterUtils.isExisted(workerGroupPath);
     }
 
     /**
@@ -157,7 +147,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
      * @return boolean
      */
     private String checkWorkerGroupAddrList(WorkerGroup workerGroup) {
-        Map<String, String> serverMaps = registryMonitor.getServerMaps(NodeType.WORKER, true);
+        Map<String, String> serverMaps = RegistryCenterUtils.getServerMaps(NodeType.WORKER, true);
         if (Strings.isNullOrEmpty(workerGroup.getAddrList())) {
             return null;
         }
@@ -258,7 +248,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         String workerPath = Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS;
         List<String> workerGroupList = null;
         try {
-            workerGroupList = registryClient.getChildrenKeys(workerPath);
+            workerGroupList = RegistryCenterUtils.getChildrenKeys(workerPath);
         } catch (Exception e) {
             logger.error("getWorkerGroups exception: {}, workerPath: {}, isPaging: {}", e.getMessage(), workerPath, isPaging);
         }
@@ -276,7 +266,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             String workerGroupPath = workerPath + Constants.SLASH + workerGroup;
             List<String> childrenNodes = null;
             try {
-                childrenNodes = registryClient.getChildrenKeys(workerGroupPath);
+                childrenNodes = RegistryCenterUtils.getChildrenKeys(workerGroupPath);
             } catch (Exception e) {
                 logger.error("getChildrenNodes exception: {}, workerGroupPath: {}", e.getMessage(), workerGroupPath);
             }
@@ -287,7 +277,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             wg.setName(workerGroup);
             if (isPaging) {
                 wg.setAddrList(String.join(Constants.COMMA, childrenNodes));
-                String registeredValue = registryClient.get(workerGroupPath + Constants.SLASH + childrenNodes.get(0));
+                String registeredValue = RegistryCenterUtils.getValue(workerGroupPath + Constants.SLASH + childrenNodes.get(0));
                 wg.setCreateTime(DateUtils.stringToDate(registeredValue.split(Constants.COMMA)[6]));
                 wg.setUpdateTime(DateUtils.stringToDate(registeredValue.split(Constants.COMMA)[7]));
                 wg.setSystemDefault(true);
@@ -334,7 +324,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
     @Override
     public Map<String, Object> getWorkerAddressList() {
         Map<String, Object> result = new HashMap<>();
-        List<String> serverNodeList = registryMonitor.getServerNodeList(NodeType.WORKER, true);
+        List<String> serverNodeList = RegistryCenterUtils.getServerNodeList(NodeType.WORKER, true);
         result.put(Constants.DATA_LIST, serverNodeList);
         putMsg(result, Status.SUCCESS);
         return result;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -137,7 +137,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         }
         // check zookeeper
         String workerGroupPath = Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SLASH + workerGroup.getName();
-        return RegistryCenterUtils.isExisted(workerGroupPath);
+        return RegistryCenterUtils.isNodeExisted(workerGroupPath);
     }
 
     /**
@@ -248,7 +248,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         String workerPath = Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS;
         List<String> workerGroupList = null;
         try {
-            workerGroupList = RegistryCenterUtils.getChildrenKeys(workerPath);
+            workerGroupList = RegistryCenterUtils.getChildrenNodes(workerPath);
         } catch (Exception e) {
             logger.error("getWorkerGroups exception: {}, workerPath: {}, isPaging: {}", e.getMessage(), workerPath, isPaging);
         }
@@ -266,7 +266,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             String workerGroupPath = workerPath + Constants.SLASH + workerGroup;
             List<String> childrenNodes = null;
             try {
-                childrenNodes = RegistryCenterUtils.getChildrenKeys(workerGroupPath);
+                childrenNodes = RegistryCenterUtils.getChildrenNodes(workerGroupPath);
             } catch (Exception e) {
                 logger.error("getChildrenNodes exception: {}, workerGroupPath: {}", e.getMessage(), workerGroupPath);
             }
@@ -277,7 +277,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             wg.setName(workerGroup);
             if (isPaging) {
                 wg.setAddrList(String.join(Constants.COMMA, childrenNodes));
-                String registeredValue = RegistryCenterUtils.getValue(workerGroupPath + Constants.SLASH + childrenNodes.get(0));
+                String registeredValue = RegistryCenterUtils.getNodeData(workerGroupPath + Constants.SLASH + childrenNodes.get(0));
                 wg.setCreateTime(DateUtils.stringToDate(registeredValue.split(Constants.COMMA)[6]));
                 wg.setUpdateTime(DateUtils.stringToDate(registeredValue.split(Constants.COMMA)[7]));
                 wg.setSystemDefault(true);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtils.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtils.java
@@ -36,21 +36,14 @@ import org.springframework.stereotype.Component;
  * fixme Some of the information obtained in the api belongs to the unique information of zk.
  * I am not sure whether there is a good abstraction method. This is related to whether the specific plug-in is provided.
  */
-@Component
-public class RegistryMonitor {
+public class RegistryCenterUtils {
 
-    @Autowired
-    RegistryClient registryClient;
-
-    @PostConstruct
-    public void initRegistry() {
-        registryClient.init();
-    }
+    private static RegistryClient registryClient = RegistryClient.getInstance();
 
     /**
      * @return zookeeper info list
      */
-    public List<ZookeeperRecord> zookeeperInfoList() {
+    public static List<ZookeeperRecord> zookeeperInfoList() {
         return null;
     }
 
@@ -59,7 +52,7 @@ public class RegistryMonitor {
      *
      * @return master server information
      */
-    public List<Server> getMasterServers() {
+    public static List<Server> getMasterServers() {
         return registryClient.getServerList(NodeType.MASTER);
     }
 
@@ -68,7 +61,7 @@ public class RegistryMonitor {
      *
      * @return worker server informations
      */
-    public List<Server> getWorkerServers() {
+    public static List<Server> getWorkerServers() {
         return registryClient.getServerList(NodeType.WORKER);
     }
 
@@ -106,11 +99,23 @@ public class RegistryMonitor {
         return list;
     }
 
-    public Map<String, String> getServerMaps(NodeType nodeType, boolean hostOnly) {
+    public static Map<String, String> getServerMaps(NodeType nodeType, boolean hostOnly) {
         return registryClient.getServerMaps(nodeType, hostOnly);
     }
 
-    public List<String> getServerNodeList(NodeType nodeType, boolean hostOnly) {
+    public static List<String> getServerNodeList(NodeType nodeType, boolean hostOnly) {
         return registryClient.getServerNodeList(nodeType, hostOnly);
+    }
+
+    public static boolean isExisted(String key) {
+        return registryClient.isExisted(key);
+    }
+
+    public static List<String> getChildrenKeys(final String key) {
+        return registryClient.getChildrenKeys(key);
+    }
+
+    public static String getValue(String key) {
+        return registryClient.get(key);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtils.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtils.java
@@ -26,11 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 /**
  * monitor zookeeper info todo registry-spi
  * fixme Some of the information obtained in the api belongs to the unique information of zk.
@@ -107,15 +102,15 @@ public class RegistryCenterUtils {
         return registryClient.getServerNodeList(nodeType, hostOnly);
     }
 
-    public static boolean isExisted(String key) {
+    public static boolean isNodeExisted(String key) {
         return registryClient.isExisted(key);
     }
 
-    public static List<String> getChildrenKeys(final String key) {
+    public static List<String> getChildrenNodes(final String key) {
         return registryClient.getChildrenKeys(key);
     }
 
-    public static String getValue(String key) {
+    public static String getNodeData(String key) {
         return registryClient.get(key);
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AbstractControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AbstractControllerTest.java
@@ -17,22 +17,24 @@
 
 package org.apache.dolphinscheduler.api.controller;
 
-import static org.mockito.Mockito.doNothing;
-
 import org.apache.dolphinscheduler.api.ApiApplicationServer;
 import org.apache.dolphinscheduler.api.service.SessionService;
+import org.apache.dolphinscheduler.api.utils.RegistryCenterUtils;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.StringUtils;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -41,8 +43,11 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * abstract controller test
  */
-@RunWith(SpringRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(SpringRunner.class)
 @SpringBootTest(classes = ApiApplicationServer.class)
+@PrepareForTest({ RegistryCenterUtils.class, RegistryClient.class })
+@PowerMockIgnore({"javax.management.*"})
 public class AbstractControllerTest {
 
     public static final String SESSION_ID = "sessionId";
@@ -59,12 +64,11 @@ public class AbstractControllerTest {
 
     protected String sessionId;
 
-    @MockBean
-    RegistryClient registryClient;
-
     @Before
     public void setUp() {
-        doNothing().when(registryClient).init();
+        PowerMockito.suppress(PowerMockito.constructor(RegistryClient.class));
+        PowerMockito.mockStatic(RegistryCenterUtils.class);
+
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 
         createSession();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/MonitorControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/MonitorControllerTest.java
@@ -55,7 +55,6 @@ public class MonitorControllerTest extends AbstractControllerTest {
         logger.info(mvcResult.getResponse().getContentAsString());
     }
 
-
     @Test
     public void testListWorker() throws Exception {
 
@@ -72,7 +71,6 @@ public class MonitorControllerTest extends AbstractControllerTest {
         logger.info(mvcResult.getResponse().getContentAsString());
     }
 
-
     @Test
     public void testQueryDatabaseState() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/monitor/database")
@@ -87,7 +85,6 @@ public class MonitorControllerTest extends AbstractControllerTest {
         Assert.assertTrue(result != null && result.isSuccess());
         logger.info(mvcResult.getResponse().getContentAsString());
     }
-
 
     @Test
     public void testQueryZookeeperState() throws Exception {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
@@ -22,9 +22,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.dolphinscheduler.api.utils.RegistryCenterUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
@@ -33,6 +30,10 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -48,7 +49,7 @@ import org.springframework.util.MultiValueMap;
 /**
  * worker group controller test
  */
-public class WorkerGroupControllerTest extends AbstractControllerTest{
+public class WorkerGroupControllerTest extends AbstractControllerTest {
 
     private static Logger logger = LoggerFactory.getLogger(WorkerGroupControllerTest.class);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
@@ -22,24 +22,21 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.apache.dolphinscheduler.api.enums.Status;
-import org.apache.dolphinscheduler.api.service.WorkerGroupService;
-import org.apache.dolphinscheduler.api.service.impl.WorkerGroupServiceImpl;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.dolphinscheduler.api.utils.RegistryCenterUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.NodeType;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
-import org.apache.dolphinscheduler.service.registry.RegistryClient;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -47,9 +44,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * worker group controller test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -26,23 +26,30 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
+import org.apache.dolphinscheduler.service.registry.RegistryClient;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * worker group service test
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RegistryClient.class })
+@PowerMockIgnore({"javax.management.*"})
 public class WorkerGroupServiceTest {
 
 
@@ -119,6 +126,12 @@ public class WorkerGroupServiceTest {
         PageInfo<WorkerGroup> pageInfo = (PageInfo) result.get(Constants.DATA_LIST);
         Assert.assertEquals(pageInfo.getLists().size(), 1);
     }*/
+
+    @Before
+    public void before() {
+        PowerMockito.suppress(PowerMockito.constructor(RegistryClient.class));
+    }
+
     @Test
     public void testQueryAllGroup() {
         Map<String, Object> result = workerGroupService.queryAllGroup();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -76,13 +76,13 @@ public class WorkerGroupServiceTest {
         List<String> workerGroupStrList = new ArrayList<>();
         workerGroupStrList.add("default");
         workerGroupStrList.add("test");
-        Mockito.when(zookeeperCachedOperator.getChildrenKeys(workerPath)).thenReturn(workerGroupStrList);
+        Mockito.when(zookeeperCachedOperator.getChildrenNodes(workerPath)).thenReturn(workerGroupStrList);
 
         List<String> defaultAddressList = new ArrayList<>();
         defaultAddressList.add("192.168.220.188:1234");
         defaultAddressList.add("192.168.220.189:1234");
 
-        Mockito.when(zookeeperCachedOperator.getChildrenKeys(workerPath + "/default")).thenReturn(defaultAddressList);
+        Mockito.when(zookeeperCachedOperator.getChildrenNodes(workerPath + "/default")).thenReturn(defaultAddressList);
 
         Mockito.when(zookeeperCachedOperator.get(workerPath + "/default" + "/" + defaultAddressList.get(0))).thenReturn("0.01,0.17,0.03,25.83,8.0,1.0,2020-07-21 11:17:59,2020-07-21 14:39:20,0,13238");
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtilsTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtilsTest.java
@@ -14,19 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.api.utils;
 
 import org.apache.dolphinscheduler.common.model.Server;
+
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import java.util.List;
 
 /**
  * zookeeper monitor utils test
  */
 @Ignore
-public class RegistryCenterUtilsUtilsTest {
+public class RegistryCenterUtilsTest {
 
     @Test
     public void testGetMasterList(){

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtilsUtilsTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/RegistryCenterUtilsUtilsTest.java
@@ -26,23 +26,15 @@ import java.util.List;
  * zookeeper monitor utils test
  */
 @Ignore
-public class RegistryMonitorUtilsTest {
-
+public class RegistryCenterUtilsUtilsTest {
 
     @Test
     public void testGetMasterList(){
-
-        RegistryMonitor registryMonitor = new RegistryMonitor();
-
-
-        List<Server> masterServerList = registryMonitor.getMasterServers();
-
-        List<Server> workerServerList = registryMonitor.getWorkerServers();
+        List<Server> masterServerList = RegistryCenterUtils.getMasterServers();
+        List<Server> workerServerList = RegistryCenterUtils.getWorkerServers();
 
         Assert.assertTrue(masterServerList.size() >= 0);
         Assert.assertTrue(workerServerList.size() >= 0);
-
-
     }
 
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryClient.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryClient.java
@@ -76,7 +76,7 @@ public class MasterRegistryClient {
      */
     @Autowired
     private ProcessService processService;
-    @Autowired
+
     private RegistryClient registryClient;
 
     /**
@@ -327,8 +327,8 @@ public class MasterRegistryClient {
     @PostConstruct
     public void init() {
         this.startTime = DateUtils.dateToString(new Date());
+        this.registryClient = RegistryClient.getInstance();
         this.heartBeatExecutor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("HeartBeatExecutor"));
-        registryClient.init();
     }
 
     /**

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManager.java
@@ -100,8 +100,7 @@ public class ServerNodeManager implements InitializingBean {
     /**
      * zk client
      */
-    @Autowired
-    private RegistryClient registryClient;
+    private RegistryClient registryClient = RegistryClient.getInstance();
 
     /**
      * worker group mapper

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThread.java
@@ -66,7 +66,7 @@ public class MasterTaskExecThread extends MasterBaseTaskExecThread {
         super(taskInstance);
         this.taskInstanceCacheManager = SpringApplicationContext.getBean(TaskInstanceCacheManagerImpl.class);
         this.nettyExecutorManager = SpringApplicationContext.getBean(NettyExecutorManager.class);
-        this.registryClient = SpringApplicationContext.getBean(RegistryClient.class);
+        this.registryClient = RegistryClient.getInstance();
     }
 
     /**

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/monitor/RegistryMonitorImpl.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/monitor/RegistryMonitorImpl.java
@@ -17,13 +17,11 @@
 
 package org.apache.dolphinscheduler.server.monitor;
 
-import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.dolphinscheduler.service.registry.RegistryClient;
 import org.springframework.stereotype.Component;
 
 /**
@@ -35,9 +33,7 @@ public class RegistryMonitorImpl extends AbstractMonitor {
     /**
      * zookeeper operator
      */
-    @Autowired
-    private RegistryClient registryClient;
-
+    private RegistryClient registryClient = RegistryClient.getInstance();
 
     /**
      * get active nodes map by path

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/monitor/RegistryMonitorImpl.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/monitor/RegistryMonitorImpl.java
@@ -17,12 +17,14 @@
 
 package org.apache.dolphinscheduler.server.monitor;
 
+import org.apache.dolphinscheduler.service.registry.RegistryClient;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.dolphinscheduler.service.registry.RegistryClient;
 import org.springframework.stereotype.Component;
+
 
 /**
  * zk monitor server impl

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/registry/HeartBeatTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/registry/HeartBeatTask.java
@@ -19,15 +19,13 @@ package org.apache.dolphinscheduler.server.registry;
 
 import static org.apache.dolphinscheduler.remote.utils.Constants.COMMA;
 
-import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.IStoppable;
-import org.apache.dolphinscheduler.common.utils.DateUtils;
-import org.apache.dolphinscheduler.common.utils.OSUtils;
-import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
 import java.util.Date;
 import java.util.Set;
 
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.utils.DateUtils;
+import org.apache.dolphinscheduler.common.utils.OSUtils;
+import org.apache.dolphinscheduler.service.registry.RegistryClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,9 +43,6 @@ public class HeartBeatTask implements Runnable {
     private Set<String> heartBeatPaths;
     private String serverType;
     private RegistryClient registryClient;
-
-    // server stop or not
-    protected IStoppable stoppable = null;
 
     public HeartBeatTask(String startTime,
                          double maxCpuloadAvg,
@@ -124,12 +119,4 @@ public class HeartBeatTask implements Runnable {
         }
     }
 
-    /**
-     * for stop server
-     *
-     * @param serverStoppable server stoppable interface
-     */
-    public void setStoppable(IStoppable serverStoppable) {
-        this.stoppable = serverStoppable;
-    }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/RemoveZKNode.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/RemoveZKNode.java
@@ -18,10 +18,8 @@
 package org.apache.dolphinscheduler.server.utils;
 
 import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -34,21 +32,17 @@ public class RemoveZKNode implements CommandLineRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(RemoveZKNode.class);
 
-
     /**
      * zookeeper operator
      */
-    @Autowired
-    private RegistryClient registryClient;
+    private RegistryClient registryClient = RegistryClient.getInstance();
 
     public static void main(String[] args) {
-
         new SpringApplicationBuilder(RemoveZKNode.class).web(WebApplicationType.NONE).run(args);
     }
 
     @Override
     public void run(String... args) throws Exception {
-
         if (args.length != ARGS_LENGTH) {
             logger.error("Usage: <node>");
             return;
@@ -56,6 +50,5 @@ public class RemoveZKNode implements CommandLineRunner {
 
         registryClient.remove(args[0]);
         registryClient.close();
-
     }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
@@ -19,6 +19,9 @@ package org.apache.dolphinscheduler.server.worker.processor;
 
 import static org.apache.dolphinscheduler.common.Constants.SLEEP_TIME_MILLIS;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.dolphinscheduler.common.thread.Stopper;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
@@ -28,13 +31,8 @@ import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
 import org.apache.dolphinscheduler.remote.utils.Host;
 import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import io.netty.channel.Channel;
@@ -60,9 +58,7 @@ public class TaskCallbackService {
     /**
      * zookeeper registry center
      */
-    @Autowired
     private RegistryClient registryClient;
-
 
     /**
      * netty remoting client
@@ -70,6 +66,7 @@ public class TaskCallbackService {
     private final NettyRemotingClient nettyRemotingClient;
 
     public TaskCallbackService() {
+        this.registryClient = RegistryClient.getInstance();
         final NettyClientConfig clientConfig = new NettyClientConfig();
         this.nettyRemotingClient = new NettyRemotingClient(clientConfig);
         this.nettyRemotingClient.registerProcessor(CommandType.DB_TASK_ACK, new DBTaskAckProcessor());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/registry/WorkerRegistryClient.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/registry/WorkerRegistryClient.java
@@ -67,8 +67,7 @@ public class WorkerRegistryClient {
      */
     private ScheduledExecutorService heartBeatExecutor;
 
-    @Autowired
-    RegistryClient registryClient;
+    private RegistryClient registryClient;
 
     /**
      * worker start time
@@ -81,8 +80,8 @@ public class WorkerRegistryClient {
     public void initWorkRegistry() {
         this.workerGroups = workerConfig.getWorkerGroups();
         this.startTime = DateUtils.dateToString(new Date());
+        this.registryClient = RegistryClient.getInstance();
         this.heartBeatExecutor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("HeartBeatExecutor"));
-        registryClient.init();
     }
 
     /**
@@ -160,10 +159,6 @@ public class WorkerRegistryClient {
 
     public void setRegistryStoppable(IStoppable stoppable) {
         registryClient.setStoppable(stoppable);
-    }
-
-    public void closeRegistry() {
-        unRegistry();
     }
 
 }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryClientTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryClientTest.java
@@ -20,6 +20,10 @@ package org.apache.dolphinscheduler.server.master.registry;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.NodeType;
 import org.apache.dolphinscheduler.common.model.Server;
@@ -28,23 +32,24 @@ import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.apache.dolphinscheduler.service.registry.RegistryClient;
-
-import java.util.Arrays;
-import java.util.Date;
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * MasterRegistryClientTest
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RegistryClient.class })
+@PowerMockIgnore({"javax.management.*"})
 public class MasterRegistryClientTest {
 
     @InjectMocks
@@ -53,21 +58,25 @@ public class MasterRegistryClientTest {
     @Mock
     private MasterConfig masterConfig;
 
-    @Mock
     private RegistryClient registryClient;
 
     @Mock
     private ScheduledExecutorService heartBeatExecutor;
+
     @Mock
     private ProcessService processService;
 
     @Before
     public void before() throws Exception {
+        PowerMockito.suppress(PowerMockito.constructor(RegistryClient.class));
+        registryClient = PowerMockito.mock(RegistryClient.class);
         given(registryClient.getLock(Mockito.anyString())).willReturn(true);
         given(registryClient.getMasterFailoverLockPath()).willReturn("/path");
         given(registryClient.releaseLock(Mockito.anyString())).willReturn(true);
         given(registryClient.getHostByEventDataPath(Mockito.anyString())).willReturn("127.0.0.1:8080");
         doNothing().when(registryClient).handleDeadServer(Mockito.anyString(), Mockito.any(NodeType.class), Mockito.anyString());
+        ReflectionTestUtils.setField(masterRegistryClient, "registryClient", registryClient);
+
         ProcessInstance processInstance = new ProcessInstance();
         processInstance.setId(1);
         processInstance.setHost("127.0.0.1:8080");
@@ -96,7 +105,6 @@ public class MasterRegistryClientTest {
 
     @Test
     public void removeNodePathTest() {
-
         masterRegistryClient.removeNodePath("/path", NodeType.MASTER, false);
         masterRegistryClient.removeNodePath("/path", NodeType.MASTER, true);
         //Cannot mock static methods

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManagerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManagerTest.java
@@ -21,29 +21,36 @@ import org.apache.dolphinscheduler.dao.AlertDao;
 import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
 import org.apache.dolphinscheduler.service.registry.RegistryClient;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * server node manager test
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RegistryClient.class })
+@PowerMockIgnore({"javax.management.*"})
 public class ServerNodeManagerTest {
 
-    @InjectMocks
-    ServerNodeManager serverNodeManager;
-
-    @Mock
-    private RegistryClient registryClient;
+    private ServerNodeManager serverNodeManager;
 
     @Mock
     private WorkerGroupMapper workerGroupMapper;
 
     @Mock
     private AlertDao alertDao;
+
+    @Before
+    public void before() {
+        PowerMockito.suppress(PowerMockito.constructor(RegistryClient.class));
+        serverNodeManager = PowerMockito.mock(ServerNodeManager.class);
+    }
 
     @Test
     public void test(){

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
@@ -28,12 +28,6 @@ import static org.apache.dolphinscheduler.common.Constants.SINGLE_SLASH;
 import static org.apache.dolphinscheduler.common.Constants.UNDERLINE;
 import static org.apache.dolphinscheduler.common.Constants.WORKER_TYPE;
 
-import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.NodeType;
-import org.apache.dolphinscheduler.common.model.Server;
-import org.apache.dolphinscheduler.common.utils.ResInfo;
-import org.apache.dolphinscheduler.common.utils.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,20 +36,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.NodeType;
+import org.apache.dolphinscheduler.common.model.Server;
+import org.apache.dolphinscheduler.common.utils.ResInfo;
+import org.apache.dolphinscheduler.common.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
- * abstract registry client
+ * registry client singleton
  */
-@Service
 public class RegistryClient extends RegistryCenter {
 
     private static final Logger logger = LoggerFactory.getLogger(RegistryClient.class);
 
-    private void loadRegistry() {
-        init();
+    private static RegistryClient registryClient = new RegistryClient();
+
+    private RegistryClient() {
+        super.init();
+    }
+
+    public static RegistryClient getInstance() {
+        return registryClient;
     }
 
     /**

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
@@ -28,6 +28,12 @@ import static org.apache.dolphinscheduler.common.Constants.SINGLE_SLASH;
 import static org.apache.dolphinscheduler.common.Constants.UNDERLINE;
 import static org.apache.dolphinscheduler.common.Constants.WORKER_TYPE;
 
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.NodeType;
+import org.apache.dolphinscheduler.common.model.Server;
+import org.apache.dolphinscheduler.common.utils.ResInfo;
+import org.apache.dolphinscheduler.common.utils.StringUtils;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,11 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.NodeType;
-import org.apache.dolphinscheduler.common.model.Server;
-import org.apache.dolphinscheduler.common.utils.ResInfo;
-import org.apache.dolphinscheduler.common.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/registry/RegistryClientTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/registry/RegistryClientTest.java
@@ -19,12 +19,14 @@ package org.apache.dolphinscheduler.service.registry;
 
 import static org.apache.dolphinscheduler.common.Constants.ADD_OP;
 import static org.apache.dolphinscheduler.common.Constants.DELETE_OP;
-import static org.mockito.BDDMockito.given;
 
-import java.util.Arrays;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.dolphinscheduler.common.enums.NodeType;
 import org.apache.dolphinscheduler.spi.register.Registry;
+
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/registry/RegistryClientTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/registry/RegistryClientTest.java
@@ -19,45 +19,37 @@ package org.apache.dolphinscheduler.service.registry;
 
 import static org.apache.dolphinscheduler.common.Constants.ADD_OP;
 import static org.apache.dolphinscheduler.common.Constants.DELETE_OP;
-
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-
-import org.apache.dolphinscheduler.common.enums.NodeType;
-import org.apache.dolphinscheduler.spi.register.Registry;
 
 import java.util.Arrays;
 
-import org.junit.Before;
+import org.apache.dolphinscheduler.common.enums.NodeType;
+import org.apache.dolphinscheduler.spi.register.Registry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RegistryClient.class })
 public class RegistryClientTest {
 
-    @InjectMocks
     private RegistryClient registryClient;
 
-    @Mock
-    private Registry registry;
-
-    @Before
-    public void before() {
-        //  registry=mock(Registry.class);
-    }
-
     @Test
-    public void te() throws Exception {
-        doNothing().when(registry).persist(Mockito.anyString(), Mockito.anyString());
-        doNothing().when(registry).update(Mockito.anyString(), Mockito.anyString());
-        given(registry.releaseLock(Mockito.anyString())).willReturn(true);
-        given(registry.getChildren("/dead-servers")).willReturn(Arrays.asList("worker_127.0.0.1:8089"));
+    public void test() throws Exception {
+        Registry registry = PowerMockito.mock(Registry.class);
+        PowerMockito.doNothing().when(registry).persist(Mockito.anyString(), Mockito.anyString());
+        PowerMockito.doNothing().when(registry).update(Mockito.anyString(), Mockito.anyString());
+        PowerMockito.when(registry.releaseLock(Mockito.anyString())).thenReturn(true);
+        PowerMockito.when(registry.getChildren("/dead-servers")).thenReturn(Arrays.asList("worker_127.0.0.1:8089"));
+
+        PowerMockito.suppress(PowerMockito.constructor(RegistryClient.class));
+        registryClient = PowerMockito.mock(RegistryClient.class);
         registryClient.persist("/key", "");
         registryClient.update("/key", "");
         registryClient.releaseLock("/key");


### PR DESCRIPTION
from #5804 

## Purpose of the pull request

- Remove spring annotation in the api utils package
- The method in registry monitor class is changed to a static method
- Perfect unit test
- Remove some unuse code

After refactor, when RegistryClient init failed, the startup of API service will not be affected.

## Brief change log

- Remove spring annotation in the utils.RegistryMonitor.java
- RegistryMonitor.java rename to RegistryCenterUtils.java
- RegistryClient.java changed to Singleton class
- Modify the related classes referenced to class RegistryClient.java
- Perfect unit test

## Verify this pull request

This pull request is already covered by existing tests