### PR TITLE
[Fix-5850][Bug][API-SERVER] An exception will be thrown directly when exporting workflow definition that includes Mysql Task

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/exportprocess/DataSourceParam.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/exportprocess/DataSourceParam.java
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.api.utils.exportprocess;
 
 import org.apache.dolphinscheduler.common.enums.TaskType;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 
@@ -26,9 +28,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -49,20 +49,13 @@ public class DataSourceParam implements ProcessAddTaskParam, InitializingBean {
      */
     @Override
     public JsonNode addExportSpecialParam(JsonNode taskNode) {
-        // add sqlParameters
-        try {
-            ObjectNode node = (ObjectNode) new ObjectMapper().readTree(taskNode.path(PARAMS).toString());
-            ObjectNode sqlParameters = (ObjectNode) new ObjectMapper().readTree(node.toString());
-            DataSource dataSource = dataSourceMapper.selectById(sqlParameters.get("datasource").asInt());
-            if (null != dataSource) {
-                sqlParameters.put("datasourceName", dataSource.getName());
-            }
-            ((ObjectNode) taskNode).set(PARAMS, sqlParameters);
-            return taskNode;
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return null;
+        ObjectNode sqlParameters = JSONUtils.parseObject(taskNode.path(PARAMS).toString());
+        DataSource dataSource = dataSourceMapper.selectById(sqlParameters.get("datasource").asInt());
+        if (null != dataSource) {
+            sqlParameters.put("datasourceName", dataSource.getName());
         }
+        ((ObjectNode) taskNode).set(PARAMS, sqlParameters);
+        return taskNode;
     }
 
     /**


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Fix #5850
Close #5850

## Brief change log
Use `JSONUtils.parseObject(taskNode.path(PARAMS).toString())`
instead of `ObjectNode sqlParameters = (ObjectNode) taskNode.path(PARAMS);`
to ensure that the sqlParameters is a instance of ObjectNode.

## Verify this pull request
Manually verified the change by testing locally and the existing UTS.
