### PR TITLE
[python] Add server port to python gateway server properties

### DIFF
--- a/dolphinscheduler-python/src/main/resources/python-gateway.properties
+++ b/dolphinscheduler-python/src/main/resources/python-gateway.properties
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+# Spring boot application server port
+server.port=54321
+
 # The address of Python gateway server start. Set its value to `0.0.0.0` if your Python API run in different
 # between Python gateway server. It could be be specific to other address like `127.0.0.1` or `localhost`
 #gateway.server.address=0.0.0.0


### PR DESCRIPTION
In version 2.0.4, the python gateway server does not have entrypoint
to change server port. users have to add config keyword
`server.port` in `python-gateway.properties` by themself. We
should add default key and value to `python-gateway.properties`
make users change easier.

close: #8642
