### PR TITLE
[Feature-8369][Document]Add docs building test instructions in pydolphinscheduler DEVELOP.md

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
+++ b/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
@@ -146,6 +146,29 @@ python -m flake8
 
 #### Testing
 
+## Build Docs
+
+We use [sphinx][sphinx] to build docs. Dolphinscheduler Python API CI would automatically build docs when you submit pull request in 
+GitHub. You may locally ensure docs could be built suceessfully in case the failure blocks CI.
+
+To build docs locally, install sphinx and related python modules first via:
+
+```shell
+pip install '.[doc]'
+``` 
+
+Then 
+
+```shell
+cd pydolphinscheduler/docs/
+make clean && make html
+```
+
+## Testing
+
+pydolphinscheduler using [pytest][pytest] to test our codebase. GitHub Action will run our test when you create
+pull request or commit to dev branch, with python version `3.6|3.7|3.8|3.9` and operating system `linux|macOS|windows`.
+
 pydolphinscheduler using [pytest][pytest] to run all tests in directory `tests`. You could run tests by the commands
 
 ```shell
@@ -209,3 +232,4 @@ users who may use it in other way.
 [black-editor]: https://black.readthedocs.io/en/stable/integrations/editors.html#pycharm-intellij-idea
 [coverage]: https://coverage.readthedocs.io/en/stable/
 [isort]: https://pycqa.github.io/isort/index.html
+[sphinx]: https://www.sphinx-doc.org/en/master/


### PR DESCRIPTION
- This pr adds instructions on how to build pydolphinscheduler docs locally in [DEVELOP.md](https://github.com/apache/dolphinscheduler/blob/dev/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md). With such instructions, developers could make sure docs could be built successfully and will not block the remote CI. As discussed in #8340 this [comment](https://github.com/apache/dolphinscheduler/pull/8340#issuecomment-1035976404)
- This pr closes: #8369