### PR TITLE
[Feature-7428][UI] display the full name of the node in DAG workflow when mouseover

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/canvas.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/canvas.vue
@@ -40,6 +40,8 @@
         />
       </div>
       <context-menu ref="contextMenu" />
+      <!-- tooltip for dag node -->
+      <node-tooltip ref="nodeTooltip" />
     </div>
     <layout-config-modal ref="layoutModal" @submit="format" />
   </div>
@@ -50,6 +52,7 @@
   import { Graph, DataUri } from '@antv/x6'
   import dagTaskbar from './taskbar.vue'
   import contextMenu from './contextMenu.vue'
+  import nodeTooltip from './nodeTooltip.vue'
   import layoutConfigModal, { LAYOUT_TYPE, DEFAULT_LAYOUT_CONFIG } from './layoutConfigModal.vue'
   import {
     NODE,
@@ -102,6 +105,7 @@
     components: {
       dagTaskbar,
       contextMenu,
+      nodeTooltip,
       layoutConfigModal
     },
     computed: {
@@ -261,6 +265,20 @@
         // node double click
         this.graph.on('node:dblclick', ({ cell }) => {
           this.dagChart.openFormModel(Number(cell.id), cell.data.taskType)
+        })
+        this.graph.on('node:mouseover', ({ cell }) => {
+          // issue#7428 display the full name of the node in DAG workflow page when mouseover
+          const node = this.graph.getCellById(cell.id)
+          if (node) {
+            let x = node.position().x
+            let y = node.position().y
+            if (x >= 0) {
+              const { left, top } = this.graph.getScrollbarPosition()
+              const o = this.originalScrollPosition
+              this.$refs.nodeTooltip.show(x + (o.left - left), y + (o.top - top), cell.data.taskName)
+            }
+            // FIXME when x < 0 , the position of the node tooltip is dislocation, the similar issue has been found on the context-menu
+          }
         })
         // create edge label
         this.graph.on('edge:dblclick', ({ cell }) => {

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/nodeTooltip.scss
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/nodeTooltip.scss
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.dag-node-tips {
+  position: absolute;
+  left: 0;
+  /*top: 50%;*/
+  transform: translateY(-50%);
+
+  margin: 0 auto;
+  width: fit-content;
+  padding-left: 10px;
+  padding-right: 10px;
+  height: 30px;
+  line-height: 30px;
+  overflow: hidden;
+
+  border: 1px dashed #e4e4e4;
+  background-color: #ffffff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+
+  .nodeTips {
+    font-size: 15px;
+    color: #333;
+  }
+}
+
+

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/nodeTooltip.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/nodeTooltip.vue
@@ -1,0 +1,70 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+<template>
+  <div
+    class="dag-node-tips"
+    v-show="visible"
+    :style="{
+      left: `${left}px`,
+      top: `${top}px`,
+    }"
+  >
+    <span class="nodeTips">{{ message }}</span>
+  </div>
+</template>
+
+<script>
+
+  export default {
+    name: 'dag-node-tooltip',
+    data () {
+      return {
+        visible: false,
+        left: 0,
+        top: 0,
+        message: ''
+      }
+    },
+    computed: {},
+    mounted () {
+      document.addEventListener('click', (e) => {
+        this.hide()
+      })
+      document.addEventListener('mouseout', (e) => {
+        this.hide()
+      })
+    },
+    methods: {
+      show (x, y, message) {
+        this.visible = true
+        // 12px is aligned to the left side of the node
+        this.left = x > 12 ? x - 12 : x
+        // 50px is reserved for the node status icon
+        this.top = y > 50 ? y - 50 : y
+        this.message = message
+      },
+      hide () {
+        this.visible = false
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+@import "./nodeTooltip";
+</style>


### PR DESCRIPTION
close: #7428. customize a tooltip for the node to display the full task name of the node in DAG workflow when mouseover.

