### PR TITLE
[Improvement-5921][CI] Improve maven connection in CI builds

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -55,6 +55,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Compile
-        run: mvn -B clean compile install -Prelease -Dmaven.test.skip=true
+        run: mvn -B clean install -Prelease -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Check dependency license
         run: tools/dependencies/check-LICENSE.sh

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -63,7 +63,7 @@ jobs:
           git fetch origin
       - name: Compile
         run: |
-          export MAVEN_OPTS='-Dmaven.repo.local=.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx5g'
+          export MAVEN_OPTS='-Dmaven.repo.local=.m2/repository -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx5g'
           mvn clean verify -B -Dmaven.test.skip=false
       - name: Upload coverage report to codecov
         run: |
@@ -84,6 +84,7 @@ jobs:
           -Dsonar.projectKey=apache-dolphinscheduler
           -Dsonar.login=e4058004bc6be89decf558ac819aa1ecbee57682
           -Dsonar.exclusions=dolphinscheduler-ui/src/**/i18n/locale/*.js,dolphinscheduler-microbench/src/**/*
+          -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docker/build/hooks/build
+++ b/docker/build/hooks/build
@@ -39,8 +39,8 @@ echo "Repo: $DOCKER_REPO"
 echo -e "Current Directory is $(pwd)\n"
 
 # maven package(Project Directory)
-echo -e "mvn -B clean compile package -Prelease -Dmaven.test.skip=true"
-mvn -B clean compile package -Prelease -Dmaven.test.skip=true
+echo -e "mvn -B clean package -Prelease -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
+mvn -B clean package -Prelease -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 # mv dolphinscheduler-bin.tar.gz file to docker/build directory
 echo -e "mv $(pwd)/dolphinscheduler-dist/target/apache-dolphinscheduler-${VERSION}-bin.tar.gz $(pwd)/docker/build/\n"

--- a/docker/build/hooks/build.bat
+++ b/docker/build/hooks/build.bat
@@ -39,8 +39,8 @@ echo "Repo: %DOCKER_REPO%"
 echo "Current Directory is %cd%"
 
 :: maven package(Project Directory)
-echo "call mvn clean compile package -Prelease"
-call mvn clean compile package -Prelease -DskipTests=true
+echo "mvn clean package -Prelease -DskipTests=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
+call mvn clean package -Prelease -DskipTests=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 if "%errorlevel%"=="1" goto :mvnFailed
 
 :: move dolphinscheduler-bin.tar.gz file to docker/build directory


### PR DESCRIPTION
Fix: #5921

## Purpose of the pull request

There are a lot of connection timeout errors in the CI build.
For example: https://github.com/apache/dolphinscheduler/runs/3192300302?check_suite_focus=true

According to https://github.com/actions/virtual-environments/issues/1499#issuecomment-689467080, we can add `-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 ` to the build command to improve maven connection.

## Brief change log

- Add `-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120` to the build command.
