### PR TITLE
Fix deadlock in master/worker caused by close method

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
@@ -229,16 +229,17 @@ public class MasterServer implements IStoppable {
             // close spring Context and will invoke method with @PreDestroy annotation to destory beans. like ServerNodeManager,HostManager,TaskResponseService,CuratorZookeeperClient,etc
             springApplicationContext.close();
             logger.info("springApplicationContext close");
-        } catch (Exception e) {
-            logger.error("master server stop exception ", e);
-        } finally {
             try {
                 // thread sleep 60 seconds for quietly stop
                 Thread.sleep(60000L);
             } catch (Exception e) {
                 logger.warn("thread sleep exception ", e);
             }
-            System.exit(1);
+            // Since close will be executed in hook, so we can't use System.exit here.
+            Runtime.getRuntime().halt(0);
+        } catch (Exception e) {
+            logger.error("master server stop exception ", e);
+            Runtime.getRuntime().halt(1);
         }
     }
 

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -200,16 +200,16 @@ public class WorkerServer implements IStoppable {
             this.alertClientService.close();
             this.springApplicationContext.close();
             logger.info("springApplicationContext close");
-        } catch (Exception e) {
-            logger.error("worker server stop exception ", e);
-        } finally {
             try {
                 // thread sleep 60 seconds for quietly stop
                 Thread.sleep(60000L);
             } catch (Exception e) {
                 logger.warn("thread sleep exception ", e);
             }
-            System.exit(1);
+            Runtime.getRuntime().halt(0);
+        } catch (Exception e) {
+            logger.error("worker server stop exception ", e);
+            Runtime.getRuntime().halt(1);
         }
     }
 


### PR DESCRIPTION
## Purpose of the pull request

In `System.exit()` will execute java hook again, so we cannot execute `System.exit()` in hook, this will cause deadlock.

## Brief change log


## Verify this pull request

This pull request is code cleanup without any test coverage.
