### PR TITLE
Add a demo docker-compose for testing the meter module

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/pom.xml
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-meter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-alert-dingtalk</artifactId>
         </dependency>
         <dependency>

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application-alert.yaml
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application-alert.yaml
@@ -18,3 +18,15 @@
 spring:
   application:
     name: alert-server
+
+server:
+  port: 50053
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -34,6 +34,10 @@
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-meter</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>

--- a/dolphinscheduler-api/src/main/resources/application-api.yaml
+++ b/dolphinscheduler-api/src/main/resources/application-api.yaml
@@ -38,3 +38,12 @@ spring:
       max-request-size: 1024MB
   messages:
     basename: i18n/messages
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/dolphinscheduler-meter/pom.xml
+++ b/dolphinscheduler-meter/pom.xml
@@ -37,7 +37,15 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -53,6 +61,7 @@
                 <configuration>
                     <excludes>
                         <exclude>grafana/</exclude>
+                        <exclude>grafana-demo/</exclude>
                         <exclude>*.yaml</exclude>
                     </excludes>
                 </configuration>

--- a/dolphinscheduler-meter/src/main/java/org/apache/dolphinscheduler/meter/MeterConfiguration.java
+++ b/dolphinscheduler-meter/src/main/java/org/apache/dolphinscheduler/meter/MeterConfiguration.java
@@ -31,7 +31,6 @@ import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 
 @Configuration
-@Profile("meter")
 @EnableAspectJAutoProxy
 @EnableAutoConfiguration
 public class MeterConfiguration {

--- a/dolphinscheduler-meter/src/main/resources/grafana-demo/dashboards/provisioning.yaml
+++ b/dolphinscheduler-meter/src/main/resources/grafana-demo/dashboards/provisioning.yaml
@@ -15,13 +15,9 @@
 # limitations under the License.
 #
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: '*'
-  server:
-    port: 5679
-  metrics:
-    tags:
-      application: ${spring.application.name}
+apiVersion: 1
+providers:
+  - name: general
+    folder: 'DolphinScheduler'
+    options:
+      path: /dashboards

--- a/dolphinscheduler-meter/src/main/resources/grafana-demo/datasources/prom.yaml
+++ b/dolphinscheduler-meter/src/main/resources/grafana-demo/datasources/prom.yaml
@@ -15,20 +15,8 @@
 # limitations under the License.
 #
 
-spring:
-  application:
-    name: standalone-server
-
-server:
-  port: 12345
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: '*'
-  server:
-    port: 8080
-  metrics:
-    tags:
-      application: ${spring.application.name}
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prom:9090

--- a/dolphinscheduler-meter/src/main/resources/grafana-demo/docker-compose.yaml
+++ b/dolphinscheduler-meter/src/main/resources/grafana-demo/docker-compose.yaml
@@ -15,20 +15,30 @@
 # limitations under the License.
 #
 
-spring:
-  application:
-    name: standalone-server
+version: '2.1'
 
-server:
-  port: 12345
+services:
+  prom:
+    image: prom/prometheus
+    networks: [ test ]
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: '*'
-  server:
-    port: 8080
-  metrics:
-    tags:
-      application: ${spring.application.name}
+  grafana:
+    image: grafana/grafana
+    networks: [ test ]
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: true
+    volumes:
+      - ../grafana:/dashboards:ro
+      - ./datasources:/etc/grafana/provisioning/datasources:ro
+      - ./dashboards/provisioning.yaml:/etc/grafana/provisioning/dashboards/provisioning.yaml:ro
+
+networks:
+  test:

--- a/dolphinscheduler-meter/src/main/resources/grafana-demo/prometheus.yml
+++ b/dolphinscheduler-meter/src/main/resources/grafana-demo/prometheus.yml
@@ -15,20 +15,17 @@
 # limitations under the License.
 #
 
-spring:
-  application:
-    name: standalone-server
-
-server:
-  port: 12345
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: '*'
-  server:
-    port: 8080
-  metrics:
-    tags:
-      application: ${spring.application.name}
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+rule_files:
+scrape_configs:
+  - job_name: 'DolphinScheduler'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+          - 'host.docker.internal:5679' # Change the address to the address of DolphinScheduler master server
+          - 'host.docker.internal:1235' # Change the address to the address of DolphinScheduler worker server
+          - 'host.docker.internal:50053' # Change the address to the address of DolphinScheduler alert server
+          - 'host.docker.internal:8080' # Change the address to the DolphinScheduler standalone server

--- a/dolphinscheduler-server/pom.xml
+++ b/dolphinscheduler-server/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-meter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-spi</artifactId>
         </dependency>
         <dependency>

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
@@ -38,15 +38,11 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-/**
- *  master server
- */
 @ComponentScan(value = "org.apache.dolphinscheduler", excludeFilters = {
     @ComponentScan.Filter(type = FilterType.REGEX, pattern = {
         "org.apache.dolphinscheduler.server.worker.*",
@@ -80,7 +76,7 @@ public class MasterServer implements IStoppable {
         Thread.currentThread().setName(Constants.THREAD_NAME_MASTER_SERVER);
         new SpringApplicationBuilder(MasterServer.class)
             .profiles("master")
-            .web(WebApplicationType.NONE).run(args);
+            .run(args);
     }
 
     /**

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -44,7 +44,6 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -115,7 +114,6 @@ public class WorkerServer implements IStoppable {
     public static void main(String[] args) {
         Thread.currentThread().setName(Constants.THREAD_NAME_WORKER_SERVER);
         new SpringApplicationBuilder(WorkerServer.class)
-            .web(WebApplicationType.NONE)
             .profiles("worker")
             .run(args);
     }

--- a/dolphinscheduler-server/src/main/resources/application-master.yaml
+++ b/dolphinscheduler-server/src/main/resources/application-master.yaml
@@ -45,3 +45,15 @@ master:
   reserved-memory: 0.3
   # master cache process definition, default: true
   cache-process-definition: true
+
+server:
+  port: 5679
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/dolphinscheduler-server/src/main/resources/application-worker.yaml
+++ b/dolphinscheduler-server/src/main/resources/application-worker.yaml
@@ -38,3 +38,15 @@ worker:
     - default
   # alert server listen host
   alert-listen-host: localhost
+
+server:
+  port: 1235
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -61,9 +61,6 @@ export DOLPHINSCHEDULER_OPTS="-server -XX:MetaspaceSize=128m -XX:MaxMetaspaceSiz
 
 export dbtype=${dbtype:-"h2"}
 export SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-"default"}
-if [ "$METER_ENABLED" = "true" ]; then
-  export SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE},meter"
-fi
 
 if [ "$command" = "api-server" ]; then
   LOG_FILE="-Dlogging.config=classpath:logback-api.xml"


### PR DESCRIPTION
FYI @caishunfeng , we can now use the following commands to quickly set up a Prometheus + Grafana environment

```shell
cd dolphinscheduler-meter/src/main/resources/grafana-demo
docker-compose up -d
```

And open http://localhost:3000