### PR TITLE
[FixBug]Close the FileOutputStream in FileUtils.java file

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -138,16 +138,20 @@ public class FileUtils {
      * @return true if write success
      */
     public static boolean writeContent2File(String content, String filePath) {
+        FileOutputStream fos = null;
         try {
             File distFile = new File(filePath);
             if (!distFile.getParentFile().exists() && !distFile.getParentFile().mkdirs()) {
                 logger.error("mkdir parent failed");
                 return false;
             }
-            IOUtils.write(content, new FileOutputStream(filePath), StandardCharsets.UTF_8);
+            fos = new FileOutputStream(filePath);
+            IOUtils.write(content, fos, StandardCharsets.UTF_8);
         } catch (IOException e) {
             logger.error(e.getMessage(), e);
             return false;
+        } finally {
+            IOUtils.closeQuietly(fos);
         }
         return true;
     }


### PR DESCRIPTION
Close the FileOutputStream in FileUtils.java file

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
