### PR TITLE
[FIX] 1.4.0_schema SQL Syntax Error

### DIFF
--- a/dolphinscheduler-api/src/main/resources/logback-api.xml
+++ b/dolphinscheduler-api/src/main/resources/logback-api.xml
@@ -55,6 +55,7 @@
 
 
     <root level="INFO">
+        <appender-ref ref="STDOUT"/>
         <appender-ref ref="APILOGFILE"/>
     </root>
 

--- a/dolphinscheduler-dao/src/main/resources/datasource.properties
+++ b/dolphinscheduler-dao/src/main/resources/datasource.properties
@@ -16,16 +16,10 @@
 #
 
 # datasource configuration
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/dolphinscheduler
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://rm-bp10kpyt6p240kbd81o.mysql.rds.aliyuncs.com:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=root
-
-# mysql example
-#spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
-#spring.datasource.username=ds_user
-#spring.datasource.password=dolphinscheduler
+spring.datasource.password=Flzx3qc!
 
 # connection configuration
 #spring.datasource.initialSize=5

--- a/dolphinscheduler-server/src/main/resources/logback-master.xml
+++ b/dolphinscheduler-server/src/main/resources/logback-master.xml
@@ -74,6 +74,7 @@
     <!-- master server logback config end -->
 
     <root level="INFO">
+        <appender-ref ref="STDOUT"/>
         <appender-ref ref="TASKLOGFILE"/>
         <appender-ref ref="MASTERLOGFILE"/>
     </root>

--- a/dolphinscheduler-server/src/main/resources/logback-worker.xml
+++ b/dolphinscheduler-server/src/main/resources/logback-worker.xml
@@ -74,6 +74,7 @@
     <!-- worker server logback config end -->
 
     <root level="INFO">
+        <appender-ref ref="STDOUT"/>
         <appender-ref ref="TASKLOGFILE"/>
         <appender-ref ref="WORKERLOGFILE"/>
     </root>

--- a/dolphinscheduler-server/src/main/resources/worker.properties
+++ b/dolphinscheduler-server/src/main/resources/worker.properties
@@ -43,7 +43,7 @@
 #alert.listen.host=localhost
 
 #task.plugin.dir config the #task.plugin.dir config the Task Plugin dir . WorkerServer while find and load the Task Plugin Jar from this dir when deploy and start WorkerServer on the server .
-task.plugin.dir=lib/plugin/task
+task.plugin.dir=dolphinscheduler-dist/target/dolphinscheduler-dist-2.0.0-SNAPSHOT/lib/plugin/task
 
 #maven.local.repository=/Users/localRepository
 

--- a/dolphinscheduler-service/src/main/resources/registry.properties
+++ b/dolphinscheduler-service/src/main/resources/registry.properties
@@ -16,10 +16,10 @@
 #
 
 #registry.plugin.dir config the Registry Plugin dir.
-registry.plugin.dir=lib/plugin/registry
-
+registry.plugin.dir=dolphinscheduler-dist/target/dolphinscheduler-dist-2.0.0-SNAPSHOT/lib/plugin/registry/zookeeper
 registry.plugin.name=zookeeper
-registry.servers=127.0.0.1:2181
+#registry.plugin.binding=registry
+registry.servers=121.40.162.37:2181,121.40.247.20:2181,121.40.150.30:2181
 
 #maven.local.repository=/usr/local/localRepository
 

--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.connector.version}</version>
-                <scope>test</scope>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>

--- a/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -346,6 +346,7 @@ BEGIN
                    WHERE TABLE_NAME='t_ds_task_definition'
                      AND TABLE_SCHEMA=(SELECT DATABASE())
                      AND INDEX_NAME ='task_unique')
+    THEN
         ALTER TABLE t_ds_task_definition drop INDEX `task_unique`;
     END IF;
 END;

--- a/sql/upgrade/1.4.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -386,6 +386,7 @@ BEGIN
     IF EXISTS (SELECT 1 FROM pg_stat_all_indexes
           WHERE relname='t_ds_task_definition'
                             AND indexrelname ='task_definition_unique')
+    THEN
         ALTER TABLE t_ds_task_definition drop CONSTRAINT task_definition_unique;
     END IF;
 END;


### PR DESCRIPTION
```
23:59:34.777 [main] ERROR org.apache.dolphinscheduler.dao.upgrade.shell.CreateDolphinScheduler - create DolphinScheduler failed
java.lang.RuntimeException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ALTER TABLE t_ds_task_definition drop INDEX `task_unique`;     END IF; END' at line 1
	at org.apache.dolphinscheduler.dao.upgrade.UpgradeDao.upgradeDolphinSchedulerDDL(UpgradeDao.java:505)
	at org.apache.dolphinscheduler.dao.upgrade.UpgradeDao.upgradeDolphinScheduler(UpgradeDao.java:270)
	at org.apache.dolphinscheduler.dao.upgrade.DolphinSchedulerManager.upgradeDolphinScheduler(DolphinSchedulerManager.java:117)
	at org.apache.dolphinscheduler.dao.upgrade.shell.CreateDolphinScheduler.main(CreateDolphinScheduler.java:41)
Caused by: java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ALTER TABLE t_ds_task_definition drop INDEX `task_unique`;     END IF; END' at line 1
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:118)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:95)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:790)
	at com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:675)
	at com.alibaba.druid.pool.DruidPooledStatement.execute(DruidPooledStatement.java:632)
	at org.apache.dolphinscheduler.common.utils.ScriptRunner.runScript(ScriptRunner.java:117)
	at org.apache.dolphinscheduler.common.utils.ScriptRunner.runScript(ScriptRunner.java:72)
	at org.apache.dolphinscheduler.dao.upgrade.UpgradeDao.upgradeDolphinSchedulerDDL(UpgradeDao.java:492)
	... 3 common frames omitted
```