### PR TITLE
Migrate http to https in maven address

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginManagerConfig.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/plugin/DolphinPluginManagerConfig.java
@@ -65,7 +65,7 @@ public class DolphinPluginManagerConfig {
      */
     private final String defaultLocalRepository = System.getProperty("user.home") + "/.m2/repository";
     private String mavenLocalRepository = getMavenLocalRepositoryOrDefault(defaultLocalRepository);
-    private List<String> mavenRemoteRepository = ImmutableList.of("http://repo1.maven.org/maven2/");
+    private List<String> mavenRemoteRepository = ImmutableList.of("https://repo1.maven.org/maven2/");
 
     File getInstalledPluginsDir() {
         return installedPluginsDir;


### PR DESCRIPTION
## Purpose of the pull request

Use https instead of http in maven address, which is recommended and otherwise will produce exception.

```
org.sonatype.aether.connector.async.TransferException: Failed to transfer http://repo1.maven.org/maven2/org/apache/dolphinscheduler/dolphinscheduler-spi/2.0.0-SNAPSHOT/maven-metadata.xml. Error code 501, HTTPS Required
	at org.sonatype.aether.connector.async.AsyncRepositoryConnector.handleResponseCode(AsyncRepositoryConnector.java:478)
		at org.sonatype.aether.connector.async.AsyncRepositoryConnector.access$1800(AsyncRepositoryConnector.java:90)
		at org.sonatype.aether.connector.async.AsyncRepositoryConnector$GetTask$1.onCompleted(AsyncRepositoryConnector.java:750)
		at org.sonatype.aether.connector.async.CompletionHandler.onCompleted(CompletionHandler.java:180)
		at org.sonatype.aether.connector.async.CompletionHandler.onCompleted(CompletionHandler.java:39)
		at com.ning.http.client.providers.netty.NettyResponseFuture.getContent(NettyResponseFuture.java:244)
		at com.ning.http.client.providers.netty.NettyResponseFuture.done(NettyResponseFuture.java:269)
		at com.ning.http.client.providers.netty.NettyAsyncHttpProvider.markAsDone(NettyAsyncHttpProvider.java:1560)
		at com.ning.http.client.providers.netty.NettyAsyncHttpProvider.finishUpdate(NettyAsyncHttpProvider.java:1582)
		at com.ning.http.client.providers.netty.NettyAsyncHttpProvider.messageReceived(NettyAsyncHttpProvider.java:1252)
		at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
		at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
		at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787)
		at org.jboss.netty.handler.stream.ChunkedWriteHandler.handleUpstream(ChunkedWriteHandler.java:142)
		at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
		at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787)
		at org.jboss.netty.handler.codec.http.HttpContentDecoder.messageReceived(HttpContentDecoder.java:108)
		at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
		at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
		at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787)
		at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:296)
		at org.jboss.netty.handler.codec.frame.FrameDecoder.unfoldAndFireMessageReceived(FrameDecoder.java:459)
		at org.jboss.netty.handler.codec.replay.ReplayingDecoder.callDecode(ReplayingDecoder.java:536)
		at org.jboss.netty.handler.codec.replay.ReplayingDecoder.messageReceived(ReplayingDecoder.java:435)
		at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
		at org.jboss.netty.handler.codec.http.HttpClientCodec.handleUpstream(HttpClientCodec.java:92)
		at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
		at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:555)
		at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:268)
		at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:255)
		at org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:88)
		at org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:107)
		at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:312)
		at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:88)
		at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178)
		at org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108)
		at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at java.lang.Thread.run(Thread.java:748)
```

## Brief change log

Just modify the schema from http to https.

## Verify this pull request

No exception is thrown in standalone server

