### PR TITLE
[Fix-6196] [Master] fix spi log level not match logback-master.xml #6196

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginLoader.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginLoader.java
@@ -59,6 +59,7 @@ public class DolphinPluginLoader {
     private static final ImmutableList<String> DOLPHIN_SPI_PACKAGES = ImmutableList.<String>builder()
             .add("org.apache.dolphinscheduler.spi.")
             .add("com.fasterxml.jackson.")
+            .add("org.slf4j.")
             .build();
 
     private final File installedPluginsDir;


### PR DESCRIPTION
## Purpose of the pull request

match spi log level and master-logback.xml

## Brief change log

add `org.slf4j.` to org.apache.dolphinscheduler.spi.plugin.DolphinPluginLoader#DOLPHIN_SPI_PACKAGES collection

## Verify this pull request

This pull request is code cleanup without any test coverage.
