### PR TITLE
fix(ProcessDefinitionServiceImpl): fix the problem of wrong display o…

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -104,6 +104,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -135,6 +137,8 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
     private static final Logger logger = LoggerFactory.getLogger(ProcessDefinitionServiceImpl.class);
 
     private static final String RELEASESTATE = "releaseState";
+
+    private static final Pattern SWITCH_NODE_REGEX = Pattern.compile("nextNode\":\\s?(\\d+)");
 
     @Autowired
     private ProjectMapper projectMapper;
@@ -1130,6 +1134,19 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 return false;
             }
             taskDefinitionLogList.add(taskDefinitionLog);
+        }
+        //fix taskParams when taskType is SWITCH
+        for (TaskDefinitionLog taskDefinitionLog: taskDefinitionLogList) {
+            if (TaskType.SWITCH.getDesc().equals(taskDefinitionLog.getTaskType())) {
+                String taskParams = taskDefinitionLog.getTaskParams();
+                Matcher matcher = SWITCH_NODE_REGEX.matcher(taskParams);
+                while (matcher.find()) {
+                    String oldTaskCode = matcher.group(1).trim();
+                    Long newTaskCode = taskCodeMap.get(Long.parseLong(oldTaskCode));
+                    taskParams = taskParams.replaceAll(oldTaskCode, newTaskCode == null ? oldTaskCode : newTaskCode.toString());
+                }
+                taskDefinitionLog.setTaskParams(taskParams);
+            }
         }
         int insert = taskDefinitionMapper.batchInsert(taskDefinitionLogList);
         int logInsert = taskDefinitionLogMapper.batchInsert(taskDefinitionLogList);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

When importing a workflow through json, if there is a Switch node in the original task flow, after the import is successful, the nextNode of the Switch node is not displayed correctly;
**The reason is that there is no update to taskParams**

```java
 for (TaskDefinition taskDefinition : taskDefinitionList) {
            TaskDefinitionLog taskDefinitionLog = new TaskDefinitionLog(taskDefinition);
            taskDefinitionLog.setName(taskDefinitionLog.getName() + "_import_" + DateUtils.getCurrentTimeStamp());
            taskDefinitionLog.setProjectCode(projectCode);
            taskDefinitionLog.setUserId(loginUser.getId());
            taskDefinitionLog.setVersion(Constants.VERSION_FIRST);
            taskDefinitionLog.setCreateTime(now);
            taskDefinitionLog.setUpdateTime(now);
            taskDefinitionLog.setOperator(loginUser.getId());
            taskDefinitionLog.setOperateTime(now);
            try {
                long code = CodeGenerateUtils.getInstance().genCode();
                taskCodeMap.put(taskDefinitionLog.getCode(), code);
                taskDefinitionLog.setCode(code);
            } catch (CodeGenerateException e) {
                logger.error("Task code get error, ", e);
                putMsg(result, Status.INTERNAL_SERVER_ERROR_ARGS, "Error generating task definition code");
                return false;
            }
            taskDefinitionLogList.add(taskDefinitionLog);
        }
        int insert = taskDefinitionMapper.batchInsert(taskDefinitionLogList);
        int logInsert = taskDefinitionLogMapper.batchInsert(taskDefinitionLogList);
```

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
Fix the problem of wrong display of nextNode of switch when importing task flow 
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.


<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
