### PR TITLE
[Fix-8037][E2E] fix stale element reference: element is not attached to the page document error accidently happen in FileManage test

### DIFF
--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/java/org/apache/dolphinscheduler/e2e/pages/security/SecurityPage.java
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/java/org/apache/dolphinscheduler/e2e/pages/security/SecurityPage.java
@@ -60,6 +60,7 @@ public class SecurityPage extends NavBarPage implements NavBarItem {
             WebElement menUserManageElement = new WebDriverWait(driver, 60)
                     .until(ExpectedConditions.elementToBeClickable(menUserManage));
             ((JavascriptExecutor)driver).executeScript("arguments[0].click();", menUserManageElement);
+            new WebDriverWait(driver, 20).until(ExpectedConditions.urlContains("/#/security/users"));
             return tab.cast(new UserPage(driver));
         }
         if (tab == WorkerGroupPage.class) {

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/java/org/apache/dolphinscheduler/e2e/pages/security/SecurityPage.java
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/java/org/apache/dolphinscheduler/e2e/pages/security/SecurityPage.java
@@ -60,7 +60,7 @@ public class SecurityPage extends NavBarPage implements NavBarItem {
             WebElement menUserManageElement = new WebDriverWait(driver, 60)
                     .until(ExpectedConditions.elementToBeClickable(menUserManage));
             ((JavascriptExecutor)driver).executeScript("arguments[0].click();", menUserManageElement);
-            new WebDriverWait(driver, 20).until(ExpectedConditions.urlContains("/#/security/users"));
+            new WebDriverWait(driver, 25).until(ExpectedConditions.urlContains("/#/security/users"));
             return tab.cast(new UserPage(driver));
         }
         if (tab == WorkerGroupPage.class) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This pr will close #8037 

I tested two PR CI running together.

The CI of this PR did not fail. And the other's CI failed. This problem is accidently happened when CI of single or multiple PR are running in parallel. Based on the test results, I have reason to suspect that GitHub action's QEMU is oversold or QEMU resource isolation is insufficient. So that the test may failed.


Failed CI:
https://github.com/apache/dolphinscheduler/runs/4813288064?check_suite_focus=true