### PR TITLE
optimize the fetch num of command of master

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
@@ -273,7 +273,7 @@ public class MasterSchedulerService extends Thread {
 
     private List<Command> findCommands() {
         int pageNumber = 0;
-        int pageSize = masterConfig.getFetchCommandNum();
+        int pageSize = masterConfig.getFetchCommandNum() * ServerNodeManager.MASTER_SIZE;
         List<Command> result = new ArrayList<>();
         while (Stopper.isRunning()) {
             if (ServerNodeManager.MASTER_SIZE == 0) {


### PR DESCRIPTION
## Purpose of the pull request

the performance of one master server is stable, and we should make sure the
master server have stable throughtouput, as we all know, there will be server 
master in the cluster, 

the fetchNum in the config is static, and when other master server shutdown,
foro code we will know, the active server will process more command which is unstable
and will make side effect, 

and actually now master server size do not take effect when fetch commnad which 
do not take the idea of performance improvement in ds 2.0,

we the command should depend on the master server size which get from zk, and user 
config fetchNum

## Brief change log

change the 

` int pageSize = masterConfig.getFetchCommandNum() * ServerNodeManager.MASTER_SIZE;`


## Verify this pull request


This pull request is code cleanup without any test coverage.

