### PR TITLE
fix the issue about mysql ddl for environment_code

### DIFF
--- a/sql/dolphinscheduler_h2.sql
+++ b/sql/dolphinscheduler_h2.sql
@@ -326,7 +326,7 @@ CREATE TABLE t_ds_command
     update_time               datetime DEFAULT NULL,
     process_instance_priority int(11) DEFAULT NULL,
     worker_group              varchar(64),
-    environment_code          bigint(20) DEFAULT NULL,
+    environment_code          bigint(20) DEFAULT '-1',
     PRIMARY KEY (id)
 );
 
@@ -376,7 +376,7 @@ CREATE TABLE t_ds_error_command
     update_time               datetime DEFAULT NULL,
     process_instance_priority int(11) DEFAULT NULL,
     worker_group              varchar(64),
-    environment_code          bigint(20) DEFAULT NULL,
+    environment_code          bigint(20) DEFAULT '-1',
     message                   text,
     PRIMARY KEY (id)
 );
@@ -461,7 +461,7 @@ CREATE TABLE t_ds_task_definition
     flag                    tinyint(2) DEFAULT NULL,
     task_priority           tinyint(4) DEFAULT NULL,
     worker_group            varchar(200) DEFAULT NULL,
-    environment_code        bigint(20) DEFAULT NULL,
+    environment_code        bigint(20) DEFAULT '-1',
     fail_retry_times        int(11) DEFAULT NULL,
     fail_retry_interval     int(11) DEFAULT NULL,
     timeout_flag            tinyint(2) DEFAULT '0',
@@ -493,7 +493,7 @@ CREATE TABLE t_ds_task_definition_log
     flag                    tinyint(2) DEFAULT NULL,
     task_priority           tinyint(4) DEFAULT NULL,
     worker_group            varchar(200) DEFAULT NULL,
-    environment_code        bigint(20) DEFAULT NULL,
+    environment_code        bigint(20) DEFAULT '-1',
     fail_retry_times        int(11) DEFAULT NULL,
     fail_retry_interval     int(11) DEFAULT NULL,
     timeout_flag            tinyint(2) DEFAULT '0',
@@ -587,7 +587,7 @@ CREATE TABLE t_ds_process_instance
     history_cmd                text,
     process_instance_priority  int(11) DEFAULT NULL,
     worker_group               varchar(64)  DEFAULT NULL,
-    environment_code           bigint(20) DEFAULT NULL,
+    environment_code           bigint(20) DEFAULT '-1',
     timeout                    int(11) DEFAULT '0',
     tenant_id                  int(11) NOT NULL DEFAULT '-1',
     var_pool                   longtext,
@@ -773,7 +773,7 @@ CREATE TABLE t_ds_schedules
     warning_group_id          int(11) DEFAULT NULL,
     process_instance_priority int(11) DEFAULT NULL,
     worker_group              varchar(64) DEFAULT '',
-    environment_code          bigint(20) DEFAULT NULL,
+    environment_code          bigint(20) DEFAULT '-1',
     create_time               datetime     NOT NULL,
     update_time               datetime     NOT NULL,
     PRIMARY KEY (id)
@@ -829,7 +829,7 @@ CREATE TABLE t_ds_task_instance
     max_retry_times         int(2) DEFAULT NULL,
     task_instance_priority  int(11) DEFAULT NULL,
     worker_group            varchar(64)  DEFAULT NULL,
-    environment_code        bigint(20) DEFAULT NULL,
+    environment_code        bigint(20) DEFAULT '-1',
     environment_config      text DEFAULT '',
     executor_id             int(11) DEFAULT NULL,
     first_submit_time       datetime     DEFAULT NULL,

--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -331,7 +331,7 @@ CREATE TABLE `t_ds_command` (
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority: 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64)  COMMENT 'worker group',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
@@ -379,7 +379,7 @@ CREATE TABLE `t_ds_error_command` (
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority, 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64)  COMMENT 'worker group',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   `message` text COMMENT 'message',
   PRIMARY KEY (`id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
@@ -460,7 +460,7 @@ CREATE TABLE `t_ds_task_definition` (
   `flag` tinyint(2) DEFAULT NULL COMMENT '0 not available, 1 available',
   `task_priority` tinyint(4) DEFAULT NULL COMMENT 'job priority',
   `worker_group` varchar(200) DEFAULT NULL COMMENT 'worker grouping',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   `fail_retry_times` int(11) DEFAULT NULL COMMENT 'number of failed retries',
   `fail_retry_interval` int(11) DEFAULT NULL COMMENT 'failed retry interval',
   `timeout_flag` tinyint(2) DEFAULT '0' COMMENT 'timeout flag:0 close, 1 open',
@@ -491,7 +491,7 @@ CREATE TABLE `t_ds_task_definition_log` (
   `flag` tinyint(2) DEFAULT NULL COMMENT '0 not available, 1 available',
   `task_priority` tinyint(4) DEFAULT NULL COMMENT 'job priority',
   `worker_group` varchar(200) DEFAULT NULL COMMENT 'worker grouping',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   `fail_retry_times` int(11) DEFAULT NULL COMMENT 'number of failed retries',
   `fail_retry_interval` int(11) DEFAULT NULL COMMENT 'failed retry interval',
   `timeout_flag` tinyint(2) DEFAULT '0' COMMENT 'timeout flag:0 close, 1 open',
@@ -582,7 +582,7 @@ CREATE TABLE `t_ds_process_instance` (
   `history_cmd` text COMMENT 'history commands of process instance operation',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority. 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64) DEFAULT NULL COMMENT 'worker group id',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   `timeout` int(11) DEFAULT '0' COMMENT 'time out',
   `tenant_id` int(11) NOT NULL DEFAULT '-1' COMMENT 'tenant id',
   `var_pool` longtext COMMENT 'var_pool',
@@ -762,7 +762,7 @@ CREATE TABLE `t_ds_schedules` (
   `warning_group_id` int(11) DEFAULT NULL COMMENT 'alert group id',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority：0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64) DEFAULT '' COMMENT 'worker group id',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   `create_time` datetime NOT NULL COMMENT 'create time',
   `update_time` datetime NOT NULL COMMENT 'update time',
   PRIMARY KEY (`id`)
@@ -816,7 +816,7 @@ CREATE TABLE `t_ds_task_instance` (
   `max_retry_times` int(2) DEFAULT NULL COMMENT 'max retry times',
   `task_instance_priority` int(11) DEFAULT NULL COMMENT 'task instance priority:0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64) DEFAULT NULL COMMENT 'worker group id',
-  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
   `environment_config` text COMMENT 'this config contains many environment variables config',
   `executor_id` int(11) DEFAULT NULL,
   `first_submit_time` datetime DEFAULT NULL COMMENT 'task first submit time',

--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -331,7 +331,7 @@ CREATE TABLE `t_ds_command` (
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority: 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64)  COMMENT 'worker group',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
@@ -379,7 +379,7 @@ CREATE TABLE `t_ds_error_command` (
   `update_time` datetime DEFAULT NULL COMMENT 'update time',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority, 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64)  COMMENT 'worker group',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   `message` text COMMENT 'message',
   PRIMARY KEY (`id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
@@ -460,7 +460,7 @@ CREATE TABLE `t_ds_task_definition` (
   `flag` tinyint(2) DEFAULT NULL COMMENT '0 not available, 1 available',
   `task_priority` tinyint(4) DEFAULT NULL COMMENT 'job priority',
   `worker_group` varchar(200) DEFAULT NULL COMMENT 'worker grouping',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   `fail_retry_times` int(11) DEFAULT NULL COMMENT 'number of failed retries',
   `fail_retry_interval` int(11) DEFAULT NULL COMMENT 'failed retry interval',
   `timeout_flag` tinyint(2) DEFAULT '0' COMMENT 'timeout flag:0 close, 1 open',
@@ -491,7 +491,7 @@ CREATE TABLE `t_ds_task_definition_log` (
   `flag` tinyint(2) DEFAULT NULL COMMENT '0 not available, 1 available',
   `task_priority` tinyint(4) DEFAULT NULL COMMENT 'job priority',
   `worker_group` varchar(200) DEFAULT NULL COMMENT 'worker grouping',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   `fail_retry_times` int(11) DEFAULT NULL COMMENT 'number of failed retries',
   `fail_retry_interval` int(11) DEFAULT NULL COMMENT 'failed retry interval',
   `timeout_flag` tinyint(2) DEFAULT '0' COMMENT 'timeout flag:0 close, 1 open',
@@ -582,7 +582,7 @@ CREATE TABLE `t_ds_process_instance` (
   `history_cmd` text COMMENT 'history commands of process instance operation',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority. 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64) DEFAULT NULL COMMENT 'worker group id',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   `timeout` int(11) DEFAULT '0' COMMENT 'time out',
   `tenant_id` int(11) NOT NULL DEFAULT '-1' COMMENT 'tenant id',
   `var_pool` longtext COMMENT 'var_pool',
@@ -762,7 +762,7 @@ CREATE TABLE `t_ds_schedules` (
   `warning_group_id` int(11) DEFAULT NULL COMMENT 'alert group id',
   `process_instance_priority` int(11) DEFAULT NULL COMMENT 'process instance priority：0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64) DEFAULT '' COMMENT 'worker group id',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   `create_time` datetime NOT NULL COMMENT 'create time',
   `update_time` datetime NOT NULL COMMENT 'update time',
   PRIMARY KEY (`id`)
@@ -816,7 +816,7 @@ CREATE TABLE `t_ds_task_instance` (
   `max_retry_times` int(2) DEFAULT NULL COMMENT 'max retry times',
   `task_instance_priority` int(11) DEFAULT NULL COMMENT 'task instance priority:0 Highest,1 High,2 Medium,3 Low,4 Lowest',
   `worker_group` varchar(64) DEFAULT NULL COMMENT 'worker group id',
-  `environment_code` bigint(20) DEFAULT '-1' COMMENT 'environment code',
+  `environment_code` bigint(20) DEFAULT NULL COMMENT 'environment code',
   `environment_config` text COMMENT 'this config contains many environment variables config',
   `executor_id` int(11) DEFAULT NULL,
   `first_submit_time` datetime DEFAULT NULL COMMENT 'task first submit time',

--- a/sql/dolphinscheduler_postgre.sql
+++ b/sql/dolphinscheduler_postgre.sql
@@ -232,7 +232,7 @@ CREATE TABLE t_ds_command (
   update_time timestamp DEFAULT NULL ,
   process_instance_priority int DEFAULT NULL ,
   worker_group varchar(64),
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   PRIMARY KEY (id)
 ) ;
 
@@ -274,7 +274,7 @@ CREATE TABLE t_ds_error_command (
   update_time timestamp DEFAULT NULL ,
   process_instance_priority int DEFAULT NULL ,
   worker_group varchar(64),
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   message text ,
   PRIMARY KEY (id)
 );
@@ -347,7 +347,7 @@ CREATE TABLE t_ds_task_definition (
   flag int DEFAULT NULL ,
   task_priority int DEFAULT NULL ,
   worker_group varchar(255) DEFAULT NULL ,
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   fail_retry_times int DEFAULT NULL ,
   fail_retry_interval int DEFAULT NULL ,
   timeout_flag int DEFAULT NULL ,
@@ -377,7 +377,7 @@ CREATE TABLE t_ds_task_definition_log (
   flag int DEFAULT NULL ,
   task_priority int DEFAULT NULL ,
   worker_group varchar(255) DEFAULT NULL ,
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   fail_retry_times int DEFAULT NULL ,
   fail_retry_interval int DEFAULT NULL ,
   timeout_flag int DEFAULT NULL ,
@@ -465,7 +465,7 @@ CREATE TABLE t_ds_process_instance (
   dependence_schedule_times text ,
   process_instance_priority int DEFAULT NULL ,
   worker_group varchar(64) ,
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   timeout int DEFAULT '0' ,
   tenant_id int NOT NULL DEFAULT '-1' ,
   var_pool text ,
@@ -626,7 +626,7 @@ CREATE TABLE t_ds_schedules (
   warning_group_id int DEFAULT NULL ,
   process_instance_priority int DEFAULT NULL ,
   worker_group varchar(64),
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   create_time timestamp NOT NULL ,
   update_time timestamp NOT NULL ,
   PRIMARY KEY (id)
@@ -674,7 +674,7 @@ CREATE TABLE t_ds_task_instance (
   max_retry_times int DEFAULT NULL ,
   task_instance_priority int DEFAULT NULL ,
   worker_group varchar(64),
-  environment_code bigint DEFAULT NULL,
+  environment_code bigint DEFAULT '-1',
   environment_config text,
   executor_id int DEFAULT NULL ,
   first_submit_time timestamp DEFAULT NULL ,

--- a/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -355,14 +355,14 @@ CREATE TABLE `t_ds_environment` (
    UNIQUE KEY `environment_code_unique` (`code`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
-ALTER TABLE t_ds_task_definition ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
-ALTER TABLE t_ds_task_definition_log ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_task_definition ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_task_definition_log ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
 
-ALTER TABLE t_ds_command ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
-ALTER TABLE t_ds_error_command ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
-ALTER TABLE t_ds_schedules ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
-ALTER TABLE t_ds_process_instance ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
-ALTER TABLE t_ds_task_instance ADD COLUMN `environment_code` bigint(20) default NULL COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_command ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_error_command ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_schedules ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_process_instance ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
+ALTER TABLE t_ds_task_instance ADD COLUMN `environment_code` bigint(20) default '-1' COMMENT 'environment code' AFTER `worker_group`;
 ALTER TABLE t_ds_task_instance ADD COLUMN `environment_config` text COMMENT 'environment config' AFTER `environment_code`;
 
 -- ----------------------------

--- a/sql/upgrade/1.4.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -340,25 +340,25 @@ CREATE TABLE t_ds_environment (
     CONSTRAINT environment_code_unique UNIQUE (code)
 );
 
-ALTER TABLE t_ds_task_definition ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_task_definition ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_task_definition.environment_code is 'environment code';
 
-ALTER TABLE t_ds_task_definition_log ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_task_definition_log ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_task_definition_log.environment_code is 'environment code';
 
-ALTER TABLE t_ds_command ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_command ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_command.environment_code is 'environment code';
 
-ALTER TABLE t_ds_error_command ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_error_command ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_error_command.environment_code is 'environment code';
 
-ALTER TABLE t_ds_schedules ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_schedules ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_schedules.environment_code is 'environment code';
 
-ALTER TABLE t_ds_process_instance ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_process_instance ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_process_instance.environment_code is 'environment code';
 
-ALTER TABLE t_ds_task_instance ADD COLUMN environment_code bigint DEFAULT NULL;
+ALTER TABLE t_ds_task_instance ADD COLUMN environment_code bigint DEFAULT '-1';
 comment on column t_ds_task_instance.environment_code is 'environment code';
 
 ALTER TABLE t_ds_task_instance ADD COLUMN environment_config text;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR will close #6159. 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
- Adjust the default value of the field environment code from '-1' to 'null' in the  dolphinscheduler_mysql.sql. So the default value of this field will be same both in  dolphinscheduler_mysql.sql and  dolphinscheduler_postgre.sql .

In the dolphinscheduler_mysql.sql:
![image](https://user-images.githubusercontent.com/4928204/132792057-95f230be-4945-462e-9ef4-ed1dfa0e5b7d.png)

In the dolphinscheduler_postgre.sql:
![image](https://user-images.githubusercontent.com/4928204/132792205-cd4e295d-b945-4d8b-95ce-c1db56b4c311.png)


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This change added tests and can be verified as follows:

  - *Manually verified the change by testing locally.* 
