### PR TITLE
[FIX]add default processInstancePriority

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/SchedulerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/SchedulerController.java
@@ -52,6 +52,7 @@ public class SchedulerController extends BaseController {
     public static final String DEFAULT_WARNING_TYPE = "NONE";
     public static final String DEFAULT_NOTIFY_GROUP_ID = "1";
     public static final String DEFAULT_FAILURE_POLICY = "CONTINUE";
+    public static final String DEFAULT_PROCESS_INSTANCE_PRIORITY = "2";
 
 
     @Autowired
@@ -99,7 +100,7 @@ public class SchedulerController extends BaseController {
                                  @RequestParam(value = "receivers", required = false) String receivers,
                                  @RequestParam(value = "receiversCc", required = false) String receiversCc,
                                  @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
-                                 @RequestParam(value = "processInstancePriority", required = false) Priority processInstancePriority) throws IOException {
+                                 @RequestParam(value = "processInstancePriority", required = false, defaultValue = DEFAULT_PROCESS_INSTANCE_PRIORITY) Priority processInstancePriority) throws IOException {
         logger.info("login user {}, project name: {}, process name: {}, create schedule: {}, warning type: {}, warning group id: {}," +
                         "failure policy: {},receivers : {},receiversCc : {},processInstancePriority : {}, workGroupId:{}",
                 loginUser.getUserName(), projectName, processDefinitionId, schedule, warningType, warningGroupId,


### PR DESCRIPTION
## Purpose of the pull request
add default processInstancePriority

## Brief change log

Modify the default value of processInstancePriority to comply with API Doc. When users deploy Scheduler in batches via API, processInstancePriority Param can be optional.

Allows users to set the timing in batches through the following operations:

curl -X POST " http://127.0.0.1:12345/dolphinscheduler/projects/%E5%BA%94%E7%94%A8%E8%B0%83%E5%BA%A6/schedule/create " -H "Request-Origion:SwaggerBootstrapUi" -H "accept: / " -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -d "processDefinitionId=6264" -d "schedule={ 'startTime':'2019-06-10 00:00:00','endTime':'2019-06-13 00:00:00','crontab':'0 0 3/6 * * ? *'} ”

## Verify this pull request

This pull request is already covered by existing tests, calss is org.apache.dolphinscheduler.api.controller.SchedulerControllerTest

