### PR TITLE
[Improvement-#5293]upgrade cron-utils version 5.0.5 -> 9.1.3

### DIFF
--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -245,7 +245,6 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-net 3.1: https://github.com/apache/commons-net, Apache 2.0
     commons-pool 1.6: https://github.com/apache/commons-pool, Apache 2.0
     cron-utils 9.1.3: https://mvnrepository.com/artifact/com.cronutils/cron-utils/9.1.3, Apache 2.0
-    javax.el 3.0.0: https://mvnrepository.com/artifact/org.glassfish/javax.el/3.0.0, CDDL GPL GPL 2.0
     commons-lang3 3.8.1: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.8.1, Apache 2.0
     curator-client 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-client/4.3.0, Apache 2.0
     curator-framework 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-framework/4.3.0, Apache 2.0
@@ -443,9 +442,9 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     jersey-guice 1.9: https://mvnrepository.com/artifact/com.sun.jersey.contribs/jersey-guice/1.9, CDDL 1.1 and GPL 1.1
     jersey-json 1.9: https://mvnrepository.com/artifact/com.sun.jersey/jersey-json/1.9, CDDL 1.1 and GPL 1.1
     jersey-server 1.9: https://mvnrepository.com/artifact/com.sun.jersey/jersey-server/1.9, CDDL 1.1 and GPL 1.1
-
     jta 1.1: https://mvnrepository.com/artifact/javax.transaction/jta/1.1, CDDL 1.0
     transaction-api 1.1: https://mvnrepository.com/artifact/javax.transaction/transaction-api/1.1, CDDL 1.0
+    javax.el 3.0.0: https://mvnrepository.com/artifact/org.glassfish/javax.el/3.0.0, CDDL and GPL and GPL 2.0
 
 ========================================================================
 EPL licenses

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -244,7 +244,9 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-math3 3.1.1: https://mvnrepository.com/artifact/org.apache.commons/commons-math3/3.1.1, Apache 2.0
     commons-net 3.1: https://github.com/apache/commons-net, Apache 2.0
     commons-pool 1.6: https://github.com/apache/commons-pool, Apache 2.0
-    cron-utils 5.0.5: https://mvnrepository.com/artifact/com.cronutils/cron-utils/5.0.5, Apache 2.0
+    cron-utils 9.1.3: https://mvnrepository.com/artifact/com.cronutils/cron-utils/9.1.3, Apache 2.0
+    javax.el 3.0.0: https://mvnrepository.com/artifact/org.glassfish/javax.el/3.0.0, CDDL GPL GPL 2.0
+    commons-lang3 3.8.1: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.8.1, Apache 2.0
     curator-client 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-client/4.3.0, Apache 2.0
     curator-framework 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-framework/4.3.0, Apache 2.0
     curator-recipes 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-recipes/4.3.0, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -245,7 +245,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-net 3.1: https://github.com/apache/commons-net, Apache 2.0
     commons-pool 1.6: https://github.com/apache/commons-pool, Apache 2.0
     cron-utils 9.1.3: https://mvnrepository.com/artifact/com.cronutils/cron-utils/9.1.3, Apache 2.0
-    commons-lang3 3.8.1: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.8.1, Apache 2.0
+    commons-lang3 3.12.0: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.12.0, Apache 2.0
     curator-client 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-client/4.3.0, Apache 2.0
     curator-framework 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-framework/4.3.0, Apache 2.0
     curator-recipes 4.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-recipes/4.3.0, Apache 2.0

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -1009,7 +1009,7 @@ public class WorkflowExecuteThread implements Runnable {
                 return true;
             }
             if (processInstance.getFailureStrategy() == FailureStrategy.CONTINUE) {
-                return readyToSubmitTaskQueue.size() == 0 || activeTaskProcessorMaps.size() == 0;
+                return readyToSubmitTaskQueue.size() == 0 && activeTaskProcessorMaps.size() == 0;
             }
         }
         return false;

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <jackson.version>2.10.5</jackson.version>
         <mybatis-plus.version>3.2.0</mybatis-plus.version>
         <mybatis.spring.version>2.0.1</mybatis.spring.version>
-        <cron.utils.version>5.0.5</cron.utils.version>
+        <cron.utils.version>9.1.3</cron.utils.version>
         <druid.version>1.2.4</druid.version>
         <h2.version>1.4.200</h2.version>
         <commons.codec.version>1.11</commons.codec.version>

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -38,7 +38,7 @@ commons-net-3.1.jar
 commons-pool-1.6.jar
 cron-utils-9.1.3.jar
 javax.el-3.0.0.jar
-commons-lang3-3.8.1.jar
+commons-lang3-3.12.1.jar
 curator-client-4.3.0.jar
 curator-framework-4.3.0.jar
 curator-recipes-4.3.0.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -36,7 +36,9 @@ commons-logging-1.1.1.jar
 commons-math3-3.1.1.jar
 commons-net-3.1.jar
 commons-pool-1.6.jar
-cron-utils-5.0.5.jar
+cron-utils-9.1.3.jar
+javax.el-3.0.0.jar
+commons-lang3-3.8.1.jar
 curator-client-4.3.0.jar
 curator-framework-4.3.0.jar
 curator-recipes-4.3.0.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -38,7 +38,7 @@ commons-net-3.1.jar
 commons-pool-1.6.jar
 cron-utils-9.1.3.jar
 javax.el-3.0.0.jar
-commons-lang3-3.12.1.jar
+commons-lang3-3.12.0.jar
 curator-client-4.3.0.jar
 curator-framework-4.3.0.jar
 curator-recipes-4.3.0.jar


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

upgrade cron-utils version 5.0.5 -> 9.1.3

## Brief change log

the upgrade information is ' https://github.com/jmrozanec/cron-utils/security/advisories/GHSA-pfj3-56hm-jwq5 '
According to the description of the vulnerability, that only projects using the @Cron annotation to validate untrusted Cron expressions are affected.

## Verify this pull request

Create a simple process and set scheduled tasks. As a result, it can be scheduled normally