### PR TITLE
[ci] Fix mergeable for ddl change and remove label unexpect

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -22,17 +22,20 @@ mergeable:
     validate:
       # Sql files must change synchronize
       - do: dependent
-        files: ['sql/dolphinscheduler_h2.sql', 'sql/dolphinscheduler_mysql.sql', 'sql/dolphinscheduler_postgre.sql']
+        files:
+          - 'dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql'
+          - 'dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql'
+          - 'dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql'
         message: 'Sql files not change synchronize'
-    # Add labels 'sql not sync' if Sql files not change synchronize
+    # Add labels 'sql not sync' and comment to reviewers if Sql files not change synchronize
     fail:
-      - do: checks
-        status: 'failure'
+      - do: comment
+        payload:
+          body: >
+            :warning: This PR do not change database DDL synchronize.
       - do: labels
         add: 'sql not sync'
     # Remove labels 'sql not sync' if pass
     pass:
-      - do: checks
-        status: 'success'
       - do: labels
         delete: 'sql not sync'


### PR DESCRIPTION
From https://github.com/apache/dolphinscheduler/pull/7054#discussion_r759804447, we found out sql change not synchronize not failed CI and this patch try to fix it.
