### PR TITLE
Inefficient Usages of Java Collections

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
@@ -24,6 +24,8 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -99,11 +101,11 @@ public class AccessLogAspect {
         if (annotation.ignoreRequestArgs().length > 0) {
             String[] parameterNames = ((MethodSignature) proceedingJoinPoint.getSignature()).getParameterNames();
             if (parameterNames.length > 0) {
-                List<String> ignoreList = Arrays.stream(annotation.ignoreRequestArgs()).collect(Collectors.toList());
+                Set<String> ignoreSet = new HashSet<>(Arrays.stream(annotation.ignoreRequestArgs()).collect(Collectors.toList()));
                 HashMap<String, Object> argsMap = new HashMap<>();
 
                 for (int i = 0; i < parameterNames.length; i++) {
-                    if (!ignoreList.contains(parameterNames[i])) {
+                    if (!ignoreSet.contains(parameterNames[i])) {
                         argsMap.put(parameterNames[i], args[i]);
                     }
                 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
@@ -23,9 +23,9 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
@@ -23,7 +23,6 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
@@ -101,7 +101,7 @@ public class AccessLogAspect {
         if (annotation.ignoreRequestArgs().length > 0) {
             String[] parameterNames = ((MethodSignature) proceedingJoinPoint.getSignature()).getParameterNames();
             if (parameterNames.length > 0) {
-                Set<String> ignoreSet = new HashSet<>(Arrays.stream(annotation.ignoreRequestArgs()).collect(Collectors.toList()));
+                Set<String> ignoreSet = Arrays.stream(annotation.ignoreRequestArgs()).collect(Collectors.toSet());
                 HashMap<String, Object> argsMap = new HashMap<>();
 
                 for (int i = 0; i < parameterNames.length; i++) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/gantt/Task.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/gantt/Task.java
@@ -19,8 +19,8 @@ package org.apache.dolphinscheduler.api.dto.gantt;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.util.Date;
-import java.util.List;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Task

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/gantt/Task.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/gantt/Task.java
@@ -18,9 +18,9 @@ package org.apache.dolphinscheduler.api.dto.gantt;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import java.util.LinkedList;
 import java.util.Date;
 import java.util.List;
+import java.util.LinkedList;
 
 /**
  * Task

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/gantt/Task.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/gantt/Task.java
@@ -18,7 +18,7 @@ package org.apache.dolphinscheduler.api.dto.gantt;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Date;
 import java.util.List;
 
@@ -34,11 +34,11 @@ public class Task {
     /**
      * task start date
      */
-    private List<Long> startDate = new ArrayList<>();
+    private List<Long> startDate = new LinkedList<>();
     /**
      * task end date
      */
-    private List<Long> endDate = new ArrayList<>();
+    private List<Long> endDate = new LinkedList<>();
 
     /**
      * task execution date

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/params/radio/RadioParam.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/params/radio/RadioParam.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.spi.params.base.ParamsOptions;
 import org.apache.dolphinscheduler.spi.params.base.PluginParams;
 import org.apache.dolphinscheduler.spi.params.base.Validate;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -65,7 +65,7 @@ public class RadioParam extends PluginParams {
 
         public Builder addParamsOptions(ParamsOptions paramsOptions) {
             if (this.options == null) {
-                this.options = new ArrayList<>();
+                this.options = new LinkedList<>();
             }
 
             this.options.add(paramsOptions);
@@ -104,7 +104,7 @@ public class RadioParam extends PluginParams {
 
         public Builder addValidate(Validate validate) {
             if (this.validateList == null) {
-                this.validateList = new ArrayList<>();
+                this.validateList = new LinkedList<>();
             }
             this.validateList.add(validate);
             return this;

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/params/select/SelectParam.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/params/select/SelectParam.java
@@ -23,7 +23,7 @@ import org.apache.dolphinscheduler.spi.params.base.ParamsOptions;
 import org.apache.dolphinscheduler.spi.params.base.PluginParams;
 import org.apache.dolphinscheduler.spi.params.base.Validate;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -60,7 +60,7 @@ public class SelectParam extends PluginParams {
 
         public Builder addOptions(ParamsOptions paramsOptions) {
             if (this.options == null) {
-                this.options = new ArrayList<>();
+                this.options = new LinkedList<>();
             }
 
             this.options.add(paramsOptions);
@@ -99,7 +99,7 @@ public class SelectParam extends PluginParams {
 
         public Builder addValidate(Validate validate) {
             if (this.validateList == null) {
-                this.validateList = new ArrayList<>();
+                this.validateList = new LinkedList<>();
             }
             this.validateList.add(validate);
             return this;


### PR DESCRIPTION
Hi,

We find that there are inefficient usages of Java Collections:

1. The contains method is invoked upon a list object in a loop. We recommend replacing it with a HashSet.
2. ArrayList is inserted before an iteration, while multiple memory reallocation might occur when the size of the list exceeds its capacity. We recommend replacing it with a LinkedList.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto