### PR TITLE
[ci] Remove GA path rule in build and unittest

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,16 +32,6 @@ on:
       - 'dolphinscheduler-rpc/**'
       - 'dolphinscheduler-server/**'
   pull_request:
-    paths:
-      - '.github/workflows/backend.yml'
-      - 'package.xml'
-      - 'pom.xml'
-      - 'dolphinscheduler-alert/**'
-      - 'dolphinscheduler-api/**'
-      - 'dolphinscheduler-common/**'
-      - 'dolphinscheduler-dao/**'
-      - 'dolphinscheduler-rpc/**'
-      - 'dolphinscheduler-server/**'
 
 concurrency:
   group: backend-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,10 +19,6 @@ name: Test
 
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'dolphinscheduler-ui'
-      - 'dolphinscheduler-python/pydolphinscheduler'
   push:
     paths-ignore:
       - '**/*.md'


### PR DESCRIPTION
CI could not be run due to we add 9113817b to asf
configure and same file change will not trigger
build or unit test github actions run. This patch
try to skip github action path ignore rule temporarily

Maybe we should find more effective way to spearate py
, js, java CI later

