### PR TITLE
[Fix-7682] After creating a task group the values of both fields 'create_time' and 'update_time' are empty. 

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
@@ -88,6 +88,9 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         }
         TaskGroup taskGroup = new TaskGroup(name, projectcode, description,
             groupSize, loginUser.getId(), Flag.YES.getCode());
+
+        taskGroup.setCreateTime(new Date());
+        taskGroup.setUpdateTime(new Date());
         if (taskGroupMapper.insert(taskGroup) > 0) {
             putMsg(result, Status.SUCCESS);
         } else {
@@ -120,6 +123,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         }
         taskGroup.setGroupSize(groupSize);
         taskGroup.setDescription(description);
+        taskGroup.setUpdateTime(new Date());
         if (StringUtils.isNotEmpty(name)) {
             taskGroup.setName(name);
         }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -2684,6 +2684,8 @@ public class ProcessService {
                                                    String taskName, Integer groupId,
                                                    Integer processId, Integer priority, TaskGroupQueueStatus status) {
         TaskGroupQueue taskGroupQueue = new TaskGroupQueue(taskId, taskName, groupId, processId, priority, status);
+        taskGroupQueue.setCreateTime(new Date());
+        taskGroupQueue.setUpdateTime(new Date());
         taskGroupQueueMapper.insert(taskGroupQueue);
         return taskGroupQueue;
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This PR will close #7682 .

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

This issue is caused by missing assigning the date time for the fields 'create_time' and 'update_time'.

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
