### PR TITLE
[python] Fix database error handler about no datasource name

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/database.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/database.py
@@ -17,11 +17,11 @@
 
 """Module database."""
 
-import logging
 from typing import Dict
 
 from py4j.protocol import Py4JJavaError
 
+from pydolphinscheduler.exceptions import PyDSParamException
 from pydolphinscheduler.java_gateway import launch_gateway
 
 
@@ -59,6 +59,5 @@ class Database(dict):
                 self._database = gateway.entry_point.getDatasourceInfo(name)
             # Handler database source do not exists error, for now we just terminate the process.
             except Py4JJavaError as ex:
-                logging.error(str(ex.java_exception))
-                exit(1)
+                raise PyDSParamException(str(ex.java_exception))
             return self._database

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/database.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/database.py
@@ -58,7 +58,7 @@ class Database(dict):
             try:
                 self._database = gateway.entry_point.getDatasourceInfo(name)
             # Handler database source do not exists error, for now we just terminate the process.
-            except Py4JJavaError:
-                logging.error("Datasource name `%s` do not exists.", name)
+            except Py4JJavaError as ex:
+                logging.error(str(ex.java_exception))
                 exit(1)
             return self._database

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/database.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/database.py
@@ -17,7 +17,10 @@
 
 """Module database."""
 
+import logging
 from typing import Dict
+
+from py4j.protocol import Py4JJavaError
 
 from pydolphinscheduler.java_gateway import launch_gateway
 
@@ -52,5 +55,10 @@ class Database(dict):
             return self._database
         else:
             gateway = launch_gateway()
-            self._database = gateway.entry_point.getDatasourceInfo(name)
+            try:
+                self._database = gateway.entry_point.getDatasourceInfo(name)
+            # Handler database source do not exists error, for now we just terminate the process.
+            except Py4JJavaError:
+                logging.error("Datasource name `%s` do not exists.", name)
+                exit(1)
             return self._database

--- a/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
+++ b/dolphinscheduler-python/src/main/java/org/apache/dolphinscheduler/server/PythonGatewayServer.java
@@ -392,12 +392,12 @@ public class PythonGatewayServer extends SpringBootServletInitializer {
     public Map<String, Object> getDatasourceInfo(String datasourceName) {
         Map<String, Object> result = new HashMap<>();
         List<DataSource> dataSourceList = dataSourceMapper.queryDataSourceByName(datasourceName);
-        if (dataSourceList.size() > 1) {
-            String msg = String.format("Get more than one datasource by name %s", datasourceName);
+        if (dataSourceList == null || dataSourceList.isEmpty()) {
+            String msg = String.format("Can not find any datasource by name %s", datasourceName);
             logger.error(msg);
             throw new IllegalArgumentException(msg);
-        } else if (dataSourceList.size() == 0) {
-            String msg = String.format("Can not find any datasource by name %s", datasourceName);
+        } else if (dataSourceList.size() > 1) {
+            String msg = String.format("Get more than one datasource by name %s", datasourceName);
             logger.error(msg);
             throw new IllegalArgumentException(msg);
         } else {


### PR DESCRIPTION
The original code show too many unrelated log when database name
do not exists. BTW, it would continue the code when error miss.
This patch is try to fix it.

close: #7616

