### PR TITLE
[FIX-BUG][Master] Parallel tasks would be Irregularly submitted twice

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -193,6 +193,12 @@ public class WorkflowExecuteThread implements Runnable {
     private ConcurrentHashMap<Integer, TaskInstance> taskTimeoutCheckList;
 
     /**
+     * start flag, true: start nodes submit completely
+     *
+     */
+    private boolean isStart = false;
+
+    /**
      * constructor of WorkflowExecuteThread
      *
      * @param processInstance processInstance
@@ -226,6 +232,14 @@ public class WorkflowExecuteThread implements Runnable {
         } catch (Exception e) {
             logger.error("handler error:", e);
         }
+    }
+
+    /**
+     * the process start nodes are submitted completely.
+     * @return
+     */
+    public boolean isStart() {
+        return this.isStart;
     }
 
     private void handleEvents() {
@@ -460,10 +474,12 @@ public class WorkflowExecuteThread implements Runnable {
     }
 
     private void startProcess() throws Exception {
-        buildFlowDag();
         if (this.taskInstanceHashMap.size() == 0) {
+            isStart = false;
+            buildFlowDag();
             initTaskQueue();
             submitPostNode(null);
+            isStart = true;
         }
     }
 


### PR DESCRIPTION
close #6279  Parallel tasks would be Irregularly submitted twice

There is a thread conflict between submitting the start task and event handling.
So i set 'isStart' flag when the start nodes are submitted completely.