### PR TITLE
[WIP][until 2.0.1 release][deploy] Use install_config.conf export datasource properties

### DIFF
--- a/dolphinscheduler-server/src/main/resources/config/install_config.conf
+++ b/dolphinscheduler-server/src/main/resources/config/install_config.conf
@@ -63,7 +63,20 @@ deployUser="dolphinscheduler"
 # ---------------------------------------------------------
 # The type for the metadata database
 # Supported values: ``postgresql``, ``mysql``.
-dbtype="mysql"
+export DATABASE_TYPE="postgresql"
 
+# Spring datasource url, following <HOST>:<PORT>/<database>?<parameter> format, If you using mysql, you could use jdbc
+# string jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8 as example
+export SPRING_DATASOURCE_URL="jdbc:postgresql://127.0.0.1:5432/dolphinscheduler"
+
+# Spring datasource username
+export SPRING_DATASOURCE_USERNAME="ds_user"
+
+# Spring datasource password
+export SPRING_DATASOURCE_PASSWORD="ds_pwd"
+
+# ---------------------------------------------------------
+# Registry Server
+# ---------------------------------------------------------
 # The root of zookeeper, for now DolphinScheduler default registry server is zookeeper.
 zkRoot="/dolphinscheduler"

--- a/script/create-dolphinscheduler.sh
+++ b/script/create-dolphinscheduler.sh
@@ -20,6 +20,8 @@ BIN_DIR=`dirname $0`
 BIN_DIR=`cd "$BIN_DIR"; pwd`
 DOLPHINSCHEDULER_HOME=$BIN_DIR/..
 
+source "${DOLPHINSCHEDULER_HOME}/conf/config/install_config.conf"
+
 export JAVA_HOME=$JAVA_HOME
 
 export DATABASE_TYPE=${DATABASE_TYPE:-"h2"}

--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -37,6 +37,7 @@ DOLPHINSCHEDULER_HOME=`cd "$BIN_DIR/.."; pwd`
 
 source /etc/profile
 source "${DOLPHINSCHEDULER_HOME}/conf/env/dolphinscheduler_env.sh"
+source "${DOLPHINSCHEDULER_HOME}/conf/config/install_config.conf"
 
 export HOSTNAME=`hostname`
 

--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -31,10 +31,14 @@ declare -A workersGroupMap=()
 workersGroup=(${workers//,/ })
 for workerGroup in ${workersGroup[@]}
 do
-  echo $workerGroup;
   worker=`echo $workerGroup|awk -F':' '{print $1}'`
-  groupsName=`echo $workerGroup|awk -F':' '{print $2}'`
-  workersGroupMap+=([$worker]=$groupsName)
+  groupName=`echo $workerGroup|awk -F':' '{print $2}'`
+  if [ -z ${workersGroupMap[$worker]} ];then
+      workersGroupMap+=([$worker]=$groupName)
+  else
+      finalGroupName="${workersGroupMap[$worker]},$groupName"
+      workersGroupMap[$worker]=$finalGroupName
+  fi
 done
 
 

--- a/script/upgrade-dolphinscheduler.sh
+++ b/script/upgrade-dolphinscheduler.sh
@@ -20,6 +20,8 @@ BIN_DIR=`dirname $0`
 BIN_DIR=`cd "$BIN_DIR"; pwd`
 DOLPHINSCHEDULER_HOME=$BIN_DIR/..
 
+source "${DOLPHINSCHEDULER_HOME}/conf/config/install_config.conf"
+
 export JAVA_HOME=$JAVA_HOME
 
 export DATABASE_TYPE=${DATABASE_TYPE:-"h2"}


### PR DESCRIPTION
Directly user install_config.conf to set spring datasource
properties, delete datasource.properties file for more clearly

This patch come from https://github.com/apache/dolphinscheduler/pull/7151 we fix in 2.0.1-prepare
