### PR TITLE
[6696/1880][UI] replace node-sass with dart-sass

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -57,7 +57,6 @@ jobs:
           node-version: 8
       - name: Compile and Build
         run: |
-          npm install node-sass --unsafe-perm
           npm install
           npm run lint
           npm run build

--- a/dolphinscheduler-ui/package.json
+++ b/dolphinscheduler-ui/package.json
@@ -78,7 +78,7 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.8.2",
     "node-notifier": "^8.0.0",
-    "node-sass": "^4.14.1",
+    "sass": "^1.45.1",
     "pack": "^2.2.0",
     "portfinder": "^1.0.28",
     "postcss-loader": "^3.0.0",

--- a/dolphinscheduler-ui/pom.xml
+++ b/dolphinscheduler-ui/pom.xml
@@ -55,16 +55,6 @@
                 </configuration>
               </execution>
               <execution>
-                <id>npm install node-sass --unsafe-perm</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <arguments>install node-sass --unsafe-perm</arguments>
-                </configuration>
-              </execution>
-              <execution>
                 <id>npm install</id>
                 <goals>
                   <goal>npm</goal>
@@ -107,16 +97,6 @@
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
                   <npmVersion>${npm.version}</npmVersion>
-                </configuration>
-              </execution>
-              <execution>
-                <id>npm install node-sass --unsafe-perm</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <arguments>install node-sass --unsafe-perm</arguments>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
LibSass and Node Sass are deprecated. 
https://www.npmjs.com/package/node-sass

fix:
https://github.com/apache/dolphinscheduler/issues/1880
https://github.com/apache/dolphinscheduler/issues/6696

## Purpose of the pull request

the lib node-sass is deprecated

## Brief change log

- *Replace node-sass with dart-sass*

## Verify this pull request

This pull request is code cleanup without any test coverage.
