### PR TITLE
[Improvement-7256][dolphinscheduler-api] Optimization for task instances query

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -132,12 +133,13 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
         exclusionSet.add(Constants.CLASS);
         exclusionSet.add("taskJson");
         List<TaskInstance> taskInstanceList = taskInstanceIPage.getRecords();
-
+        List<Integer> executorIds = taskInstanceList.stream().map(TaskInstance::getExecutorId).distinct().collect(Collectors.toList());
+        List<User> users = usersService.queryUser(executorIds);
+        Map<Integer, User> userMap = users.stream().collect(Collectors.toMap(User::getId, v -> v));
         for (TaskInstance taskInstance : taskInstanceList) {
             taskInstance.setDuration(DateUtils.format2Duration(taskInstance.getStartTime(), taskInstance.getEndTime()));
-            User executor = usersService.queryUser(taskInstance.getExecutorId());
-            if (null != executor) {
-                taskInstance.setExecutorName(executor.getUserName());
+            if (userMap.containsKey(taskInstance.getExecutorId())) {
+                taskInstance.setExecutorName(userMap.get(taskInstance.getExecutorId()).getUserName());
             }
         }
         pageInfo.setTotal((int) taskInstanceIPage.getTotal());


### PR DESCRIPTION
assemble a Map<Long, User> outside of the loop instead of the query inside