### PR TITLE
[Fix-6286] [API] fix deleteProcessDefinitionVersion bug

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationLogMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationLogMapper.java
@@ -47,4 +47,14 @@ public interface ProcessTaskRelationLogMapper extends BaseMapper<ProcessTaskRela
      * @return int
      */
     int batchInsert(@Param("taskRelationList") List<ProcessTaskRelationLog> taskRelationList);
+
+    /**
+     * delete process task relation log by processCode and version
+     *
+     * @param processCode process definition code
+     * @param processVersion process version
+     * @return int
+     */
+    int deleteByCode(@Param("processCode") long processCode,
+                     @Param("processVersion") int processVersion);
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationLogMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTaskRelationLogMapper.xml
@@ -41,4 +41,9 @@
             #{relation.createTime},#{relation.updateTime})
         </foreach>
     </insert>
+    <delete id="deleteByCode">
+        delete from t_ds_process_task_relation_log
+        WHERE process_definition_code = #{processCode}
+        and process_definition_version = #{processVersion}
+    </delete>
 </mapper>


### PR DESCRIPTION
close #6286
When deleting the workflow version, the workflow relationship of the corresponding version will be deleted.