### PR TITLE
[Bug-8110][WorkerServer] kill all running task before worker stop

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/task/TaskExecutionContextCacheManager.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/task/TaskExecutionContextCacheManager.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.spi.task;
 
 import org.apache.dolphinscheduler.spi.task.request.TaskRequest;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -65,5 +66,9 @@ public class TaskExecutionContextCacheManager {
     public static boolean updateTaskExecutionContext(TaskRequest request) {
         taskRequestContextCache.computeIfPresent(request.getTaskInstanceId(), (k, v) -> request);
         return taskRequestContextCache.containsKey(request.getTaskInstanceId());
+    }
+
+    public static Collection<TaskRequest> getAllTaskRequestList() {
+        return taskRequestContextCache.values();
     }
 }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -202,12 +202,15 @@ public class WorkerServer implements IStoppable {
                 logger.warn("thread sleep exception", e);
             }
 
-            this.killAllRunningTasks();
-
             // close
             this.nettyRemotingServer.close();
             this.workerRegistryClient.unRegistry();
             this.alertClientService.close();
+
+            // kill running tasks
+            this.killAllRunningTasks();
+
+            // close the application context
             this.springApplicationContext.close();
         } catch (Exception e) {
             logger.error("worker server stop exception ", e);

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -21,12 +21,10 @@ import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.IStoppable;
 import org.apache.dolphinscheduler.common.enums.NodeType;
 import org.apache.dolphinscheduler.common.thread.Stopper;
-import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.remote.NettyRemotingServer;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.apache.dolphinscheduler.server.log.LoggerRequestProcessor;
-import org.apache.dolphinscheduler.server.utils.ProcessUtils;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
 import org.apache.dolphinscheduler.server.worker.plugin.TaskPluginManager;
 import org.apache.dolphinscheduler.server.worker.processor.DBTaskAckProcessor;
@@ -39,7 +37,6 @@ import org.apache.dolphinscheduler.server.worker.runner.RetryReportTaskStatusThr
 import org.apache.dolphinscheduler.server.worker.runner.WorkerManagerThread;
 import org.apache.dolphinscheduler.service.alert.AlertClientService;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
-import org.apache.dolphinscheduler.service.queue.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.spi.task.TaskExecutionContextCacheManager;
 import org.apache.dolphinscheduler.spi.task.request.TaskRequest;
 
@@ -234,9 +231,6 @@ public class WorkerServer implements IStoppable {
         }
 
         for (TaskRequest taskRequest : taskRequests) {
-            // kill yarn task if not finish
-            ProcessUtils.killYarnJob(JSONUtils.parseObject(JSONUtils.toJsonString(taskRequest), TaskExecutionContext.class));
-
             // kill task when it's not finished yet
             org.apache.dolphinscheduler.plugin.task.api.ProcessUtils.kill(taskRequest);
         }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -205,7 +205,7 @@ public class WorkerServer implements IStoppable {
                 logger.warn("thread sleep exception", e);
             }
 
-            this.killAllRunningYarnTasks();
+            this.killAllRunningTasks();
 
             // close
             this.nettyRemotingServer.close();
@@ -223,9 +223,9 @@ public class WorkerServer implements IStoppable {
     }
 
     /**
-     * kill all yarn tasks which are running
+     * kill all tasks which are running
      */
-    public void killAllRunningYarnTasks() {
+    public void killAllRunningTasks() {
         Collection<TaskRequest> taskRequests = TaskExecutionContextCacheManager.getAllTaskRequestList();
         logger.info("ready to kill all cache job, job size:{}", taskRequests.size());
 
@@ -235,8 +235,10 @@ public class WorkerServer implements IStoppable {
 
         for (TaskRequest taskRequest : taskRequests) {
             // kill yarn task if not finish
-            // don't need to kill shell here because when the task got processId, it was finished.
             ProcessUtils.killYarnJob(JSONUtils.parseObject(JSONUtils.toJsonString(taskRequest), TaskExecutionContext.class));
+
+            // kill task when it's not finished yet
+            org.apache.dolphinscheduler.plugin.task.api.ProcessUtils.kill(taskRequest);
         }
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->
this pr close #8110

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
