### PR TITLE
[Fix-8394][Server]fix when the data is supplemented business time still date+1

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/placeholder/BusinessTimeUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/placeholder/BusinessTimeUtils.java
@@ -53,7 +53,6 @@ public class BusinessTimeUtils {
                 if (runTime == null) {
                     return result;
                 }
-                break;
             case START_PROCESS:
             case START_CURRENT_TASK_PROCESS:
             case RECOVER_TOLERANCE_FAULT_PROCESS:


### PR DESCRIPTION
fix #8394   when the data is supplemented business time still date+1

Does not take effect:
[#7451](https://github.com/apache/dolphinscheduler/issues/7451) Remove '+1' (day) in the date of the complement data