### PR TITLE
[Bug][UI][dev] Solute some bug of process function in dev ui module

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/actions.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/actions.js
@@ -176,8 +176,8 @@ export default {
   copyProcess ({ state }, payload) {
     return new Promise((resolve, reject) => {
       io.post(`projects/${state.projectCode}/process-definition/batch-copy`, {
-        processDefinitionIds: payload.processDefinitionIds,
-        targetProjectId: payload.targetProjectId
+        codes: payload.processDefinitionIds,
+        targetProjectCode: payload.targetProjectId
       }, res => {
         resolve(res)
       }).catch(e => {
@@ -192,8 +192,8 @@ export default {
   moveProcess ({ state }, payload) {
     return new Promise((resolve, reject) => {
       io.post(`projects/${state.projectCode}/process-definition/batch-move`, {
-        processDefinitionIds: payload.processDefinitionIds,
-        targetProjectId: payload.targetProjectId
+        codes: payload.processDefinitionIds,
+        targetProjectCode: payload.targetProjectId
       }, res => {
         resolve(res)
       }).catch(e => {
@@ -674,7 +674,7 @@ export default {
       }
     }
 
-    io.post(`projects/${state.projectCode}/process-definition/batch-export`, { processDefinitionIds: payload.processDefinitionIds }, res => {
+    io.post(`projects/${state.projectCode}/process-definition/batch-export`, { codes: payload.processDefinitionIds }, res => {
       downloadBlob(res, payload.fileName)
     }, e => {
 
@@ -772,7 +772,7 @@ export default {
    */
   getViewGantt ({ state }, payload) {
     return new Promise((resolve, reject) => {
-      io.get(`projects/${state.projectCode}/process-instances/${payload.code}/view-gantt`, payload, res => {
+      io.get(`projects/${state.projectCode}/process-instances/${payload.processInstanceId}/view-gantt`, payload, res => {
         resolve(res.data)
       }).catch(e => {
         reject(e)

--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/actions.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/actions.js
@@ -81,7 +81,7 @@ export default {
    */
   deleteProcessDefinitionVersion ({ state }, payload) {
     return new Promise((resolve, reject) => {
-      io.delete(`projects/${state.projectCode}/process-definition/${payload.code}/versiond/${payload.version}`, {}, res => {
+      io.delete(`projects/${state.projectCode}/process-definition/${payload.code}/versions/${payload.version}`, {}, res => {
         resolve(res)
       }).catch(e => {
         reject(e)
@@ -760,7 +760,7 @@ export default {
    */
   getViewTree ({ state }, payload) {
     return new Promise((resolve, reject) => {
-      io.get(`projects/${state.projectCode}/process-definition/${payload.code}/view-tree`, payload, res => {
+      io.get(`projects/${state.projectCode}/process-definition/${payload.processId}/view-tree`, payload, res => {
         resolve(res.data)
       }).catch(e => {
         reject(e)


### PR DESCRIPTION
1. The code of the process tree is not put in url
2. Processinstanceid of process instance Gantt chart is not put into url
3. The process export front-end does not replace processdefinitionids with codes
4. The process replication front-end does not replace processdefinitionids with codes
5. When the process definition enters DAG, select a task to view the version. The versions interface of process definition is called, and the versions interface of task definition should be called

1、工作流树形图路径的code没有放入
2、工作流实例甘特图路径的processInstanceId未放入
3、工作流导出前端未将processDefinitionIds换成codes
4、工作流复制前端未将processDefinitionIds换成codes
5、工作流定义进入dag选中某个task--查看版本，调用的是process-definition 的versions接口，应该调用task-definition的versions接口

has soluted 1, 2, 3, 4