### PR TITLE
[Fix-8370][UI] Rectify this issue with missing the re-uploading file button when the file is under the root directory.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/list/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/list/_source/list.vue
@@ -51,8 +51,11 @@
             <span>{{scope.row.updateTime | formatDate}}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="$t('Operation')" width="150">
+        <el-table-column :label="$t('Operation')" width="180">
           <template slot-scope="scope">
+            <el-tooltip :content="$t('ReUpload File')" placement="top" :enterable="false">
+              <span><el-button type="primary" size="mini" icon="el-icon-refresh-right" @click="_reUploadFile(scope.row)" v-show="scope.row.directory? false: true" circle></el-button></span>
+            </el-tooltip>
             <el-tooltip :content="$t('Edit')" placement="top">
               <span><el-button id="btnEdit" type="primary" size="mini" icon="el-icon-edit-outline" @click="_edit(scope.row)" :disabled="_rtDisb(scope.row)" circle></el-button></span>
             </el-tooltip>
@@ -92,7 +95,9 @@
   import { filtTypeArr } from '../../_source/common'
   import { bytesToSize } from '@/module/util/util'
   import { downloadFile } from '@/module/download'
+  import { findComponentDownward } from '@/module/util/'
   import localStore from '@/module/util/localStorage'
+
   export default {
     name: 'file-manage-list',
     data () {
@@ -122,6 +127,9 @@
         } else {
           this.$router.push({ path: `/resource/file/list/${item.id}` })
         }
+      },
+      _reUploadFile (item) {
+        findComponentDownward(this.$root, 'roof-nav')._fileReUpload(item)
       },
       _downloadFile (item) {
         downloadFile(`resources/${item.id}/download`)

--- a/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileReUpload.vue
+++ b/dolphinscheduler-ui/src/js/module/components/fileUpdate/fileReUpload.vue
@@ -112,6 +112,12 @@
       }
     },
     watch: {
+      originalFileData: {
+        deep: true,
+        handler () {
+          this._init()
+        }
+      }
     },
     props: {
       originalFileData: Object
@@ -244,16 +250,21 @@
         this.file = file
         this.name = file.name
         this.$refs.file.value = null
+      },
+      _init () {
+        if (this.originalFileData) {
+          this.id = this.originalFileData.id
+          this.name = this.originalFileData.fileName
+          if (this.originalFileData.desc) {
+            this.description = this.originalFileData.desc
+          }
+          this.currentDir = this.originalFileData.fullName.substring(0, this.originalFileData.fullName.length - this.originalFileData.fileName.length)
+        }
       }
     },
     mounted () {
       this.reset()
-      this.id = this.originalFileData.id
-      this.name = this.originalFileData.fileName
-      if (this.originalFileData.desc) {
-        this.description = this.originalFileData.desc
-      }
-      this.currentDir = this.originalFileData.fullName.substring(0, this.originalFileData.fullName.length - this.originalFileData.fileName.length)
+      this._init()
     },
     components: { mPopup, mListBoxF, mProgressBar }
   }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This PR will close #8370 .

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
  Now you can re-upload the file under the root directory.
![image](https://user-images.githubusercontent.com/4928204/153844675-b08c186d-3f5c-4314-b5fb-5eb0824fbc42.png)

