### PR TITLE
[Improvement] Fix inefficient map iterator

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/AbstractParameters.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/AbstractParameters.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
@@ -152,7 +153,7 @@ public abstract class AbstractParameters implements IParameters {
         ArrayNode paramsByJson = JSONUtils.parseArray(json);
         Iterator<JsonNode> listIterator = paramsByJson.iterator();
         while (listIterator.hasNext()) {
-            Map<String, String> param = JSONUtils.toMap(listIterator.next().toString(), String.class, String.class);
+            Map<String, String> param = JSONUtils.parseObject(listIterator.next().toString(), new TypeReference<Map<String, String>>() {});
             allParams.add(param);
         }
         return allParams;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/sql/SqlParameters.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/sql/SqlParameters.java
@@ -251,10 +251,9 @@ public class SqlParameters extends AbstractParameters {
                 sqlResultFormat.put(key, new ArrayList<>());
             }
             for (Map<String, String> info : sqlResult) {
-                for (Map.Entry<String, String> entry : info.entrySet()) {
-                    String key = entry.getKey();
-                    sqlResultFormat.get(key).add(String.valueOf(entry.getValue()));
-                }
+                info.forEach((key, value) -> {
+                    sqlResultFormat.get(key).add(value);
+                });
             }
             for (Property info : outProperty) {
                 if (info.getType() == DataType.LIST) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/sql/SqlParameters.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/sql/SqlParameters.java
@@ -251,8 +251,9 @@ public class SqlParameters extends AbstractParameters {
                 sqlResultFormat.put(key, new ArrayList<>());
             }
             for (Map<String, String> info : sqlResult) {
-                for (String key : info.keySet()) {
-                    sqlResultFormat.get(key).add(String.valueOf(info.get(key)));
+                for (Map.Entry<String, String> entry : info.entrySet()) {
+                    String key = entry.getKey();
+                    sqlResultFormat.get(key).add(String.valueOf(entry.getValue()));
                 }
             }
             for (Property info : outProperty) {


### PR DESCRIPTION
Fix inefficient iteration using Map#keySet, instead iterate using Map#entrySet, this avoids an expensive call to `info.get` on each iteration.

### Brief change log

* Fix inefficient iteration of Map#keySet in `SqlParameters.java`

### Verify this pull request

No functional changes, test coverage is not affected.

---

This patch was generated automatically using [Logifix](https://github.com/lyxell/logifix).