### PR TITLE
[Fix-7019][MasterServer] Fix the issue with failing to save and run the process that contains the switch task.

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/switchtask/SwitchResultVo.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/switchtask/SwitchResultVo.java
@@ -42,6 +42,10 @@ public class SwitchResultVo {
             List<String> nextNodeList = new ArrayList<>();
             nextNodeList.add(String.valueOf(nextNode));
             this.nextNode = nextNodeList;
+        } else if(nextNode instanceof Number) {
+            List<String> nextNodeList = new ArrayList<>();
+            nextNodeList.add(nextNode.toString());
+            this.nextNode = nextNodeList;
         } else {
             this.nextNode = (ArrayList) nextNode;
         }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/switchtask/SwitchResultVo.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/switchtask/SwitchResultVo.java
@@ -42,7 +42,7 @@ public class SwitchResultVo {
             List<String> nextNodeList = new ArrayList<>();
             nextNodeList.add(String.valueOf(nextNode));
             this.nextNode = nextNodeList;
-        } else if(nextNode instanceof Number) {
+        } else if (nextNode instanceof Number) {
             List<String> nextNodeList = new ArrayList<>();
             nextNodeList.add(nextNode.toString());
             this.nextNode = nextNodeList;

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/DagHelper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/DagHelper.java
@@ -406,7 +406,7 @@ public class DagHelper {
                                                     Map<String, TaskInstance> completeTaskList,
                                                     DAG<String, TaskNode, TaskNodeRelation> dag) {
 
-        SwitchParameters switchParameters = completeTaskList.get(taskNode.getName()).getSwitchDependency();
+        SwitchParameters switchParameters = completeTaskList.get(Long.toString(taskNode.getCode())).getSwitchDependency();
         int resultConditionLocation = switchParameters.getResultConditionLocation();
         List<SwitchResultVo> conditionResultVoList = switchParameters.getDependTaskList();
         List<String> switchTaskList = conditionResultVoList.get(resultConditionLocation).getNextNode();

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/SwitchTaskProcessor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/SwitchTaskProcessor.java
@@ -210,7 +210,7 @@ public class SwitchTaskProcessor extends BaseTaskProcessor {
             if (!org.apache.commons.lang.math.NumberUtils.isNumber(value)) {
                 value = "\"" + value + "\"";
             }
-            logger.info("paramName：{}，paramValue{}", paramName, value);
+            logger.info("paramName:{}，paramValue:{}", paramName, value);
             content = content.replace("${" + paramName + "}", value);
         }
         return content;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This PR will close #7019 .

## Brief change log

 There are two functions to need be improved.
First , the function 'setNextNode(Object nextNode) ' contained an 'ClassCastException' in the class 'SwitchResultVo.java ' ,because the original type of the  parameter nextNode is 'Long' .

Second, the function 'isTaskNodeNeedSkip(TaskNode taskNode,Map<String, TaskInstance> completeTaskList,DAG<String, TaskNode, TaskNodeRelation> dag) ' contained a bug, because the key in  the map of completeTaskList is 'taskCode', so need to use 'taskCode' to look for the mapping object.

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
  
1.Create a new process that contains the switch task.
![image](https://user-images.githubusercontent.com/4928204/143847508-7a2ad513-4e6a-49a1-8a14-2b9155e8e695.png)

2.Set a global parameter named 'id' ,and its value equals 1.
![image](https://user-images.githubusercontent.com/4928204/143847738-e9ea1d55-154d-46d5-bc26-c590422a9b71.png)

3. Set two conditions for the switch task , when '${id} == 1 ' , the lower task1 will be executed, when '${id} == 2' , the lower task2 will be executed.
![image](https://user-images.githubusercontent.com/4928204/143847897-201a8f68-770a-4ef1-934d-d41a62c95739.png)

4.Then save the process and run it, you will see the results.
When  the value of the global parameter id  equals 1.
![image](https://user-images.githubusercontent.com/4928204/143848364-77d43865-075c-4921-8e10-01870e52cda3.png)
When the value of the global parameter id equals 2.
![image](https://user-images.githubusercontent.com/4928204/143848428-159f1241-eb60-4d65-80d5-21b661e81b97.png)


