### PR TITLE
[Fix-4476] Upgrade jsp-2.1 version deal with api-server start failed

### DIFF
--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -207,14 +207,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jsp-2.1</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>servlet-api-2.5</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-jsp-2.1</artifactId>
     </dependency>
 
     <!-- just for test -->

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <oshi.core.version>3.9.1</oshi.core.version>
         <clickhouse.jdbc.version>0.1.52</clickhouse.jdbc.version>
         <mssql.jdbc.version>6.1.0.jre8</mssql.jdbc.version>
-        <jsp-2.1.version>6.1.14</jsp-2.1.version>
+        <jsp-2.1.version>7.5.4.v20111024</jsp-2.1.version>
         <spotbugs.version>3.1.12</spotbugs.version>
         <checkstyle.version>3.0.0</checkstyle.version>
         <apache.rat.version>0.13</apache.rat.version>
@@ -512,8 +512,8 @@
 
             <!-- for api module -->
             <dependency>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jsp-2.1</artifactId>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jsp-2.1</artifactId>
                 <version>${jsp-2.1.version}</version>
             </dependency>
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

* fixed #4476, #4194, #3036
* upgrade jsp-2.1 version deal with api-server start failed with hadoop3

## Brief change log

* modify root pom and api-server pom, upgrade jsp-2.1 version from 6.1.4 to 7.5.4.v20111024
## Verify this pull request

* tested on CDH5.16.2 and hadoop 3.2.2 