### PR TITLE
[BUG][PLUG_SQL_TASK]format the outProperty to toUpperCase when get the value from result in the sql task

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlParameters.java
@@ -266,7 +266,7 @@ public class SqlParameters extends AbstractParameters {
             //result only one line
             Map<String, String> firstRow = sqlResult.get(0);
             for (Property info : outProperty) {
-                info.setValue(String.valueOf(firstRow.get(info.getProp())));
+                info.setValue(String.valueOf(firstRow.get(info.getProp().toUpperCase())));
                 varPool.add(info);
             }
         }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix bug of #8396

what to do fix the bug
      format the outProperty to toUpperCase when get the value from result in the sql task


## Brief change log
      format the outProperty to toUpperCase when get the value from result in the sql task

![image](https://user-images.githubusercontent.com/8596901/156543846-4e8ca268-fdef-41f9-a405-509c6b324897.png)
![image](https://user-images.githubusercontent.com/8596901/156543868-949a2a30-c672-45fd-8969-72f09da54edd.png)


AS we all know the col name in the result is all in upper_case format, so 
when we get the value from the result set, we can not get the right value, so 
to uppercase the property value when want to get value from result set




## Verify this pull request


This pull request is code cleanup without any test coverage.


This pull request is already covered by existing tests, such as *(please describe tests)*.


This change added tests and can be verified as follows:

<!--*

format the outProperty to toUpperCase when get the value from result in the sql task
* -->
