### PR TITLE
[FIX 6701] [API] Fix paging error when worker group number more than 10

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -185,6 +185,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
 
         List<WorkerGroup> workerGroups = getWorkerGroups(true);
         List<WorkerGroup> resultDataList = new ArrayList<>();
+        int total = 0;
 
         if (CollectionUtils.isNotEmpty(workerGroups)) {
             List<WorkerGroup> searchValDataList = new ArrayList<>();
@@ -198,7 +199,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             } else {
                 searchValDataList = workerGroups;
             }
-
+            total = searchValDataList.size();
             if (fromIndex < searchValDataList.size()) {
                 if (toIndex > searchValDataList.size()) {
                     toIndex = searchValDataList.size();
@@ -208,7 +209,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         }
 
         PageInfo<WorkerGroup> pageInfo = new PageInfo<>(pageNo, pageSize);
-        pageInfo.setTotal(resultDataList.size());
+        pageInfo.setTotal(total);
         pageInfo.setTotalList(resultDataList);
 
         result.setData(pageInfo);


### PR DESCRIPTION
When worker group number has been added more than 10,page size is 10,paging is error:there is no second page.

Purpose of the pull request
Fix Query worker group list ，paging error #6701
Brief change log
modify the total number of PageInfo
Verify this pull request
This pull request is already covered by existing tests, such as swagger ui test.