### PR TITLE
[Fix-5830][Improvement][UI] Improve the selection style in dag edit dialog

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.vue
@@ -893,4 +893,22 @@
   .operBtn {
     padding: 8px 6px;
   }
+
+  .el-drawer__body {
+    ::selection {
+      background: #409EFF;
+      color: white;
+    }
+
+    ::-moz-selection {
+      background: #409EFF;
+      color: white;
+    }
+
+    ::-webkit-selection {
+      background: #409EFF;
+      color: white;
+    }
+  }
+
 </style>

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.vue
@@ -899,16 +899,6 @@
       background: #409EFF;
       color: white;
     }
-
-    ::-moz-selection {
-      background: #409EFF;
-      color: white;
-    }
-
-    ::-webkit-selection {
-      background: #409EFF;
-      color: white;
-    }
   }
 
 </style>

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/udp.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/udp.vue
@@ -251,6 +251,19 @@
       max-height: 600px;
       overflow-y: scroll;
       padding:0 20px;
+
+      ::selection {
+        background: #409EFF ;
+        color: white;
+      }
+      ::-moz-selection {
+        background: #409EFF;
+        color: white;
+      }
+      ::-webkit-selection {
+        background: #409EFF;
+        color: white;
+      }
     }
     .title {
       line-height: 36px;

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/udp.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/udp.vue
@@ -256,14 +256,6 @@
         background: #409EFF ;
         color: white;
       }
-      ::-moz-selection {
-        background: #409EFF;
-        color: white;
-      }
-      ::-webkit-selection {
-        background: #409EFF;
-        color: white;
-      }
     }
     .title {
       line-height: 36px;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
Fix:#5830
Close #5830 #5352

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
dag.scss set a global selection:
```css
.dag-model {
  background: url("../img/dag_bg.png");
  height: calc(100vh - 100px);

  ::selection {
    background: transparent;
  }

  ::-moz-selection {
    background: transparent;
  }

  ::-webkit-selection {
    background: transparent;
  }
# ...
```

I try to set a new background binds el-drawer. 
udp.vue also updates like this above.
## Verify this pull request

Manually verified the change by testing locally.

![8b6d0a8d215c34fa53b563ea023dfdf26e0dad3a](https://user-images.githubusercontent.com/52202080/125909254-a3084e51-e667-487d-ba7c-182557308fe7.gif)

![image](https://user-images.githubusercontent.com/52202080/126668334-25081989-a419-4219-a730-f88043b844e0.png)

