### PR TITLE
Fix the definition error of loginInterceptor

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -45,7 +45,7 @@ public class AppConfiguration implements WebMvcConfigurer {
 
     public static final String LOGIN_INTERCEPTOR_PATH_PATTERN = "/**/*";
     public static final String LOGIN_PATH_PATTERN = "/login";
-    public static final String REGISTER_PATH_PATTERN = "/users/registry";
+    public static final String REGISTER_PATH_PATTERN = "/users/register";
     public static final String PATH_PATTERN = "/**";
     public static final String LOCALE_LANGUAGE_COOKIE = "language";
 


### PR DESCRIPTION
The patch fixes the error defined in the REGISTER_PATH_PATTERN, and the authentication cannot be exempted when the api `/dolphinscheduler/users/register` is called.