### PR TITLE
[Bug][Standalone] fix start standalone fail because db not init yet

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertPluginManager.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertPluginManager.java
@@ -39,6 +39,8 @@ import javax.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -53,8 +55,8 @@ public final class AlertPluginManager {
         this.pluginDao = pluginDao;
     }
 
-    @PostConstruct
-    public void installPlugin() {
+    @EventListener
+    public void installPlugin(ApplicationReadyEvent readyEvent) {
         final Set<String> names = new HashSet<>();
 
         ServiceLoader.load(AlertChannelFactory.class).forEach(factory -> {

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertServer.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertServer.java
@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.event.EventListener;
 
 @SpringBootApplication
 @ComponentScan("org.apache.dolphinscheduler")
@@ -68,8 +70,8 @@ public class AlertServer implements Closeable {
         SpringApplication.run(AlertServer.class, args);
     }
 
-    @PostConstruct
-    public void start() {
+    @EventListener
+    public void start(ApplicationReadyEvent readyEvent) {
         logger.info("Starting Alert server");
 
         checkTable();

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/test/java/org/apache/dolphinscheduler/alert/AlertPluginManagerTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/test/java/org/apache/dolphinscheduler/alert/AlertPluginManagerTest.java
@@ -41,7 +41,7 @@ public class AlertPluginManagerTest extends TestCase {
     public void testAlertPluginManager() {
         Mockito.when(pluginDao.addOrUpdatePluginDefine(Mockito.any(PluginDefine.class))).thenReturn(0);
         
-        alertPluginManager.installPlugin();
+        alertPluginManager.installPlugin(null);
         
         Assert.assertEquals(1, alertPluginManager.size());
         

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/test/java/org/apache/dolphinscheduler/alert/AlertServerTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/test/java/org/apache/dolphinscheduler/alert/AlertServerTest.java
@@ -49,7 +49,7 @@ public class AlertServerTest extends TestCase {
         
         Mockito.when(alertConfig.getPort()).thenReturn(50053);
         
-        alertServer.start();
+        alertServer.start(null);
     
         NettyRemotingServer nettyRemotingServer = Whitebox.getInternalState(alertServer, "server");
     


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
![1393ead13acdae34da106fe9a629bc2](https://user-images.githubusercontent.com/11962619/150948480-14bf0347-5b73-4a40-86ed-29f83eba7d8f.png)


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
