### PR TITLE
[Fix-7825] Remedy the value of create time and update time to be current time when importing a process json file.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -900,9 +900,9 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         List<ProcessTaskRelationLog> processTaskRelationList = new ArrayList<>();
 
         // for Zip Bomb Attack
-        int THRESHOLD_ENTRIES = 10000;
-        int THRESHOLD_SIZE = 1000000000; // 1 GB
-        double THRESHOLD_RATIO = 10;
+        final int THRESHOLD_ENTRIES = 10000;
+        final int THRESHOLD_SIZE = 1000000000; // 1 GB
+        final double THRESHOLD_RATIO = 10;
         int totalEntryArchive = 0;
         int totalSizeEntry = 0;
         // In most cases, there will be only one data source
@@ -921,7 +921,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
 
             ZipEntry entry;
             while ((entry = zIn.getNextEntry()) != null) {
-                totalEntryArchive ++;
+                totalEntryArchive++;
                 int totalSizeArchive = 0;
                 if (!entry.isDirectory()) {
                     StringBuilder sql = new StringBuilder();
@@ -934,7 +934,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                         totalSizeEntry += nBytes;
                         totalSizeArchive += nBytes;
                         long compressionRatio = totalSizeEntry / entry.getCompressedSize();
-                        if(compressionRatio > THRESHOLD_RATIO) {
+                        if (compressionRatio > THRESHOLD_RATIO) {
                             throw new IllegalStateException("ratio between compressed and uncompressed data is highly suspicious, looks like a Zip Bomb Attack");
                         }
                         int commentIndex = line.indexOf("-- ");
@@ -995,11 +995,11 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                     taskNameToUpstream.put(taskDefinition.getName(), upstreams);
                 }
 
-                if(totalSizeArchive > THRESHOLD_SIZE) {
+                if (totalSizeArchive > THRESHOLD_SIZE) {
                     throw new IllegalStateException("the uncompressed data size is too much for the application resource capacity");
                 }
 
-                if(totalEntryArchive > THRESHOLD_ENTRIES) {
+                if (totalEntryArchive > THRESHOLD_ENTRIES) {
                     throw new IllegalStateException("too much entries in this archive, can lead to inodes exhaustion of the system");
                 }
             }
@@ -1166,6 +1166,8 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
             }
             processDefinition.setLocations(newArrayNode.toString());
         }
+        processDefinition.setCreateTime(new Date());
+        processDefinition.setUpdateTime(new Date());
         Map<String, Object> createDagResult = createDagDefine(loginUser, taskRelationLogList, processDefinition, Lists.newArrayList());
         if (Status.SUCCESS.equals(createDagResult.get(Constants.STATUS))) {
             putMsg(createDagResult, Status.SUCCESS);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR will close #7825 .

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
When importing a process json file the value of create time and update time will be reassigned to be current time.

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
![image](https://user-images.githubusercontent.com/4928204/148214783-d13b4a93-a94a-41e9-b6d8-fa55f64ff672.png)
