### PR TITLE
[Fix-5551][common] Fix ExecutionStatus for hive-on-Tez application

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -658,6 +658,10 @@ public final class Constants {
      */
     public static final String SUCCEEDED = "SUCCEEDED";
     /**
+     * ENDED
+     */
+    public static final String ENDED = "ENDED";
+    /**
      * NEW
      */
     public static final String NEW = "NEW";

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -446,6 +446,7 @@ public class HadoopUtils implements Closeable {
             case Constants.ACCEPTED:
                 return ExecutionStatus.SUBMITTED_SUCCESS;
             case Constants.SUCCEEDED:
+            case Constants.ENDED:
                 return ExecutionStatus.SUCCESS;
             case Constants.NEW:
             case Constants.NEW_SAVING:


### PR DESCRIPTION
## Purpose of the pull request

Fix #5551 , which will update `ExecutionStatus` as success when application final state is ended and the work flow goes on.


see also code:  [FinalApplicationStatus](https://github.com/apache/hadoop/blob/branch-3.3.1/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/FinalApplicationStatus.java )

## Brief change log

add "ENDED" as success state

## Verify this pull request

This change can be verified as follows:

create a simple sql file contains any query, such as `query1.sql` , and run the query as `hive -f query1.sql`
