### PR TITLE
Simplify constants variables

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -138,7 +138,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             }
         }
         // check zookeeper
-        String workerGroupPath = Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SLASH + workerGroup.getName();
+        String workerGroupPath = Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SINGLE_SLASH + workerGroup.getName();
         return RegistryCenterUtils.isNodeExisted(workerGroupPath);
     }
 
@@ -266,7 +266,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         }
 
         for (String workerGroup : workerGroupList) {
-            String workerGroupPath = workerPath + Constants.SLASH + workerGroup;
+            String workerGroupPath = workerPath + Constants.SINGLE_SLASH + workerGroup;
             List<String> childrenNodes = null;
             try {
                 childrenNodes = RegistryCenterUtils.getChildrenNodes(workerGroupPath);
@@ -280,7 +280,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             wg.setName(workerGroup);
             if (isPaging) {
                 wg.setAddrList(String.join(Constants.COMMA, childrenNodes));
-                String registeredValue = RegistryCenterUtils.getNodeData(workerGroupPath + Constants.SLASH + childrenNodes.get(0));
+                String registeredValue = RegistryCenterUtils.getNodeData(workerGroupPath + Constants.SINGLE_SLASH + childrenNodes.get(0));
                 wg.setCreateTime(DateUtils.stringToDate(registeredValue.split(Constants.COMMA)[6]));
                 wg.setUpdateTime(DateUtils.stringToDate(registeredValue.split(Constants.COMMA)[7]));
                 wg.setSystemDefault(true);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -73,6 +73,28 @@ public final class Constants {
     public static final String COMMON_PROPERTIES_PATH = "/common.properties";
 
     /**
+     * alter properties
+     */
+    public static final String ALERT_PLUGIN_BINDING = "alert.plugin.binding";
+    public static final String ALERT_PLUGIN_DIR = "alert.plugin.dir";
+    public static final int ALERT_RPC_PORT = 50052;
+
+    /**
+     * registry properties
+     */
+    public static final String REGISTRY_DOLPHINSCHEDULER_MASTERS = "/nodes/master";
+    public static final String REGISTRY_DOLPHINSCHEDULER_WORKERS = "/nodes/worker";
+    public static final String REGISTRY_DOLPHINSCHEDULER_DEAD_SERVERS = "/dead-servers";
+    public static final String REGISTRY_DOLPHINSCHEDULER_NODE = "/nodes";
+    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_MASTERS = "/lock/masters";
+    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_MASTERS = "/lock/failover/masters";
+    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_WORKERS = "/lock/failover/workers";
+    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_STARTUP_MASTERS = "/lock/failover/startup-masters";
+    public static final String REGISTRY_PLUGIN_BINDING = "registry.plugin.binding";
+    public static final String REGISTRY_PLUGIN_DIR = "registry.plugin.dir";
+    public static final String REGISTRY_SERVERS = "registry.servers";
+
+    /**
      * fs.defaultFS
      */
     public static final String FS_DEFAULTFS = "fs.defaultFS";
@@ -184,56 +206,9 @@ public final class Constants {
     public static final String RESOURCE_STORAGE_TYPE = "resource.storage.type";
 
     /**
-     * MasterServer directory registered in zookeeper
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_MASTERS = "/nodes/master";
-
-    /**
-     * WorkerServer directory registered in zookeeper
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_WORKERS = "/nodes/worker";
-
-    /**
-     * all servers directory registered in zookeeper
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_DEAD_SERVERS = "/dead-servers";
-
-    /**
-     * registry node prefix
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_NODE = "/nodes";
-
-    /**
-     * MasterServer lock directory registered in zookeeper
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_MASTERS = "/lock/masters";
-
-
-    /**
-     * MasterServer failover directory registered in zookeeper
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_MASTERS = "/lock/failover/masters";
-
-    /**
-     * WorkerServer failover directory registered in zookeeper
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_WORKERS = "/lock/failover/workers";
-
-    /**
-     * MasterServer startup  failover runing and fault tolerance process
-     */
-    public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_STARTUP_MASTERS = "/lock/failover/startup-masters";
-
-
-    /**
      * comma ,
      */
     public static final String COMMA = ",";
-
-    /**
-     * slash /
-     */
-    public static final String SLASH = "/";
 
     /**
      * COLON :
@@ -415,11 +390,6 @@ public final class Constants {
      * rpc port
      */
     public static final int RPC_PORT = 50051;
-
-    /***
-     * alert rpc port
-     */
-    public static final int ALERT_RPC_PORT = 50052;
 
     /**
      * forbid running task

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/registry/WorkerRegistryClient.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/registry/WorkerRegistryClient.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.server.worker.registry;
 
 import static org.apache.dolphinscheduler.common.Constants.DEFAULT_WORKER_GROUP;
 import static org.apache.dolphinscheduler.common.Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS;
-import static org.apache.dolphinscheduler.common.Constants.SLASH;
+import static org.apache.dolphinscheduler.common.Constants.SINGLE_SLASH;
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.IStoppable;
@@ -134,7 +134,7 @@ public class WorkerRegistryClient {
         String workerZkPathPrefix = REGISTRY_DOLPHINSCHEDULER_WORKERS;
 
         for (String workGroup : this.workerGroups) {
-            StringJoiner workerPathJoiner = new StringJoiner(SLASH);
+            StringJoiner workerPathJoiner = new StringJoiner(SINGLE_SLASH);
             workerPathJoiner.add(workerZkPathPrefix);
             if (StringUtils.isEmpty(workGroup)) {
                 workGroup = DEFAULT_WORKER_GROUP;

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
@@ -122,9 +122,9 @@ public class RegistryClient extends RegistryCenter {
         if (nodeType == NodeType.WORKER) {
             List<String> workerList = new ArrayList<>();
             for (String group : serverList) {
-                List<String> groupServers = getChildrenKeys(path + Constants.SLASH + group);
+                List<String> groupServers = getChildrenKeys(path + SINGLE_SLASH + group);
                 for (String groupServer : groupServers) {
-                    workerList.add(group + Constants.SLASH + groupServer);
+                    workerList.add(group + SINGLE_SLASH + groupServer);
                 }
             }
             serverList = workerList;
@@ -147,9 +147,9 @@ public class RegistryClient extends RegistryCenter {
             for (String server : serverList) {
                 String host = server;
                 if (nodeType == NodeType.WORKER && hostOnly) {
-                    host = server.split(Constants.SLASH)[1];
+                    host = server.split(SINGLE_SLASH)[1];
                 }
-                serverMap.putIfAbsent(host, get(path + Constants.SLASH + server));
+                serverMap.putIfAbsent(host, get(path + SINGLE_SLASH + server));
             }
         } catch (Exception e) {
             logger.error("get server list failed", e);
@@ -182,7 +182,7 @@ public class RegistryClient extends RegistryCenter {
             for (String server : serverList) {
                 String host = server;
                 if (nodeType == NodeType.WORKER && hostOnly) {
-                    host = server.split(Constants.SLASH)[1];
+                    host = server.split(SINGLE_SLASH)[1];
                 }
                 serverSet.add(host);
             }


### PR DESCRIPTION
Simplify constants variables

* Combine `alter` and `registry` properties,
  bese on #6180
* Remove duplicate variable `SLASH` and `SINGLE_SLASH`