### PR TITLE
[Fix][Task]Task lost resource information (#6292)

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/process/ResourceInfo.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/process/ResourceInfo.java
@@ -20,26 +20,43 @@ package org.apache.dolphinscheduler.common.process;
  * resource info
  */
 public class ResourceInfo {
-  /**
-   * res the name of the resource that was uploaded
-   */
-  private int id;
+    /**
+     * res id of the resource that was uploaded
+     */
+    private int id;
 
-  public int getId() {
-    return id;
-  }
+    private String res;
 
-  public void setId(int id) {
-    this.id = id;
-  }
+    /**
+     * full name of the resource that was uploaded
+     */
+    private String resourceName;
 
-  private String res;
+    public ResourceInfo() {
+        // do nothing, void constructor
+    }
 
-  public String getRes() {
-    return res;
-  }
+    public int getId() {
+        return id;
+    }
 
-  public void setRes(String res) {
-    this.res = res;
-  }
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getRes() {
+        return res;
+    }
+
+    public void setRes(String res) {
+        this.res = res;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/process/ResourceInfo.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/process/ResourceInfo.java
@@ -21,9 +21,20 @@ package org.apache.dolphinscheduler.common.process;
  */
 public class ResourceInfo {
   /**
-   * res the name of the resource that was uploaded
+   * res id of the resource that was uploaded
    */
   private int id;
+
+  private String res;
+
+  /**
+   * full name of the resource that was uploaded
+   */
+  private String resourceName;
+
+  public ResourceInfo() {
+    // do nothing, void constructor
+  }
 
   public int getId() {
     return id;
@@ -33,13 +44,19 @@ public class ResourceInfo {
     this.id = id;
   }
 
-  private String res;
-
   public String getRes() {
     return res;
   }
 
   public void setRes(String res) {
     this.res = res;
+  }
+
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  public void setResourceName(String resourceName) {
+    this.resourceName = resourceName;
   }
 }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -30,6 +30,7 @@ import static org.apache.dolphinscheduler.common.Constants.YYYY_MM_DD_HH_MM_SS;
 
 import static java.util.stream.Collectors.toSet;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.CommandType;
@@ -106,17 +107,8 @@ import org.apache.dolphinscheduler.service.log.LogClientService;
 
 import org.apache.commons.lang.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -1527,6 +1519,36 @@ public class ProcessService {
         TaskDefinition taskDefinition = taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
             taskInstance.getTaskCode(),
             taskInstance.getTaskDefinitionVersion());
+        // if contains mainJar field, query resource from database
+        // Flink, Spark, MR
+        Map<String, Object> taskParameters = JSONUtils.parseObject(
+                taskDefinition.getTaskParams(),
+                new TypeReference<Map<String, Object>>() {});
+        if (taskParameters != null && taskParameters.containsKey("mainJar")) {
+            Object mainJarObj = taskParameters.get("mainJar");
+            ResourceInfo mainJar = JSONUtils.parseObject(
+                    JSONUtils.toJsonString(mainJarObj),
+                    ResourceInfo.class);
+            // only if mainJar is not null and does not contains "resourceName" field
+            if (mainJar != null && StringUtils.isEmpty(mainJar.getResourceName())) {
+                int resourceId = mainJar.getId();
+                // get resource from database, only one resource should be returned
+                List<Integer> resourceIds = Collections.singletonList(resourceId);
+                List<Resource> resourceList = resourceMapper.queryResourceListById(resourceIds);
+                // update mainJar field
+                if (!resourceList.isEmpty()) {
+                    Resource resource = resourceList.get(0);
+                    if (logger.isInfoEnabled()) {
+                        logger.info("get main jar resource for task {}, {}",
+                                taskInstId, JSONUtils.toJsonString(resource));
+                    }
+                    mainJar.setResourceName(resource.getFullName());
+                    taskParameters.put("mainJar", mainJar);
+                }
+                // set task parameters
+                taskDefinition.setTaskParams(JSONUtils.toJsonString(taskParameters));
+            }
+        }
         taskInstance.setTaskDefine(taskDefinition);
         return taskInstance;
     }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -17,12 +17,7 @@
 
 package org.apache.dolphinscheduler.service.process;
 
-import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_RECOVER_PROCESS_ID_STRING;
-import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_START_PARAMS;
-import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_SUB_PROCESS_DEFINE_ID;
-
-import static org.mockito.ArgumentMatchers.any;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.Flag;
@@ -31,36 +26,13 @@ import org.apache.dolphinscheduler.common.enums.WarningType;
 import org.apache.dolphinscheduler.common.graph.DAG;
 import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.common.model.TaskNodeRelation;
+import org.apache.dolphinscheduler.common.process.ResourceInfo;
+import org.apache.dolphinscheduler.common.task.spark.SparkParameters;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-import org.apache.dolphinscheduler.dao.entity.Command;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionLog;
-import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
-import org.apache.dolphinscheduler.dao.entity.ProcessInstanceMap;
-import org.apache.dolphinscheduler.dao.entity.ProcessTaskRelation;
-import org.apache.dolphinscheduler.dao.entity.ProcessTaskRelationLog;
-import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
-import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessTaskRelationLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessTaskRelationMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.entity.*;
+import org.apache.dolphinscheduler.dao.mapper.*;
 import org.apache.dolphinscheduler.service.quartz.cron.CronUtilsTest;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,10 +40,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.dolphinscheduler.common.Constants.*;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * process service test
@@ -103,6 +81,8 @@ public class ProcessServiceTest {
     private ProcessTaskRelationMapper processTaskRelationMapper;
     @Mock
     private ProcessDefinitionLogMapper processDefineLogMapper;
+    @Mock
+    private ResourceMapper resourceMapper;
 
     @Test
     public void testCreateSubCommand() {
@@ -230,7 +210,7 @@ public class ProcessServiceTest {
         command.setProcessDefinitionCode(222);
         command.setCommandType(CommandType.REPEAT_RUNNING);
         command.setCommandParam("{\"" + CMD_PARAM_RECOVER_PROCESS_ID_STRING + "\":\"111\",\""
-            + CMD_PARAM_SUB_PROCESS_DEFINE_ID + "\":\"222\"}");
+                + CMD_PARAM_SUB_PROCESS_DEFINE_ID + "\":\"222\"}");
         Assert.assertNull(processService.handleCommand(logger, host, validThreadNum, command));
 
         //there is not enough thread for this command
@@ -250,7 +230,7 @@ public class ProcessServiceTest {
         processInstance.setProcessDefinitionVersion(1);
         Mockito.when(processDefineMapper.queryByCode(command1.getProcessDefinitionCode())).thenReturn(processDefinition);
         Mockito.when(processDefineLogMapper.queryByDefinitionCodeAndVersion(processInstance.getProcessDefinitionCode(),
-            processInstance.getProcessDefinitionVersion())).thenReturn(new ProcessDefinitionLog(processDefinition));
+                processInstance.getProcessDefinitionVersion())).thenReturn(new ProcessDefinitionLog(processDefinition));
         Mockito.when(processInstanceMapper.queryDetailById(222)).thenReturn(processInstance);
         Assert.assertNotNull(processService.handleCommand(logger, host, validThreadNum, command1));
 
@@ -331,7 +311,7 @@ public class ProcessServiceTest {
         processTaskRelationLog.setPostTaskVersion(postTaskVersion);
         relationLogList.add(processTaskRelationLog);
         Mockito.when(processTaskRelationLogMapper.queryByProcessCodeAndVersion(parentProcessDefineCode
-            , parentProcessDefineVersion)).thenReturn(relationLogList);
+                , parentProcessDefineVersion)).thenReturn(relationLogList);
 
         List<TaskDefinitionLog> taskDefinitionLogs = new ArrayList<>();
         TaskDefinitionLog taskDefinitionLog1 = new TaskDefinitionLog();
@@ -433,11 +413,128 @@ public class ProcessServiceTest {
         processInstance.setId(62);
         taskInstance.setVarPool("[{\"direct\":\"OUT\",\"prop\":\"test1\",\"type\":\"VARCHAR\",\"value\":\"\"}]");
         taskInstance.setTaskParams("{\"type\":\"MYSQL\",\"datasource\":1,\"sql\":\"select id from tb_test limit 1\","
-            + "\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\","
-            + "\"groupId\":null,\"localParams\":[{\"prop\":\"test1\",\"direct\":\"OUT\",\"type\":\"VARCHAR\",\"value\":\"12\"}],"
-            + "\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"conditionResult\":\"{\\\"successNode\\\":[\\\"\\\"],"
-            + "\\\"failedNode\\\":[\\\"\\\"]}\",\"dependence\":\"{}\"}");
+                + "\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\","
+                + "\"groupId\":null,\"localParams\":[{\"prop\":\"test1\",\"direct\":\"OUT\",\"type\":\"VARCHAR\",\"value\":\"12\"}],"
+                + "\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"conditionResult\":\"{\\\"successNode\\\":[\\\"\\\"],"
+                + "\\\"failedNode\\\":[\\\"\\\"]}\",\"dependence\":\"{}\"}");
         processService.changeOutParam(taskInstance);
+    }
+
+    @Test
+    public void testUpdateTaskDefinitionResources() throws Exception {
+        TaskDefinition taskDefinition = new TaskDefinition();
+        String taskParameters = "{\n" +
+                "    \"mainClass\": \"org.apache.dolphinscheduler.SparkTest\",\n" +
+                "    \"mainJar\": {\n" +
+                "        \"id\": 1\n" +
+                "    },\n" +
+                "    \"deployMode\": \"cluster\",\n" +
+                "    \"resourceList\": [\n" +
+                "        {\n" +
+                "            \"id\": 3\n" +
+                "        },\n" +
+                "        {\n" +
+                "            \"id\": 4\n" +
+                "        }\n" +
+                "    ],\n" +
+                "    \"localParams\": [],\n" +
+                "    \"driverCores\": 1,\n" +
+                "    \"driverMemory\": \"512M\",\n" +
+                "    \"numExecutors\": 2,\n" +
+                "    \"executorMemory\": \"2G\",\n" +
+                "    \"executorCores\": 2,\n" +
+                "    \"appName\": \"\",\n" +
+                "    \"mainArgs\": \"\",\n" +
+                "    \"others\": \"\",\n" +
+                "    \"programType\": \"JAVA\",\n" +
+                "    \"sparkVersion\": \"SPARK2\",\n" +
+                "    \"dependence\": {},\n" +
+                "    \"conditionResult\": {\n" +
+                "        \"successNode\": [\n" +
+                "            \"\"\n" +
+                "        ],\n" +
+                "        \"failedNode\": [\n" +
+                "            \"\"\n" +
+                "        ]\n" +
+                "    },\n" +
+                "    \"waitStartTimeout\": {}\n" +
+                "}";
+        taskDefinition.setTaskParams(taskParameters);
+
+        Map<Integer, Resource> resourceMap =
+                Stream.of(1, 3, 4)
+                        .map(i -> {
+                            Resource resource = new Resource();
+                            resource.setId(i);
+                            resource.setFileName("file" + i);
+                            resource.setFullName("/file" + i);
+                            return resource;
+                        })
+                        .collect(
+                                Collectors.toMap(
+                                        Resource::getId,
+                                        resource -> resource)
+                        );
+        for (Integer integer : Arrays.asList(1, 3, 4)) {
+            Mockito.when(resourceMapper.selectById(integer))
+                    .thenReturn(resourceMap.get(integer));
+        }
+
+        Whitebox.invokeMethod(processService,
+                "updateTaskDefinitionResources",
+                taskDefinition);
+
+        String taskParams = taskDefinition.getTaskParams();
+        SparkParameters sparkParameters = JSONUtils.parseObject(taskParams, SparkParameters.class);
+        ResourceInfo mainJar = sparkParameters.getMainJar();
+        Assert.assertEquals(1, mainJar.getId());
+        Assert.assertEquals("file1", mainJar.getRes());
+        Assert.assertEquals("/file1", mainJar.getResourceName());
+
+        Assert.assertEquals(2, sparkParameters.getResourceList().size());
+        ResourceInfo res1 = sparkParameters.getResourceList().get(0);
+        ResourceInfo res2 = sparkParameters.getResourceList().get(1);
+        Assert.assertEquals(3, res1.getId());
+        Assert.assertEquals("file3", res1.getRes());
+        Assert.assertEquals("/file3", res1.getResourceName());
+        Assert.assertEquals(4, res2.getId());
+        Assert.assertEquals("file4", res2.getRes());
+        Assert.assertEquals("/file4", res2.getResourceName());
+
+    }
+
+    @Test
+    public void testUpdateResourceInfo() throws Exception {
+        // test if input is null
+        ResourceInfo resourceInfoNull = null;
+        ResourceInfo updatedResourceInfo1 = Whitebox.invokeMethod(processService,
+                "updateResourceInfo",
+                resourceInfoNull);
+        Assert.assertNull(updatedResourceInfo1);
+
+        // test if resource id less than 1
+        ResourceInfo resourceInfoVoid = new ResourceInfo();
+        ResourceInfo updatedResourceInfo2 = Whitebox.invokeMethod(processService,
+                "updateResourceInfo",
+                resourceInfoVoid);
+        Assert.assertNull(updatedResourceInfo2);
+
+        // test normal situation
+        ResourceInfo resourceInfoNormal = new ResourceInfo();
+        resourceInfoNormal.setId(1);
+        Resource resource = new Resource();
+        resource.setId(1);
+        resource.setFileName("test.txt");
+        resource.setFullName("/test.txt");
+        Mockito.when(resourceMapper.selectById(1)).thenReturn(resource);
+        ResourceInfo updatedResourceInfo3 = Whitebox.invokeMethod(processService,
+                "updateResourceInfo",
+                resourceInfoNormal);
+
+        Assert.assertEquals(1, updatedResourceInfo3.getId());
+        Assert.assertEquals("test.txt", updatedResourceInfo3.getRes());
+        Assert.assertEquals("/test.txt", updatedResourceInfo3.getResourceName());
+
     }
 
 }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -20,7 +20,6 @@ package org.apache.dolphinscheduler.service.process;
 import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_RECOVER_PROCESS_ID_STRING;
 import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_START_PARAMS;
 import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_SUB_PROCESS_DEFINE_ID;
-
 import static org.mockito.ArgumentMatchers.any;
 
 import org.apache.dolphinscheduler.common.Constants;
@@ -241,7 +240,7 @@ public class ProcessServiceTest {
         command.setProcessDefinitionCode(222);
         command.setCommandType(CommandType.REPEAT_RUNNING);
         command.setCommandParam("{\"" + CMD_PARAM_RECOVER_PROCESS_ID_STRING + "\":\"111\",\""
-                + CMD_PARAM_SUB_PROCESS_DEFINE_ID + "\":\"222\"}");
+            + CMD_PARAM_SUB_PROCESS_DEFINE_ID + "\":\"222\"}");
         Assert.assertNull(processService.handleCommand(logger, host, validThreadNum, command));
 
         //there is not enough thread for this command
@@ -261,7 +260,7 @@ public class ProcessServiceTest {
         processInstance.setProcessDefinitionVersion(1);
         Mockito.when(processDefineMapper.queryByCode(command1.getProcessDefinitionCode())).thenReturn(processDefinition);
         Mockito.when(processDefineLogMapper.queryByDefinitionCodeAndVersion(processInstance.getProcessDefinitionCode(),
-                processInstance.getProcessDefinitionVersion())).thenReturn(new ProcessDefinitionLog(processDefinition));
+            processInstance.getProcessDefinitionVersion())).thenReturn(new ProcessDefinitionLog(processDefinition));
         Mockito.when(processInstanceMapper.queryDetailById(222)).thenReturn(processInstance);
         Assert.assertNotNull(processService.handleCommand(logger, host, validThreadNum, command1));
 
@@ -342,7 +341,7 @@ public class ProcessServiceTest {
         processTaskRelationLog.setPostTaskVersion(postTaskVersion);
         relationLogList.add(processTaskRelationLog);
         Mockito.when(processTaskRelationLogMapper.queryByProcessCodeAndVersion(parentProcessDefineCode
-                , parentProcessDefineVersion)).thenReturn(relationLogList);
+            , parentProcessDefineVersion)).thenReturn(relationLogList);
 
         List<TaskDefinitionLog> taskDefinitionLogs = new ArrayList<>();
         TaskDefinitionLog taskDefinitionLog1 = new TaskDefinitionLog();
@@ -444,10 +443,10 @@ public class ProcessServiceTest {
         processInstance.setId(62);
         taskInstance.setVarPool("[{\"direct\":\"OUT\",\"prop\":\"test1\",\"type\":\"VARCHAR\",\"value\":\"\"}]");
         taskInstance.setTaskParams("{\"type\":\"MYSQL\",\"datasource\":1,\"sql\":\"select id from tb_test limit 1\","
-                + "\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\","
-                + "\"groupId\":null,\"localParams\":[{\"prop\":\"test1\",\"direct\":\"OUT\",\"type\":\"VARCHAR\",\"value\":\"12\"}],"
-                + "\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"conditionResult\":\"{\\\"successNode\\\":[\\\"\\\"],"
-                + "\\\"failedNode\\\":[\\\"\\\"]}\",\"dependence\":\"{}\"}");
+            + "\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\","
+            + "\"groupId\":null,\"localParams\":[{\"prop\":\"test1\",\"direct\":\"OUT\",\"type\":\"VARCHAR\",\"value\":\"12\"}],"
+            + "\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"conditionResult\":\"{\\\"successNode\\\":[\\\"\\\"],"
+            + "\\\"failedNode\\\":[\\\"\\\"]}\",\"dependence\":\"{}\"}");
         processService.changeOutParam(taskInstance);
     }
 
@@ -455,65 +454,65 @@ public class ProcessServiceTest {
     public void testUpdateTaskDefinitionResources() throws Exception {
         TaskDefinition taskDefinition = new TaskDefinition();
         String taskParameters = "{\n"
-                + "    \"mainClass\": \"org.apache.dolphinscheduler.SparkTest\",\n"
-                + "    \"mainJar\": {\n"
-                + "        \"id\": 1\n"
-                + "    },\n"
-                + "    \"deployMode\": \"cluster\",\n"
-                + "    \"resourceList\": [\n"
-                + "        {\n"
-                + "            \"id\": 3\n"
-                + "        },\n"
-                + "        {\n"
-                + "            \"id\": 4\n"
-                + "        }\n"
-                + "    ],\n"
-                + "    \"localParams\": [],\n"
-                + "    \"driverCores\": 1,\n"
-                + "    \"driverMemory\": \"512M\",\n"
-                + "    \"numExecutors\": 2,\n"
-                + "    \"executorMemory\": \"2G\",\n"
-                + "    \"executorCores\": 2,\n"
-                + "    \"appName\": \"\",\n"
-                + "    \"mainArgs\": \"\",\n"
-                + "    \"others\": \"\",\n"
-                + "    \"programType\": \"JAVA\",\n"
-                + "    \"sparkVersion\": \"SPARK2\",\n"
-                + "    \"dependence\": {},\n"
-                + "    \"conditionResult\": {\n"
-                + "        \"successNode\": [\n"
-                + "            \"\"\n"
-                + "        ],\n"
-                + "        \"failedNode\": [\n"
-                + "            \"\"\n"
-                + "        ]\n"
-                + "    },\n"
-                + "    \"waitStartTimeout\": {}\n"
-                + "}";
+            + "    \"mainClass\": \"org.apache.dolphinscheduler.SparkTest\",\n"
+            + "    \"mainJar\": {\n"
+            + "        \"id\": 1\n"
+            + "    },\n"
+            + "    \"deployMode\": \"cluster\",\n"
+            + "    \"resourceList\": [\n"
+            + "        {\n"
+            + "            \"id\": 3\n"
+            + "        },\n"
+            + "        {\n"
+            + "            \"id\": 4\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"localParams\": [],\n"
+            + "    \"driverCores\": 1,\n"
+            + "    \"driverMemory\": \"512M\",\n"
+            + "    \"numExecutors\": 2,\n"
+            + "    \"executorMemory\": \"2G\",\n"
+            + "    \"executorCores\": 2,\n"
+            + "    \"appName\": \"\",\n"
+            + "    \"mainArgs\": \"\",\n"
+            + "    \"others\": \"\",\n"
+            + "    \"programType\": \"JAVA\",\n"
+            + "    \"sparkVersion\": \"SPARK2\",\n"
+            + "    \"dependence\": {},\n"
+            + "    \"conditionResult\": {\n"
+            + "        \"successNode\": [\n"
+            + "            \"\"\n"
+            + "        ],\n"
+            + "        \"failedNode\": [\n"
+            + "            \"\"\n"
+            + "        ]\n"
+            + "    },\n"
+            + "    \"waitStartTimeout\": {}\n"
+            + "}";
         taskDefinition.setTaskParams(taskParameters);
 
         Map<Integer, Resource> resourceMap =
-                Stream.of(1, 3, 4)
-                        .map(i -> {
-                            Resource resource = new Resource();
-                            resource.setId(i);
-                            resource.setFileName("file" + i);
-                            resource.setFullName("/file" + i);
-                            return resource;
-                        })
-                        .collect(
-                                Collectors.toMap(
-                                        Resource::getId,
-                                        resource -> resource)
-                        );
+            Stream.of(1, 3, 4)
+                .map(i -> {
+                    Resource resource = new Resource();
+                    resource.setId(i);
+                    resource.setFileName("file" + i);
+                    resource.setFullName("/file" + i);
+                    return resource;
+                })
+                .collect(
+                    Collectors.toMap(
+                        Resource::getId,
+                        resource -> resource)
+                );
         for (Integer integer : Arrays.asList(1, 3, 4)) {
             Mockito.when(resourceMapper.selectById(integer))
-                    .thenReturn(resourceMap.get(integer));
+                .thenReturn(resourceMap.get(integer));
         }
 
         Whitebox.invokeMethod(processService,
-                "updateTaskDefinitionResources",
-                taskDefinition);
+            "updateTaskDefinitionResources",
+            taskDefinition);
 
         String taskParams = taskDefinition.getTaskParams();
         SparkParameters sparkParameters = JSONUtils.parseObject(taskParams, SparkParameters.class);
@@ -539,15 +538,15 @@ public class ProcessServiceTest {
         // test if input is null
         ResourceInfo resourceInfoNull = null;
         ResourceInfo updatedResourceInfo1 = Whitebox.invokeMethod(processService,
-                "updateResourceInfo",
-                resourceInfoNull);
+            "updateResourceInfo",
+            resourceInfoNull);
         Assert.assertNull(updatedResourceInfo1);
 
         // test if resource id less than 1
         ResourceInfo resourceInfoVoid = new ResourceInfo();
         ResourceInfo updatedResourceInfo2 = Whitebox.invokeMethod(processService,
-                "updateResourceInfo",
-                resourceInfoVoid);
+            "updateResourceInfo",
+            resourceInfoVoid);
         Assert.assertNull(updatedResourceInfo2);
 
         // test normal situation
@@ -559,8 +558,8 @@ public class ProcessServiceTest {
         resource.setFullName("/test.txt");
         Mockito.when(resourceMapper.selectById(1)).thenReturn(resource);
         ResourceInfo updatedResourceInfo3 = Whitebox.invokeMethod(processService,
-                "updateResourceInfo",
-                resourceInfoNormal);
+            "updateResourceInfo",
+            resourceInfoNormal);
 
         Assert.assertEquals(1, updatedResourceInfo3.getId());
         Assert.assertEquals("test.txt", updatedResourceInfo3.getRes());

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -454,42 +454,42 @@ public class ProcessServiceTest {
     @Test
     public void testUpdateTaskDefinitionResources() throws Exception {
         TaskDefinition taskDefinition = new TaskDefinition();
-        String taskParameters = "{\n" +
-                "    \"mainClass\": \"org.apache.dolphinscheduler.SparkTest\",\n" +
-                "    \"mainJar\": {\n" +
-                "        \"id\": 1\n" +
-                "    },\n" +
-                "    \"deployMode\": \"cluster\",\n" +
-                "    \"resourceList\": [\n" +
-                "        {\n" +
-                "            \"id\": 3\n" +
-                "        },\n" +
-                "        {\n" +
-                "            \"id\": 4\n" +
-                "        }\n" +
-                "    ],\n" +
-                "    \"localParams\": [],\n" +
-                "    \"driverCores\": 1,\n" +
-                "    \"driverMemory\": \"512M\",\n" +
-                "    \"numExecutors\": 2,\n" +
-                "    \"executorMemory\": \"2G\",\n" +
-                "    \"executorCores\": 2,\n" +
-                "    \"appName\": \"\",\n" +
-                "    \"mainArgs\": \"\",\n" +
-                "    \"others\": \"\",\n" +
-                "    \"programType\": \"JAVA\",\n" +
-                "    \"sparkVersion\": \"SPARK2\",\n" +
-                "    \"dependence\": {},\n" +
-                "    \"conditionResult\": {\n" +
-                "        \"successNode\": [\n" +
-                "            \"\"\n" +
-                "        ],\n" +
-                "        \"failedNode\": [\n" +
-                "            \"\"\n" +
-                "        ]\n" +
-                "    },\n" +
-                "    \"waitStartTimeout\": {}\n" +
-                "}";
+        String taskParameters = "{\n"
+                + "    \"mainClass\": \"org.apache.dolphinscheduler.SparkTest\",\n"
+                + "    \"mainJar\": {\n"
+                + "        \"id\": 1\n"
+                + "    },\n"
+                + "    \"deployMode\": \"cluster\",\n"
+                + "    \"resourceList\": [\n"
+                + "        {\n"
+                + "            \"id\": 3\n"
+                + "        },\n"
+                + "        {\n"
+                + "            \"id\": 4\n"
+                + "        }\n"
+                + "    ],\n"
+                + "    \"localParams\": [],\n"
+                + "    \"driverCores\": 1,\n"
+                + "    \"driverMemory\": \"512M\",\n"
+                + "    \"numExecutors\": 2,\n"
+                + "    \"executorMemory\": \"2G\",\n"
+                + "    \"executorCores\": 2,\n"
+                + "    \"appName\": \"\",\n"
+                + "    \"mainArgs\": \"\",\n"
+                + "    \"others\": \"\",\n"
+                + "    \"programType\": \"JAVA\",\n"
+                + "    \"sparkVersion\": \"SPARK2\",\n"
+                + "    \"dependence\": {},\n"
+                + "    \"conditionResult\": {\n"
+                + "        \"successNode\": [\n"
+                + "            \"\"\n"
+                + "        ],\n"
+                + "        \"failedNode\": [\n"
+                + "            \"\"\n"
+                + "        ]\n"
+                + "    },\n"
+                + "    \"waitStartTimeout\": {}\n"
+                + "}";
         taskDefinition.setTaskParams(taskParameters);
 
         Map<Integer, Resource> resourceMap =

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -17,7 +17,12 @@
 
 package org.apache.dolphinscheduler.service.process;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_RECOVER_PROCESS_ID_STRING;
+import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_START_PARAMS;
+import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_SUB_PROCESS_DEFINE_ID;
+
+import static org.mockito.ArgumentMatchers.any;
+
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.Flag;
@@ -30,9 +35,40 @@ import org.apache.dolphinscheduler.common.process.ResourceInfo;
 import org.apache.dolphinscheduler.common.task.spark.SparkParameters;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-import org.apache.dolphinscheduler.dao.entity.*;
-import org.apache.dolphinscheduler.dao.mapper.*;
+import org.apache.dolphinscheduler.dao.entity.Command;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionLog;
+import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
+import org.apache.dolphinscheduler.dao.entity.ProcessInstanceMap;
+import org.apache.dolphinscheduler.dao.entity.ProcessTaskRelation;
+import org.apache.dolphinscheduler.dao.entity.ProcessTaskRelationLog;
+import org.apache.dolphinscheduler.dao.entity.Resource;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
+import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionLogMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessTaskRelationLogMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProcessTaskRelationMapper;
+import org.apache.dolphinscheduler.dao.mapper.ResourceMapper;
+import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
+import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.service.quartz.cron.CronUtilsTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,12 +80,7 @@ import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.apache.dolphinscheduler.common.Constants.*;
-import static org.mockito.ArgumentMatchers.any;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * process service test


### PR DESCRIPTION
## Purpose of the pull request
fix #6292 

## Brief change log
* fetch mainJar information when worker get task details
* add resourceName field to org.apache.dolphinscheduler.common.process.ResourceInfo

## Verify this pull request
this pr modified org.apache.dolphinscheduler.common.process.ResourceInfo, but it seems  like that two class named ResourceInfo has the same fields...
i suppose we should delete one of them

resolves #6292 