### PR TITLE
Fix: sub-process and dependent tasks may fall into an endless-loop by recovery from Kill

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -1279,6 +1279,14 @@ public class ProcessService {
      */
     public ExecutionStatus getSubmitTaskState(TaskInstance taskInstance, ExecutionStatus processInstanceState) {
         ExecutionStatus state = taskInstance.getState();
+        
+        // in the recovery mode after the Kill,
+        // sub-process and dependent tasks should be submitted with SUBMITTED_SUCCESS state
+        // to run a sub/ref-task/process check at least once in waitTaskQuit()
+        if (state == ExecutionStatus.KILL && (taskInstance.isSubProcess() || taskInstance.isDependTask())) {
+            return ExecutionStatus.SUBMITTED_SUCCESS;
+        }
+
         // running, delayed or killed
         // the task already exists in task queue
         // return state


### PR DESCRIPTION
## Purpose of the pull request

When recovery a stopping instance, sub-process-task's state may be KILL, but the sub-process-instance is already submitted by RECOVER_TOLERANCE_FAULT_PROCESS command,
the SubProcessTaskExecThread.waitTaskQuit() will return directly, and set task state with sub-process's state (even if the sub-process is running), so the sub-process-task will ended with an unfinished state,
so the parent thread MasterExecThread will fall into an endless-loop.


## Brief change log

Add a check in getSubmitTaskState:
if taskInstance is sub-process or dependent node, and the state is KILL, return SUBMITTED_SUCCESS state.

## Issue
[#6055](https://github.com/apache/dolphinscheduler/issues/6055)