### PR TITLE
[Fix-8410][ui] solve the problem that when the data source is selected as hive in sqoop export, mysql cannot be selected as the data purpose

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/sqoop.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/sqoop.vue
@@ -754,11 +754,11 @@
       _handleModelTypeChange (a) {
         this._getSourceTypeList(a)
         this.sourceType = this.sourceTypeList[0].code
-        this._handleSourceTypeChange({ label: this.sourceType, value: this.sourceType })
+        this._handleSourceTypeChange(this.sourceType)
       },
 
       _handleSourceTypeChange (a) {
-        this._getTargetTypeList(a.label)
+        this._getTargetTypeList(a)
         this.targetType = this.targetTypeList[0].code
       },
 


### PR DESCRIPTION
solve the problem that when the data source is selected as hive in sqoop export, mysql cannot be selected as the data purpose
主要是为了解决sqoop export中选择数据源为hive的时候 无法选择mysql为数据目的

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This pr will close [issues:8410](https://github.com/apache/dolphinscheduler/issues/8410)
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
