### PR TITLE
[#6309] [Bug] [UI] when one task instance has been deleted, then create another task instance with the same name,throw 'name already exist' error. 

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/mutations.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/mutations.js
@@ -143,7 +143,7 @@ export default {
    */
   removeTask (state, code) {
     state.isEditDag = true
-    state.tasks = state.tasks.filter(task => task.code !== code)
+    state.tasks = state.tasks.filter(task => task.code === code)
   },
   resetLocalParam (state, payload) {
     const tasks = state.tasks


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix #6309 issue

## Brief change log

in origin version, when it's code not equals the previous code, the removeTask will take effect. 
after fixed, the removeTask function will take effect when delete the same code and the we can create another task instance with the same name.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

resolve #6309

