### PR TITLE
[Improvement-6024][dist] Remove useless packaging commands

### DIFF
--- a/dolphinscheduler-dist/src/main/assembly/dolphinscheduler-bin.xml
+++ b/dolphinscheduler-dist/src/main/assembly/dolphinscheduler-bin.xml
@@ -62,15 +62,6 @@
         </fileSet>
 
         <fileSet>
-            <directory>${basedir}/../dolphinscheduler-common/src/main/resources/bin</directory>
-            <includes>
-                <include>*.*</include>
-            </includes>
-            <directoryMode>755</directoryMode>
-            <outputDirectory>bin</outputDirectory>
-        </fileSet>
-
-        <fileSet>
             <directory>${basedir}/../dolphinscheduler-dao/src/main/resources</directory>
             <includes>
                 <include>**/*.properties</include>


### PR DESCRIPTION
·Remove useless packaging commands in dolphinscheduler-bin.xml

This closes #6024
