### PR TITLE
[2.0.3][Bug] [on k8s] query log can not show contents when task log in master on k8s #7949

### DIFF
--- a/docker/build/startup.sh
+++ b/docker/build/startup.sh
@@ -97,6 +97,7 @@ case "$1" in
         waitZK
         waitDatabase
         export MASTER_START_ENABLED=true
+        export LOGGER_START_ENABLED=true
     ;;
     (worker-server)
         waitZK

--- a/docker/kubernetes/dolphinscheduler/values.yaml
+++ b/docker/kubernetes/dolphinscheduler/values.yaml
@@ -155,6 +155,7 @@ master:
   #     cpu: "500m"
   ## Configmap
   configmap:
+    LOGGER_SERVER_OPTS: "-Xms512m -Xmx512m -Xmn256m"
     MASTER_SERVER_OPTS: "-Xms1g -Xmx1g -Xmn512m"
     MASTER_EXEC_THREADS: "100"
     MASTER_EXEC_TASK_NUM: "20"


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

https://github.com/apache/dolphinscheduler/issues/7949

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
