### PR TITLE
[CI][E2E] Optimize CI E2E test performance

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,7 +95,7 @@ jobs:
         name: Download Docker Images
         with:
           name: standalone-image
-          path: /tmp/standalone-image.tar
+          path: /tmp
       - name: Load Docker Images
         run: |
             docker load -i /tmp/standalone-image.tar

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,8 @@ jobs:
         run: docker images
       - name: Export Docker Images
         run: |
-          docker save $(docker images --format '{{.Repository}}:{{.Tag}}') -o /tmp/docker-images.tar
+          images_name=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep dolphinscheduler | grep ci) \
+          docker save %{images_name} -o /tmp/docker-images.tar
       - uses: actions/upload-artifact@v2
         name: Upload Docker Images
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,8 @@ jobs:
           -Dmaven.checkstyle.skip \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Export Docker Images
         run: |
           docker save $(docker images | grep -v REPOSITORY | awk 'BEGIN{OFS=":";ORS=" "}{print $1,$2}') -o /tmp/docker-images.tar
@@ -93,9 +95,12 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - uses: actions/download-artifact@v2
+        name: Download Docker Images
         with:
           name: docker-images
           path: /tmp/docker-images.tar
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Load Docker Images
         run: |
             docker load -i /tmp/docker-images.tar

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Export Docker Images
         run: |
           docker save apache/dolphinscheduler-standalone-server:ci -o /tmp/standalone-image.tar \
-          du -sh /tmp/standalone-image.tar
+          && du -sh /tmp/standalone-image.tar
       - uses: actions/upload-artifact@v2
         name: Upload Docker Images
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,8 @@ jobs:
             class: org.apache.dolphinscheduler.e2e.cases.WorkerGroupE2ETest
           - name: Project
             class: org.apache.dolphinscheduler.e2e.cases.ProjectE2ETest
+          - name: Queue
+              class: org.apache.dolphinscheduler.e2e.cases.QueueE2ETest
           - name: Workflow
             class: org.apache.dolphinscheduler.e2e.cases.WorkflowE2ETest
           - name: FileManage

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,28 +28,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
-    name: ${{ matrix.case.name }}
+  build:
+    name: E2E-Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        case:
-          - name: Tenant
-            class: org.apache.dolphinscheduler.e2e.cases.TenantE2ETest
-          - name: User
-            class: org.apache.dolphinscheduler.e2e.cases.UserE2ETest
-          - name: WorkerGroup
-            class: org.apache.dolphinscheduler.e2e.cases.WorkerGroupE2ETest
-          - name: Project
-            class: org.apache.dolphinscheduler.e2e.cases.ProjectE2ETest
-          - name: Queue
-            class: org.apache.dolphinscheduler.e2e.cases.QueueE2ETest
-          - name: Workflow
-            class: org.apache.dolphinscheduler.e2e.cases.WorkflowE2ETest
-          - name: FileManage
-            class: org.apache.dolphinscheduler.e2e.cases.FileManageE2ETest
-    env:
-      RECORDING_PATH: /tmp/recording-${{ matrix.case.name }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -70,6 +51,39 @@ jobs:
           -Dmaven.checkstyle.skip \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
+  e2e:
+    name: ${{ matrix.case.name }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        case:
+          - name: Tenant
+            class: org.apache.dolphinscheduler.e2e.cases.TenantE2ETest
+          - name: User
+            class: org.apache.dolphinscheduler.e2e.cases.UserE2ETest
+          - name: WorkerGroup
+            class: org.apache.dolphinscheduler.e2e.cases.WorkerGroupE2ETest
+          - name: Project
+            class: org.apache.dolphinscheduler.e2e.cases.ProjectE2ETest
+          - name: Workflow
+            class: org.apache.dolphinscheduler.e2e.cases.WorkflowE2ETest
+          - name: FileManage
+            class: org.apache.dolphinscheduler.e2e.cases.FileManageE2ETest
+    env:
+      RECORDING_PATH: /tmp/recording-${{ matrix.case.name }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Sanity Check
+        uses: ./.github/actions/sanity-check
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Run Test
         run: |
           ./mvnw -B -f dolphinscheduler-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,14 @@ jobs:
           -Dmaven.checkstyle.skip \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
+      - name: Export Docker Images
+        run: |
+          docker save $(docker images | grep -v REPOSITORY | awk 'BEGIN{OFS=":";ORS=" "}{print $1,$2}') -o /tmp/docker-images.tar
+      - uses: actions/upload-artifact@v2
+        name: Upload Docker Images
+        with:
+          name: docker-images
+          path: /tmp/docker-images.tar
   e2e:
     name: ${{ matrix.case.name }}
     needs: build
@@ -84,6 +92,13 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
+      - uses: actions/download-artifact@v2
+        with:
+          name: docker-images
+          path: /tmp/docker-images.tar
+      - name: Load Docker Images
+        run: |
+            docker load -i /tmp/docker-images.tar
       - name: Run Test
         run: |
           ./mvnw -B -f dolphinscheduler-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,11 +51,11 @@ jobs:
           -Dmaven.checkstyle.skip \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Check Docker Info
+        uses: docker info
       - name: Export Docker Images
         run: |
-          docker save $(docker images | grep -v REPOSITORY | awk 'BEGIN{OFS=":";ORS=" "}{print $1,$2}') -o /tmp/docker-images.tar
+          docker save $(docker images -q) -o /tmp/docker-images.tar
       - uses: actions/upload-artifact@v2
         name: Upload Docker Images
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           name: standalone-image
           path: /tmp/standalone-image.tar
+          retention-days: 1
   e2e:
     name: ${{ matrix.case.name }}
     needs: build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,17 +51,15 @@ jobs:
           -Dmaven.checkstyle.skip \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
-      - name: Check Docker Info
-        run: docker images
       - name: Export Docker Images
         run: |
-          images_name=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep dolphinscheduler | grep ci) \
-          docker save %{images_name} -o /tmp/docker-images.tar
+          docker save apache/dolphinscheduler-standalone-server:ci -o /tmp/standalone-image.tar \
+          du -sh /tmp/standalone-image.tar
       - uses: actions/upload-artifact@v2
         name: Upload Docker Images
         with:
-          name: docker-images
-          path: /tmp/docker-images.tar
+          name: standalone-image
+          path: /tmp/standalone-image.tar
   e2e:
     name: ${{ matrix.case.name }}
     needs: build
@@ -87,8 +85,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Sanity Check
-        uses: ./.github/actions/sanity-check
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
@@ -98,13 +94,11 @@ jobs:
       - uses: actions/download-artifact@v2
         name: Download Docker Images
         with:
-          name: docker-images
-          path: /tmp/docker-images.tar
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+          name: standalone-image
+          path: /tmp/standalone-image.tar
       - name: Load Docker Images
         run: |
-            docker load -i /tmp/docker-images.tar
+            docker load -i /tmp/standalone-image.tar
       - name: Run Test
         run: |
           ./mvnw -B -f dolphinscheduler-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,7 +76,7 @@ jobs:
           - name: Project
             class: org.apache.dolphinscheduler.e2e.cases.ProjectE2ETest
           - name: Queue
-              class: org.apache.dolphinscheduler.e2e.cases.QueueE2ETest
+            class: org.apache.dolphinscheduler.e2e.cases.QueueE2ETest
           - name: Workflow
             class: org.apache.dolphinscheduler.e2e.cases.WorkflowE2ETest
           - name: FileManage

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,7 @@ concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+
 jobs:
   build:
     name: E2E-Build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,10 +52,10 @@ jobs:
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
       - name: Check Docker Info
-        run: docker info
+        run: docker images
       - name: Export Docker Images
         run: |
-          docker save $(docker images -q) -o /tmp/docker-images.tar
+          docker save $(docker images --format '{{.Repository}}:{{.Tag}}') -o /tmp/docker-images.tar
       - uses: actions/upload-artifact@v2
         name: Upload Docker Images
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
       - name: Check Docker Info
-        uses: docker info
+        run: docker info
       - name: Export Docker Images
         run: |
           docker save $(docker images -q) -o /tmp/docker-images.tar

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,6 @@ concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     name: E2E-Build


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

The E2E tests of the current CI are executed in parallel, and Maven is compiled repeatedly during each test. Under the limited CI server resources, the server load will be very high, which may lead to the instability of E2E test.

This PR mainly changes multiple Maven compilations to one. So that E2E tests executed in parallel only need to pull the docker image to complete the test. This will greatly improve the stability of E2E test.
