### PR TITLE
[Fix][Common] Remove unnecessary judgments because method(getMapByStr…

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/AbstractParameters.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/AbstractParameters.java
@@ -127,7 +127,7 @@ public abstract class AbstractParameters implements IParameters {
             return;
         }
         Map<String, String> taskResult = getMapByString(result);
-        if (taskResult == null || taskResult.size() == 0) {
+        if (taskResult.isEmpty()) {
             return;
         }
         for (Property info : outProperty) {


### PR DESCRIPTION
[Fix][Common] Remove unnecessary judgments because method(getMapByString) returns are never NULL