### PR TITLE
Add processInstance.setProcessDefinitionCode in UT

### DIFF
--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapperTest.java
@@ -66,6 +66,7 @@ public class TaskInstanceMapperTest {
         ProcessInstance processInstance = new ProcessInstance();
         processInstance.setWarningGroupId(0);
         processInstance.setCommandParam("");
+        processInstance.setProcessDefinitionCode(1L);
         processInstanceMapper.insert(processInstance);
         processInstanceId = processInstance.getId();
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
Fixes #6336 Add processInstance.setProcessDefinitionCode to resolve the issue of not having process_definition_code when inserting a process object into DB
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
add processInstance.setProcessDefinitionCode
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is already covered by existing tests, such as `TaskInstanceMapperTest.java `.

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
