### PR TITLE
[python] Fix task procedure define error

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/database.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/database.py
@@ -40,14 +40,11 @@ class Database(Task):
     database type and database instance would run this sql.
     """
 
-    _task_custom_attr = {"sql"}
-
     def __init__(
-        self, task_type: str, name: str, datasource_name: str, sql: str, *args, **kwargs
+        self, task_type: str, name: str, datasource_name: str, *args, **kwargs
     ):
         super().__init__(name, task_type, *args, **kwargs)
         self.datasource_name = datasource_name
-        self.sql = sql
         self._datasource = {}
 
     def get_datasource_type(self) -> str:

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/procedure.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/procedure.py
@@ -37,7 +37,8 @@ class Procedure(Database):
     database type and database instance would run this sql.
     """
 
-    def __init__(self, name: str, datasource_name: str, sql: str, *args, **kwargs):
-        super().__init__(
-            TaskType.PROCEDURE, name, datasource_name, sql, *args, **kwargs
-        )
+    _task_custom_attr = {"method"}
+
+    def __init__(self, name: str, datasource_name: str, method: str, *args, **kwargs):
+        super().__init__(TaskType.PROCEDURE, name, datasource_name, *args, **kwargs)
+        self.method = method

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/sql.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/sql.py
@@ -66,7 +66,8 @@ class Sql(Database):
         *args,
         **kwargs
     ):
-        super().__init__(TaskType.SQL, name, datasource_name, sql, *args, **kwargs)
+        super().__init__(TaskType.SQL, name, datasource_name, *args, **kwargs)
+        self.sql = sql
         self.pre_statements = pre_statements or []
         self.post_statements = post_statements or []
         self.display_rows = display_rows

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_database.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_database.py
@@ -55,12 +55,10 @@ def test_get_datasource_detail(mock_datasource, mock_code_version):
                 "task_type": TEST_DATABASE_TASK_TYPE,
                 "name": "test-task-params",
                 "datasource_name": TEST_DATABASE_DATASOURCE_NAME,
-                "sql": TEST_DATABASE_SQL,
             },
             {
                 "type": "MYSQL",
                 "datasource": 1,
-                "sql": TEST_DATABASE_SQL,
                 "localParams": [],
                 "resourceList": [],
                 "dependence": {},
@@ -105,7 +103,6 @@ def test_database_get_define(mock_datasource, mock_code_version):
         "taskParams": {
             "type": "MYSQL",
             "datasource": 1,
-            "sql": TEST_DATABASE_SQL,
             "localParams": [],
             "resourceList": [],
             "dependence": {},
@@ -121,7 +118,5 @@ def test_database_get_define(mock_datasource, mock_code_version):
         "timeoutNotifyStrategy": None,
         "timeout": 0,
     }
-    task = Database(
-        TEST_DATABASE_TASK_TYPE, name, TEST_DATABASE_DATASOURCE_NAME, TEST_DATABASE_SQL
-    )
+    task = Database(TEST_DATABASE_TASK_TYPE, name, TEST_DATABASE_DATASOURCE_NAME)
     assert task.get_define() == expect

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_procedure.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_procedure.py
@@ -52,10 +52,10 @@ def test_get_datasource_detail(mock_datasource, mock_code_version):
             {
                 "name": "test-procedure-task-params",
                 "datasource_name": TEST_PROCEDURE_DATASOURCE_NAME,
-                "sql": TEST_PROCEDURE_SQL,
+                "method": TEST_PROCEDURE_SQL,
             },
             {
-                "sql": TEST_PROCEDURE_SQL,
+                "method": TEST_PROCEDURE_SQL,
                 "type": "MYSQL",
                 "datasource": 1,
                 "localParams": [],
@@ -102,7 +102,7 @@ def test_sql_get_define(mock_datasource, mock_code_version):
         "taskParams": {
             "type": "MYSQL",
             "datasource": 1,
-            "sql": TEST_PROCEDURE_SQL,
+            "method": TEST_PROCEDURE_SQL,
             "localParams": [],
             "resourceList": [],
             "dependence": {},


### PR DESCRIPTION
Cause procedure parameter name need `method` instead of `sql`
we change it's name. And remove parameter `sql` from parent
class `Database`

closes: #7386

