### PR TITLE
[Improvement-5852][server] Support two parameters related to task for the rest of type of tasks.

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ParamUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ParamUtils.java
@@ -118,6 +118,8 @@ public class ParamUtils {
         // combining local and global parameters
         Map<String,Property> localParams = parameters.getLocalParametersMap();
 
+        Map<String,Property> varParams = parameters.getVarPoolMap();
+
         if (globalParams == null && localParams == null) {
             return null;
         }
@@ -141,6 +143,10 @@ public class ParamUtils {
             globalParams.putAll(localParams);
         } else if (globalParams == null && localParams != null) {
             globalParams = localParams;
+        }
+        if (varParams != null) {
+            varParams.putAll(globalParams);
+            globalParams = varParams;
         }
         Iterator<Map.Entry<String, Property>> iter = globalParams.entrySet().iterator();
         while (iter.hasNext()) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ParamUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ParamUtils.java
@@ -43,69 +43,15 @@ public class ParamUtils {
 
     /**
      * parameter conversion
-     * @param globalParams      global params
-     * @param globalParamsMap   global params map
-     * @param localParams       local params
-     * @param commandType       command type
-     * @param scheduleTime      schedule time
-     * @return global params
-     */
-    public static Map<String,Property> convert(Map<String,Property> globalParams,
-                                                           Map<String,String> globalParamsMap,
-                                                           Map<String,Property> localParams,
-                                                           Map<String,Property> varParams,
-                                                           CommandType commandType,
-                                                           Date scheduleTime) {
-        if (globalParams == null && localParams == null) {
-            return null;
-        }
-        // if it is a complement,
-        // you need to pass in the task instance id to locate the time
-        // of the process instance complement
-        Map<String,String> timeParams = BusinessTimeUtils
-                .getBusinessTime(commandType,
-                        scheduleTime);
-
-        if (globalParamsMap != null) {
-            timeParams.putAll(globalParamsMap);
-        }
-
-        if (globalParams != null && localParams != null) {
-            localParams.putAll(globalParams);
-            globalParams = localParams;
-        } else if (globalParams == null && localParams != null) {
-            globalParams = localParams;
-        }
-        if (varParams != null) {
-            varParams.putAll(globalParams);
-            globalParams = varParams;
-        }
-        Iterator<Map.Entry<String, Property>> iter = globalParams.entrySet().iterator();
-        while (iter.hasNext()) {
-            Map.Entry<String, Property> en = iter.next();
-            Property property = en.getValue();
-
-            if (StringUtils.isNotEmpty(property.getValue())
-                    && property.getValue().startsWith("$")) {
-                /**
-                 *  local parameter refers to global parameter with the same name
-                 *  note: the global parameters of the process instance here are solidified parameters,
-                 *  and there are no variables in them.
-                 */
-                String val = property.getValue();
-                val  = ParameterUtils.convertParameterPlaceholders(val, timeParams);
-                property.setValue(val);
-            }
-        }
-
-        return globalParams;
-    }
-
-    /**
-     * parameter conversion
+     * Warning:
+     *  When you first invoke the function of convert, the variables of localParams and varPool in the ShellParameters will be modified.
+     *  But in the whole system the variables of localParams and varPool have been used in other functions. I'm not sure if this current
+     *  situation is wrong. So I cannot modify the original logic.
+     *
      * @param taskExecutionContext the context of this task instance
      * @param parameters the parameters
      * @return global params
+     *
      */
     public static Map<String,Property> convert(TaskExecutionContext taskExecutionContext, AbstractParameters parameters) {
         Preconditions.checkNotNull(taskExecutionContext);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ParamUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ParamUtils.java
@@ -115,6 +115,7 @@ public class ParamUtils {
         CommandType commandType = CommandType.of(taskExecutionContext.getCmdTypeIfComplement());
         Date scheduleTime = taskExecutionContext.getScheduleTime();
 
+        // combining local and global parameters
         Map<String,Property> localParams = parameters.getLocalParametersMap();
 
         if (globalParams == null && localParams == null) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/datax/DataxTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/datax/DataxTask.java
@@ -20,7 +20,6 @@ package org.apache.dolphinscheduler.server.worker.task.datax;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.datasource.BaseConnectionParam;
 import org.apache.dolphinscheduler.common.datasource.DatasourceUtil;
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.process.Property;
@@ -154,13 +153,8 @@ public class DataxTask extends AbstractTask {
             String threadLoggerInfoName = String.format("TaskLogInfo-%s", taskExecutionContext.getTaskAppId());
             Thread.currentThread().setName(threadLoggerInfoName);
 
-            // combining local and global parameters
-            Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                    taskExecutionContext.getDefinedParams(),
-                    dataXParameters.getLocalParametersMap(),
-                    dataXParameters.getVarPoolMap(),
-                    CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                    taskExecutionContext.getScheduleTime());
+            // replace placeholder,and combine local and global parameters
+            Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
             // run datax procesDataSourceService.s
             String jsonFilePath = buildDataxJsonFile(paramsMap);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/flink/FlinkTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/flink/FlinkTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.worker.task.flink;
 
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.process.ResourceInfo;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
@@ -80,13 +79,8 @@ public class FlinkTask extends AbstractYarnTask {
         if (StringUtils.isNotEmpty(flinkParameters.getMainArgs())) {
             String args = flinkParameters.getMainArgs();
 
-            // replace placeholder
-            Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                    taskExecutionContext.getDefinedParams(),
-                    flinkParameters.getLocalParametersMap(),
-                    flinkParameters.getVarPoolMap(),
-                    CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                    taskExecutionContext.getScheduleTime());
+            // combining local and global parameters
+            Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
             logger.info("param Map : {}", paramsMap);
             if (paramsMap != null) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/http/HttpTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/http/HttpTask.java
@@ -18,7 +18,6 @@
 package org.apache.dolphinscheduler.server.worker.task.http;
 
 import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.HttpMethod;
 import org.apache.dolphinscheduler.common.enums.HttpParametersType;
 import org.apache.dolphinscheduler.common.process.HttpProperty;
@@ -137,13 +136,9 @@ public class HttpTask extends AbstractTask {
     protected CloseableHttpResponse sendRequest(CloseableHttpClient client) throws IOException {
         RequestBuilder builder = createRequestBuilder();
 
-        // replace placeholder
-        Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                taskExecutionContext.getDefinedParams(),
-                httpParameters.getLocalParametersMap(),
-                httpParameters.getVarPoolMap(),
-                CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                taskExecutionContext.getScheduleTime());
+        // replace placeholder,and combine local and global parameters
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
+
         List<HttpProperty> httpPropertyList = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(httpParameters.getHttpParams())) {
             for (HttpProperty httpProperty : httpParameters.getHttpParams()) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/mr/MapReduceTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/mr/MapReduceTask.java
@@ -18,7 +18,6 @@
 package org.apache.dolphinscheduler.server.worker.task.mr;
 
 import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.ProgramType;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.process.ResourceInfo;
@@ -84,13 +83,8 @@ public class MapReduceTask extends AbstractYarnTask {
         mapreduceParameters.setQueue(taskExecutionContext.getQueue());
         setMainJarName();
 
-        // replace placeholder
-        Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                taskExecutionContext.getDefinedParams(),
-                mapreduceParameters.getLocalParametersMap(),
-                mapreduceParameters.getVarPoolMap(),
-                CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                taskExecutionContext.getScheduleTime());
+        // replace placeholder,and combine local and global parameters
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
         if (paramsMap != null) {
             String args = ParameterUtils.convertParameterPlaceholders(mapreduceParameters.getMainArgs(),  ParamUtils.convert(paramsMap));

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/procedure/ProcedureTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/procedure/ProcedureTask.java
@@ -30,7 +30,6 @@ import static org.apache.dolphinscheduler.common.enums.DataType.VARCHAR;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.common.datasource.DatasourceUtil;
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.DataType;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.enums.Direct;
@@ -119,12 +118,7 @@ public class ProcedureTask extends AbstractTask {
             connection = DatasourceUtil.getConnection(dbType, connectionParam);
 
             // combining local and global parameters
-            Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                    taskExecutionContext.getDefinedParams(),
-                    procedureParameters.getLocalParametersMap(),
-                    procedureParameters.getVarPoolMap(),
-                    CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                    taskExecutionContext.getScheduleTime());
+            Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
             // call method
             stmt = connection.prepareCall(procedureParameters.getMethod());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/python/PythonTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/python/PythonTask.java
@@ -14,24 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.server.worker.task.python;
 
-
 import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
 import org.apache.dolphinscheduler.common.task.python.PythonParameters;
-import org.apache.dolphinscheduler.common.utils.*;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.common.utils.VarPoolUtils;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.utils.ParamUtils;
 import org.apache.dolphinscheduler.server.worker.task.AbstractTask;
 import org.apache.dolphinscheduler.server.worker.task.CommandExecuteResult;
 import org.apache.dolphinscheduler.server.worker.task.PythonCommandExecutor;
-import org.slf4j.Logger;
 
 import java.util.Map;
+
+import org.slf4j.Logger;
 
 /**
  *  python task
@@ -115,13 +116,8 @@ public class PythonTask extends AbstractTask {
     private String buildCommand() throws Exception {
         String rawPythonScript = pythonParameters.getRawScript().replaceAll("\\r\\n", "\n");
 
-        // replace placeholder
-        Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                        taskExecutionContext.getDefinedParams(),
-                        pythonParameters.getLocalParametersMap(),
-                        pythonParameters.getVarPoolMap(),
-                        CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                        taskExecutionContext.getScheduleTime());
+        // combining local and global parameters
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
         
         try {
             rawPythonScript = VarPoolUtils.convertPythonScriptPlaceholders(rawPythonScript);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
@@ -21,7 +21,6 @@ import static java.util.Calendar.DAY_OF_MONTH;
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
-import org.apache.dolphinscheduler.common.enums.Direct;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
 import org.apache.dolphinscheduler.common.task.shell.ShellParameters;
@@ -42,10 +41,8 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -166,7 +163,7 @@ public class ShellTask extends AbstractTask {
 
     private String parseScript(String script) {
         // combining local and global parameters
-        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,shellParameters);
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
         // replace variable TIME with $[YYYYmmddd...] in shell file when history run job and batch complement job
         if (taskExecutionContext.getScheduleTime() != null) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/spark/SparkTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/spark/SparkTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.worker.task.spark;
 
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.SparkVersion;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.process.ResourceInfo;
@@ -109,13 +108,8 @@ public class SparkTask extends AbstractYarnTask {
         // other parameters
         args.addAll(SparkArgsUtils.buildArgs(sparkParameters));
 
-        // replace placeholder
-        Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-            taskExecutionContext.getDefinedParams(),
-            sparkParameters.getLocalParametersMap(),
-            sparkParameters.getVarPoolMap(),
-            CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-            taskExecutionContext.getScheduleTime());
+        // replace placeholder, and combining local and global parameters
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
         String command = null;
 

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
@@ -20,7 +20,6 @@ package org.apache.dolphinscheduler.server.worker.task.sql;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.datasource.BaseConnectionParam;
 import org.apache.dolphinscheduler.common.datasource.DatasourceUtil;
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.enums.Direct;
 import org.apache.dolphinscheduler.common.enums.TaskTimeoutStrategy;
@@ -166,14 +165,8 @@ public class SqlTask extends AbstractTask {
         Map<Integer, Property> sqlParamsMap = new HashMap<>();
         StringBuilder sqlBuilder = new StringBuilder();
 
-        // find process instance by task id
-
-        Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(taskExecutionContext.getDefinedParams()),
-                taskExecutionContext.getDefinedParams(),
-                sqlParameters.getLocalParametersMap(),
-                sqlParameters.getVarPoolMap(),
-                CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
-                taskExecutionContext.getScheduleTime());
+        // combining local and global parameters
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext,getParameters());
 
         // spell SQL according to the final user-defined variable
         if (paramsMap == null) {
@@ -275,7 +268,6 @@ public class SqlTask extends AbstractTask {
             close(resultSet, stmt, connection);
         }
     }
-
 
     public String setNonQuerySqlReturn(String updateResult, List<Property> properties) {
         String result = null;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sqoop/SqoopTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sqoop/SqoopTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.worker.task.sqoop;
 
-import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
 import org.apache.dolphinscheduler.common.task.sqoop.SqoopParameters;
@@ -73,12 +72,8 @@ public class SqoopTask extends AbstractYarnTask {
         SqoopJobGenerator generator = new SqoopJobGenerator();
         String script = generator.generateSqoopJob(sqoopParameters, sqoopTaskExecutionContext);
 
-        Map<String, Property> paramsMap = ParamUtils.convert(ParamUtils.getUserDefParamsMap(sqoopTaskExecutionContext.getDefinedParams()),
-            sqoopTaskExecutionContext.getDefinedParams(),
-            sqoopParameters.getLocalParametersMap(),
-            sqoopParameters.getVarPoolMap(),
-            CommandType.of(sqoopTaskExecutionContext.getCmdTypeIfComplement()),
-            sqoopTaskExecutionContext.getScheduleTime());
+        // combining local and global parameters
+        Map<String, Property> paramsMap = ParamUtils.convert(sqoopTaskExecutionContext,getParameters());
 
         if (paramsMap != null) {
             String resultScripts = ParameterUtils.convertParameterPlaceholders(script, ParamUtils.convert(paramsMap));

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/ParamsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/ParamsTest.java
@@ -14,26 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.server.master;
 
 import org.apache.dolphinscheduler.common.enums.CommandType;
-import org.apache.dolphinscheduler.common.enums.DataType;
-import org.apache.dolphinscheduler.common.enums.Direct;
-import org.apache.dolphinscheduler.common.process.Property;
-import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
 import org.apache.dolphinscheduler.common.utils.placeholder.BusinessTimeUtils;
-import org.apache.dolphinscheduler.server.utils.ParamUtils;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  *  user define param
@@ -42,9 +36,8 @@ public class ParamsTest {
 
     private static  final Logger logger = LoggerFactory.getLogger(ParamsTest.class);
 
-
     @Test
-    public void systemParamsTest()throws Exception{
+    public void systemParamsTest() throws Exception {
         String command = "${system.biz.date}";
 
         // start process
@@ -56,11 +49,9 @@ public class ParamsTest {
 
         logger.info("start process : {}",command);
 
-
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(new Date());
         calendar.add(Calendar.DAY_OF_MONTH, -5);
-
 
         command = "${system.biz.date}";
         // complement data
@@ -69,42 +60,6 @@ public class ParamsTest {
                         calendar.getTime());
         command = ParameterUtils.convertParameterPlaceholders(command, timeParams);
         logger.info("complement data : {}",command);
-
-    }
-
-    @Test
-    public void convertTest() throws Exception {
-        Map<String, Property> globalParams = new HashMap<>();
-        Property property = new Property();
-        property.setProp("global_param");
-        property.setDirect(Direct.IN);
-        property.setType(DataType.VARCHAR);
-        property.setValue("${system.biz.date}");
-        globalParams.put("global_param", property);
-
-        Map<String, String> globalParamsMap = new HashMap<>();
-        globalParamsMap.put("global_param", "${system.biz.date}");
-
-        Map<String, Property> localParams = new HashMap<>();
-        Property localProperty = new Property();
-        localProperty.setProp("local_param");
-        localProperty.setDirect(Direct.IN);
-        localProperty.setType(DataType.VARCHAR);
-        localProperty.setValue("${global_param}");
-        localParams.put("local_param", localProperty);
-
-        Map<String, Property> varPoolParams = new HashMap<>();
-        Property varProperty = new Property();
-        varProperty.setProp("local_param");
-        varProperty.setDirect(Direct.IN);
-        varProperty.setType(DataType.VARCHAR);
-        varProperty.setValue("${global_param}");
-        varPoolParams.put("varPool", varProperty);
-
-        Map<String, Property> paramsMap = ParamUtils.convert(globalParams, globalParamsMap,
-                localParams,varPoolParams, CommandType.START_PROCESS, new Date());
-        logger.info(JSONUtils.toJsonString(paramsMap));
-
 
     }
 }


### PR DESCRIPTION
Purpose of the pull request

this pr close #5852

Introduce two system parameters for the rest of type of tasks, these two system parameters include 'task.instance.id' and 'task.execute.path'.

You can use these parameters in the self-defined parameters field like following examples:

Example 1 for the python task:

![image](https://user-images.githubusercontent.com/4928204/126306078-eb456b74-dd1d-4b7d-ba9c-72e30dcf3342.png)

Example 2 for the shell task:

![image](https://user-images.githubusercontent.com/4928204/126306379-86a01830-d256-481d-9f9e-cb2a99311257.png)

Brief change log

Verify this pull request

This change added tests and can be verified as follows:

org.apache.dolphinscheduler.server.utils.ParamUtilsTest.testConvertForParamsRelatedTask