### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: 'adopt'
+          distribution: 'zulu'
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Run SonarCloud Analysis
         run: >
           ./mvnw --batch-mode verify sonar:sonar


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/
## Brief change log

https://github.com/carldea/dolphinscheduler/commit/7e867ae2be6e47349be635db9d0a5b78aca88a48
 - Updated `distribution:` to `zulu`

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->
 - GitHub actions will pass all unit tests using the latest Zulu Java OpenJDK builds (8 & 11).

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
