### PR TITLE
[community] Add stale bot close issue/pr days

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,7 +18,7 @@
 name: Bug report
 title: "[Bug] [Module Name] Bug title "
 description: Problems and issues with code of Apache Dolphinscheduler
-labels: [ "bug" ]
+labels: [ "bug", "Waiting for reply" ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -17,7 +17,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "[Feature][Module Name] Feature title"
-labels: [ "new feature" ]
+labels: [ "new feature", "Waiting for reply" ]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue_robot.yml
+++ b/.github/workflows/issue_robot.yml
@@ -42,9 +42,3 @@ jobs:
         with:
           message: "Hi:\n* Thank you for your feedback, we have received your issue, Please wait patiently for a reply.\n* In order for us to understand your request as soon as possible, please provide detailed information、version or pictures.\n* If you haven't received a reply for a long time, you can subscribe to the developer's email，Mail subscription steps reference https://dolphinscheduler.apache.org/en-us/community/development/subscribe.html ,Then write the issue URL in the email content and send question to dev@dolphinscheduler.apache.org."
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Add lable in issue"
-        uses: ./.github/actions/lable-on-issue
-        with:
-          add-labels: "Waiting for reply"
-          ignore-if-labeled: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,22 +30,22 @@ jobs:
       - uses: actions/stale@v4
         with:
           # Stale Issues
-          days-before-issue-stale: 14
-          days-before-issue-close: 3
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
           # We do not stale Issues with label `Waiting for reply`, `new feature` and `DSIP`
           exempt-issue-labels: 'Waiting for reply,new feature,DSIP'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had recent activity
-            for 14 days. It will be closed in next 3 days if no further activity occurs.
+            for 30 days. It will be closed in next 7 days if no further activity occurs.
           close-issue-message: >
             This issue has been closed because it has not received response for too long time. You could
             reopen it if you encountered similar problems in the future.
           # Stale PRs
-          days-before-pr-stale: 60
-          days-before-pr-close: 5
+          days-before-pr-stale: 120
+          days-before-pr-close: 7
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had recent
-            activity for 60 days. It will be closed in 5 days if no further activity occurs.
+            activity for 120 days. It will be closed in 7 days if no further activity occurs.
           close-pr-message: >
             This pull request has been closed because it has not had recent activity. You could reopen it
             if you try to continue your work, and anyone who are interested in it are encouraged to continue

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,9 +18,6 @@
 [submodule ".github/actions/comment-on-issue"]
 	path = .github/actions/comment-on-issue
 	url = https://github.com/xingchun-chen/actions-comment-on-issue
-[submodule ".github/actions/lable-on-issue"]
-	path = .github/actions/lable-on-issue
-	url = https://github.com/xingchun-chen/labeler
 [submodule ".github/actions/translate-on-issue"]
 	path = .github/actions/translate-on-issue
 	url = https://github.com/xingchun-chen/translation-helper

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -42,7 +42,6 @@ header:
     - '**/NOTICE'
     - '**/node_modules/**'
     - '.github/actions/comment-on-issue/**'
-    - '.github/actions/lable-on-issue/**'
     - '.github/actions/reviewdog-setup/**'
     - '.github/actions/translate-on-issue/**'
 


### PR DESCRIPTION
According to #6673, and after this PR merge.

* When user create bug/feature issue, it will add addition labeled `Waiting for reply`. If issue without activity for 17 days, it will not be close cause labeled `Waiting for reply` will not be close by stale bot. and this fix situation one in #6673 .
* **But situation two in #6673, still do not have good way to fix**. Some community will make stale bot only close issue with specific label, such as `waiting user response`. This requests issue reviewer add label `waiting user response` after they  finish review add ask user for additional information. I do not know weather it will increase reviewer's load or not.