### PR TITLE
[Fix][UI Next] Fix the problem that the left menu of task group management is not displayed.

### DIFF
--- a/dolphinscheduler-ui-next/src/router/modules/resources.ts
+++ b/dolphinscheduler-ui-next/src/router/modules/resources.ts
@@ -113,12 +113,20 @@ export default {
     {
       path: '/resource/task-group-option',
       name: 'task-group-option',
-      component: components['resource-task-group-option']
+      component: components['resource-task-group-option'],
+      meta: {
+        title: '任务组配置',
+        showSide: true
+      }
     },
     {
       path: '/resource/task-group-queue',
       name: 'task-group-queue',
-      component: components['resource-task-group-queue']
+      component: components['resource-task-group-queue'],
+      meta: {
+        title: '任务组队列',
+        showSide: true
+      }
     }
   ]
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
[#8070](https://github.com/apache/dolphinscheduler/issues/8070)
![image](https://user-images.githubusercontent.com/19239641/152941257-27ee65f9-bcc2-4e48-bf53-70c7e1063ee2.png)

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
