### PR TITLE
[Improvement#6438][Worker]remove meaningless DB query

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/builder/TaskExecutionContextBuilder.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/builder/TaskExecutionContextBuilder.java
@@ -61,6 +61,7 @@ public class TaskExecutionContextBuilder {
         taskExecutionContext.setResources(taskInstance.getResources());
         taskExecutionContext.setDelayTime(taskInstance.getDelayTime());
         taskExecutionContext.setVarPool(taskInstance.getVarPool());
+        taskExecutionContext.setDryRun(taskInstance.getDryRun());
         return this;
     }
 

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/queue/entity/TaskExecutionContext.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/queue/entity/TaskExecutionContext.java
@@ -233,6 +233,11 @@ public class TaskExecutionContext implements Serializable {
     private String varPool;
 
     /**
+     * dry run flag
+     */
+    private int dryRun;
+
+    /**
      * business param
      */
     private Map<String, Property> paramsMap;
@@ -552,6 +557,14 @@ public class TaskExecutionContext implements Serializable {
         this.sqoopTaskExecutionContext = sqoopTaskExecutionContext;
     }
 
+    public int getDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(int dryRun) {
+        this.dryRun = dryRun;
+    }
+
     @Override
     public String toString() {
         return "TaskExecutionContext{"
@@ -579,6 +592,7 @@ public class TaskExecutionContext implements Serializable {
                 + ", projectCode=" + projectCode
                 + ", taskParams='" + taskParams + '\''
                 + ", envFile='" + envFile + '\''
+                + ", dryRun='" + dryRun + '\''
                 + ", definedParams=" + definedParams
                 + ", taskAppId='" + taskAppId + '\''
                 + ", taskTimeoutStrategy=" + taskTimeoutStrategy


### PR DESCRIPTION
org.apache.dolphinscheduler.server.worker.runner.TaskExecuteThread
In the process of task kill, it will query the DB to obtain the task instance object, but this judgment does not make any sense. In fact, the relevant context is already clear, so there is no need to query from DB.

#6104 dryRun can be passed through the context without the need to perform DB query again.

and this closes #6438

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
