### PR TITLE
[Fix-7510] Remedy the issue with clicking the breadcrumb on the page of file resources.

### DIFF
--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -19,10 +19,10 @@
 data.basedir.path=/tmp/dolphinscheduler
 
 # resource storage type: HDFS, S3, NONE
-resource.storage.type=HDFS
+resource.storage.type=NONE
 
 # resource store on HDFS/S3 path, resource file will store to this hadoop hdfs path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
-resource.upload.path=/user/calvin/dolphinscheduler
+resource.upload.path=/dolphinscheduler
 
 # whether to startup kerberos
 hadoop.security.authentication.startup.state=false
@@ -43,10 +43,10 @@ kerberos.expire.time=2
 #resource.view.suffixs=txt,log,sh,bat,conf,cfg,py,java,sql,xml,hql,properties,json,yml,yaml,ini,js
 
 # if resource.storage.type=HDFS, the user must have the permission to create directories under the HDFS root path
-hdfs.root.user=calvin
+hdfs.root.user=hdfs
 
 # if resource.storage.type=S3, the value like: s3a://dolphinscheduler; if resource.storage.type=HDFS and namenode HA is enabled, you need to copy core-site.xml and hdfs-site.xml to conf dir
-fs.defaultFS=hdfs://zp-data-hadoop-qa-001:8020
+fs.defaultFS=hdfs://mycluster:8020
 
 # if resource.storage.type=S3, s3 endpoint
 fs.s3a.endpoint=http://192.168.xx.xx:9010

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -19,10 +19,10 @@
 data.basedir.path=/tmp/dolphinscheduler
 
 # resource storage type: HDFS, S3, NONE
-resource.storage.type=NONE
+resource.storage.type=HDFS
 
 # resource store on HDFS/S3 path, resource file will store to this hadoop hdfs path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
-resource.upload.path=/dolphinscheduler
+resource.upload.path=/user/calvin/dolphinscheduler
 
 # whether to startup kerberos
 hadoop.security.authentication.startup.state=false
@@ -43,10 +43,10 @@ kerberos.expire.time=2
 #resource.view.suffixs=txt,log,sh,bat,conf,cfg,py,java,sql,xml,hql,properties,json,yml,yaml,ini,js
 
 # if resource.storage.type=HDFS, the user must have the permission to create directories under the HDFS root path
-hdfs.root.user=hdfs
+hdfs.root.user=calvin
 
 # if resource.storage.type=S3, the value like: s3a://dolphinscheduler; if resource.storage.type=HDFS and namenode HA is enabled, you need to copy core-site.xml and hdfs-site.xml to conf dir
-fs.defaultFS=hdfs://mycluster:8020
+fs.defaultFS=hdfs://zp-data-hadoop-qa-001:8020
 
 # if resource.storage.type=S3, s3 endpoint
 fs.s3a.endpoint=http://192.168.xx.xx:9010

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/subdirectory/index.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/subdirectory/index.vue
@@ -18,7 +18,7 @@
   <div class="home-main list-construction-model">
     <div class="content-title">
       <a class="bread" style="padding-left: 15px;" @click="() => $router.push({path: `/resource/file`})">{{$t('File Manage')}}</a>
-      <a class="bread" v-for="(item,$index) in breadList" :key="$index" @click="_ckOperation($index)">{{'>'+item}}</a>
+      <a class="bread" v-for="(item,$index) in breadList" :key="$index" @click="_ckOperation(item, $index)">{{'>'+item}}</a>
     </div>
     <div class="conditions-box">
       <m-conditions @on-conditions="_onConditions">
@@ -135,7 +135,7 @@
         this.searchParams.id = this.$route.params.id
         this._debounceGET()
       },
-      _ckOperation (index) {
+      _ckOperation (item, index) {
         let breadName = ''
         this.breadList.forEach((item, i) => {
           if (i <= index) {
@@ -147,7 +147,8 @@
       transferApi (api) {
         this.getResourceId({
           type: 'FILE',
-          fullName: api
+          fullName: api,
+          id: this.searchParams.id
         }).then(res => {
           localStore.setItem('currentDir', `${res.fullName}`)
           this.$router.push({ path: `/resource/file/subdirectory/${res.id}` })


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR will close #7510 .

## Brief change log

This issue is caused by missing a parameter of 'id' when requesting the backend api.

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
![image](https://user-images.githubusercontent.com/4928204/147801528-196a4a90-f16e-4c38-917d-c0fed93f25e6.png)
