### PR TITLE
Fix StandaloneServer start with error

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-shell/pom.xml
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-shell/pom.xml
@@ -44,6 +44,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Start standalone server with error
NoClassDefFoundError

closes: https://github.com/apache/dolphinscheduler/issues/6265


## Purpose of the pull request

Start standalone server with error
NoClassDefFoundError

closes: https://github.com/apache/dolphinscheduler/issues/6265


## Brief change log

Fix StandaloneServer class no found error when start server in IDEA

## Verify this pull request

