### PR TITLE
[Fix-#6779] add default constructor

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/PageInfo.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/PageInfo.java
@@ -51,6 +51,10 @@ public class PageInfo<T> {
      */
     private Integer pageNo;
 
+    public PageInfo() {
+        
+    }
+
     public PageInfo(Integer currentPage, Integer pageSize) {
         if (currentPage == null) {
             currentPage = 1;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request


com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of org.apache.dolphinscheduler.api.utils.PageInfo (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)

https://github.com/apache/dolphinscheduler/issues/6779

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
