### PR TITLE
Revert "Change the number of approving_review_count to 2 (#6456)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,4 +44,4 @@ github:
         strict: true
       required_pull_request_reviews:
         dismiss_stale_reviews: true
-        required_approving_review_count: 2
+        required_approving_review_count: 1


### PR DESCRIPTION
This reverts commit 4d69685b

When approver up to 2, we find our PR merge more slower than before, and it will lost some contributors connection. So this patch revert approver number change.