### PR TITLE
[python] Add independent deployment for python gateway server

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -140,6 +140,29 @@ services:
     networks:
       - dolphinscheduler
 
+  dolphinscheduler-python-gateway:
+    image: ${HUB}/dolphinscheduler-python-gateway:${TAG}
+    ports:
+      - "54321:54321"
+      - "25333:25333"
+    env_file: .env
+    healthcheck:
+      test: [ "CMD", "curl", "http://localhost:54321/actuator/health" ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      dolphinscheduler-schema-initializer:
+        condition: service_completed_successfully
+      dolphinscheduler-zookeeper:
+        condition: service_healthy
+    volumes:
+      - dolphinscheduler-logs:/opt/dolphinscheduler/logs
+      - dolphinscheduler-shared-local:/opt/soft
+      - dolphinscheduler-resource-local:/dolphinscheduler
+    networks:
+      - dolphinscheduler
+
 networks:
   dolphinscheduler:
     driver: bridge

--- a/deploy/docker/docker-stack.yml
+++ b/deploy/docker/docker-stack.yml
@@ -118,6 +118,27 @@ services:
       mode: replicated
       replicas: 1
 
+  dolphinscheduler-python-gateway:
+    image: apache/dolphinscheduler-python-gateway
+    ports:
+      - 54321:54321
+      - 25333:25333
+    env_file: .env
+    healthcheck:
+      test: [ "CMD", "curl", "http://localhost:54321/actuator/health" ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - dolphinscheduler-logs:/opt/dolphinscheduler/logs
+      - dolphinscheduler-shared-local:/opt/soft
+      - dolphinscheduler-resource-local:/dolphinscheduler
+    networks:
+      - dolphinscheduler
+    deploy:
+      mode: replicated
+      replicas: 1
+
 networks:
   dolphinscheduler:
     driver: overlay

--- a/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
+++ b/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
@@ -44,6 +44,9 @@ Create default docker images' fullname.
 {{- define "dolphinscheduler.image.fullname.tools" -}}
 {{- .Values.image.registry }}/dolphinscheduler-tools:{{ .Values.image.tag | default .Chart.AppVersion -}}
 {{- end -}}
+{{- define "dolphinscheduler.image.fullname.python-gateway" -}}
+{{- .Values.image.registry }}/dolphinscheduler-python-gateway:{{ .Values.image.tag | default .Chart.AppVersion -}}
+{{- end -}}
 
 {{/*
 Create a default common labels.

--- a/dolphinscheduler-dist/src/main/assembly/dolphinscheduler-bin.xml
+++ b/dolphinscheduler-dist/src/main/assembly/dolphinscheduler-bin.xml
@@ -51,6 +51,11 @@
         </fileSet>
 
         <fileSet>
+            <directory>${basedir}/../dolphinscheduler-python/target/python-gateway-server</directory>
+            <outputDirectory>python-gateway-server</outputDirectory>
+        </fileSet>
+
+        <fileSet>
             <directory>${basedir}/../dolphinscheduler-standalone-server/target/standalone-server</directory>
             <outputDirectory>standalone-server</outputDirectory>
         </fileSet>

--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -57,4 +57,52 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>*.yaml</exclude>
+                        <exclude>*.xml</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dolphinscheduler-python-gateway-server</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>python-gateway-server</finalName>
+                            <descriptors>
+                                <descriptor>src/main/assembly/dolphinscheduler-python-gateway-server.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/dolphinscheduler-python/src/main/assembly/dolphinscheduler-python-gateway-server.xml
+++ b/dolphinscheduler-python/src/main/assembly/dolphinscheduler-python-gateway-server.xml
@@ -1,0 +1,64 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    <id>dolphinscheduler-python-gateway-server</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>python-gateway-server</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>*.yaml</include>
+                <include>*.xml</include>
+            </includes>
+            <outputDirectory>conf</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/src/main/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../script/env</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>dolphinscheduler_env.sh</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../dolphinscheduler-common/src/main/resources</directory>
+            <includes>
+                <include>**/*.properties</include>
+            </includes>
+            <outputDirectory>conf</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>libs</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/dolphinscheduler-python/src/main/bin/start.sh
+++ b/dolphinscheduler-python/src/main/bin/start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+BIN_DIR=$(dirname $0)
+DOLPHINSCHEDULER_HOME=${DOLPHINSCHEDULER_HOME:-$(cd $BIN_DIR/..; pwd)}
+
+source "$BIN_DIR/dolphinscheduler_env.sh"
+
+JAVA_OPTS=${JAVA_OPTS:-"-server -Xms1g -Xmx1g -Xmn512m -XX:+PrintGCDetails -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof"}
+
+if [[ "$DOCKER" == "true" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -XX:-UseContainerSupport"
+fi
+
+java $JAVA_OPTS \
+  -cp "$DOLPHINSCHEDULER_HOME/conf":"$DOLPHINSCHEDULER_HOME/libs/*" \
+  org.apache.dolphinscheduler.server.PythonGatewayServer

--- a/dolphinscheduler-python/src/main/docker/Dockerfile
+++ b/dolphinscheduler-python/src/main/docker/Dockerfile
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:8-jre-slim-buster
+
+ENV DOCKER true
+ENV TZ Asia/Shanghai
+ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
+
+RUN apt update ; \
+    apt install -y curl sudo ; \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR $DOLPHINSCHEDULER_HOME
+
+ADD ./target/python-gateway-server $DOLPHINSCHEDULER_HOME
+
+EXPOSE 25333
+
+CMD [ "/bin/bash", "./bin/start.sh" ]

--- a/dolphinscheduler-python/src/main/docker/Dockerfile
+++ b/dolphinscheduler-python/src/main/docker/Dockerfile
@@ -29,6 +29,6 @@ WORKDIR $DOLPHINSCHEDULER_HOME
 
 ADD ./target/python-gateway-server $DOLPHINSCHEDULER_HOME
 
-EXPOSE 25333
+EXPOSE 25333 54321
 
 CMD [ "/bin/bash", "./bin/start.sh" ]

--- a/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
+++ b/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
@@ -55,8 +55,6 @@ import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -502,12 +500,9 @@ public class PythonGatewayServer extends SpringBootServletInitializer {
     }
 
     @PostConstruct
-    public void run() throws UnknownHostException {
+    public void run() {
+        GatewayServer server = new GatewayServer(this);
         GatewayServer.turnLoggingOn();
-
-        InetAddress host = InetAddress.getLocalHost();
-        LOGGER.info("GatewayServer for " + this.getClass().getName() + " started on host: " + host.toString());
-        GatewayServer server = new GatewayServer(this, 25333, 25334, host, host, 0, 0, null);
         // Start server to accept python client RPC
         server.start();
     }

--- a/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
+++ b/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
@@ -503,7 +503,7 @@ public class PythonGatewayServer extends SpringBootServletInitializer {
     public void run() {
         GatewayServer server = new GatewayServer(this);
         GatewayServer.turnLoggingOn();
-        // Start server to accept python client RPC
+        // Start server to accept python client socket
         server.start();
     }
 

--- a/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
+++ b/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
@@ -55,6 +55,8 @@ import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -500,9 +502,12 @@ public class PythonGatewayServer extends SpringBootServletInitializer {
     }
 
     @PostConstruct
-    public void run() {
-        GatewayServer server = new GatewayServer(this);
+    public void run() throws UnknownHostException {
         GatewayServer.turnLoggingOn();
+
+        InetAddress host = InetAddress.getLocalHost();
+        LOGGER.info("GatewayServer for " + this.getClass().getName() + " started on host: " + host.toString());
+        GatewayServer server = new GatewayServer(this, 25333, 25334, host, host, 0, 0, null);
         // Start server to accept python client RPC
         server.start();
     }

--- a/dolphinscheduler-python/src/main/resources/application.yaml
+++ b/dolphinscheduler-python/src/main/resources/application.yaml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring:
+  application:
+    name: python-gateway-server
+  main:
+    banner-mode: off
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;INIT=runscript from 'classpath:sql/dolphinscheduler_h2.sql'
+    username: sa
+    password: ""
+    hikari:
+      connection-test-query: select 1
+      minimum-idle: 5
+      auto-commit: true
+      validation-timeout: 3000
+      pool-name: DolphinScheduler
+      maximum-pool-size: 50
+      connection-timeout: 30000
+      idle-timeout: 600000
+      leak-detection-threshold: 0
+      initialization-fail-timeout: 1
+
+server:
+  port: 4321
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+# Override by profile
+---
+spring:
+  config:
+    activate:
+      on-profile: postgresql
+  quartz:
+    properties:
+      org.quartz.jobStore.driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate

--- a/dolphinscheduler-python/src/main/resources/application.yaml
+++ b/dolphinscheduler-python/src/main/resources/application.yaml
@@ -20,9 +20,6 @@ spring:
     name: python-gateway-server
   main:
     banner-mode: off
-  sql:
-    init:
-      schema-locations: classpath:sql/dolphinscheduler_h2.sql
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true

--- a/dolphinscheduler-python/src/main/resources/application.yaml
+++ b/dolphinscheduler-python/src/main/resources/application.yaml
@@ -20,25 +20,28 @@ spring:
     name: python-gateway-server
   main:
     banner-mode: off
+  sql:
+    init:
+      schema-locations: classpath:sql/dolphinscheduler_h2.sql
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;INIT=runscript from 'classpath:sql/dolphinscheduler_h2.sql'
+    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true
     username: sa
     password: ""
-    hikari:
-      connection-test-query: select 1
-      minimum-idle: 5
-      auto-commit: true
-      validation-timeout: 3000
-      pool-name: DolphinScheduler
-      maximum-pool-size: 50
-      connection-timeout: 30000
-      idle-timeout: 600000
-      leak-detection-threshold: 0
-      initialization-fail-timeout: 1
+  jackson:
+    time-zone: GMT+8
+  servlet:
+    multipart:
+      max-file-size: 1024MB
+      max-request-size: 1024MB
+  messages:
+    basename: i18n/messages
+  jpa:
+    hibernate:
+      ddl-auto: none
 
 server:
-  port: 4321
+  port: 54321
 
 management:
   endpoints:
@@ -58,3 +61,4 @@ spring:
   quartz:
     properties:
       org.quartz.jobStore.driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+

--- a/dolphinscheduler-python/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-python/src/main/resources/logback-spring.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration scan="true" scanPeriod="120 seconds">
+<property name="log.base" value="logs"/>
+
+<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+        <pattern>
+            [%level] %date{yyyy-MM-dd HH:mm:ss.SSS} %logger{96}:[%line] - %msg%n
+        </pattern>
+        <charset>UTF-8</charset>
+    </encoder>
+</appender>
+
+<appender name="PYTHONGATEWAYLOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${log.base}/dolphinscheduler-python-gateway.log</file>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>INFO</level>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${log.base}/dolphinscheduler-python-gateway.%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+        <maxHistory>168</maxHistory>
+        <maxFileSize>64MB</maxFileSize>
+    </rollingPolicy>
+    <encoder>
+        <pattern>
+            [%level] %date{yyyy-MM-dd HH:mm:ss.SSS} %logger{96}:[%line] - %msg%n
+        </pattern>
+        <charset>UTF-8</charset>
+    </encoder>
+</appender>
+
+<root level="INFO">
+    <if condition="${DOCKER:-false}">
+        <then>
+            <appender-ref ref="STDOUT"/>
+        </then>
+    </if>
+    <appender-ref ref="PYTHONGATEWAYLOGFILE"/>
+</root>
+</configuration>
+

--- a/dolphinscheduler-python/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-python/src/main/resources/logback-spring.xml
@@ -55,4 +55,3 @@
     <appender-ref ref="PYTHONGATEWAYLOGFILE"/>
 </root>
 </configuration>
-

--- a/dolphinscheduler-standalone-server/pom.xml
+++ b/dolphinscheduler-standalone-server/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-python</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>${curator.test}</version>
@@ -60,10 +65,6 @@
                     <artifactId>javassist</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-python</artifactId>
         </dependency>
     </dependencies>
 

--- a/dolphinscheduler-standalone-server/src/main/assembly/dolphinscheduler-standalone-server.xml
+++ b/dolphinscheduler-standalone-server/src/main/assembly/dolphinscheduler-standalone-server.xml
@@ -60,6 +60,13 @@
             </includes>
             <outputDirectory>.</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/../dolphinscheduler-python-gateway/target/python-gateway</directory>
+            <includes>
+                <include>libs</include>
+            </includes>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
 
         <fileSet>
             <directory>${basedir}/src/main/resources</directory>

--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-usage="Usage: dolphinscheduler-daemon.sh (start|stop|status) <api-server|master-server|worker-server|alert-server|standalone-server> "
+usage="Usage: dolphinscheduler-daemon.sh (start|stop|status) <api-server|master-server|worker-server|alert-server|python-gateway-server|standalone-server> "
 
 # if no args specified, show usage
 if [ $# -le 1 ]; then
@@ -61,6 +61,8 @@ elif [ "$command" = "worker-server" ]; then
 elif [ "$command" = "alert-server" ]; then
   :
 elif [ "$command" = "standalone-server" ]; then
+  :
+elif [ "$command" = "python-gateway-server" ]; then
   :
 else
   echo "Error: No command named '$command' was found."

--- a/script/env/install_env.sh
+++ b/script/env/install_env.sh
@@ -48,6 +48,11 @@ alertServer=${alertServer:-"ds3"}
 # Example for hostname: apiServers="ds1", Example for IP: apiServers="192.168.8.1"
 apiServers=${apiServers:-"ds1"}
 
+# A comma separated list of machine hostname or IP would be installed Python gateway server, it
+# must be a subset of configuration `ips`.
+# Example for hostname: pythonGatewayServers="ds1", Example for IP: pythonGatewayServers="192.168.8.1"
+pythonGatewayServers=${pythonGatewayServers:-"ds1"}
+
 # The directory to install DolphinScheduler for all machine we config above. It will automatically be created by `install.sh` script if not exists.
 # Do not set this configuration same as the current path (pwd)
 installPath=${installPath:-"/tmp/dolphinscheduler"}

--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -49,7 +49,7 @@ do
   echo "scp dirs to $host/$installPath starting"
 	ssh -p $sshPort $host  "cd $installPath/; rm -rf bin/ conf/ lib/ script/ sql/ ui/"
 
-  for dsDir in bin master-server worker-server alert-server api-server ui
+  for dsDir in bin master-server worker-server alert-server api-server ui python-gateway-server
   do
     # if worker in workersGroupMap
     if [[ "${workersGroupMap[${host}]}" ]]; then

--- a/script/start-all.sh
+++ b/script/start-all.sh
@@ -56,6 +56,13 @@ do
   ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh start api-server;"
 done
 
+pythonGatewayHost=(${pythonGatewayServers//,/ })
+for pythonGatewayServer in "${pythonGatewayHost[@]}"
+do
+  echo "$pythonGatewayServer python gateway server is starting"
+  ssh -p $sshPort $pythonGatewayServer "cd $installPath/; sh bin/dolphinscheduler-daemon.sh start python-gateway-server;"
+done
+
 # query server status
 echo "query server status"
 cd $installPath/; sh bin/status-all.sh

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -74,3 +74,11 @@ do
   apiState=`ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status api-server;"`
   echo "$apiServer  $apiState"
 done
+
+# python gateway server check state
+pythonGatewayHost=(${pythonGatewayServers//,/ })
+for pythonGatewayServer in "${pythonGatewayHost[@]}"
+do
+  pythonGatewayState=`ssh -p $sshPort $pythonGatewayServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status python-gateway-server;"`
+  echo "$apiServer  $pythonGatewayState"
+done

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -80,5 +80,5 @@ pythonGatewayHost=(${pythonGatewayServers//,/ })
 for pythonGatewayServer in "${pythonGatewayHost[@]}"
 do
   pythonGatewayState=`ssh -p $sshPort $pythonGatewayServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status python-gateway-server;"`
-  echo "$apiServer  $pythonGatewayState"
+  echo "$pythonGatewayServer  $pythonGatewayState"
 done

--- a/script/stop-all.sh
+++ b/script/stop-all.sh
@@ -58,6 +58,6 @@ done
 pythonGatewayHost=(${pythonGatewayServers//,/ })
 for pythonGatewayServer in "${pythonGatewayHost[@]}"
 do
-  echo "$pythonGatewayServer worker server is stopping"
+  echo "$pythonGatewayServer python gateway server is stopping"
   ssh -p $sshPort $pythonGatewayServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh stop python-gateway-server;"
 done

--- a/script/stop-all.sh
+++ b/script/stop-all.sh
@@ -54,3 +54,10 @@ do
   echo "$apiServer api server is stopping"
   ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh stop api-server;"
 done
+
+pythonGatewayHost=(${pythonGatewayServers//,/ })
+for pythonGatewayServer in "${pythonGatewayHost[@]}"
+do
+  echo "$pythonGatewayServer worker server is stopping"
+  ssh -p $sshPort $pythonGatewayServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh stop python-gateway-server;"
+done


### PR DESCRIPTION
For now, pythonGatewayServer could only run in a standalone server, and standalone is not for the production environment, we should make pythonGatewayServer work like api-server or master-server. We should also make python gateway server work in docker/K8S enviroment.

close: #7539
