### PR TITLE
[Feature-7993][E2E] Replace HDFS image with MinIO S3 image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,13 +105,6 @@ jobs:
       - name: Load Docker Images
         run: |
             docker load -i /tmp/standalone-image.tar
-#      - name: Create S3 Bucket
-#        if: "contains(matrix.case.name, 'FileManage')"
-#        run: |
-#          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
-#          && chmod +x /tmp/mc \
-#          && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
-#          && /tmp/mc mb s3/dolphinscheduler
       - name: Run Test
         run: |
           ./mvnw -B -f dolphinscheduler-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,13 @@ jobs:
       - name: Load Docker Images
         run: |
             docker load -i /tmp/standalone-image.tar
+      - name: Create S3 Bucket
+        if: "contains(matrix.case.name, 'FileManage')"
+        run: |
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
+          && chmod +x /tmo/mc \
+          && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
+          && /tmp/mc mb s3/dolphinscheduler
       - name: Run Test
         run: |
           ./mvnw -B -f dolphinscheduler-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,13 +105,13 @@ jobs:
       - name: Load Docker Images
         run: |
             docker load -i /tmp/standalone-image.tar
-      - name: Create S3 Bucket
-        if: "contains(matrix.case.name, 'FileManage')"
-        run: |
-          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
-          && chmod +x /tmp/mc \
-          && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
-          && /tmp/mc mb s3/dolphinscheduler
+#      - name: Create S3 Bucket
+#        if: "contains(matrix.case.name, 'FileManage')"
+#        run: |
+#          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
+#          && chmod +x /tmp/mc \
+#          && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
+#          && /tmp/mc mb s3/dolphinscheduler
       - name: Run Test
         run: |
           ./mvnw -B -f dolphinscheduler-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,7 @@ jobs:
         if: "contains(matrix.case.name, 'FileManage')"
         run: |
           wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
-          && chmod +x /tmo/mc \
+          && chmod +x /tmp/mc \
           && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
           && /tmp/mc mb s3/dolphinscheduler
       - name: Run Test

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
@@ -49,7 +49,7 @@ hdfs.root.user=hdfs
 fs.defaultFS=s3a://dolphinscheduler
 
 # if resource.storage.type=S3, s3 endpoint
-fs.s3a.endpoint=http://s3:9000
+fs.s3a.endpoint=http://awss3:9000
 
 # if resource.storage.type=S3, s3 access key
 fs.s3a.access.key=accessKey123

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
@@ -49,7 +49,7 @@ hdfs.root.user=hdfs
 fs.defaultFS=s3a://dolphinscheduler
 
 # if resource.storage.type=S3, s3 endpoint
-fs.s3a.endpoint=http://awss3:9000
+fs.s3a.endpoint=http://s3:9000
 
 # if resource.storage.type=S3, s3 access key
 fs.s3a.access.key=accessKey123

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
@@ -49,7 +49,7 @@ hdfs.root.user=hdfs
 fs.defaultFS=s3a://dolphinscheduler
 
 # if resource.storage.type=S3, s3 endpoint
-fs.s3a.endpoint=http://s3:9000
+fs.s3a.endpoint=http://10.1.1.1:9000
 
 # if resource.storage.type=S3, s3 access key
 fs.s3a.access.key=accessKey123

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
@@ -19,7 +19,7 @@
 data.basedir.path=/tmp/dolphinscheduler
 
 # resource storage type: HDFS, S3, NONE
-resource.storage.type=HDFS
+resource.storage.type=S3
 
 # resource store on HDFS/S3 path, resource file will store to this hadoop hdfs path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
 resource.upload.path=/dolphinscheduler
@@ -46,16 +46,16 @@ kerberos.expire.time=2
 hdfs.root.user=hdfs
 
 # if resource.storage.type=S3, the value like: s3a://dolphinscheduler; if resource.storage.type=HDFS and namenode HA is enabled, you need to copy core-site.xml and hdfs-site.xml to conf dir
-fs.defaultFS=hdfs://hdfs:8020
+fs.defaultFS=s3a://dolphinscheduler
 
 # if resource.storage.type=S3, s3 endpoint
-fs.s3a.endpoint=http://192.168.xx.xx:9010
+fs.s3a.endpoint=http://s3:9000
 
 # if resource.storage.type=S3, s3 access key
-fs.s3a.access.key=A3DXS30FO22544RE
+fs.s3a.access.key=accessKey123
 
 # if resource.storage.type=S3, s3 secret key
-fs.s3a.secret.key=OloCLq3n+8+sdPHUhJ21XrSxTC+JK
+fs.s3a.secret.key=secretKey123
 
 # resourcemanager port, the default value is 8088 if not specified
 resource.manager.httpaddress.port=8088

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/common.properties
@@ -49,7 +49,7 @@ hdfs.root.user=hdfs
 fs.defaultFS=s3a://dolphinscheduler
 
 # if resource.storage.type=S3, s3 endpoint
-fs.s3a.endpoint=http://10.1.1.1:9000
+fs.s3a.endpoint=http://10.1.0.1:9000
 
 # if resource.storage.type=S3, s3 access key
 fs.s3a.access.key=accessKey123

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -81,5 +81,5 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 10.1.1.0/24
-          gateway: 10.1.1.1
+        - subnet: 10.1.0.0/24
+          gateway: 10.1.0.1

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -35,19 +35,23 @@ services:
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
     depends_on:
-      hdfs:
+      s3:
         condition: service_healthy
-  hdfs:
-    image: mdouchement/hdfs:latest
-    hostname: hdfs
+  s3:
+    image: minio/minio:latest
+    hostname: s3
     tty: true
     stdin_open: true
-    expose:
-      - 8020
+    ports:
+      - 9000:9000
     networks:
       - e2e
+    environment:
+      MINIO_ROOT_USER: accessKey123
+      MINIO_ROOT_PASSWORD: secretKey123
+    command: server /data --console-address ":9001"
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:50070" ]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 120s
       retries: 120

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
     expose:
       - 9000
     networks:
-      - e2e
+      - e2e1
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
     expose:
       - 9000
     networks:
-      - e2e1
+      - e2e
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -62,6 +62,8 @@ services:
     hostname: mc
     tty: true
     stdin_open: true
+    networks:
+      - e2e
     command: bash -c '
       mc alias set s3 http://s3:9000 accessKey123 secretKey123
       && mc mb s3/dolphinscheduler && tail -f /dev/null'

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -44,6 +44,7 @@ services:
     hostname: s3
     tty: true
     stdin_open: true
+    command: server /data --console-address ":9001"
     expose:
       - 9000
     networks:

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -37,29 +37,41 @@ services:
     depends_on:
       s3:
         condition: service_healthy
+      mc:
+        condition: service_healthy
   s3:
     image: minio/minio:latest
     hostname: s3
     tty: true
     stdin_open: true
-    ports:
-      - 9000:9000
+    expose:
+      - 9000
     networks:
       - e2e
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123
-    command: |
-      server /data --console-address ":9001" \
-      && wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
-      && chmod +x /tmp/mc \
-      && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
-      && /tmp/mc mb s3/dolphinscheduler
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 120s
       retries: 120
-
+  mc:
+    image: minio/mc:latest
+    entrypoint: ""
+    hostname: mc
+    tty: true
+    stdin_open: true
+    command: bash -c '
+      mc alias set s3 http://s3:9000 accessKey123 secretKey123
+      && mc mb s3/dolphinscheduler && tail -f /dev/null'
+    healthcheck:
+      test: [ "CMD", "echo", "1" ]
+      interval: 5s
+      timeout: 120s
+      retries: 120
+    depends_on:
+      s3:
+        condition: service_healthy
 networks:
   e2e:

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-version: "3.8"
+version: "3"
 
 services:
   dolphinscheduler:

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123
-      OSTNAME_EXTERNAL: s3
+      HOSTNAME_EXTERNAL: s3
       SERVICES: s3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -54,8 +54,6 @@ services:
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123
-      HOSTNAME_EXTERNAL: s3
-      SERVICES: s3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
     links:
       - s3:dolphinscheduler.s3
+      - s3:dolphinscheduler.us-west-1.s3
     depends_on:
       s3:
         condition: service_healthy

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       s3:
         condition: service_healthy
       mc:
-        condition: service_healthy
+        condition: service_completed_successfully
   s3:
     image: minio/minio:latest
     hostname: s3
@@ -67,12 +67,12 @@ services:
       - e2e
     command: bash -c '
       mc alias set s3 http://s3:9000 accessKey123 secretKey123
-      && mc mb s3/dolphinscheduler && tail -f /dev/null'
-    healthcheck:
-      test: [ "CMD", "echo", "1" ]
-      interval: 5s
-      timeout: 120s
-      retries: 120
+      && mc mb s3/dolphinscheduler'
+#    healthcheck:
+#      test: [ "CMD", "echo", "1" ]
+#      interval: 5s
+#      timeout: 120s
+#      retries: 120
     depends_on:
       s3:
         condition: service_healthy

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -81,5 +81,5 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 10.1.1.0/124
+        - subnet: 10.1.1.0/24
           gateway: 10.1.1.1

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -35,13 +35,13 @@ services:
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
     depends_on:
-      s3:
+      awss3:
         condition: service_healthy
       mc:
         condition: service_healthy
-  s3:
+  awss3:
     image: minio/minio:latest
-    hostname: s3
+    hostname: awss3
     tty: true
     stdin_open: true
     command: server /data --console-address ":9001"
@@ -66,7 +66,7 @@ services:
     networks:
       - e2e
     command: bash -c '
-      mc alias set s3 http://s3:9000 accessKey123 secretKey123
+      mc alias set s3 http://awss3:9000 accessKey123 secretKey123
       && mc mb s3/dolphinscheduler && tail -f /dev/null'
     healthcheck:
       test: [ "CMD", "echo", "1" ]
@@ -74,7 +74,7 @@ services:
       timeout: 120s
       retries: 120
     depends_on:
-      s3:
+      awss3:
         condition: service_healthy
 networks:
   e2e:

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
     links:
-      - dolphinscheduler.s3:s3
+      - s3:dolphinscheduler.s3
     depends_on:
       s3:
         condition: service_healthy

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -34,6 +34,8 @@ services:
       retries: 120
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
+    links:
+      - dolphinscheduler.s3:s3
     depends_on:
       s3:
         condition: service_healthy

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-version: "2.1"
+version: "3.8"
 
 services:
   dolphinscheduler:

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -49,7 +49,12 @@ services:
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123
-    command: server /data --console-address ":9001"
+    command: |
+      server /data --console-address ":9001" \
+      && wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc \
+      && chmod +x /tmp/mc \
+      && /tmp/mc alias set s3 http://0.0.0.0:9000 accessKey123 secretKey123 \
+      && /tmp/mc mb s3/dolphinscheduler
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -34,8 +34,6 @@ services:
       retries: 120
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
-    extra_hosts:
-      - "s3:dolphinscheduler.s3"
     depends_on:
       s3:
         condition: service_healthy
@@ -54,6 +52,8 @@ services:
     environment:
       MINIO_ROOT_USER: accessKey123
       MINIO_ROOT_PASSWORD: secretKey123
+      OSTNAME_EXTERNAL: s3
+      SERVICES: s3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-version: "3"
+version: "2.1"
 
 services:
   dolphinscheduler:
@@ -38,7 +38,7 @@ services:
       s3:
         condition: service_healthy
       mc:
-        condition: service_completed_successfully
+        condition: service_healthy
   s3:
     image: minio/minio:latest
     hostname: s3
@@ -67,12 +67,12 @@ services:
       - e2e
     command: bash -c '
       mc alias set s3 http://s3:9000 accessKey123 secretKey123
-      && mc mb s3/dolphinscheduler'
-#    healthcheck:
-#      test: [ "CMD", "echo", "1" ]
-#      interval: 5s
-#      timeout: 120s
-#      retries: 120
+      && mc mb s3/dolphinscheduler && tail -f /dev/null'
+    healthcheck:
+      test: [ "CMD", "echo", "1" ]
+      interval: 5s
+      timeout: 120s
+      retries: 120
     depends_on:
       s3:
         condition: service_healthy

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -34,9 +34,6 @@ services:
       retries: 120
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
-    links:
-      - s3:dolphinscheduler.s3
-      - s3:dolphinscheduler.us-west-1.s3
     depends_on:
       s3:
         condition: service_healthy
@@ -48,8 +45,8 @@ services:
     tty: true
     stdin_open: true
     command: server /data --console-address ":9001"
-    expose:
-      - 9000
+    ports:
+      - 9000:9000
     networks:
       - e2e
     environment:
@@ -81,3 +78,8 @@ services:
         condition: service_healthy
 networks:
   e2e:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.1.1.0/124
+          gateway: 10.1.1.1

--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/file-manage/docker-compose.yaml
@@ -34,14 +34,16 @@ services:
       retries: 120
     volumes:
       - ./common.properties:/opt/dolphinscheduler/conf/common.properties
+    extra_hosts:
+      - "s3:dolphinscheduler.s3"
     depends_on:
-      awss3:
+      s3:
         condition: service_healthy
       mc:
         condition: service_healthy
-  awss3:
+  s3:
     image: minio/minio:latest
-    hostname: awss3
+    hostname: s3
     tty: true
     stdin_open: true
     command: server /data --console-address ":9001"
@@ -66,7 +68,7 @@ services:
     networks:
       - e2e
     command: bash -c '
-      mc alias set s3 http://awss3:9000 accessKey123 secretKey123
+      mc alias set s3 http://s3:9000 accessKey123 secretKey123
       && mc mb s3/dolphinscheduler && tail -f /dev/null'
     healthcheck:
       test: [ "CMD", "echo", "1" ]
@@ -74,7 +76,7 @@ services:
       timeout: 120s
       retries: 120
     depends_on:
-      awss3:
+      s3:
         condition: service_healthy
 networks:
   e2e:


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This pr will close #7993 

Because Minio S3 cannot be accessed through the container network, it can only be accessed through IP + port, so the gateway of docker network is added.