### PR TITLE
bugfix:[Bug] [remote-rpc] the asynchronous call method cannot use oth…

### DIFF
--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/rpc/remote/NettyClient.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/rpc/remote/NettyClient.java
@@ -211,7 +211,8 @@ public class NettyClient {
         if (Boolean.TRUE.equals(async)) {
             result = new RpcResponse();
             result.setStatus((byte) 0);
-            result.setResult(true);
+            //firstly return a null value when meet the async call
+            result.setResult(null);
             return result;
         }
         try {

--- a/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/rpc/IUserService.java
+++ b/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/rpc/IUserService.java
@@ -31,4 +31,7 @@ public interface IUserService {
 
     @Rpc(async = true)
     Boolean callBackIsFalse(String s);
+
+    @Rpc(async = true)
+    String returnType(String type);
 }

--- a/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/rpc/RpcTest.java
+++ b/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/rpc/RpcTest.java
@@ -52,6 +52,7 @@ public class RpcTest {
         Assert.assertSame(5, result);
         userService.say("sync");
         userService.callBackIsFalse("async no call back");
+        userService.returnType("string");
         userService.hi(999999);
     }
 

--- a/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/rpc/UserService.java
+++ b/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/rpc/UserService.java
@@ -49,4 +49,10 @@ public class UserService implements IUserService {
         logger.info("Kris UserService callBackIsFalse-------------------------------async call msg{}", s);
         return null;
     }
+
+    @Override
+    public String returnType(String type) {
+        logger.info("Kris UserService returnType-------------------------------async call msg{}", type);
+        return type;
+    }
 }


### PR DESCRIPTION
something detail is in [Bug] [remote-rpc] the asynchronous call's method can't use other return type except Boolean #8262
https://github.com/apache/dolphinscheduler/issues/8262

in a summary. I add a test mehod which return string,but happend a error
![image](https://user-images.githubusercontent.com/22393849/151665788-44ee4212-64ac-4c7a-9396-249c9a5ec573.png)
so i fix it.