### PR TITLE
[Improvement] Fix unchecked type conversions

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/graph/DAG.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/graph/DAG.java
@@ -432,13 +432,11 @@ public class DAG<Node, NodeInfo, EdgeInfo> {
    * @return all neighbor nodes of the node
    */
   private Set<Node> getNeighborNodes(Node node, final Map<Node, Map<Node, EdgeInfo>> edges) {
-    final Map<Node, EdgeInfo> neighborEdges = edges.get(node);
-
-    if (neighborEdges == null) {
-      return Collections.emptySet();
-    }
-
-    return neighborEdges.keySet();
+        final Map<Node, EdgeInfo> neighborEdges = edges.get(node);
+        if (neighborEdges == null) {
+            return Collections.emptySet();
+        }
+        return neighborEdges.keySet();
   }
 
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/graph/DAG.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/graph/DAG.java
@@ -435,7 +435,7 @@ public class DAG<Node, NodeInfo, EdgeInfo> {
     final Map<Node, EdgeInfo> neighborEdges = edges.get(node);
 
     if (neighborEdges == null) {
-      return Collections.EMPTY_MAP.keySet();
+      return Collections.emptySet();
     }
 
     return neighborEdges.keySet();

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/utils/ResourceProcessDefinitionUtilsTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/utils/ResourceProcessDefinitionUtilsTest.java
@@ -31,7 +31,7 @@ public class ResourceProcessDefinitionUtilsTest {
     @Test
     public void getResourceProcessDefinitionMapTest(){
         List<Map<String,Object>> mapList = new ArrayList<>();
-        Map<String,Object> map = new HashMap();
+        Map<String,Object> map = new HashMap<>();
         map.put("code",1L);
         map.put("resource_ids","1,2,3");
         mapList.add(map);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManager.java
@@ -178,7 +178,7 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean>{
      * @return nodes
      */
     private Set<String> getAllNodes(ExecutionContext context){
-        Set<String> nodes = Collections.EMPTY_SET;
+        Set<String> nodes = Collections.emptySet();
         /**
          * executor type
          */

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/MasterExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/MasterExecThreadTest.java
@@ -101,8 +101,8 @@ public class MasterExecThreadTest {
         cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, "2020-01-20 23:00:00");
         Mockito.when(processInstance.getCommandParam()).thenReturn(JSONUtils.toJsonString(cmdParam));
         ProcessDefinition processDefinition = new ProcessDefinition();
-        processDefinition.setGlobalParamMap(Collections.EMPTY_MAP);
-        processDefinition.setGlobalParamList(Collections.EMPTY_LIST);
+        processDefinition.setGlobalParamMap(Collections.emptyMap());
+        processDefinition.setGlobalParamList(Collections.emptyList());
         Mockito.when(processInstance.getProcessDefinition()).thenReturn(processDefinition);
 
         masterExecThread = PowerMockito.spy(new MasterExecThread(processInstance, processService, null, null, config));
@@ -256,7 +256,7 @@ public class MasterExecThreadTest {
     }
 
     private List<Schedule> zeroSchedulerList() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     private List<Schedule> oneSchedulerList() {


### PR DESCRIPTION
Fix compiler warnings about unchecked type conversions.

### Brief change log

* Fix compiler warnings about unchecked type conversions in `DAG.java`, `ResourceProcessDefinitionUtilsTest.java`, `NettyExecutorManager.java` and `MasterExecThreadTest.java`

### Verify this pull request

No functional changes, test coverage is not affected.

---

This patch was generated automatically using [Logifix](https://github.com/lyxell/logifix).