### PR TITLE
[Fix-7203] Remedy the issue about importing a process json file.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -944,11 +944,12 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
             ArrayNode newArrayNode = JSONUtils.createArrayNode();
             for (int i = 0; i < arrayNode.size(); i++) {
                 ObjectNode newObjectNode = newArrayNode.addObject();
-                long oldTaskCode = arrayNode.get(i).get("taskCode").asLong();
-                if (taskCodeMap.containsKey(oldTaskCode)) {
-                    newObjectNode.put("taskCode", taskCodeMap.get(oldTaskCode));
-                    newObjectNode.set("x", arrayNode.get(i).get("x"));
-                    newObjectNode.set("y", arrayNode.get(i).get("y"));
+                JsonNode jsonNode = arrayNode.get(i);
+                Long taskCode = taskCodeMap.get(jsonNode.get("taskCode").asLong());
+                if (Objects.nonNull(taskCode)) {
+                    newObjectNode.put("taskCode", taskCode);
+                    newObjectNode.set("x", jsonNode.get("x"));
+                    newObjectNode.set("y", jsonNode.get("y"));
                 }
             }
             processDefinition.setLocations(newArrayNode.toString());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -77,7 +77,6 @@ import org.apache.dolphinscheduler.service.process.ProcessService;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.directory.api.util.Strings;
 
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -940,13 +939,14 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
             processTaskRelationLog.setPostTaskVersion(Constants.VERSION_FIRST);
             taskRelationLogList.add(processTaskRelationLog);
         }
-        if (Strings.isNotEmpty(processDefinition.getLocations()) && JSONUtils.checkJsonValid(processDefinition.getLocations())) {
+        if (StringUtils.isNotEmpty(processDefinition.getLocations()) && JSONUtils.checkJsonValid(processDefinition.getLocations())) {
             ArrayNode arrayNode = JSONUtils.parseArray(processDefinition.getLocations());
             ArrayNode newArrayNode = JSONUtils.createArrayNode();
             for (int i = 0; i < arrayNode.size(); i++) {
                 ObjectNode newObjectNode = newArrayNode.addObject();
-                if (taskCodeMap.containsKey(arrayNode.get(i).get("taskCode").asLong())) {
-                    newObjectNode.put("taskCode", taskCodeMap.get(arrayNode.get(i).get("taskCode").asLong()));
+                long oldTaskCode = arrayNode.get(i).get("taskCode").asLong();
+                if (taskCodeMap.containsKey(oldTaskCode)) {
+                    newObjectNode.put("taskCode", taskCodeMap.get(oldTaskCode));
                     newObjectNode.set("x", arrayNode.get(i).get("x"));
                     newObjectNode.set("y", arrayNode.get(i).get("y"));
                 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -107,6 +107,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
This PR will close #7203 .

## Brief change log
The original codes didn't deal with the part of locations in the process definition json.So when the user employs this function  of importing a process definition file the system would lose the locations.

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
The original process is as follows:
![image](https://user-images.githubusercontent.com/4928204/148175599-4d3457bc-8b15-46f6-84d1-383fe6ce95fb.png)

The imported process is as follows:
![image](https://user-images.githubusercontent.com/4928204/148175588-7a641f1a-cbae-45e7-aa67-0a6118a13f74.png)
