### PR TITLE
[Fix-5825][BUG][WEB] the resource tree in the process definition of latest dev branch can't display correctly

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/resourceTree.js
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/resourceTree.js
@@ -14,8 +14,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export function diGuiTree (item) { // Recursive convenience tree structure
-  item.forEach(item => {
+export function diGuiTree (items) { // Recursive convenience tree structure
+  items.forEach(item => {
     item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
       ? operationTree(item) : diGuiTree(item.children)
   })

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/resourceTree.js
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/resourceTree.js
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 export function diGuiTree (item) { // Recursive convenience tree structure
   item.forEach(item => {
     item.children === '' || item.children === undefined || item.children === null || item.children.length === 0

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/resourceTree.js
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/_source/resourceTree.js
@@ -1,0 +1,28 @@
+export function diGuiTree (item) { // Recursive convenience tree structure
+  item.forEach(item => {
+    item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
+      ? operationTree(item) : diGuiTree(item.children)
+  })
+}
+
+export function operationTree (item) {
+  if (item.dirctory) {
+    item.isDisabled = true
+  }
+  delete item.children
+}
+
+export function searchTree (element, id) {
+  // 根据id查找节点
+  if (element.id === id) {
+    return element
+  } else if (element.children) {
+    let i
+    let result = null
+    for (i = 0; result === null && i < element.children.length; i++) {
+      result = searchTree(element.children[i], id)
+    }
+    return result
+  }
+  return null
+}

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/flink.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/flink.vue
@@ -204,7 +204,7 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import disabledState from '@/module/mixin/disabledState'
   import Clipboard from 'clipboard'
-  import {diGuiTree, searchTree} from './_source/resourceTree'
+  import { diGuiTree, searchTree } from './_source/resourceTree'
 
   export default {
     name: 'flink',

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/flink.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/flink.vue
@@ -204,6 +204,7 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import disabledState from '@/module/mixin/disabledState'
   import Clipboard from 'clipboard'
+  import {diGuiTree, searchTree} from './_source/resourceTree'
 
   export default {
     name: 'flink',
@@ -398,40 +399,14 @@
         })
         return true
       },
-      diGuiTree (item) { // Recursive convenience tree structure
-        item.forEach(item => {
-          item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
-            ? this.operationTree(item) : this.diGuiTree(item.children)
-        })
-      },
-      operationTree (item) {
-        if (item.dirctory) {
-          item.isDisabled = true
-        }
-        delete item.children
-      },
-      searchTree (element, id) {
-        // 根据id查找节点
-        if (element.id === id) {
-          return element
-        } else if (element.children !== null) {
-          let i
-          let result = null
-          for (i = 0; result === null && i < element.children.length; i++) {
-            result = this.searchTree(element.children[i], id)
-          }
-          return result
-        }
-        return null
-      },
       dataProcess (backResource) {
         let isResourceId = []
         let resourceIdArr = []
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.mainJarList.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -503,8 +478,8 @@
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.mainJarList.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -538,8 +513,8 @@
     created () {
       let item = this.store.state.dag.resourcesListS
       let items = this.store.state.dag.resourcesListJar
-      this.diGuiTree(item)
-      this.diGuiTree(items)
+      diGuiTree(item)
+      diGuiTree(items)
       this.mainJarList = item
       this.mainJarLists = items
       let o = this.backfillItem

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/mr.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/mr.vue
@@ -117,7 +117,7 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import disabledState from '@/module/mixin/disabledState'
   import Clipboard from 'clipboard'
-  import {diGuiTree, searchTree} from './_source/resourceTree'
+  import { diGuiTree, searchTree } from './_source/resourceTree'
 
   export default {
     name: 'mr',

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/mr.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/mr.vue
@@ -117,6 +117,7 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import disabledState from '@/module/mixin/disabledState'
   import Clipboard from 'clipboard'
+  import {diGuiTree, searchTree} from './_source/resourceTree'
 
   export default {
     name: 'mr',
@@ -210,40 +211,14 @@
       _onCacheResourcesData (a) {
         this.cacheResourceList = a
       },
-      diGuiTree (item) { // Recursive convenience tree structure
-        item.forEach(item => {
-          item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
-            ? this.operationTree(item) : this.diGuiTree(item.children)
-        })
-      },
-      operationTree (item) {
-        if (item.dirctory) {
-          item.isDisabled = true
-        }
-        delete item.children
-      },
-      searchTree (element, id) {
-        // 根据id查找节点
-        if (element.id === id) {
-          return element
-        } else if (element.children !== null) {
-          let i
-          let result = null
-          for (i = 0; result === null && i < element.children.length; i++) {
-            result = this.searchTree(element.children[i], id)
-          }
-          return result
-        }
-        return null
-      },
       dataProcess (backResource) {
         let isResourceId = []
         let resourceIdArr = []
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.mainJarList.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -359,8 +334,8 @@
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.mainJarList.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -388,8 +363,8 @@
     created () {
       let item = this.store.state.dag.resourcesListS
       let items = this.store.state.dag.resourcesListJar
-      this.diGuiTree(item)
-      this.diGuiTree(items)
+      diGuiTree(item)
+      diGuiTree(items)
       this.mainJarList = item
       this.mainJarLists = items
       let o = this.backfillItem

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/python.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/python.vue
@@ -66,6 +66,8 @@
   import disabledState from '@/module/mixin/disabledState'
   import codemirror from '@/conf/home/pages/resource/pages/file/pages/_source/codemirror'
   import Clipboard from 'clipboard'
+  import {diGuiTree, searchTree} from './_source/resourceTree'
+
   let editor
 
   export default {
@@ -198,40 +200,14 @@
 
         return editor
       },
-      diGuiTree (item) { // Recursive convenience tree structure
-        item.forEach(item => {
-          item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
-            ? this.operationTree(item) : this.diGuiTree(item.children)
-        })
-      },
-      operationTree (item) {
-        if (item.dirctory) {
-          item.isDisabled = true
-        }
-        delete item.children
-      },
-      searchTree (element, id) {
-        // 根据id查找节点
-        if (element.id === id) {
-          return element
-        } else if (element.children !== null) {
-          let i
-          let result = null
-          for (i = 0; result === null && i < element.children.length; i++) {
-            result = this.searchTree(element.children[i], id)
-          }
-          return result
-        }
-        return null
-      },
       dataProcess (backResource) {
         let isResourceId = []
         let resourceIdArr = []
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.resourceOptions.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -297,8 +273,8 @@
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.resourceOptions.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -317,7 +293,7 @@
     },
     created () {
       let item = this.store.state.dag.resourcesListS
-      this.diGuiTree(item)
+      diGuiTree(item)
       this.resourceOptions = item
       let o = this.backfillItem
 

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/python.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/python.vue
@@ -66,7 +66,7 @@
   import disabledState from '@/module/mixin/disabledState'
   import codemirror from '@/conf/home/pages/resource/pages/file/pages/_source/codemirror'
   import Clipboard from 'clipboard'
-  import {diGuiTree, searchTree} from './_source/resourceTree'
+  import { diGuiTree, searchTree } from './_source/resourceTree'
 
   let editor
 

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/shell.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/shell.vue
@@ -69,7 +69,7 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import codemirror from '@/conf/home/pages/resource/pages/file/pages/_source/codemirror'
   import Clipboard from 'clipboard'
-  import {diGuiTree, searchTree} from './_source/resourceTree'
+  import { diGuiTree, searchTree } from './_source/resourceTree'
 
   let editor
 

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/shell.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/shell.vue
@@ -69,6 +69,8 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import codemirror from '@/conf/home/pages/resource/pages/file/pages/_source/codemirror'
   import Clipboard from 'clipboard'
+  import {diGuiTree, searchTree} from './_source/resourceTree'
+
   let editor
 
   export default {
@@ -208,40 +210,14 @@
 
         return editor
       },
-      diGuiTree (item) { // Recursive convenience tree structure
-        item.forEach(item => {
-          item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
-            ? this.operationTree(item) : this.diGuiTree(item.children)
-        })
-      },
-      operationTree (item) {
-        if (item.dirctory) {
-          item.isDisabled = true
-        }
-        delete item.children
-      },
-      searchTree (element, id) {
-        // 根据id查找节点
-        if (element.id === id) {
-          return element
-        } else if (element.children !== null) {
-          let i
-          let result = null
-          for (i = 0; result === null && i < element.children.length; i++) {
-            result = this.searchTree(element.children[i], id)
-          }
-          return result
-        }
-        return null
-      },
       dataProcess (backResource) {
         let isResourceId = []
         let resourceIdArr = []
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.options.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -307,8 +283,8 @@
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.options.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -327,7 +303,7 @@
     },
     created () {
       let item = this.store.state.dag.resourcesListS
-      this.diGuiTree(item)
+      diGuiTree(item)
       this.options = item
       let o = this.backfillItem
 

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/spark.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/spark.vue
@@ -205,6 +205,9 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import disabledState from '@/module/mixin/disabledState'
   import Clipboard from 'clipboard'
+  import {diGuiTree, searchTree} from './_source/resourceTree'
+
+
   export default {
     name: 'spark',
     data () {
@@ -313,40 +316,14 @@
       _onCacheResourcesData (a) {
         this.cacheResourceList = a
       },
-      diGuiTree (item) { // Recursive convenience tree structure
-        item.forEach(item => {
-          item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
-            ? this.operationTree(item) : this.diGuiTree(item.children)
-        })
-      },
-      operationTree (item) {
-        if (item.dirctory) {
-          item.isDisabled = true
-        }
-        delete item.children
-      },
-      searchTree (element, id) {
-        // 根据id查找节点
-        if (element.id === id) {
-          return element
-        } else if (element.children !== null) {
-          let i
-          let result = null
-          for (i = 0; result === null && i < element.children.length; i++) {
-            result = this.searchTree(element.children[i], id)
-          }
-          return result
-        }
-        return null
-      },
       dataProcess (backResource) {
         let isResourceId = []
         let resourceIdArr = []
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.mainJarList.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -521,8 +498,8 @@
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.mainJarList.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -557,8 +534,8 @@
     created () {
       let item = this.store.state.dag.resourcesListS
       let items = this.store.state.dag.resourcesListJar
-      this.diGuiTree(item)
-      this.diGuiTree(items)
+      diGuiTree(item)
+      diGuiTree(items)
       this.mainJarList = item
       this.mainJarLists = items
       let o = this.backfillItem

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/spark.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/spark.vue
@@ -205,8 +205,7 @@
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
   import disabledState from '@/module/mixin/disabledState'
   import Clipboard from 'clipboard'
-  import {diGuiTree, searchTree} from './_source/resourceTree'
-
+  import { diGuiTree, searchTree } from './_source/resourceTree'
 
   export default {
     name: 'spark',

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/waterdrop.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/waterdrop.vue
@@ -99,7 +99,7 @@
   import disabledState from '@/module/mixin/disabledState'
   import Treeselect from '@riophae/vue-treeselect'
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
-  import {diGuiTree, searchTree} from './_source/resourceTree'
+  import { diGuiTree, searchTree } from './_source/resourceTree'
 
   export default {
     name: 'waterdrop',

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/waterdrop.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/waterdrop.vue
@@ -99,6 +99,7 @@
   import disabledState from '@/module/mixin/disabledState'
   import Treeselect from '@riophae/vue-treeselect'
   import '@riophae/vue-treeselect/dist/vue-treeselect.css'
+  import {diGuiTree, searchTree} from './_source/resourceTree'
 
   export default {
     name: 'waterdrop',
@@ -228,40 +229,14 @@
 
         return true
       },
-      diGuiTree (item) { // Recursive convenience tree structure
-        item.forEach(item => {
-          item.children === '' || item.children === undefined || item.children === null || item.children.length === 0
-            ? this.operationTree(item) : this.diGuiTree(item.children)
-        })
-      },
-      operationTree (item) {
-        if (item.dirctory) {
-          item.isDisabled = true
-        }
-        delete item.children
-      },
-      searchTree (element, id) {
-        // 根据id查找节点
-        if (element.id === id) {
-          return element
-        } else if (element.children !== null) {
-          let i
-          let result = null
-          for (i = 0; result === null && i < element.children.length; i++) {
-            result = this.searchTree(element.children[i], id)
-          }
-          return result
-        }
-        return null
-      },
       dataProcess (backResource) {
         let isResourceId = []
         let resourceIdArr = []
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.options.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -340,8 +315,8 @@
         if (this.resourceList.length > 0) {
           this.resourceList.forEach(v => {
             this.options.forEach(v1 => {
-              if (this.searchTree(v1, v)) {
-                isResourceId.push(this.searchTree(v1, v))
+              if (searchTree(v1, v)) {
+                isResourceId.push(searchTree(v1, v))
               }
             })
           })
@@ -364,7 +339,7 @@
     },
     created () {
       let item = this.store.state.dag.resourcesListS
-      this.diGuiTree(item)
+      diGuiTree(item)
       this.options = item
       let o = this.backfillItem
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
Fix #5825
Close #5825

## Brief change log
+ enhance the if condition   
in the latest dev branch, [mr.vue#L229](https://github.com/apache/dolphinscheduler/blob/1f0c67bfb772f46a0e7d6289b13a499aae403fe3/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/mr.vue#L229) `else if (element.children != null) `  changes to `else if (element.children !== null) `  
According to the doc in MDN：https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Equality_comparisons_and_sameness
```javascript
// this would be true
console.log(undefined !== null)
```
`undefind` can run into the `else if` statement, it would cause the code to throw an excpetion. so I change `else if (element.children !== null)` to `else if (element.children)`

+ Since the code for loading resource lists in flink task, mapreduce task, etc are exactly the same,  I try to refactor the js by extracting the common code to a seperate js so the common part can be updated only one time.


## Verify this pull request

Manually verified the change by testing locally.
