### PR TITLE
[Bug] [monitor] task-state-count

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -81,8 +81,11 @@
                 #{i}
             </foreach>
         </if>
-        <if test="startTime != null and endTime != null">
-            and t.start_time > #{startTime} and t.start_time <![CDATA[ <= ]]> #{endTime}
+        <if test="startTime != null">
+            and t.start_time <![CDATA[ > ]]> #{startTime}
+        </if>
+        <if test="endTime != null">
+            and t.start_time <![CDATA[ <= ]]> #{endTime}
         </if>
         group by t.state
     </select>


### PR DESCRIPTION
When calling the statistics function of the interface "dolphinscheduler/projects/analysis/task-state-count", if you just filter it with the parameter "startDate". It does not work. Without any filtering parameters, the result is the same. I modified part of the code to make sure that the startDate and endDate parameters do not affect each other and both fulfill the filtering requirement.
#7527