### PR TITLE
Fix wrong Python gateway docker image name

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -141,7 +141,7 @@ services:
       - dolphinscheduler
 
   dolphinscheduler-python-gateway:
-    image: ${HUB}/dolphinscheduler-python-gateway:${TAG}
+    image: ${HUB}/dolphinscheduler-python:${TAG}
     ports:
       - "54321:54321"
       - "25333:25333"


### PR DESCRIPTION
This is a minor change so I didn't create an issue first.