### PR TITLE
[Fix-7112] The modal of datasource will disappear when I click the area outside of this modal.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/datasource/pages/list/index.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/datasource/pages/list/index.vue
@@ -25,7 +25,8 @@
             v-if="dialogVisible"
             :visible.sync="dialogVisible"
             width="auto"
-            :append-to-body="true">
+            :append-to-body="true"
+            :close-on-click-modal="false">
             <m-create-data-source :item="item" @onUpdate="onUpdate" @close="close"></m-create-data-source>
           </el-dialog>
         </template>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This PR will close #7112 .

## Brief change log

The datasource modal missed an attribute named 'close-on-click-modal'. It can control  whether  this modal can be closed or not when clicking the area outside of the modal.

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
  
Create a datasource and click the area outside of this modal, the modal won't disappear again.
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/4928204/144371525-5335218e-9e21-49bd-8725-1b0114bcb7dd.png">

