### PR TITLE
Add a property to enable/disable metrics module

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application.yaml
@@ -52,6 +52,9 @@ management:
 alert:
   port: 50052
 
+metrics:
+  enabled: true
+
 # Override by profile
 
 ---

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -104,6 +104,9 @@ registry:
 audit:
   enabled: false
 
+metrics:
+  enabled: true
+
 # Override by profile
 
 ---

--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -121,6 +121,9 @@ management:
     tags:
       application: ${spring.application.name}
 
+metrics:
+  enabled: true
+
 # Override by profile
 
 ---

--- a/dolphinscheduler-meter/src/main/java/org/apache/dolphinscheduler/meter/MeterConfiguration.java
+++ b/dolphinscheduler-meter/src/main/java/org/apache/dolphinscheduler/meter/MeterConfiguration.java
@@ -21,10 +21,10 @@
 package org.apache.dolphinscheduler.meter;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Profile;
 
 import io.micrometer.core.aop.CountedAspect;
 import io.micrometer.core.aop.TimedAspect;
@@ -33,6 +33,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 @Configuration
 @EnableAspectJAutoProxy
 @EnableAutoConfiguration
+@ConditionalOnProperty(prefix = "metrics", name = "enabled", havingValue = "true")
 public class MeterConfiguration {
     @Bean
     public TimedAspect timedAspect(MeterRegistry registry) {

--- a/dolphinscheduler-python/src/main/resources/application.yaml
+++ b/dolphinscheduler-python/src/main/resources/application.yaml
@@ -67,6 +67,9 @@ management:
     tags:
       application: ${spring.application.name}
 
+metrics:
+  enabled: true
+
 # Override by profile
 ---
 spring:

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -180,6 +180,9 @@ management:
 audit:
   enabled: true
 
+metrics:
+  enabled: true
+
 # Override by profile
 ---
 spring:

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -83,3 +83,6 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+
+metrics:
+  enabled: true


### PR DESCRIPTION
This patch add a property to enable/disable the metrics module, allowing users who don't need metrics to disable the configuration without effecting the performance.