### PR TITLE
[fix-5737] [Bug][Datasource] datsource other param check error

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/datasource/AbstractDatasourceProcessor.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/datasource/AbstractDatasourceProcessor.java
@@ -30,7 +30,7 @@ public abstract class AbstractDatasourceProcessor implements DatasourceProcessor
 
     private static final Pattern DATABASE_PATTER = Pattern.compile("^[a-zA-Z0-9\\_\\-\\.]+$");
 
-    private static final Pattern PARAMS_PATTER = Pattern.compile("^[a-zA-Z0-9]+$");
+    private static final Pattern PARAMS_PATTER = Pattern.compile("^[a-zA-Z0-9\\-\\_\\/]+$");
 
     @Override
     public void checkDatasourceParam(BaseDataSourceParamDTO baseDataSourceParamDTO) {

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/datasource/DatasourceUtilTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/datasource/DatasourceUtilTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.common.datasource;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.dolphinscheduler.common.datasource.mysql.MysqlConnectionParam;
 import org.apache.dolphinscheduler.common.datasource.mysql.MysqlDatasourceParamDTO;
 import org.apache.dolphinscheduler.common.datasource.mysql.MysqlDatasourceProcessor;
@@ -44,7 +46,11 @@ public class DatasourceUtilTest {
         MysqlDatasourceParamDTO mysqlDatasourceParamDTO = new MysqlDatasourceParamDTO();
         mysqlDatasourceParamDTO.setHost("localhost");
         mysqlDatasourceParamDTO.setDatabase("default");
-        mysqlDatasourceParamDTO.setOther(null);
+        Map<String, String> other = new HashMap<>();
+        other.put("serverTimezone", "Asia/Shanghai");
+        other.put("queryTimeout", "-1");
+        other.put("characterEncoding", "utf8");
+        mysqlDatasourceParamDTO.setOther(other);
         DatasourceUtil.checkDatasourceParam(mysqlDatasourceParamDTO);
         Assert.assertTrue(true);
     }


### PR DESCRIPTION
## Purpose of the pull request
when add a mysql datasource, I wan't to set connec param with serverTimezone=Asia/Shanghai

so add other param with json format {"serverTimezone":"Asia/Shanghai"}

but the check rule make the param not working.

the Pattern PARAMS_PATTER = Pattern.compile("^[a-zA-Z0-9]+$"); make '/' illegal.

## solution
change regex to allow negtive number and char like '/'

related issue: fix #5737 