### PR TITLE
[fix-6562][dao]fix sql syntax error in sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql

### DIFF
--- a/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.4.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -346,6 +346,7 @@ BEGIN
                    WHERE TABLE_NAME='t_ds_task_definition'
                      AND TABLE_SCHEMA=(SELECT DATABASE())
                      AND INDEX_NAME ='task_unique')
+    THEN
         ALTER TABLE t_ds_task_definition drop INDEX `task_unique`;
     END IF;
 END;


### PR DESCRIPTION
[#6562](https://github.com/apache/dolphinscheduler/issues/6562)