### PR TITLE
[FIX-7732][fix] fix column 'is_directory' of table `t_ds_resources` type error in PG database

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/Resource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/Resource.java
@@ -28,93 +28,93 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 @TableName("t_ds_resources")
 public class Resource {
-  /**
-   * id
-   */
-  @TableId(value="id", type=IdType.AUTO)
-  private int id;
+    /**
+     * id
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private int id;
 
-  /**
-   * parent id
-   */
-  private int pid;
+    /**
+     * parent id
+     */
+    private int pid;
 
-  /**
-   * resource alias
-   */
-  private String alias;
+    /**
+     * resource alias
+     */
+    private String alias;
 
-  /**
-   * full name
-   */
-  private String fullName;
+    /**
+     * full name
+     */
+    private String fullName;
 
-  /**
-   * is directory
-   */
-  private boolean isDirectory=false;
+    /**
+     * is directory
+     */
+    private boolean isDirectory = false;
 
-  /**
-   * description
-   */
-  private String description;
+    /**
+     * description
+     */
+    private String description;
 
-  /**
-   * file alias
-   */
-  private String fileName;
+    /**
+     * file alias
+     */
+    private String fileName;
 
-  /**
-   * user id
-   */
-  private int userId;
+    /**
+     * user id
+     */
+    private int userId;
 
-  /**
-   * resource type
-   */
-  private ResourceType type;
+    /**
+     * resource type
+     */
+    private ResourceType type;
 
-  /**
-   * resource size
-   */
-  private long size;
+    /**
+     * resource size
+     */
+    private long size;
 
-  /**
-   * create time
-   */
-  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss",timezone="GMT+8")
-  private Date createTime;
+    /**
+     * create time
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private Date createTime;
 
-  /**
-   * update time
-   */
-  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss",timezone="GMT+8")
-  private Date updateTime;
+    /**
+     * update time
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private Date updateTime;
 
-  public Resource() {
-  }
+    public Resource() {
+    }
 
-  public Resource(int id, String alias, String fileName, String description, int userId,
-                  ResourceType type, long size,
-                  Date createTime, Date updateTime) {
-    this.id = id;
-    this.alias = alias;
-    this.fileName = fileName;
-    this.description = description;
-    this.userId = userId;
-    this.type = type;
-    this.size = size;
-    this.createTime = createTime;
-    this.updateTime = updateTime;
-  }
+    public Resource(int id, String alias, String fileName, String description, int userId,
+                    ResourceType type, long size,
+                    Date createTime, Date updateTime) {
+        this.id = id;
+        this.alias = alias;
+        this.fileName = fileName;
+        this.description = description;
+        this.userId = userId;
+        this.type = type;
+        this.size = size;
+        this.createTime = createTime;
+        this.updateTime = updateTime;
+    }
 
-  public Resource(int id, int pid, String alias, String fullName, boolean isDirectory) {
-    this.id = id;
-    this.pid = pid;
-    this.alias = alias;
-    this.fullName = fullName;
-    this.isDirectory = isDirectory;
-  }
+    public Resource(int id, int pid, String alias, String fullName, boolean isDirectory) {
+        this.id = id;
+        this.pid = pid;
+        this.alias = alias;
+        this.fullName = fullName;
+        this.isDirectory = isDirectory;
+    }
 
   /*public Resource(String alias, String fileName, String description, int userId, ResourceType type, long size, Date createTime, Date updateTime) {
     this.alias = alias;
@@ -127,120 +127,120 @@ public class Resource {
     this.updateTime = updateTime;
   }*/
 
-  public Resource(int pid, String alias, String fullName, boolean isDirectory, String description, String fileName, int userId, ResourceType type, long size, Date createTime, Date updateTime) {
-    this.pid = pid;
-    this.alias = alias;
-    this.fullName = fullName;
-    this.isDirectory = isDirectory;
-    this.description = description;
-    this.fileName = fileName;
-    this.userId = userId;
-    this.type = type;
-    this.size = size;
-    this.createTime = createTime;
-    this.updateTime = updateTime;
-  }
+    public Resource(int pid, String alias, String fullName, boolean isDirectory, String description, String fileName, int userId, ResourceType type, long size, Date createTime, Date updateTime) {
+        this.pid = pid;
+        this.alias = alias;
+        this.fullName = fullName;
+        this.isDirectory = isDirectory;
+        this.description = description;
+        this.fileName = fileName;
+        this.userId = userId;
+        this.type = type;
+        this.size = size;
+        this.createTime = createTime;
+        this.updateTime = updateTime;
+    }
 
-  public int getId() {
-    return id;
-  }
+    public int getId() {
+        return id;
+    }
 
-  public void setId(int id) {
-    this.id = id;
-  }
+    public void setId(int id) {
+        this.id = id;
+    }
 
-  public String getAlias() {
-    return alias;
-  }
+    public String getAlias() {
+        return alias;
+    }
 
-  public void setAlias(String alias) {
-    this.alias = alias;
-  }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
 
-  public int getPid() {
-    return pid;
-  }
+    public int getPid() {
+        return pid;
+    }
 
-  public void setPid(int pid) {
-    this.pid = pid;
-  }
+    public void setPid(int pid) {
+        this.pid = pid;
+    }
 
-  public String getFullName() {
-    return fullName;
-  }
+    public String getFullName() {
+        return fullName;
+    }
 
-  public void setFullName(String fullName) {
-    this.fullName = fullName;
-  }
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
 
-  public boolean isDirectory() {
-    return isDirectory;
-  }
+    public boolean isDirectory() {
+        return isDirectory;
+    }
 
-  public void setDirectory(boolean directory) {
-    isDirectory = directory;
-  }
+    public void setDirectory(boolean directory) {
+        isDirectory = directory;
+    }
 
-  public String getFileName() {
-    return fileName;
-  }
+    public String getFileName() {
+        return fileName;
+    }
 
-  public void setFileName(String fileName) {
-    this.fileName = fileName;
-  }
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
 
-  public String getDescription() {
-    return description;
-  }
+    public String getDescription() {
+        return description;
+    }
 
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-  public int getUserId() {
-    return userId;
-  }
+    public int getUserId() {
+        return userId;
+    }
 
-  public void setUserId(int userId) {
-    this.userId = userId;
-  }
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
 
 
-  public ResourceType getType() {
-    return type;
-  }
+    public ResourceType getType() {
+        return type;
+    }
 
-  public void setType(ResourceType type) {
-    this.type = type;
-  }
+    public void setType(ResourceType type) {
+        this.type = type;
+    }
 
-  public long getSize() {
-    return size;
-  }
+    public long getSize() {
+        return size;
+    }
 
-  public void setSize(long size) {
-    this.size = size;
-  }
+    public void setSize(long size) {
+        this.size = size;
+    }
 
-  public Date getCreateTime() {
-    return createTime;
-  }
+    public Date getCreateTime() {
+        return createTime;
+    }
 
-  public void setCreateTime(Date createTime) {
-    this.createTime = createTime;
-  }
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
 
-  public Date getUpdateTime() {
-    return updateTime;
-  }
+    public Date getUpdateTime() {
+        return updateTime;
+    }
 
-  public void setUpdateTime(Date updateTime) {
-    this.updateTime = updateTime;
-  }
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
 
-  @Override
-  public String toString() {
-    return "Resource{" +
+    @Override
+    public String toString() {
+        return "Resource{" +
             "id=" + id +
             ", pid=" + pid +
             ", alias='" + alias + '\'' +
@@ -254,30 +254,30 @@ public class Resource {
             ", createTime=" + createTime +
             ", updateTime=" + updateTime +
             '}';
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-        return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-        return false;
     }
 
-    Resource resource = (Resource) o;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
-    if (id != resource.id) {
-        return false;
+        Resource resource = (Resource) o;
+
+        if (id != resource.id) {
+            return false;
+        }
+        return alias.equals(resource.alias);
+
     }
-    return alias.equals(resource.alias);
 
-  }
-
-  @Override
-  public int hashCode() {
-    int result = id;
-    result = 31 * result + alias.hashCode();
-    return result;
-  }
+    @Override
+    public int hashCode() {
+        int result = id;
+        result = 31 * result + alias.hashCode();
+        return result;
+    }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/Resource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/Resource.java
@@ -116,17 +116,6 @@ public class Resource {
         this.isDirectory = isDirectory;
     }
 
-  /*public Resource(String alias, String fileName, String description, int userId, ResourceType type, long size, Date createTime, Date updateTime) {
-    this.alias = alias;
-    this.fileName = fileName;
-    this.description = description;
-    this.userId = userId;
-    this.type = type;
-    this.size = size;
-    this.createTime = createTime;
-    this.updateTime = updateTime;
-  }*/
-
     public Resource(int pid, String alias, String fullName, boolean isDirectory, String description, String fileName, int userId, ResourceType type, long size, Date createTime, Date updateTime) {
         this.pid = pid;
         this.alias = alias;

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
@@ -664,7 +664,7 @@ CREATE TABLE t_ds_resources (
   update_time timestamp DEFAULT NULL ,
   pid int,
   full_name varchar(64),
-  is_directory int,
+  is_directory boolean DEFAULT FALSE,
   PRIMARY KEY (id),
   CONSTRAINT t_ds_resources_un UNIQUE (full_name, type)
 ) ;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix column 'is_directory' of table `t_ds_resources` type error in PG database
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
1. alter column from int to boolean. In the origin `Resource.java` ,`isDirectory` has a default value, so in the init sql set column default false
2. Format class `Resource.java`

can close #7732 
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
