### PR TITLE
[DS-6593][DAO] t_ds_error_command miss message in pgsql

### DIFF
--- a/sql/dolphinscheduler_postgre.sql
+++ b/sql/dolphinscheduler_postgre.sql
@@ -302,6 +302,7 @@ CREATE TABLE t_ds_error_command (
   worker_group              varchar(64),
   environment_code          bigint DEFAULT '-1',
   dry_run                   int DEFAULT '0' ,
+  message                   text ,
   process_instance_id       int DEFAULT 0,
   process_definition_version int DEFAULT 0,
   PRIMARY KEY (id)


### PR DESCRIPTION
this pr close #6593 
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
