### PR TITLE
[Fix-8010] Rectify this issue about not editing the form of task node when it was under the mode of full screen.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.scss
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.scss
@@ -27,7 +27,7 @@
     height: 100%;
     top: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 10000;
   }
 }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR will close #8010 .

## Brief change log

When it's under the mode of full screen the stack order of the div element is less than the form modal's. So I assign the z-index as a huge number '10000' to fix this issue.

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
![image](https://user-images.githubusercontent.com/4928204/149459281-e20766ae-56ee-4834-afdc-d66e4e350f11.png)

