### PR TITLE
[UI] Fix wrong dialogs for process definition's version info

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/versions.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/versions.vue
@@ -36,7 +36,7 @@
         <el-table-column prop="description" :label="$t('Description')"></el-table-column>
         <el-table-column :label="$t('Create Time')" min-width="120">
           <template slot-scope="scope">
-            <span>{{scope.row.createTime | formatDate}}</span>
+            <span>{{scope.row.updateTime | formatDate}}</span>
           </template>
         </el-table-column>
         <el-table-column :label="$t('Operation')" width="100">


### PR DESCRIPTION
We should use process_definition.update_time instead of create time
to make more sense.

close: #7660