### PR TITLE
[Fix-6347][Master]fix bug the first schedule_time is error in complement data

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
@@ -187,7 +187,7 @@ public class MasterSchedulerService extends Thread {
                     if (processInstance.getTimeout() > 0) {
                         this.processTimeoutCheckList.put(processInstance.getId(), processInstance);
                     }
-                    logger.info("command {} process {} start...",
+                    logger.info("handle command end, command {} process {} start...",
                             command.getId(), processInstance.getId());
                     masterExecService.execute(workflowExecuteThread);
                 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -438,9 +438,14 @@ public class WorkflowExecuteThread implements Runnable {
             endProcess();
             int index = complementListDate.indexOf(scheduleDate);
             if (index >= complementListDate.size() - 1 || !processInstance.getState().typeIsSuccess()) {
+                logger.info("process complement end. process id:{}", processInstance.getId());
                 // complement data ends || no success
                 return false;
             }
+            logger.info("process complement continue. process id:{}, schedule time:{} complementListDate:{}",
+                    processInstance.getId(),
+                    processInstance.getScheduleTime(),
+                    complementListDate.toString());
             scheduleDate = complementListDate.get(index + 1);
             //the next process complement
             processInstance.setId(0);
@@ -555,16 +560,9 @@ public class WorkflowExecuteThread implements Runnable {
         }
 
         if (complementListDate.size() == 0 && needComplementProcess()) {
-            Map<String, String> cmdParam = JSONUtils.toMap(processInstance.getCommandParam());
-            Date startDate = DateUtils.getScheduleDate(cmdParam.get(CMDPARAM_COMPLEMENT_DATA_START_DATE));
-            Date endDate = DateUtils.getScheduleDate(cmdParam.get(CMDPARAM_COMPLEMENT_DATA_END_DATE));
-            if (startDate.after(endDate)) {
-                Date tmp = startDate;
-                startDate = endDate;
-                endDate = tmp;
-            }
-            List<Schedule> schedules = processService.queryReleaseSchedulerListByProcessDefinitionCode(processInstance.getProcessDefinitionCode());
-            complementListDate.addAll(CronUtils.getSelfFireDateList(startDate, endDate, schedules));
+            complementListDate = processService.getComplementDateList(
+                    JSONUtils.toMap(processInstance.getCommandParam()),
+                    processInstance.getProcessDefinitionCode());
             logger.info(" process definition code:{} complement data: {}",
                 processInstance.getProcessDefinitionCode(), complementListDate.toString());
         }


### PR DESCRIPTION
fix bug #6347  fix bug the first schedule_time is error in complement data

the first scheduler_time setting cannot be 'start_date'

It should be obtained according to the first of timing list .