### PR TITLE
[Fix-7713] Handling the sensitive data in the log

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspect.java
@@ -17,13 +17,6 @@
 
 package org.apache.dolphinscheduler.api.aspect;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.IntStream;
-import org.apache.commons.lang3.RegExUtils;
-import org.apache.dolphinscheduler.api.utils.RegexUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
@@ -33,7 +26,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -58,8 +54,6 @@ public class AccessLogAspect {
     public static final String sensitiveDataRegEx = "(password=[\'\"]+)(\\S+)([\'\"]+)";
 
     private static final Pattern sensitiveDataPattern = Pattern.compile(sensitiveDataRegEx, Pattern.CASE_INSENSITIVE);
-
-    public static final Map<String,String> SENSITIVE_DATA_PATTERN_MAPPING = ImmutableMap.of("password=", "");
 
     @Pointcut("@annotation(org.apache.dolphinscheduler.api.aspect.AccessLogAnnotation)")
     public void logPointCut(){

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspectTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/aspect/AccessLogAspectTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.aspect;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Hua Jiang
+ */
+
+public class AccessLogAspectTest {
+
+    private AccessLogAspect accessLogAspect = new AccessLogAspect();
+
+    @Test
+    public void testHandleSensitiveData() {
+        String data = "userPassword='7ad2410b2f4c074479a8937a28a22b8f', email='xxx@qq.com', database='null', userName='root', password='root', other='null'";
+        String expected = "userPassword='********************************', email='xxx@qq.com', database='null', userName='root', password='****', other='null'";
+
+        String actual = accessLogAspect.handleSensitiveData(data);
+
+        Assert.assertEquals(expected, actual);
+
+    }
+
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR will close #7713 .

## Brief change log

When requesting api interface, the class AccessLogAspect will output the logs about the request parameters. But somtimes the request parameters includes a few sensitive data like password. So I add a function to deal with the writing logs that contains 'password' , and then it  will convert the value of 'password' into '****'.

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
I manually verify the new function, and it can successfully pass through the test case.