### PR TITLE
Remove invalid character `\n` in `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,7 @@
 #
 
 github:
-  description: |
+  description: >
     Apache DolphinScheduler is a distributed and extensible workflow scheduler platform with powerful DAG
     visual interfaces, dedicated to solving complex job dependencies in the data pipeline and providing
     various types of jobs available out of box.


### PR DESCRIPTION
Hey @CalvinKirs , it turns out the invalid character is `\n` in `.asf.yaml`, and #6075 didn't fix it