### PR TITLE
[Fix-5875][API] When I saved the task that had the same name task in another flow ,the service would throw DuplicateKeyException.

### DIFF
--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -471,7 +471,7 @@ CREATE TABLE `t_ds_task_definition` (
   `create_time` datetime NOT NULL COMMENT 'create time',
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`,`code`),
-  UNIQUE KEY `task_unique` (`name`,`project_code`) USING BTREE
+  UNIQUE KEY `task_unique` (`code`,`project_code`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- ----------------------------

--- a/sql/dolphinscheduler_postgre.sql
+++ b/sql/dolphinscheduler_postgre.sql
@@ -358,7 +358,7 @@ CREATE TABLE t_ds_task_definition (
   create_time timestamp DEFAULT NULL ,
   update_time timestamp DEFAULT NULL ,
   PRIMARY KEY (id) ,
-  CONSTRAINT task_definition_unique UNIQUE (name, project_code)
+  CONSTRAINT task_definition_unique UNIQUE (code, project_code)
 ) ;
 
 create index task_definition_index on t_ds_task_definition (project_code,id);

--- a/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -358,7 +358,7 @@ CREATE TABLE `t_ds_task_definition` (
   `create_time` datetime NOT NULL COMMENT 'create time',
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`,`code`),
-  UNIQUE KEY `task_unique` (`name`,`project_code`) USING BTREE
+  UNIQUE KEY `task_unique` (`code`,`project_code`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 create index task_definition_index on t_ds_task_definition (project_code,id);
 

--- a/sql/upgrade/1.4.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -339,7 +339,7 @@ BEGIN
         create_time timestamp DEFAULT NULL ,
         update_time timestamp DEFAULT NULL ,
         PRIMARY KEY (id) ,
-        CONSTRAINT task_definition_unique UNIQUE (name, project_code)
+        CONSTRAINT task_definition_unique UNIQUE (code, project_code)
     ) ;
     create index task_definition_index on t_ds_task_definition (project_code,id);
     DROP SEQUENCE IF EXISTS t_ds_task_definition_id_sequence;


### PR DESCRIPTION
## Purpose of the pull request

This PR closes #5875.

## Brief change log

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
  I created two new workflows separately called 'SameNameTestWorkFlow1' and 'SameNameTestWorkFlow2', and then added a task called the same name 'SameNameTask' in these two flows. Finally these two flows would be executed  correctly.

These Two Workflows:
![image](https://user-images.githubusercontent.com/4928204/127983437-80dd596a-c695-44db-b7d7-ac3808364fba.png)

Having the same name task:
![image](https://user-images.githubusercontent.com/4928204/127983569-43a65ffd-099c-40ff-adc5-f431d8e68c04.png)

The result:
![image](https://user-images.githubusercontent.com/4928204/127983702-48ffb564-d4d3-465c-ab20-188b2ae343fe.png)



