### PR TITLE
fixed the problem:zk closed immediately when session established

### DIFF
--- a/docker/build/conf/dolphinscheduler/registry.properties.tpl
+++ b/docker/build/conf/dolphinscheduler/registry.properties.tpl
@@ -21,6 +21,10 @@ registry.plugin.dir=${REGISTRY_PLUGIN_DIR}
 registry.plugin.name=${REGISTRY_PLUGIN_NAME}
 registry.servers=${REGISTRY_SERVERS}
 
+#registry.session.timeout.ms=60000
+#registry.connection.timeout.ms=60000
+#registry.block.until.connected.wait=60000
+
 #maven.local.repository=/usr/local/localRepository
 
 #registry.plugin.binding config the Registry Plugin need be load when development and run in IDE

--- a/docker/build/conf/dolphinscheduler/registry.properties.tpl
+++ b/docker/build/conf/dolphinscheduler/registry.properties.tpl
@@ -22,8 +22,8 @@ registry.plugin.name=${REGISTRY_PLUGIN_NAME}
 registry.servers=${REGISTRY_SERVERS}
 
 #registry.session.timeout.ms=60000
-#registry.connection.timeout.ms=60000
-#registry.block.until.connected.wait=60000
+#registry.connection.timeout.ms=15000
+#registry.block.until.connected.wait=15000
 
 #maven.local.repository=/usr/local/localRepository
 

--- a/dolphinscheduler-registry-plugin/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperConfiguration.java
+++ b/dolphinscheduler-registry-plugin/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperConfiguration.java
@@ -34,11 +34,11 @@ public enum ZookeeperConfiguration {
     MAX_RETRIES("max.retries", 5, Integer::valueOf),
 
 
-    //todo
-    SESSION_TIMEOUT_MS("session.timeout.ms", 1000, Integer::valueOf),
-    CONNECTION_TIMEOUT_MS("connection.timeout.ms", 1000, Integer::valueOf),
+    // Reference Hadoop config
+    SESSION_TIMEOUT_MS("session.timeout.ms", 60000, Integer::valueOf),
+    CONNECTION_TIMEOUT_MS("connection.timeout.ms", 15000, Integer::valueOf),
 
-    BLOCK_UNTIL_CONNECTED_WAIT_MS("block.until.connected.wait", 600, Integer::valueOf),
+    BLOCK_UNTIL_CONNECTED_WAIT_MS("block.until.connected.wait", 15000, Integer::valueOf),
     ;
     private final String name;
 

--- a/dolphinscheduler-service/src/main/resources/registry.properties
+++ b/dolphinscheduler-service/src/main/resources/registry.properties
@@ -23,5 +23,9 @@ registry.servers=127.0.0.1:2181
 
 #maven.local.repository=/usr/local/localRepository
 
+#registry.session.timeout.ms=60000
+#registry.connection.timeout.ms=15000
+#registry.block.until.connected.wait=15000
+
 #registry.plugin.binding config the Registry Plugin need be load when development and run in IDE
 #registry.plugin.binding=./dolphinscheduler-registry-plugin/dolphinscheduler-registry-zookeeper/pom.xml


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This pull request fixed zk registry timeout problem.

Someone meet the same issue #5792 and maybe #5968

## Brief change log

According to Hadoop configuration, increase the default timeout, and added them to the config file

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.