### PR TITLE
Change feature issue label to "new feature"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -17,7 +17,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "[Feature][Module Name] Feature title"
-labels: [ "feature" ]
+labels: [ "new feature" ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
I find out our feature labels named "new feature" instead of "feature". So when user submit new feature , the feature would not add label, such as https://github.com/apache/dolphinscheduler/issues/6600.

Without label, our stale bot https://github.com/apache/dolphinscheduler/pull/6468 could not work. And the feature issue will be close in 14 days.

And @dailidong suggest we should not close feature issue by bot, cause some of them would been implemented for more than a year https://lists.apache.org/thread.html/r7ffcfe99e6ac262ac46cb0aaa0edc31852641a2673cc52cd531517fe%40%3Cdev.dolphinscheduler.apache.org%3E