### PR TITLE
Fix alert plugin instance filter (#7172)

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
@@ -30,6 +30,7 @@ import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.AlertPluginInstanceService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.utils.ParameterUtils;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.Map;
@@ -213,12 +214,14 @@ public class AlertPluginInstanceController extends BaseController {
      * paging query alert plugin instance group list
      *
      * @param loginUser login user
+     * @param searchVal search value
      * @param pageNo page number
      * @param pageSize page size
      * @return alert plugin instance list page
      */
     @ApiOperation(value = "queryAlertPluginInstanceListPaging", notes = "QUERY_ALERT_PLUGIN_INSTANCE_LIST_PAGING_NOTES")
     @ApiImplicitParams({
+        @ApiImplicitParam(name = "searchVal", value = "SEARCH_VAL", type = "String"),
         @ApiImplicitParam(name = "pageNo", value = "PAGE_NO", required = true, dataType = "Int", example = "1"),
         @ApiImplicitParam(name = "pageSize", value = "PAGE_SIZE", required = true, dataType = "Int", example = "20")
     })
@@ -227,13 +230,15 @@ public class AlertPluginInstanceController extends BaseController {
     @ApiException(LIST_PAGING_ALERT_PLUGIN_INSTANCE_ERROR)
     @AccessLogAnnotation(ignoreRequestArgs = "loginUser")
     public Result listPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                             @RequestParam(value = "searchVal", required = false) String searchVal,
                              @RequestParam("pageNo") Integer pageNo,
                              @RequestParam("pageSize") Integer pageSize) {
         Result result = checkPageParams(pageNo, pageSize);
         if (!result.checkResult()) {
             return result;
         }
-        return alertPluginInstanceService.queryPluginPage(pageNo, pageSize);
+        searchVal = ParameterUtils.handleEscapes(searchVal);
+        return alertPluginInstanceService.listPaging(loginUser, searchVal, pageNo, pageSize);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceService.java
@@ -82,9 +82,11 @@ public interface AlertPluginInstanceService {
 
     /**
      * queryPluginPage
-     * @param pageIndex page index
+     * @param loginUser login user
+     * @param searchVal search value
+     * @param pageNo    page index
      * @param pageSize  page size
      * @return plugins
      */
-    Result queryPluginPage(int pageIndex, int pageSize);
+    Result listPaging(User loginUser, String searchVal, int pageNo, int pageSize);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
@@ -199,9 +199,9 @@ public class AlertPluginInstanceServiceImpl extends BaseServiceImpl implements A
         Page<AlertPluginInstance> page = new Page<>(pageNo, pageSize);
         IPage<AlertPluginInstance> alertPluginInstanceIPage = alertPluginInstanceMapper.queryByInstanceNamePage(page, searchVal);
 
-        PageInfo<AlertPluginInstance> pageInfo = new PageInfo<>(pageNo, pageSize);
+        PageInfo<AlertPluginInstanceVO> pageInfo = new PageInfo<>(pageNo, pageSize);
         pageInfo.setTotal((int) alertPluginInstanceIPage.getTotal());
-        pageInfo.setTotalList(alertPluginInstanceIPage.getRecords());
+        pageInfo.setTotalList(buildPluginInstanceVOList(alertPluginInstanceIPage.getRecords()));
         result.setData(pageInfo);
         putMsg(result, Status.SUCCESS);
         return result;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
@@ -188,14 +188,20 @@ public class AlertPluginInstanceServiceImpl extends BaseServiceImpl implements A
     }
 
     @Override
-    public Result queryPluginPage(int pageIndex, int pageSize) {
-        IPage<AlertPluginInstance> pluginInstanceIPage = new Page<>(pageIndex, pageSize);
-        pluginInstanceIPage = alertPluginInstanceMapper.selectPage(pluginInstanceIPage, null);
+    public Result listPaging(User loginUser, String searchVal, int pageNo, int pageSize) {
 
-        PageInfo<AlertPluginInstanceVO> pageInfo = new PageInfo<>(pageIndex, pageSize);
-        pageInfo.setTotal((int) pluginInstanceIPage.getTotal());
-        pageInfo.setTotalList(buildPluginInstanceVOList(pluginInstanceIPage.getRecords()));
         Result result = new Result();
+        if (!isAdmin(loginUser)) {
+            putMsg(result,Status.USER_NO_OPERATION_PERM);
+            return result;
+        }
+
+        Page<AlertPluginInstance> page = new Page<>(pageNo, pageSize);
+        IPage<AlertPluginInstance> alertPluginInstanceIPage = alertPluginInstanceMapper.queryByInstanceNamePage(page, searchVal);
+
+        PageInfo<AlertPluginInstance> pageInfo = new PageInfo<>(pageNo, pageSize);
+        pageInfo.setTotal((int) alertPluginInstanceIPage.getTotal());
+        pageInfo.setTotalList(alertPluginInstanceIPage.getRecords());
         result.setData(pageInfo);
         putMsg(result, Status.SUCCESS);
         return result;

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AlertPluginInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AlertPluginInstanceMapper.java
@@ -24,6 +24,8 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 public interface AlertPluginInstanceMapper extends BaseMapper<AlertPluginInstance> {
 
@@ -42,7 +44,13 @@ public interface AlertPluginInstanceMapper extends BaseMapper<AlertPluginInstanc
      */
     List<AlertPluginInstance> queryByIds(@Param("ids") List<Integer> ids);
 
-    List<AlertPluginInstance> queryByInstanceName(@Param("instanceName")String instanceName);
+    /**
+     * Query alert plugin instance by given name
+     * @param page                page
+     * @param instanceName         Alert plugin name
+     * @return alertPluginInstance Ipage
+     */
+    IPage<AlertPluginInstance> queryByInstanceNamePage(Page page, @Param("instanceName") String instanceName);
 
     /**
      *

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AlertPluginInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AlertPluginInstanceMapper.xml
@@ -36,11 +36,14 @@
         </foreach>
     </select>
 
-    <select id="queryByInstanceName" resultType="org.apache.dolphinscheduler.dao.entity.AlertPluginInstance">
+    <select id="queryByInstanceNamePage" resultType="org.apache.dolphinscheduler.dao.entity.AlertPluginInstance">
         select
         *
         from t_ds_alert_plugin_instance
-        where instance_name = #{instanceName}
+        where 1 = 1
+        <if test="instanceName != null and instanceName != ''">
+            and instance_name like concat('%', #{instanceName}, '%')
+        </if>
     </select>
 
     <select id="existInstanceName" resultType="java.lang.Boolean">


### PR DESCRIPTION
alert plugin could not filter by given
pattern, cause api server do not handle
parameter searchVal, This patch add parameter
`searchVal` for alert plugin.

fix: #7209
