### PR TITLE
Fix: Sub-process and Dependent tasks may fall into an endless-loop by submitting with a finished state

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -1279,6 +1279,14 @@ public class ProcessService {
      */
     public ExecutionStatus getSubmitTaskState(TaskInstance taskInstance, ExecutionStatus processInstanceState) {
         ExecutionStatus state = taskInstance.getState();
+        
+        // in the recovery mode after the Kill/Pause/Stop command,
+        // sub-process and dependent tasks should be submitted with SUBMITTED_SUCCESS state
+        // to run a sub/ref-task/process check at least once in waitTaskQuit()
+        if (taskInstance.isSubProcess() || taskInstance.isDependTask()) {
+            return ExecutionStatus.SUBMITTED_SUCCESS;
+        }
+
         // running, delayed or killed
         // the task already exists in task queue
         // return state


### PR DESCRIPTION
## Purpose of the pull request

* When sub-process and dependent tasks submitted with a finished state, the `SubProcessTaskExecThread.waitTaskQuit()` will [return directly](https://github.com/apache/dolphinscheduler/blob/e0eea995200f673d6406ec62c464c77f1d5b6171/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/SubProcessTaskExecThread.java#L128), and [set task state with sub-process's state](https://github.com/reele/dolphinscheduler/blob/3215cfb9f7c62bef7fa197b37ffc38cedd2c7ef5/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/SubProcessTaskExecThread.java#L66) (even if the sub-process is running, such as `READY_PAUSE`/`READY_STOP` or others), so the sub-process-task will ended with an unfinished state (`READY_PAUSE` or `READY_STOP`),
so the parent thread `MasterExecThread` will fall into an endless-loop.


## Brief change log

Add a check in getSubmitTaskState:
if taskInstance is sub-process or dependent node, return SUBMITTED_SUCCESS state.

## Issue
#6055 