### PR TITLE
[ci] Run only py-ci if just pydolphinscheduler change

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,11 +19,11 @@ on:
   pull_request:
     paths-ignore:
       - '**/*.md'
-      - 'dolphinscheduler-python/pydolphinscheduler'
+      - 'dolphinscheduler-python/pydolphinscheduler/**'
   push:
     paths-ignore:
       - '**/*.md'
-      - 'dolphinscheduler-python/pydolphinscheduler'
+      - 'dolphinscheduler-python/pydolphinscheduler/**'
     branches:
       - dev
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,12 +21,12 @@ on:
   pull_request:
     paths-ignore:
       - '**/*.md'
-      - 'dolphinscheduler-ui'
+      - 'dolphinscheduler-ui/**'
       - 'dolphinscheduler-python/pydolphinscheduler/**'
   push:
     paths-ignore:
       - '**/*.md'
-      - 'dolphinscheduler-ui'
+      - 'dolphinscheduler-ui/**'
       - 'dolphinscheduler-python/pydolphinscheduler/**'
     branches:
       - dev

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,12 +22,12 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'dolphinscheduler-ui'
-      - 'dolphinscheduler-python/pydolphinscheduler'
+      - 'dolphinscheduler-python/pydolphinscheduler/**'
   push:
     paths-ignore:
       - '**/*.md'
       - 'dolphinscheduler-ui'
-      - 'dolphinscheduler-python/pydolphinscheduler'
+      - 'dolphinscheduler-python/pydolphinscheduler/**'
     branches:
       - dev
 


### PR DESCRIPTION
closes: #6754 

This patch separate py-ci, and it only run py-ci if just python code changed