### PR TITLE
Fix env vars are not passed in from docker-compose

### DIFF
--- a/dolphinscheduler-server/src/main/resources/config/install_config.conf
+++ b/dolphinscheduler-server/src/main/resources/config/install_config.conf
@@ -76,17 +76,17 @@ apiServerPort="12345"
 # ---------------------------------------------------------
 # The type for the metadata database
 # Supported values: ``postgresql``, ``mysql``.
-DATABASE_TYPE="postgresql"
+DATABASE_TYPE=${DATABASE_TYPE:-"postgresql"}
 
 # Spring datasource url, following <HOST>:<PORT>/<database>?<parameter> format, If you using mysql, you could use jdbc
 # string jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8 as example
-SPRING_DATASOURCE_URL="jdbc:postgresql://127.0.0.1:5432/dolphinscheduler"
+SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-"jdbc:postgresql://127.0.0.1:5432/dolphinscheduler"}
 
 # Spring datasource username
-SPRING_DATASOURCE_USERNAME="ds_user"
+SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME:-"ds_user"}
 
 # Spring datasource password
-SPRING_DATASOURCE_PASSWORD="dolphinscheduler"
+SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD:-"dolphinscheduler"}
 
 # ---------------------------------------------------------
 # Registry Server


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
