### PR TITLE
fix: SubProcess task may fall into an endless-loop by fault-tolerant

### DIFF
--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/SubProcessTaskTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/SubProcessTaskTest.java
@@ -138,6 +138,23 @@ public class SubProcessTaskTest {
         Assert.assertEquals(ExecutionStatus.FAILURE, taskExecThread.getTaskInstance().getState());
     }
 
+    @Test
+    public void testFaultTolerant2() {
+        TaskInstance taskInstance = getTaskInstance(getTaskNode(), processInstance);
+        
+        Mockito.when(processService
+                .findProcessInstanceById(subProcessInstance.getId()))
+                .thenReturn(subProcessInstance);
+        Mockito.when(processService
+                .findSubProcessInstance(processInstance.getId(), taskInstance.getId()))
+                .thenReturn(null);
+
+        taskInstance.setState(ExecutionStatus.KILL);
+        SubProcessTaskExecThread taskExecThread = new SubProcessTaskExecThread(taskInstance);
+        taskExecThread.call();
+        Assert.assertEquals(ExecutionStatus.KILL, taskExecThread.getTaskInstance().getState());
+    }
+
     private TaskNode getTaskNode() {
         TaskNode taskNode = new TaskNode();
         taskNode.setId("tasks-10");

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/SubProcessTaskTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/SubProcessTaskTest.java
@@ -143,11 +143,8 @@ public class SubProcessTaskTest {
         TaskInstance taskInstance = getTaskInstance(getTaskNode(), processInstance);
         
         Mockito.when(processService
-                .findProcessInstanceById(subProcessInstance.getId()))
-                .thenReturn(subProcessInstance);
-        Mockito.when(processService
-                .findSubProcessInstance(processInstance.getId(), taskInstance.getId()))
-                .thenReturn(null);
+                .findProcessInstanceById(processInstance.getId()))
+                .thenReturn(processInstance);
 
         taskInstance.setState(ExecutionStatus.KILL);
         SubProcessTaskExecThread taskExecThread = new SubProcessTaskExecThread(taskInstance);

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/SubProcessTaskTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/SubProcessTaskTest.java
@@ -129,6 +129,15 @@ public class SubProcessTaskTest {
         Assert.assertEquals(ExecutionStatus.FAILURE, taskExecThread.getTaskInstance().getState());
     }
 
+    @Test
+    public void testFaultTolerant() {
+        TaskInstance taskInstance = testBasicInit(ExecutionStatus.FAILURE);
+        taskInstance.setState(ExecutionStatus.KILL);
+        SubProcessTaskExecThread taskExecThread = new SubProcessTaskExecThread(taskInstance);
+        taskExecThread.call();
+        Assert.assertEquals(ExecutionStatus.FAILURE, taskExecThread.getTaskInstance().getState());
+    }
+
     private TaskNode getTaskNode() {
         TaskNode taskNode = new TaskNode();
         taskNode.setId("tasks-10");


### PR DESCRIPTION
## Purpose of the pull request

* When sub-process task submitted with a finished state, the `SubProcessTaskExecThread.waitTaskQuit()` will [return directly](https://github.com/apache/dolphinscheduler/blob/e0eea995200f673d6406ec62c464c77f1d5b6171/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/SubProcessTaskExecThread.java#L128), and [set task state with sub-process's state](https://github.com/reele/dolphinscheduler/blob/3215cfb9f7c62bef7fa197b37ffc38cedd2c7ef5/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/SubProcessTaskExecThread.java#L66) (even if the sub-process is running, such as `READY_PAUSE`/`READY_STOP` or others), so the sub-process-task will ended with an unfinished state (`READY_PAUSE` or `READY_STOP`),
so the parent thread `MasterExecThread` will fall into an endless-loop.


## Brief change log

`SubProcessTaskExecThread.waitTaskQuit()` should check `subProcessInstance`'s state first:
* If `subProcessInstance` is not null and its state is unfinished, it still enters the waiting loop.

## Issue
#6062