### PR TITLE
docker-compose dolphinscheduler/2.0.0-SNAPSHOT erro #6720

### DIFF
--- a/docker/docker-swarm/docker-compose.yml
+++ b/docker/docker-swarm/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     - dolphinscheduler
 
   dolphinscheduler-api:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: api-server
     ports:
     - 12345:12345
@@ -68,7 +68,7 @@ services:
     - dolphinscheduler
 
   dolphinscheduler-alert:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: alert-server
     environment:
       TZ: Asia/Shanghai
@@ -87,7 +87,7 @@ services:
     - dolphinscheduler
 
   dolphinscheduler-master:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: master-server
     environment:
       TZ: Asia/Shanghai
@@ -108,7 +108,7 @@ services:
     - dolphinscheduler
 
   dolphinscheduler-worker:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: worker-server
     environment:
       TZ: Asia/Shanghai

--- a/docker/docker-swarm/docker-stack.yml
+++ b/docker/docker-swarm/docker-stack.yml
@@ -48,7 +48,7 @@ services:
       replicas: 1
 
   dolphinscheduler-api:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: api-server
     ports:
     - 12345:12345
@@ -71,7 +71,7 @@ services:
       replicas: 1
 
   dolphinscheduler-alert:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: alert-server
     environment:
       TZ: Asia/Shanghai
@@ -90,7 +90,7 @@ services:
       replicas: 1
 
   dolphinscheduler-master:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: master-server
     environment:
       TZ: Asia/Shanghai
@@ -110,7 +110,7 @@ services:
       replicas: 1
 
   dolphinscheduler-worker:
-    image: apache/dolphinscheduler:2.0.0-SNAPSHOT
+    image: apache/dolphinscheduler:2.0.0-alpha
     command: worker-server
     environment:
       TZ: Asia/Shanghai


### PR DESCRIPTION
The image not found error occurs because image is Apache / Dolphin scheduler: 2.0.0-snapshot in docker-compose.yml and docker-stack.yml_ hub image is apache/dolphinscheduler:2.0.0-alpha