### PR TITLE
[FIX-7815] [dolphinscheduler-api] There are duplicate processes in the process definition list

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
@@ -84,7 +84,7 @@
         <if test=" userId != 0">
             and td.user_id = #{userId}
         </if>
-        order by sc.schedule_release_state desc,td.update_time desc
+        order by sc.schedule_release_state desc,td.update_time desc,td.id asc
     </select>
 
     <select id="queryAllDefinitionList" resultType="org.apache.dolphinscheduler.dao.entity.ProcessDefinition">


### PR DESCRIPTION
this pr close #7815 

When upgrading from 1.x to 2.x, the update time of all process definition is modified to 00:00:00 on the same day, resulting in duplicate data for process definition list paging.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
