### PR TITLE
[Improvement-7697][Master/Worker] Change the task ack to runnning callback

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -17,9 +17,10 @@
 
 package org.apache.dolphinscheduler.common;
 
+import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
-import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
 
 import java.util.regex.Pattern;
 
@@ -48,20 +49,20 @@ public final class Constants {
     public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_MASTERS = "/lock/failover/masters";
     public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_WORKERS = "/lock/failover/workers";
     public static final String REGISTRY_DOLPHINSCHEDULER_LOCK_FAILOVER_STARTUP_MASTERS = "/lock/failover/startup-masters";
-    public static final String FORMAT_SS ="%s%s";
-    public static final String FORMAT_S_S ="%s/%s";
-    public static final String AWS_ACCESS_KEY_ID="aws.access.key.id";
-    public static final String AWS_SECRET_ACCESS_KEY="aws.secret.access.key";
-    public static final String AWS_REGION="aws.region";
-    public static final String FOLDER_SEPARATOR ="/";
+    public static final String FORMAT_SS = "%s%s";
+    public static final String FORMAT_S_S = "%s/%s";
+    public static final String AWS_ACCESS_KEY_ID = "aws.access.key.id";
+    public static final String AWS_SECRET_ACCESS_KEY = "aws.secret.access.key";
+    public static final String AWS_REGION = "aws.region";
+    public static final String FOLDER_SEPARATOR = "/";
 
     public static final String RESOURCE_TYPE_FILE = "resources";
 
-    public static final String RESOURCE_TYPE_UDF="udfs";
+    public static final String RESOURCE_TYPE_UDF = "udfs";
 
-    public static final String STORAGE_S3="S3";
+    public static final String STORAGE_S3 = "S3";
 
-    public static final String STORAGE_HDFS="HDFS";
+    public static final String STORAGE_HDFS = "HDFS";
 
     public static final String BUCKET_NAME = "dolphinscheduler-test";
 
@@ -69,7 +70,6 @@ public final class Constants {
      * fs.defaultFS
      */
     public static final String FS_DEFAULT_FS = "fs.defaultFS";
-
 
 
     /**
@@ -254,7 +254,7 @@ public final class Constants {
      * user name regex
      */
     public static final Pattern REGEX_USER_NAME = Pattern.compile("^[a-zA-Z0-9._-]{3,39}$");
-    
+
     /**
      * read permission
      */
@@ -424,7 +424,7 @@ public final class Constants {
     /**
      * process or task definition first version
      */
-    public static final int VERSION_FIRST  = 1;
+    public static final int VERSION_FIRST = 1;
 
     /**
      * date format of yyyyMMdd
@@ -584,7 +584,6 @@ public final class Constants {
     public static final long DEPENDENT_ALL_TASK_CODE = 0;
 
 
-
     /**
      * preview schedule execute count
      */
@@ -640,20 +639,22 @@ public final class Constants {
      */
     public static final String TASK_LOG_INFO_FORMAT = "TaskLogInfo-%s";
 
-    public static final int[] NOT_TERMINATED_STATES = new int[] {
-        ExecutionStatus.SUBMITTED_SUCCESS.ordinal(),
-        ExecutionStatus.RUNNING_EXECUTION.ordinal(),
-        ExecutionStatus.DELAY_EXECUTION.ordinal(),
-        ExecutionStatus.READY_PAUSE.ordinal(),
-        ExecutionStatus.READY_STOP.ordinal(),
-        ExecutionStatus.NEED_FAULT_TOLERANCE.ordinal(),
-        ExecutionStatus.WAITING_THREAD.ordinal(),
-        ExecutionStatus.WAITING_DEPEND.ordinal()
+    public static final int[] NOT_TERMINATED_STATES = new int[]{
+            ExecutionStatus.SUBMITTED_SUCCESS.ordinal(),
+            ExecutionStatus.DISPATCH.ordinal(),
+            ExecutionStatus.RUNNING_EXECUTION.ordinal(),
+            ExecutionStatus.DELAY_EXECUTION.ordinal(),
+            ExecutionStatus.READY_PAUSE.ordinal(),
+            ExecutionStatus.READY_STOP.ordinal(),
+            ExecutionStatus.NEED_FAULT_TOLERANCE.ordinal(),
+            ExecutionStatus.WAITING_THREAD.ordinal(),
+            ExecutionStatus.WAITING_DEPEND.ordinal()
     };
 
-    public static final int[] RUNNING_PROCESS_STATE = new int[] {
+    public static final int[] RUNNING_PROCESS_STATE = new int[]{
             ExecutionStatus.RUNNING_EXECUTION.ordinal(),
             ExecutionStatus.SUBMITTED_SUCCESS.ordinal(),
+            ExecutionStatus.DISPATCH.ordinal(),
             ExecutionStatus.SERIAL_WAIT.ordinal()
     };
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/Event.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/Event.java
@@ -18,6 +18,8 @@
 package org.apache.dolphinscheduler.common.enums;
 
 public enum Event {
-    ACK,
-    RESULT;
+    DELAY,
+    RUNNING,
+    RESULT,
+    ;
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/Event.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/Event.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.common.enums;
 
 public enum Event {
+    DISPATCH,
     DELAY,
     RUNNING,
     RESULT,

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/TaskStateType.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/TaskStateType.java
@@ -54,6 +54,7 @@ public enum TaskStateType {
                 };
             case RUNNING:
                 return new int[]{ExecutionStatus.SUBMITTED_SUCCESS.ordinal(),
+                        ExecutionStatus.DISPATCH.ordinal(),
                         ExecutionStatus.RUNNING_EXECUTION.ordinal(),
                         ExecutionStatus.DELAY_EXECUTION.ordinal(),
                         ExecutionStatus.READY_PAUSE.ordinal(),

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
@@ -27,10 +27,10 @@ import org.apache.dolphinscheduler.server.log.LoggerRequestProcessor;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.processor.CacheProcessor;
 import org.apache.dolphinscheduler.server.master.processor.StateEventProcessor;
-import org.apache.dolphinscheduler.server.master.processor.TaskAckProcessor;
 import org.apache.dolphinscheduler.server.master.processor.TaskEventProcessor;
+import org.apache.dolphinscheduler.server.master.processor.TaskExecuteResponseProcessor;
+import org.apache.dolphinscheduler.server.master.processor.TaskExecuteRunningProcessor;
 import org.apache.dolphinscheduler.server.master.processor.TaskKillResponseProcessor;
-import org.apache.dolphinscheduler.server.master.processor.TaskResponseProcessor;
 import org.apache.dolphinscheduler.server.master.registry.MasterRegistryClient;
 import org.apache.dolphinscheduler.server.master.runner.EventExecuteService;
 import org.apache.dolphinscheduler.server.master.runner.FailoverExecuteThread;
@@ -75,10 +75,10 @@ public class MasterServer implements IStoppable {
     private Scheduler scheduler;
 
     @Autowired
-    private TaskAckProcessor taskAckProcessor;
+    private TaskExecuteRunningProcessor taskExecuteRunningProcessor;
 
     @Autowired
-    private TaskResponseProcessor taskResponseProcessor;
+    private TaskExecuteResponseProcessor taskExecuteResponseProcessor;
 
     @Autowired
     private TaskEventProcessor taskEventProcessor;
@@ -115,8 +115,8 @@ public class MasterServer implements IStoppable {
         NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(masterConfig.getListenPort());
         this.nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, taskResponseProcessor);
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, taskAckProcessor);
+        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, taskExecuteResponseProcessor);
+        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RUNNING, taskExecuteRunningProcessor);
         this.nettyRemotingServer.registerProcessor(CommandType.TASK_KILL_RESPONSE, taskKillResponseProcessor);
         this.nettyRemotingServer.registerProcessor(CommandType.STATE_EVENT_REQUEST, stateEventProcessor);
         this.nettyRemotingServer.registerProcessor(CommandType.TASK_FORCE_STATE_EVENT_REQUEST, taskEventProcessor);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
@@ -178,7 +178,7 @@ public class TaskPriorityQueueConsumer extends Thread {
             result = dispatcher.dispatch(executionContext);
 
             if (result) {
-                changeTaskStateToDispatch(context);
+                changeTaskStateToDispatch(context, executionContext);
             }
         } catch (RuntimeException | ExecuteException e) {
             logger.error("dispatch error: {}", e.getMessage(), e);
@@ -189,11 +189,12 @@ public class TaskPriorityQueueConsumer extends Thread {
     /**
      * change task state to dispatch
      */
-    private void changeTaskStateToDispatch(TaskExecutionContext context) {
+    private void changeTaskStateToDispatch(TaskExecutionContext context, ExecutionContext executionContext) {
         WorkflowExecuteThread workflowExecuteThread = this.processInstanceExecCacheManager.getByProcessInstanceId(context.getProcessInstanceId());
         if (workflowExecuteThread != null && workflowExecuteThread.checkTaskInstanceById(context.getTaskInstanceId())) {
             TaskInstance taskInstance = workflowExecuteThread.getTaskInstance(context.getTaskInstanceId());
             taskInstance.setState(ExecutionStatus.DISPATCH);
+            taskInstance.setHost(executionContext.getHost().getAddress());
             processService.saveTaskInstance(taskInstance);
         }
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManager.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManager.java
@@ -26,9 +26,9 @@ import org.apache.dolphinscheduler.remote.utils.Host;
 import org.apache.dolphinscheduler.server.master.dispatch.context.ExecutionContext;
 import org.apache.dolphinscheduler.server.master.dispatch.enums.ExecutorType;
 import org.apache.dolphinscheduler.server.master.dispatch.exceptions.ExecuteException;
-import org.apache.dolphinscheduler.server.master.processor.TaskAckProcessor;
+import org.apache.dolphinscheduler.server.master.processor.TaskExecuteResponseProcessor;
+import org.apache.dolphinscheduler.server.master.processor.TaskExecuteRunningProcessor;
 import org.apache.dolphinscheduler.server.master.processor.TaskKillResponseProcessor;
-import org.apache.dolphinscheduler.server.master.processor.TaskResponseProcessor;
 import org.apache.dolphinscheduler.server.master.registry.ServerNodeManager;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -46,7 +46,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
- *  netty executor manager
+ * netty executor manager
  */
 @Service
 public class NettyExecutorManager extends AbstractExecutorManager<Boolean> {
@@ -60,13 +60,13 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean> {
     private ServerNodeManager serverNodeManager;
 
     @Autowired
-    private TaskAckProcessor taskAckProcessor;
+    private TaskExecuteRunningProcessor taskExecuteRunningProcessor;
 
     @Autowired
     private TaskKillResponseProcessor taskKillResponseProcessor;
 
     @Autowired
-    private TaskResponseProcessor taskResponseProcessor;
+    private TaskExecuteResponseProcessor taskExecuteResponseProcessor;
 
     /**
      * netty remote client
@@ -83,13 +83,14 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean> {
 
     @PostConstruct
     public void init() {
-        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, taskResponseProcessor);
-        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_ACK, taskAckProcessor);
+        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, taskExecuteResponseProcessor);
+        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_RUNNING, taskExecuteRunningProcessor);
         this.nettyRemotingClient.registerProcessor(CommandType.TASK_KILL_RESPONSE, taskKillResponseProcessor);
     }
 
     /**
      * execute logic
+     *
      * @param context context
      * @return result
      * @throws ExecuteException if error throws ExecuteException
@@ -119,7 +120,7 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean> {
         boolean success = false;
         while (!success) {
             try {
-                doExecute(host,command);
+                doExecute(host, command);
                 success = true;
                 context.setHost(host);
             } catch (ExecuteException ex) {
@@ -150,7 +151,8 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean> {
     }
 
     /**
-     *  execute logic
+     * execute logic
+     *
      * @param host host
      * @param command command
      * @throws ExecuteException if error throws ExecuteException
@@ -178,7 +180,8 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean> {
     }
 
     /**
-     *  get all nodes
+     * get all nodes
+     *
      * @param context context
      * @return nodes
      */

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/TaskExecuteResponseProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/TaskExecuteResponseProcessor.java
@@ -36,12 +36,12 @@ import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
 
 /**
- * task response processor
+ * task execute response processor
  */
 @Component
-public class TaskResponseProcessor implements NettyRequestProcessor {
+public class TaskExecuteResponseProcessor implements NettyRequestProcessor {
 
-    private final Logger logger = LoggerFactory.getLogger(TaskResponseProcessor.class);
+    private final Logger logger = LoggerFactory.getLogger(TaskExecuteResponseProcessor.class);
 
     @Autowired
     private TaskResponseService taskResponseService;
@@ -57,18 +57,18 @@ public class TaskResponseProcessor implements NettyRequestProcessor {
     public void process(Channel channel, Command command) {
         Preconditions.checkArgument(CommandType.TASK_EXECUTE_RESPONSE == command.getType(), String.format("invalid command type : %s", command.getType()));
 
-        TaskExecuteResponseCommand responseCommand = JSONUtils.parseObject(command.getBody(), TaskExecuteResponseCommand.class);
-        logger.info("received command : {}", responseCommand);
+        TaskExecuteResponseCommand taskExecuteResponseCommand = JSONUtils.parseObject(command.getBody(), TaskExecuteResponseCommand.class);
+        logger.info("received command : {}", taskExecuteResponseCommand);
 
         // TaskResponseEvent
-        TaskResponseEvent taskResponseEvent = TaskResponseEvent.newResult(ExecutionStatus.of(responseCommand.getStatus()),
-                responseCommand.getEndTime(),
-                responseCommand.getProcessId(),
-                responseCommand.getAppIds(),
-                responseCommand.getTaskInstanceId(),
-                responseCommand.getVarPool(),
+        TaskResponseEvent taskResponseEvent = TaskResponseEvent.newResultAck(ExecutionStatus.of(taskExecuteResponseCommand.getStatus()),
+                taskExecuteResponseCommand.getEndTime(),
+                taskExecuteResponseCommand.getProcessId(),
+                taskExecuteResponseCommand.getAppIds(),
+                taskExecuteResponseCommand.getTaskInstanceId(),
+                taskExecuteResponseCommand.getVarPool(),
                 channel,
-                responseCommand.getProcessInstanceId()
+                taskExecuteResponseCommand.getProcessInstanceId()
         );
         taskResponseService.addResponse(taskResponseEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/TaskExecuteResponseProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/TaskExecuteResponseProcessor.java
@@ -18,13 +18,12 @@
 package org.apache.dolphinscheduler.server.master.processor;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseCommand;
 import org.apache.dolphinscheduler.remote.processor.NettyRequestProcessor;
-import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseEvent;
-import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseService;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskEvent;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskEventService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +43,7 @@ public class TaskExecuteResponseProcessor implements NettyRequestProcessor {
     private final Logger logger = LoggerFactory.getLogger(TaskExecuteResponseProcessor.class);
 
     @Autowired
-    private TaskResponseService taskResponseService;
+    private TaskEventService taskEventService;
 
     /**
      * task final result response
@@ -60,16 +59,7 @@ public class TaskExecuteResponseProcessor implements NettyRequestProcessor {
         TaskExecuteResponseCommand taskExecuteResponseCommand = JSONUtils.parseObject(command.getBody(), TaskExecuteResponseCommand.class);
         logger.info("received command : {}", taskExecuteResponseCommand);
 
-        // TaskResponseEvent
-        TaskResponseEvent taskResponseEvent = TaskResponseEvent.newResultAck(ExecutionStatus.of(taskExecuteResponseCommand.getStatus()),
-                taskExecuteResponseCommand.getEndTime(),
-                taskExecuteResponseCommand.getProcessId(),
-                taskExecuteResponseCommand.getAppIds(),
-                taskExecuteResponseCommand.getTaskInstanceId(),
-                taskExecuteResponseCommand.getVarPool(),
-                channel,
-                taskExecuteResponseCommand.getProcessInstanceId()
-        );
-        taskResponseService.addResponse(taskResponseEvent);
+        TaskEvent taskResponseEvent = TaskEvent.newResultEvent(taskExecuteResponseCommand, channel);
+        taskEventService.addEvent(taskResponseEvent);
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskEvent.java
@@ -19,6 +19,9 @@ package org.apache.dolphinscheduler.server.master.processor.queue;
 
 import org.apache.dolphinscheduler.common.enums.Event;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseCommand;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningCommand;
+import org.apache.dolphinscheduler.remote.utils.ChannelUtils;
 
 import java.util.Date;
 
@@ -27,7 +30,7 @@ import io.netty.channel.Channel;
 /**
  * task event
  */
-public class TaskResponseEvent {
+public class TaskEvent {
 
     /**
      * taskInstanceId
@@ -90,46 +93,45 @@ public class TaskResponseEvent {
     private Channel channel;
 
     private int processInstanceId;
-    
-    public static TaskResponseEvent newRunningAck(ExecutionStatus state,
-                                           Date startTime,
-                                           String workerAddress,
-                                           String executePath,
-                                           String logPath,
-                                           int taskInstanceId,
-                                           Channel channel,
-                                           int processInstanceId) {
-        TaskResponseEvent event = new TaskResponseEvent();
-        event.setState(state);
-        event.setStartTime(startTime);
-        event.setWorkerAddress(workerAddress);
-        event.setExecutePath(executePath);
-        event.setLogPath(logPath);
-        event.setTaskInstanceId(taskInstanceId);
-        event.setEvent(Event.RUNNING);
-        event.setChannel(channel);
+
+    public static TaskEvent newDispatchEvent(int processInstanceId, int taskInstanceId, String workerAddress) {
+        TaskEvent event = new TaskEvent();
         event.setProcessInstanceId(processInstanceId);
+        event.setTaskInstanceId(taskInstanceId);
+        event.setWorkerAddress(workerAddress);
+        event.setEvent(Event.DISPATCH);
         return event;
     }
 
-    public static TaskResponseEvent newResultAck(ExecutionStatus state,
-                                              Date endTime,
-                                              int processId,
-                                              String appIds,
-                                              int taskInstanceId,
-                                              String varPool,
-                                              Channel channel,
-                                              int processInstanceId) {
-        TaskResponseEvent event = new TaskResponseEvent();
-        event.setState(state);
-        event.setEndTime(endTime);
-        event.setProcessId(processId);
-        event.setAppIds(appIds);
-        event.setTaskInstanceId(taskInstanceId);
-        event.setEvent(Event.RESULT);
-        event.setVarPool(varPool);
+    public static TaskEvent newRunningEvent(TaskExecuteRunningCommand command, Channel channel) {
+        TaskEvent event = new TaskEvent();
+        event.setProcessInstanceId(command.getProcessInstanceId());
+        event.setTaskInstanceId(command.getTaskInstanceId());
+        event.setState(ExecutionStatus.of(command.getStatus()));
+        event.setStartTime(command.getStartTime());
+        event.setExecutePath(command.getExecutePath());
+        event.setLogPath(command.getLogPath());
         event.setChannel(channel);
-        event.setProcessInstanceId(processInstanceId);
+        event.setWorkerAddress(ChannelUtils.toAddress(channel).getAddress());
+        event.setEvent(Event.RUNNING);
+        return event;
+    }
+
+    public static TaskEvent newResultEvent(TaskExecuteResponseCommand command, Channel channel) {
+        TaskEvent event = new TaskEvent();
+        event.setProcessInstanceId(command.getProcessInstanceId());
+        event.setTaskInstanceId(command.getTaskInstanceId());
+        event.setState(ExecutionStatus.of(command.getStatus()));
+        event.setStartTime(command.getStartTime());
+        event.setExecutePath(command.getExecutePath());
+        event.setLogPath(command.getLogPath());
+        event.setEndTime(command.getEndTime());
+        event.setProcessId(command.getProcessId());
+        event.setAppIds(command.getAppIds());
+        event.setVarPool(command.getVarPool());
+        event.setChannel(channel);
+        event.setWorkerAddress(ChannelUtils.toAddress(channel).getAddress());
+        event.setEvent(Event.RESULT);
         return event;
     }
 
@@ -140,7 +142,7 @@ public class TaskResponseEvent {
     public void setVarPool(String varPool) {
         this.varPool = varPool;
     }
-    
+
     public int getTaskInstanceId() {
         return taskInstanceId;
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseEvent.java
@@ -91,7 +91,7 @@ public class TaskResponseEvent {
 
     private int processInstanceId;
     
-    public static TaskResponseEvent newAck(ExecutionStatus state,
+    public static TaskResponseEvent newRunningAck(ExecutionStatus state,
                                            Date startTime,
                                            String workerAddress,
                                            String executePath,
@@ -106,13 +106,13 @@ public class TaskResponseEvent {
         event.setExecutePath(executePath);
         event.setLogPath(logPath);
         event.setTaskInstanceId(taskInstanceId);
-        event.setEvent(Event.ACK);
+        event.setEvent(Event.RUNNING);
         event.setChannel(channel);
         event.setProcessInstanceId(processInstanceId);
         return event;
     }
 
-    public static TaskResponseEvent newResult(ExecutionStatus state,
+    public static TaskResponseEvent newResultAck(ExecutionStatus state,
                                               Date endTime,
                                               int processId,
                                               String appIds,

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/BaseTaskProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/BaseTaskProcessor.java
@@ -259,11 +259,8 @@ public abstract class BaseTaskProcessor implements ITaskProcessor {
 
         // verify tenant is null
         if (verifyTenantIsNull(tenant, taskInstance)) {
-            processService.changeTaskState(taskInstance, ExecutionStatus.FAILURE,
-                    taskInstance.getStartTime(),
-                    taskInstance.getHost(),
-                    null,
-                    null);
+            taskInstance.setState(ExecutionStatus.FAILURE);
+            processService.saveTaskInstance(taskInstance);
             return null;
         }
         // set queue for process instance, user-specified queue takes precedence over tenant queue

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/utils/DataQualityResultOperator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/utils/DataQualityResultOperator.java
@@ -27,7 +27,7 @@ import org.apache.dolphinscheduler.plugin.task.api.enums.dp.CheckType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.dp.DqFailureStrategy;
 import org.apache.dolphinscheduler.plugin.task.api.enums.dp.DqTaskState;
 import org.apache.dolphinscheduler.plugin.task.api.enums.dp.OperatorType;
-import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseEvent;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskEvent;
 import org.apache.dolphinscheduler.service.alert.ProcessAlertManager;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
@@ -59,7 +59,7 @@ public class DataQualityResultOperator {
      * @param taskResponseEvent
      * @param taskInstance
      */
-    public void operateDqExecuteResult(TaskResponseEvent taskResponseEvent, TaskInstance taskInstance) {
+    public void operateDqExecuteResult(TaskEvent taskResponseEvent, TaskInstance taskInstance) {
         if (TASK_TYPE_DATA_QUALITY.equals(taskInstance.getTaskType())) {
 
             ProcessInstance processInstance =
@@ -92,7 +92,7 @@ public class DataQualityResultOperator {
      * @param dqExecuteResult
      * @param processInstance
      */
-    private void checkDqExecuteResult(TaskResponseEvent taskResponseEvent,
+    private void checkDqExecuteResult(TaskEvent taskResponseEvent,
                                       DqExecuteResult dqExecuteResult,
                                       ProcessInstance processInstance) {
         if (isFailure(dqExecuteResult)) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/utils/DependentExecute.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/utils/DependentExecute.java
@@ -231,6 +231,7 @@ public class DependentExecute {
 
         if (state.typeIsRunning()
                 || state == ExecutionStatus.SUBMITTED_SUCCESS
+                || state == ExecutionStatus.DISPATCH
                 || state == ExecutionStatus.WAITING_THREAD) {
             return DependResult.WAITING;
         } else {

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskAckProcessorTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskAckProcessorTest.java
@@ -18,8 +18,8 @@
 package org.apache.dolphinscheduler.server.master.processor;
 
 import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningCommand;
-import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseEvent;
-import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseService;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskEvent;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskEventService;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
@@ -38,22 +38,22 @@ import io.netty.channel.Channel;
  * task ack processor test
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({SpringApplicationContext.class, TaskResponseEvent.class})
+@PrepareForTest({SpringApplicationContext.class, TaskEvent.class})
 public class TaskAckProcessorTest {
 
     private TaskExecuteRunningProcessor taskExecuteRunningProcessor;
-    private TaskResponseService taskResponseService;
+    private TaskEventService taskEventService;
     private ProcessService processService;
     private TaskExecuteRunningCommand taskExecuteRunningCommand;
-    private TaskResponseEvent taskResponseEvent;
+    private TaskEvent taskResponseEvent;
     private Channel channel;
 
     @Before
     public void before() {
         PowerMockito.mockStatic(SpringApplicationContext.class);
 
-        taskResponseService = PowerMockito.mock(TaskResponseService.class);
-        PowerMockito.when(SpringApplicationContext.getBean(TaskResponseService.class)).thenReturn(taskResponseService);
+        taskEventService = PowerMockito.mock(TaskEventService.class);
+        PowerMockito.when(SpringApplicationContext.getBean(TaskEventService.class)).thenReturn(taskEventService);
 
         processService = PowerMockito.mock(ProcessService.class);
         PowerMockito.when(SpringApplicationContext.getBean(ProcessService.class)).thenReturn(processService);
@@ -61,7 +61,7 @@ public class TaskAckProcessorTest {
         taskExecuteRunningProcessor = new TaskExecuteRunningProcessor();
 
         channel = PowerMockito.mock(Channel.class);
-        taskResponseEvent = PowerMockito.mock(TaskResponseEvent.class);
+        taskResponseEvent = PowerMockito.mock(TaskEvent.class);
 
         taskExecuteRunningCommand = new TaskExecuteRunningCommand();
         taskExecuteRunningCommand.setStatus(1);

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskAckProcessorTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskAckProcessorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.master.processor;
+
+import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningCommand;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseEvent;
+import org.apache.dolphinscheduler.server.master.processor.queue.TaskResponseService;
+import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
+import org.apache.dolphinscheduler.service.process.ProcessService;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.netty.channel.Channel;
+
+/**
+ * task ack processor test
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SpringApplicationContext.class, TaskResponseEvent.class})
+public class TaskAckProcessorTest {
+
+    private TaskExecuteRunningProcessor taskExecuteRunningProcessor;
+    private TaskResponseService taskResponseService;
+    private ProcessService processService;
+    private TaskExecuteRunningCommand taskExecuteRunningCommand;
+    private TaskResponseEvent taskResponseEvent;
+    private Channel channel;
+
+    @Before
+    public void before() {
+        PowerMockito.mockStatic(SpringApplicationContext.class);
+
+        taskResponseService = PowerMockito.mock(TaskResponseService.class);
+        PowerMockito.when(SpringApplicationContext.getBean(TaskResponseService.class)).thenReturn(taskResponseService);
+
+        processService = PowerMockito.mock(ProcessService.class);
+        PowerMockito.when(SpringApplicationContext.getBean(ProcessService.class)).thenReturn(processService);
+
+        taskExecuteRunningProcessor = new TaskExecuteRunningProcessor();
+
+        channel = PowerMockito.mock(Channel.class);
+        taskResponseEvent = PowerMockito.mock(TaskResponseEvent.class);
+
+        taskExecuteRunningCommand = new TaskExecuteRunningCommand();
+        taskExecuteRunningCommand.setStatus(1);
+        taskExecuteRunningCommand.setExecutePath("/dolphinscheduler/worker");
+        taskExecuteRunningCommand.setHost("localhost");
+        taskExecuteRunningCommand.setLogPath("/temp/worker.log");
+        taskExecuteRunningCommand.setStartTime(new Date());
+        taskExecuteRunningCommand.setTaskInstanceId(1);
+        taskExecuteRunningCommand.setProcessInstanceId(1);
+    }
+
+    @Test
+    public void testProcess() {
+//        Command command = taskExecuteAckCommand.convert2Command();
+//        Assert.assertEquals(CommandType.TASK_EXECUTE_ACK,command.getType());
+//        InetSocketAddress socketAddress = new InetSocketAddress("localhost",12345);
+//        PowerMockito.when(channel.remoteAddress()).thenReturn(socketAddress);
+//        PowerMockito.mockStatic(TaskResponseEvent.class);
+//
+//        PowerMockito.when(TaskResponseEvent.newAck(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), channel))
+//                .thenReturn(taskResponseEvent);
+//        TaskInstance taskInstance = PowerMockito.mock(TaskInstance.class);
+//        PowerMockito.when(processService.findTaskInstanceById(Mockito.any())).thenReturn(taskInstance);
+//
+//        taskAckProcessor.process(channel,command);
+    }
+}

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseServiceTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseServiceTest.java
@@ -60,7 +60,7 @@ public class TaskResponseServiceTest {
     public void before() {
         taskRspService.start();
 
-        ackEvent = TaskResponseEvent.newAck(ExecutionStatus.RUNNING_EXECUTION,
+        ackEvent = TaskResponseEvent.newRunningAck(ExecutionStatus.RUNNING_EXECUTION,
                 new Date(),
                 "127.*.*.*",
                 "path",
@@ -69,7 +69,7 @@ public class TaskResponseServiceTest {
                 channel,
                 1);
 
-        resultEvent = TaskResponseEvent.newResult(ExecutionStatus.SUCCESS,
+        resultEvent = TaskResponseEvent.newResultAck(ExecutionStatus.SUCCESS,
                 new Date(),
                 1,
                 "ids",

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseServiceTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseServiceTest.java
@@ -19,9 +19,14 @@ package org.apache.dolphinscheduler.server.master.processor.queue;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseCommand;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningCommand;
 import org.apache.dolphinscheduler.server.master.cache.impl.ProcessInstanceExecCacheManagerImpl;
+import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteThreadPool;
+import org.apache.dolphinscheduler.server.utils.DataQualityResultOperator;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
+import java.net.InetSocketAddress;
 import java.util.Date;
 
 import org.junit.After;
@@ -42,41 +47,52 @@ public class TaskResponseServiceTest {
     private ProcessService processService;
 
     @InjectMocks
-    TaskResponseService taskRspService;
+    TaskEventService taskEventService;
 
     @Mock
     private Channel channel;
 
-    private TaskResponseEvent ackEvent;
+    private TaskEvent ackEvent;
 
-    private TaskResponseEvent resultEvent;
+    private TaskEvent resultEvent;
 
     private TaskInstance taskInstance;
 
     @Mock
     private ProcessInstanceExecCacheManagerImpl processInstanceExecCacheManager;
 
+    @Mock
+    private DataQualityResultOperator dataQualityResultOperator;
+
+    @Mock
+    private WorkflowExecuteThreadPool workflowExecuteThreadPool;
+
     @Before
     public void before() {
-        taskRspService.start();
+        taskEventService.start();
 
-        ackEvent = TaskResponseEvent.newRunningAck(ExecutionStatus.RUNNING_EXECUTION,
-                new Date(),
-                "127.*.*.*",
-                "path",
-                "logPath",
-                22,
-                channel,
-                1);
+        Mockito.when(channel.remoteAddress()).thenReturn(InetSocketAddress.createUnresolved("127.0.0.1", 1234));
 
-        resultEvent = TaskResponseEvent.newResultAck(ExecutionStatus.SUCCESS,
-                new Date(),
-                1,
-                "ids",
-                22,
-                "varPol",
-                channel,
-                1);
+        TaskExecuteRunningCommand taskExecuteRunningCommand = new TaskExecuteRunningCommand();
+        taskExecuteRunningCommand.setProcessId(1);
+        taskExecuteRunningCommand.setTaskInstanceId(22);
+        taskExecuteRunningCommand.setStatus(ExecutionStatus.RUNNING_EXECUTION.getCode());
+        taskExecuteRunningCommand.setExecutePath("path");
+        taskExecuteRunningCommand.setLogPath("logPath");
+        taskExecuteRunningCommand.setHost("127.*.*.*");
+        taskExecuteRunningCommand.setStartTime(new Date());
+
+        ackEvent = TaskEvent.newRunningEvent(taskExecuteRunningCommand, channel);
+
+        TaskExecuteResponseCommand taskExecuteResponseCommand = new TaskExecuteResponseCommand();
+        taskExecuteResponseCommand.setProcessInstanceId(1);
+        taskExecuteResponseCommand.setTaskInstanceId(22);
+        taskExecuteResponseCommand.setStatus(ExecutionStatus.SUCCESS.getCode());
+        taskExecuteResponseCommand.setEndTime(new Date());
+        taskExecuteResponseCommand.setVarPool("varPol");
+        taskExecuteResponseCommand.setAppIds("ids");
+        taskExecuteResponseCommand.setProcessId(1);
+        resultEvent = TaskEvent.newResultEvent(taskExecuteResponseCommand, channel);
 
         taskInstance = new TaskInstance();
         taskInstance.setId(22);
@@ -87,14 +103,14 @@ public class TaskResponseServiceTest {
     public void testAddResponse() {
         Mockito.when(processService.findTaskInstanceById(Mockito.any())).thenReturn(taskInstance);
         Mockito.when(channel.writeAndFlush(Mockito.any())).thenReturn(null);
-        taskRspService.addResponse(ackEvent);
-        taskRspService.addResponse(resultEvent);
+        taskEventService.addEvent(ackEvent);
+        taskEventService.addEvent(resultEvent);
     }
 
     @After
     public void after() {
-        if (taskRspService != null) {
-            taskRspService.stop();
+        if (taskEventService != null) {
+            taskEventService.stop();
         }
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/CommandType.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/CommandType.java
@@ -69,24 +69,24 @@ public enum CommandType {
     TASK_EXECUTE_REQUEST,
 
     /**
-     * execute task ack
+     * task execute running, from worker to master
      */
-    TASK_EXECUTE_ACK,
+    TASK_EXECUTE_RUNNING,
 
     /**
-     * execute task response
+     * task execute running ack, from master to worker
+     */
+    TASK_EXECUTE_RUNNING_ACK,
+
+    /**
+     * task execute response, from worker to master
      */
     TASK_EXECUTE_RESPONSE,
 
     /**
-     * db task ack
+     * task execute response ack, from master to worker
      */
-    DB_TASK_ACK,
-
-    /**
-     * db task response
-     */
-    DB_TASK_RESPONSE,
+    TASK_EXECUTE_RESPONSE_ACK,
 
     /**
      * kill task

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/StateEventResponseCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/StateEventResponseCommand.java
@@ -61,7 +61,7 @@ public class StateEventResponseCommand implements Serializable {
      */
     public Command convert2Command() {
         Command command = new Command();
-        command.setType(CommandType.DB_TASK_RESPONSE);
+        command.setType(CommandType.TASK_EXECUTE_RESPONSE_ACK);
         byte[] body = JSONUtils.toJsonByteArray(this);
         command.setBody(body);
         return command;

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteResponseAckCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteResponseAckCommand.java
@@ -22,18 +22,19 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import java.io.Serializable;
 
 /**
- * db task final result response command
+ * task execute response ack command
+ * from master to worker
  */
-public class DBTaskResponseCommand implements Serializable {
+public class TaskExecuteResponseAckCommand implements Serializable {
 
     private int taskInstanceId;
     private int status;
 
-    public DBTaskResponseCommand() {
+    public TaskExecuteResponseAckCommand() {
         super();
     }
 
-    public DBTaskResponseCommand(int status, int taskInstanceId) {
+    public TaskExecuteResponseAckCommand(int status, int taskInstanceId) {
         this.status = status;
         this.taskInstanceId = taskInstanceId;
     }
@@ -61,7 +62,7 @@ public class DBTaskResponseCommand implements Serializable {
      */
     public Command convert2Command() {
         Command command = new Command();
-        command.setType(CommandType.DB_TASK_RESPONSE);
+        command.setType(CommandType.TASK_EXECUTE_RESPONSE_ACK);
         byte[] body = JSONUtils.toJsonByteArray(this);
         command.setBody(body);
         return command;
@@ -69,7 +70,7 @@ public class DBTaskResponseCommand implements Serializable {
 
     @Override
     public String toString() {
-        return "DBTaskResponseCommand{"
+        return "TaskExecuteResponseAckCommand{"
             + "taskInstanceId=" + taskInstanceId
             + ", status=" + status
             + '}';

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteResponseCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteResponseCommand.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import java.util.Date;
 
 /**
- *  execute task response command
+ * execute task response command
  */
 public class TaskExecuteResponseCommand implements Serializable {
 
@@ -36,23 +36,43 @@ public class TaskExecuteResponseCommand implements Serializable {
     }
 
     /**
-     *  task instance id
+     * task instance id
      */
     private int taskInstanceId;
 
     /**
      * process instance id
      */
-    private  int processInstanceId;
+    private int processInstanceId;
 
     /**
-     *  status
+     * status
      */
     private int status;
 
+    /**
+     * startTime
+     */
+    private Date startTime;
 
     /**
-     *  end time
+     * host
+     */
+    private String host;
+
+    /**
+     * logPath
+     */
+    private String logPath;
+
+    /**
+     * executePath
+     */
+    private String executePath;
+
+
+    /**
+     * end time
      */
     private Date endTime;
 
@@ -72,6 +92,38 @@ public class TaskExecuteResponseCommand implements Serializable {
      */
     private String varPool;
 
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getLogPath() {
+        return logPath;
+    }
+
+    public void setLogPath(String logPath) {
+        this.logPath = logPath;
+    }
+
+    public String getExecutePath() {
+        return executePath;
+    }
+
+    public void setExecutePath(String executePath) {
+        this.executePath = executePath;
+    }
+
     public void setVarPool(String varPool) {
         this.varPool = varPool;
     }
@@ -79,7 +131,7 @@ public class TaskExecuteResponseCommand implements Serializable {
     public String getVarPool() {
         return varPool;
     }
-    
+
     public int getTaskInstanceId() {
         return taskInstanceId;
     }
@@ -122,6 +174,7 @@ public class TaskExecuteResponseCommand implements Serializable {
 
     /**
      * package response command
+     *
      * @return command
      */
     public Command convert2Command() {
@@ -136,10 +189,16 @@ public class TaskExecuteResponseCommand implements Serializable {
     public String toString() {
         return "TaskExecuteResponseCommand{"
                 + "taskInstanceId=" + taskInstanceId
+                + ", processInstanceId=" + processInstanceId
                 + ", status=" + status
+                + ", startTime=" + startTime
                 + ", endTime=" + endTime
+                + ", host=" + host
+                + ", logPath=" + logPath
+                + ", executePath=" + executePath
                 + ", processId=" + processId
                 + ", appIds='" + appIds + '\''
+                + ", varPool=" + varPool
                 + '}';
     }
 

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteRunningAckCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteRunningAckCommand.java
@@ -22,18 +22,19 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import java.io.Serializable;
 
 /**
- * db task ack request command
+ * task execute running ack command
+ * from master to worker
  */
-public class DBTaskAckCommand implements Serializable {
+public class TaskExecuteRunningAckCommand implements Serializable {
 
     private int taskInstanceId;
     private int status;
 
-    public DBTaskAckCommand() {
+    public TaskExecuteRunningAckCommand() {
         super();
     }
 
-    public DBTaskAckCommand(int status, int taskInstanceId) {
+    public TaskExecuteRunningAckCommand(int status, int taskInstanceId) {
         this.status = status;
         this.taskInstanceId = taskInstanceId;
     }
@@ -61,7 +62,7 @@ public class DBTaskAckCommand implements Serializable {
      */
     public Command convert2Command() {
         Command command = new Command();
-        command.setType(CommandType.DB_TASK_ACK);
+        command.setType(CommandType.TASK_EXECUTE_RUNNING_ACK);
         byte[] body = JSONUtils.toJsonByteArray(this);
         command.setBody(body);
         return command;
@@ -69,6 +70,6 @@ public class DBTaskAckCommand implements Serializable {
 
     @Override
     public String toString() {
-        return "DBTaskAckCommand{" + "taskInstanceId=" + taskInstanceId + ", status=" + status + '}';
+        return "TaskExecuteRunningAckCommand{" + "taskInstanceId=" + taskInstanceId + ", status=" + status + '}';
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteRunningCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/TaskExecuteRunningCommand.java
@@ -23,9 +23,10 @@ import java.io.Serializable;
 import java.util.Date;
 
 /**
- * execute task request command
+ * task execute running command
+ * from worker to master
  */
-public class TaskExecuteAckCommand implements Serializable {
+public class TaskExecuteRunningCommand implements Serializable {
 
     /**
      * taskInstanceId
@@ -62,6 +63,16 @@ public class TaskExecuteAckCommand implements Serializable {
      */
     private String executePath;
 
+    /**
+     * processId
+     */
+    private int processId;
+
+    /**
+     * appIds
+     */
+    private String appIds;
+
     public Date getStartTime() {
         return startTime;
     }
@@ -94,6 +105,14 @@ public class TaskExecuteAckCommand implements Serializable {
         this.taskInstanceId = taskInstanceId;
     }
 
+    public int getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public void setProcessInstanceId(int processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
     public String getLogPath() {
         return logPath;
     }
@@ -110,6 +129,22 @@ public class TaskExecuteAckCommand implements Serializable {
         this.executePath = executePath;
     }
 
+    public int getProcessId() {
+        return processId;
+    }
+
+    public void setProcessId(int processId) {
+        this.processId = processId;
+    }
+
+    public String getAppIds() {
+        return appIds;
+    }
+
+    public void setAppIds(String appIds) {
+        this.appIds = appIds;
+    }
+
     /**
      * package request command
      *
@@ -117,7 +152,7 @@ public class TaskExecuteAckCommand implements Serializable {
      */
     public Command convert2Command() {
         Command command = new Command();
-        command.setType(CommandType.TASK_EXECUTE_ACK);
+        command.setType(CommandType.TASK_EXECUTE_RUNNING);
         byte[] body = JSONUtils.toJsonByteArray(this);
         command.setBody(body);
         return command;
@@ -125,22 +160,16 @@ public class TaskExecuteAckCommand implements Serializable {
 
     @Override
     public String toString() {
-        return "TaskExecuteAckCommand{"
+        return "TaskExecuteRunningCommand{"
                 + "taskInstanceId=" + taskInstanceId
+                + ", processInstanceId='" + processInstanceId + '\''
                 + ", startTime=" + startTime
                 + ", host='" + host + '\''
                 + ", status=" + status
                 + ", logPath='" + logPath + '\''
                 + ", executePath='" + executePath + '\''
-                + ", processInstanceId='" + processInstanceId + '\''
+                + ", processId=" + processId + '\''
+                + ", appIds='" + appIds + '\''
                 + '}';
-    }
-
-    public int getProcessInstanceId() {
-        return processInstanceId;
-    }
-
-    public void setProcessInstanceId(int processInstanceId) {
-        this.processInstanceId = processInstanceId;
     }
 }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -1796,6 +1796,7 @@ public class ProcessService {
     }
 
     /**
+<<<<<<< HEAD
      * change task state
      *
      * @param state       state
@@ -1819,6 +1820,8 @@ public class ProcessService {
     }
 
     /**
+=======
+>>>>>>> rebase dev
      * update process instance
      *
      * @param processInstance processInstance
@@ -1829,6 +1832,7 @@ public class ProcessService {
     }
 
     /**
+<<<<<<< HEAD
      * change task state
      *
      * @param state   state
@@ -1850,6 +1854,8 @@ public class ProcessService {
     }
 
     /**
+=======
+>>>>>>> rebase dev
      * for show in page of taskInstance
      */
     public void changeOutParam(TaskInstance taskInstance) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskExecutionContext.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskExecutionContext.java
@@ -208,6 +208,16 @@ public class TaskExecutionContext {
     private ResourceParametersHelper resourceParametersHelper;
 
     /**
+     * endTime
+     */
+    private Date endTime;
+
+    /**
+     * sql TaskExecutionContext
+     */
+    private SQLTaskExecutionContext sqlTaskExecutionContext;
+
+    /**
      * resources full name and tenant code
      */
     private Map<String, String> resources;
@@ -538,12 +548,61 @@ public class TaskExecutionContext {
         this.dataQualityTaskExecutionContext = dataQualityTaskExecutionContext;
     }
 
+    public void setCurrentExecutionStatus(ExecutionStatus currentExecutionStatus) {
+        this.currentExecutionStatus = currentExecutionStatus;
+    }
+
     public ExecutionStatus getCurrentExecutionStatus() {
         return currentExecutionStatus;
     }
 
-    public void setCurrentExecutionStatus(ExecutionStatus currentExecutionStatus) {
-        this.currentExecutionStatus = currentExecutionStatus;
+    public Date getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Date endTime) {
+        this.endTime = endTime;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskExecutionContext{"
+                + "taskInstanceId=" + taskInstanceId
+                + ", taskName='" + taskName + '\''
+                + ", currentExecutionStatus=" + currentExecutionStatus
+                + ", firstSubmitTime=" + firstSubmitTime
+                + ", startTime=" + startTime
+                + ", taskType='" + taskType + '\''
+                + ", host='" + host + '\''
+                + ", executePath='" + executePath + '\''
+                + ", logPath='" + logPath + '\''
+                + ", taskJson='" + taskJson + '\''
+                + ", processId=" + processId
+                + ", processDefineCode=" + processDefineCode
+                + ", processDefineVersion=" + processDefineVersion
+                + ", appIds='" + appIds + '\''
+                + ", processInstanceId=" + processInstanceId
+                + ", scheduleTime=" + scheduleTime
+                + ", globalParams='" + globalParams + '\''
+                + ", executorId=" + executorId
+                + ", cmdTypeIfComplement=" + cmdTypeIfComplement
+                + ", tenantCode='" + tenantCode + '\''
+                + ", queue='" + queue + '\''
+                + ", projectCode=" + projectCode
+                + ", taskParams='" + taskParams + '\''
+                + ", envFile='" + envFile + '\''
+                + ", dryRun='" + dryRun + '\''
+                + ", definedParams=" + definedParams
+                + ", taskAppId='" + taskAppId + '\''
+                + ", taskTimeoutStrategy=" + taskTimeoutStrategy
+                + ", taskTimeout=" + taskTimeout
+                + ", workerGroup='" + workerGroup + '\''
+                + ", environmentConfig='" + environmentConfig + '\''
+                + ", delayTime=" + delayTime
+                + ", resources=" + resources
+                + ", sqlTaskExecutionContext=" + sqlTaskExecutionContext
+                + ", dataQualityTaskExecutionContext=" + dataQualityTaskExecutionContext
+                + '}';
     }
 
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/enums/ExecutionStatus.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/enums/ExecutionStatus.java
@@ -62,7 +62,9 @@ public enum ExecutionStatus {
     FORCED_SUCCESS(13, "forced success"),
     SERIAL_WAIT(14, "serial wait"),
     READY_BLOCK(15, "ready block"),
-    BLOCK(16, "block");
+    BLOCK(16, "block"),
+    DISPATCH(17, "dispatch"),
+    ;
 
     ExecutionStatus(int code, String descp) {
         this.code = code;

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -28,10 +28,10 @@ import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.apache.dolphinscheduler.server.log.LoggerRequestProcessor;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
-import org.apache.dolphinscheduler.server.worker.processor.DBTaskAckProcessor;
-import org.apache.dolphinscheduler.server.worker.processor.DBTaskResponseProcessor;
 import org.apache.dolphinscheduler.server.worker.processor.HostUpdateProcessor;
 import org.apache.dolphinscheduler.server.worker.processor.TaskExecuteProcessor;
+import org.apache.dolphinscheduler.server.worker.processor.TaskExecuteResponseAckProcessor;
+import org.apache.dolphinscheduler.server.worker.processor.TaskExecuteRunningAckProcessor;
 import org.apache.dolphinscheduler.server.worker.processor.TaskKillProcessor;
 import org.apache.dolphinscheduler.server.worker.registry.WorkerRegistryClient;
 import org.apache.dolphinscheduler.server.worker.runner.RetryReportTaskStatusThread;
@@ -111,10 +111,10 @@ public class WorkerServer implements IStoppable {
     private TaskKillProcessor taskKillProcessor;
 
     @Autowired
-    private DBTaskAckProcessor dbTaskAckProcessor;
+    private TaskExecuteRunningAckProcessor taskExecuteRunningAckProcessor;
 
     @Autowired
-    private DBTaskResponseProcessor dbTaskResponseProcessor;
+    private TaskExecuteResponseAckProcessor taskExecuteResponseAckProcessor;
 
     @Autowired
     private HostUpdateProcessor hostUpdateProcessor;
@@ -143,8 +143,8 @@ public class WorkerServer implements IStoppable {
         this.nettyRemotingServer = new NettyRemotingServer(serverConfig);
         this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_REQUEST, taskExecuteProcessor);
         this.nettyRemotingServer.registerProcessor(CommandType.TASK_KILL_REQUEST, taskKillProcessor);
-        this.nettyRemotingServer.registerProcessor(CommandType.DB_TASK_ACK, dbTaskAckProcessor);
-        this.nettyRemotingServer.registerProcessor(CommandType.DB_TASK_RESPONSE, dbTaskResponseProcessor);
+        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RUNNING_ACK, taskExecuteRunningAckProcessor);
+        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE_ACK, taskExecuteResponseAckProcessor);
         this.nettyRemotingServer.registerProcessor(CommandType.PROCESS_HOST_UPDATE_REQUEST, hostUpdateProcessor);
 
         // logger server

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/cache/ResponseCache.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/cache/ResponseCache.java
@@ -30,28 +30,30 @@ public class ResponseCache {
 
     private static final ResponseCache instance = new ResponseCache();
 
-    private ResponseCache(){}
+    private ResponseCache() {
+    }
 
     public static ResponseCache get() {
         return instance;
     }
 
-    private Map<Integer,Command> ackCache = new ConcurrentHashMap<>();
-    private Map<Integer,Command> responseCache = new ConcurrentHashMap<>();
+    private Map<Integer, Command> runningCache = new ConcurrentHashMap<>();
+    private Map<Integer, Command> responseCache = new ConcurrentHashMap<>();
 
     /**
      * cache response
+     *
      * @param taskInstanceId taskInstanceId
      * @param command command
      * @param event event ACK/RESULT
      */
     public void cache(Integer taskInstanceId, Command command, Event event) {
         switch (event) {
-            case ACK:
-                ackCache.put(taskInstanceId,command);
+            case RUNNING:
+                runningCache.put(taskInstanceId, command);
                 break;
             case RESULT:
-                responseCache.put(taskInstanceId,command);
+                responseCache.put(taskInstanceId, command);
                 break;
             default:
                 throw new IllegalArgumentException("invalid event type : " + event);
@@ -59,15 +61,17 @@ public class ResponseCache {
     }
 
     /**
-     * remove ack cache
+     * remove running cache
+     *
      * @param taskInstanceId taskInstanceId
      */
-    public void removeAckCache(Integer taskInstanceId) {
-        ackCache.remove(taskInstanceId);
+    public void removeRunningCache(Integer taskInstanceId) {
+        runningCache.remove(taskInstanceId);
     }
 
     /**
-     * remove reponse cache
+     * remove response cache
+     *
      * @param taskInstanceId taskInstanceId
      */
     public void removeResponseCache(Integer taskInstanceId) {
@@ -75,18 +79,20 @@ public class ResponseCache {
     }
 
     /**
-     * getAckCache
+     * get running cache
+     *
      * @return getAckCache
      */
-    public Map<Integer,Command> getAckCache() {
-        return ackCache;
+    public Map<Integer, Command> getRunningCache() {
+        return runningCache;
     }
 
     /**
      * getResponseCache
+     *
      * @return getResponseCache
      */
-    public Map<Integer,Command> getResponseCache() {
+    public Map<Integer, Command> getResponseCache() {
         return responseCache;
     }
 }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
@@ -19,16 +19,25 @@ package org.apache.dolphinscheduler.server.worker.processor;
 
 import static org.apache.dolphinscheduler.common.Constants.SLEEP_TIME_MILLIS;
 
+import org.apache.dolphinscheduler.common.enums.Event;
+import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.remote.NettyRemotingClient;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseCommand;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningCommand;
+import org.apache.dolphinscheduler.remote.command.TaskKillResponseCommand;
 import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
 import org.apache.dolphinscheduler.remote.processor.NettyRemoteChannel;
+import org.apache.dolphinscheduler.server.worker.cache.ResponseCache;
 
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import io.netty.channel.Channel;
@@ -45,6 +54,12 @@ public class TaskCallbackService {
     private final Logger logger = LoggerFactory.getLogger(TaskCallbackService.class);
     private static final int[] RETRY_BACKOFF = {1, 2, 3, 5, 10, 20, 40, 100, 100, 100, 100, 200, 200, 200};
 
+    @Autowired
+    private TaskExecuteResponseAckProcessor taskExecuteRunningProcessor;
+
+    @Autowired
+    private TaskExecuteResponseAckProcessor taskExecuteResponseAckProcessor;
+
     /**
      * remote channels
      */
@@ -58,15 +73,15 @@ public class TaskCallbackService {
     public TaskCallbackService() {
         final NettyClientConfig clientConfig = new NettyClientConfig();
         this.nettyRemotingClient = new NettyRemotingClient(clientConfig);
-        this.nettyRemotingClient.registerProcessor(CommandType.DB_TASK_ACK, new DBTaskAckProcessor());
-        this.nettyRemotingClient.registerProcessor(CommandType.DB_TASK_RESPONSE, new DBTaskResponseProcessor());
+        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_RUNNING_ACK, taskExecuteRunningProcessor);
+        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE_ACK, taskExecuteResponseAckProcessor);
     }
 
     /**
      * add callback channel
      *
      * @param taskInstanceId taskInstanceId
-     * @param channel        channel
+     * @param channel channel
      */
     public void addRemoteChannel(int taskInstanceId, NettyRemoteChannel channel) {
         REMOTE_CHANNELS.put(taskInstanceId, channel);
@@ -129,25 +144,12 @@ public class TaskCallbackService {
     }
 
     /**
-     * send ack
-     *
-     * @param taskInstanceId taskInstanceId
-     * @param command        command
-     */
-    public void sendAck(int taskInstanceId, Command command) {
-        NettyRemoteChannel nettyRemoteChannel = getRemoteChannel(taskInstanceId);
-        if (nettyRemoteChannel != null) {
-            nettyRemoteChannel.writeAndFlush(command);
-        }
-    }
-
-    /**
      * send result
      *
      * @param taskInstanceId taskInstanceId
-     * @param command        command
+     * @param command command
      */
-    public void sendResult(int taskInstanceId, Command command) {
+    public void send(int taskInstanceId, Command command) {
         NettyRemoteChannel nettyRemoteChannel = getRemoteChannel(taskInstanceId);
         if (nettyRemoteChannel != null) {
             nettyRemoteChannel.writeAndFlush(command).addListener(new ChannelFutureListener() {
@@ -161,6 +163,99 @@ public class TaskCallbackService {
                 }
             });
         }
+    }
 
+    /**
+     * build task execute running command
+     *
+     * @param taskExecutionContext taskExecutionContext
+     * @return TaskExecuteAckCommand
+     */
+    private TaskExecuteRunningCommand buildTaskExecuteRunningCommand(TaskExecutionContext taskExecutionContext) {
+        TaskExecuteRunningCommand command = new TaskExecuteRunningCommand();
+        command.setTaskInstanceId(taskExecutionContext.getTaskInstanceId());
+        command.setProcessInstanceId(taskExecutionContext.getProcessInstanceId());
+        command.setStatus(taskExecutionContext.getCurrentExecutionStatus().getCode());
+        command.setLogPath(taskExecutionContext.getLogPath());
+        command.setHost(taskExecutionContext.getHost());
+        command.setStartTime(taskExecutionContext.getStartTime());
+        command.setExecutePath(taskExecutionContext.getExecutePath());
+        return command;
+    }
+
+    /**
+     * build task execute response command
+     *
+     * @param taskExecutionContext taskExecutionContext
+     * @return TaskExecuteResponseCommand
+     */
+    private TaskExecuteResponseCommand buildTaskExecuteResponseCommand(TaskExecutionContext taskExecutionContext) {
+        TaskExecuteResponseCommand command = new TaskExecuteResponseCommand();
+        command.setProcessInstanceId(taskExecutionContext.getProcessInstanceId());
+        command.setTaskInstanceId(taskExecutionContext.getTaskInstanceId());
+        command.setStatus(taskExecutionContext.getCurrentExecutionStatus().getCode());
+        command.setLogPath(taskExecutionContext.getLogPath());
+        command.setExecutePath(taskExecutionContext.getExecutePath());
+        command.setAppIds(taskExecutionContext.getAppIds());
+        command.setProcessId(taskExecutionContext.getProcessId());
+        command.setHost(taskExecutionContext.getHost());
+        command.setStartTime(taskExecutionContext.getStartTime());
+        command.setEndTime(taskExecutionContext.getEndTime());
+        command.setVarPool(taskExecutionContext.getVarPool());
+        command.setExecutePath(taskExecutionContext.getExecutePath());
+        return command;
+    }
+
+    /**
+     * build TaskKillResponseCommand
+     *
+     * @param taskExecutionContext taskExecutionContext
+     * @return build TaskKillResponseCommand
+     */
+    private TaskKillResponseCommand buildKillTaskResponseCommand(TaskExecutionContext taskExecutionContext) {
+        TaskKillResponseCommand taskKillResponseCommand = new TaskKillResponseCommand();
+        taskKillResponseCommand.setStatus(taskExecutionContext.getCurrentExecutionStatus().getCode());
+        taskKillResponseCommand.setAppIds(Arrays.asList(taskExecutionContext.getAppIds().split(TaskConstants.COMMA)));
+        taskKillResponseCommand.setTaskInstanceId(taskExecutionContext.getTaskInstanceId());
+        taskKillResponseCommand.setHost(taskExecutionContext.getHost());
+        taskKillResponseCommand.setProcessId(taskExecutionContext.getProcessId());
+        return taskKillResponseCommand;
+    }
+
+    /**
+     * send task execute running command
+     * todo unified callback command
+     */
+    public void sendTaskExecuteRunningCommand(TaskExecutionContext taskExecutionContext) {
+        TaskExecuteRunningCommand command = buildTaskExecuteRunningCommand(taskExecutionContext);
+        // add response cache
+        ResponseCache.get().cache(taskExecutionContext.getTaskInstanceId(), command.convert2Command(), Event.RUNNING);
+        send(taskExecutionContext.getTaskInstanceId(), command.convert2Command());
+    }
+
+    /**
+     * send task execute delay command
+     * todo unified callback command
+     */
+    public void sendTaskExecuteDelayCommand(TaskExecutionContext taskExecutionContext) {
+        TaskExecuteRunningCommand command = buildTaskExecuteRunningCommand(taskExecutionContext);
+        send(taskExecutionContext.getTaskInstanceId(), command.convert2Command());
+    }
+
+    /**
+     * send task execute response command
+     * todo unified callback command
+     */
+    public void sendTaskExecuteResponseCommand(TaskExecutionContext taskExecutionContext) {
+        TaskExecuteResponseCommand command = buildTaskExecuteResponseCommand(taskExecutionContext);
+        // add response cache
+        ResponseCache.get().cache(taskExecutionContext.getTaskInstanceId(), command.convert2Command(), Event.RESULT);
+        send(taskExecutionContext.getTaskInstanceId(), command.convert2Command());
+    }
+
+    public void sendTaskKillResponseCommand(TaskExecutionContext taskExecutionContext) {
+        TaskKillResponseCommand taskKillResponseCommand = buildKillTaskResponseCommand(taskExecutionContext);
+        send(taskExecutionContext.getTaskInstanceId(), taskKillResponseCommand.convert2Command());
+        TaskCallbackService.remove(taskExecutionContext.getTaskInstanceId());
     }
 }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -171,7 +171,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
         // submit task to manager
         boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager));
         if (!offer) {
-            logger.info("submit task to manager error, queue is full, queue size is {}, taskInstanceId: {}",
+            logger.error("submit task to manager error, queue is full, queue size is {}, taskInstanceId: {}",
                     workerManager.getDelayQueueSize(), taskExecutionContext.getTaskInstanceId());
             taskExecutionContext.setCurrentExecutionStatus(ExecutionStatus.FAILURE);
             taskCallbackService.sendTaskExecuteResponseCommand(taskExecutionContext);

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -18,7 +18,6 @@
 package org.apache.dolphinscheduler.server.worker.processor;
 
 import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.enums.Event;
 import org.apache.dolphinscheduler.common.utils.CommonUtils;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
@@ -30,12 +29,10 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContextCacheMana
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
-import org.apache.dolphinscheduler.remote.command.TaskExecuteAckCommand;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteRequestCommand;
 import org.apache.dolphinscheduler.remote.processor.NettyRemoteChannel;
 import org.apache.dolphinscheduler.remote.processor.NettyRequestProcessor;
 import org.apache.dolphinscheduler.server.utils.LogUtils;
-import org.apache.dolphinscheduler.server.worker.cache.ResponseCache;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
 import org.apache.dolphinscheduler.server.worker.runner.TaskExecuteThread;
 import org.apache.dolphinscheduler.server.worker.runner.WorkerManagerThread;
@@ -133,14 +130,29 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
             logger.info("task instance local execute path : {}", execLocalPath);
             taskExecutionContext.setExecutePath(execLocalPath);
 
+            // check if the OS user exists
+            if (!OSUtils.getUserList().contains(taskExecutionContext.getTenantCode())) {
+                logger.error("tenantCode: {} does not exist, taskInstanceId: {}",
+                        taskExecutionContext.getTenantCode(), taskExecutionContext.getTaskInstanceId());
+                TaskExecutionContextCacheManager.removeByTaskInstanceId(taskExecutionContext.getTaskInstanceId());
+                taskExecutionContext.setCurrentExecutionStatus(ExecutionStatus.FAILURE);
+                taskExecutionContext.setEndTime(new Date());
+                taskCallbackService.sendTaskExecuteResponseCommand(taskExecutionContext);
+                return;
+            }
+
             try {
                 FileUtils.createWorkDirIfAbsent(execLocalPath);
                 if (CommonUtils.isSudoEnable() && workerConfig.isTenantAutoCreate()) {
                     OSUtils.createUserIfAbsent(taskExecutionContext.getTenantCode());
                 }
             } catch (Throwable ex) {
-                logger.error("create execLocalPath: {}", execLocalPath, ex);
+                logger.error("create execLocalPath fail, path: {}, taskInstanceId: {}", execLocalPath, taskExecutionContext.getTaskInstanceId());
+                logger.error("create executeLocalPath fail", ex);
                 TaskExecutionContextCacheManager.removeByTaskInstanceId(taskExecutionContext.getTaskInstanceId());
+                taskExecutionContext.setCurrentExecutionStatus(ExecutionStatus.FAILURE);
+                taskCallbackService.sendTaskExecuteResponseCommand(taskExecutionContext);
+                return;
             }
         }
 
@@ -153,46 +165,17 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
             logger.info("delay the execution of task instance {}, delay time: {} s", taskExecutionContext.getTaskInstanceId(), remainTime);
             taskExecutionContext.setCurrentExecutionStatus(ExecutionStatus.DELAY_EXECUTION);
             taskExecutionContext.setStartTime(null);
-        } else {
-            taskExecutionContext.setCurrentExecutionStatus(ExecutionStatus.RUNNING_EXECUTION);
-            taskExecutionContext.setStartTime(new Date());
+            taskCallbackService.sendTaskExecuteDelayCommand(taskExecutionContext);
         }
-
-        this.doAck(taskExecutionContext);
 
         // submit task to manager
-        if (!workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager))) {
-            logger.info("submit task to manager error, queue is full, queue size is {}", workerManager.getDelayQueueSize());
+        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager));
+        if (!offer) {
+            logger.info("submit task to manager error, queue is full, queue size is {}, taskInstanceId: {}",
+                    workerManager.getDelayQueueSize(), taskExecutionContext.getTaskInstanceId());
+            taskExecutionContext.setCurrentExecutionStatus(ExecutionStatus.FAILURE);
+            taskCallbackService.sendTaskExecuteResponseCommand(taskExecutionContext);
         }
-    }
-
-    private void doAck(TaskExecutionContext taskExecutionContext) {
-        // tell master that task is in executing
-        TaskExecuteAckCommand ackCommand = buildAckCommand(taskExecutionContext);
-        ResponseCache.get().cache(taskExecutionContext.getTaskInstanceId(), ackCommand.convert2Command(), Event.ACK);
-        taskCallbackService.sendAck(taskExecutionContext.getTaskInstanceId(), ackCommand.convert2Command());
-    }
-
-    /**
-     * build ack command
-     *
-     * @param taskExecutionContext taskExecutionContext
-     * @return TaskExecuteAckCommand
-     */
-    private TaskExecuteAckCommand buildAckCommand(TaskExecutionContext taskExecutionContext) {
-        TaskExecuteAckCommand ackCommand = new TaskExecuteAckCommand();
-        ackCommand.setTaskInstanceId(taskExecutionContext.getTaskInstanceId());
-        ackCommand.setStatus(taskExecutionContext.getCurrentExecutionStatus().getCode());
-        ackCommand.setLogPath(LogUtils.getTaskLogPath(taskExecutionContext));
-        ackCommand.setHost(taskExecutionContext.getHost());
-        ackCommand.setStartTime(taskExecutionContext.getStartTime());
-
-        ackCommand.setExecutePath(taskExecutionContext.getExecutePath());
-
-        taskExecutionContext.setLogPath(ackCommand.getLogPath());
-        ackCommand.setProcessInstanceId(taskExecutionContext.getProcessInstanceId());
-
-        return ackCommand;
     }
 
     /**

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteResponseAckProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteResponseAckProcessor.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
-import org.apache.dolphinscheduler.remote.command.DBTaskResponseCommand;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseAckCommand;
 import org.apache.dolphinscheduler.remote.processor.NettyRequestProcessor;
 import org.apache.dolphinscheduler.server.worker.cache.ResponseCache;
 
@@ -34,31 +34,31 @@ import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
 
 /**
- *  db task response processor
+ * task execute running ack, from master to worker
  */
 @Component
-public class DBTaskResponseProcessor implements NettyRequestProcessor {
+public class TaskExecuteResponseAckProcessor implements NettyRequestProcessor {
 
-    private final Logger logger = LoggerFactory.getLogger(DBTaskResponseProcessor.class);
+    private final Logger logger = LoggerFactory.getLogger(TaskExecuteResponseAckProcessor.class);
 
     @Override
     public void process(Channel channel, Command command) {
-        Preconditions.checkArgument(CommandType.DB_TASK_RESPONSE == command.getType(),
+        Preconditions.checkArgument(CommandType.TASK_EXECUTE_RESPONSE_ACK == command.getType(),
                 String.format("invalid command type : %s", command.getType()));
 
-        DBTaskResponseCommand taskResponseCommand = JSONUtils.parseObject(
-                command.getBody(), DBTaskResponseCommand.class);
+        TaskExecuteResponseAckCommand taskExecuteResponseAckCommand = JSONUtils.parseObject(
+                command.getBody(), TaskExecuteResponseAckCommand.class);
 
-        if (taskResponseCommand == null) {
-            logger.error("dBTask Response  command is null");
+        if (taskExecuteResponseAckCommand == null) {
+            logger.error("task execute response ack command is null");
             return;
         }
-        logger.info("dBTask Response command : {}", taskResponseCommand);
+        logger.info("task execute response ack command : {}", taskExecuteResponseAckCommand);
 
-        if (taskResponseCommand.getStatus() == ExecutionStatus.SUCCESS.getCode()) {
-            ResponseCache.get().removeResponseCache(taskResponseCommand.getTaskInstanceId());
-            TaskCallbackService.remove(taskResponseCommand.getTaskInstanceId());
-            logger.debug("remove REMOTE_CHANNELS, task instance id:{}", taskResponseCommand.getTaskInstanceId());
+        if (taskExecuteResponseAckCommand.getStatus() == ExecutionStatus.SUCCESS.getCode()) {
+            ResponseCache.get().removeResponseCache(taskExecuteResponseAckCommand.getTaskInstanceId());
+            TaskCallbackService.remove(taskExecuteResponseAckCommand.getTaskInstanceId());
+            logger.debug("remove REMOTE_CHANNELS, task instance id:{}", taskExecuteResponseAckCommand.getTaskInstanceId());
         }
     }
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteRunningAckProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteRunningAckProcessor.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
-import org.apache.dolphinscheduler.remote.command.DBTaskAckCommand;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningAckCommand;
 import org.apache.dolphinscheduler.remote.processor.NettyRequestProcessor;
 import org.apache.dolphinscheduler.server.worker.cache.ResponseCache;
 
@@ -34,29 +34,29 @@ import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
 
 /**
- *  db task ack processor
+ * task execute running ack processor
  */
 @Component
-public class DBTaskAckProcessor implements NettyRequestProcessor {
+public class TaskExecuteRunningAckProcessor implements NettyRequestProcessor {
 
-    private final Logger logger = LoggerFactory.getLogger(DBTaskAckProcessor.class);
+    private final Logger logger = LoggerFactory.getLogger(TaskExecuteRunningAckProcessor.class);
 
     @Override
     public void process(Channel channel, Command command) {
-        Preconditions.checkArgument(CommandType.DB_TASK_ACK == command.getType(),
+        Preconditions.checkArgument(CommandType.TASK_EXECUTE_RUNNING_ACK == command.getType(),
                 String.format("invalid command type : %s", command.getType()));
 
-        DBTaskAckCommand taskAckCommand = JSONUtils.parseObject(
-                command.getBody(), DBTaskAckCommand.class);
+        TaskExecuteRunningAckCommand runningAckCommand = JSONUtils.parseObject(
+                command.getBody(), TaskExecuteRunningAckCommand.class);
 
-        if (taskAckCommand == null) {
-            logger.error("dBTask ACK request command is null");
+        if (runningAckCommand == null) {
+            logger.error("task execute running ack command is null");
             return;
         }
-        logger.info("dBTask ACK request command : {}", taskAckCommand);
+        logger.info("task execute running ack command : {}", runningAckCommand);
 
-        if (taskAckCommand.getStatus() == ExecutionStatus.SUCCESS.getCode()) {
-            ResponseCache.get().removeAckCache(taskAckCommand.getTaskInstanceId());
+        if (runningAckCommand.getStatus() == ExecutionStatus.SUCCESS.getCode()) {
+            ResponseCache.get().removeRunningCache(runningAckCommand.getTaskInstanceId());
         }
     }
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/RetryReportTaskStatusThread.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/RetryReportTaskStatusThread.java
@@ -47,7 +47,7 @@ public class RetryReportTaskStatusThread implements Runnable {
     private TaskCallbackService taskCallbackService;
 
     public void start() {
-        Thread thread = new Thread(this,"RetryReportTaskStatusThread");
+        Thread thread = new Thread(this, "RetryReportTaskStatusThread");
         thread.setDaemon(true);
         thread.start();
     }
@@ -65,21 +65,21 @@ public class RetryReportTaskStatusThread implements Runnable {
             ThreadUtils.sleep(RETRY_REPORT_TASK_STATUS_INTERVAL);
 
             try {
-                if (!instance.getAckCache().isEmpty()) {
-                    Map<Integer,Command> ackCache =  instance.getAckCache();
-                    for (Map.Entry<Integer, Command> entry : ackCache.entrySet()) {
+                if (!instance.getRunningCache().isEmpty()) {
+                    Map<Integer, Command> runningCache = instance.getRunningCache();
+                    for (Map.Entry<Integer, Command> entry : runningCache.entrySet()) {
                         Integer taskInstanceId = entry.getKey();
-                        Command ackCommand = entry.getValue();
-                        taskCallbackService.sendAck(taskInstanceId,ackCommand);
+                        Command runningCommand = entry.getValue();
+                        taskCallbackService.send(taskInstanceId, runningCommand);
                     }
                 }
 
                 if (!instance.getResponseCache().isEmpty()) {
-                    Map<Integer,Command> responseCache =  instance.getResponseCache();
+                    Map<Integer, Command> responseCache = instance.getResponseCache();
                     for (Map.Entry<Integer, Command> entry : responseCache.entrySet()) {
                         Integer taskInstanceId = entry.getKey();
                         Command responseCommand = entry.getValue();
-                        taskCallbackService.sendResult(taskInstanceId,responseCommand);
+                        taskCallbackService.send(taskInstanceId, responseCommand);
                     }
                 }
             } catch (Exception e) {

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerManagerThread.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerManagerThread.java
@@ -108,7 +108,7 @@ public class WorkerManagerThread implements Runnable {
         TaskExecuteResponseCommand responseCommand = new TaskExecuteResponseCommand(taskExecutionContext.getTaskInstanceId(), taskExecutionContext.getProcessInstanceId());
         responseCommand.setStatus(ExecutionStatus.KILL.getCode());
         ResponseCache.get().cache(taskExecutionContext.getTaskInstanceId(), responseCommand.convert2Command(), Event.RESULT);
-        taskCallbackService.sendResult(taskExecutionContext.getTaskInstanceId(), responseCommand.convert2Command());
+        taskCallbackService.sendTaskExecuteResponseCommand(taskExecutionContext);
     }
 
     /**

--- a/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessorTest.java
+++ b/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessorTest.java
@@ -24,8 +24,8 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
-import org.apache.dolphinscheduler.remote.command.TaskExecuteAckCommand;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteRequestCommand;
+import org.apache.dolphinscheduler.remote.command.TaskExecuteRunningCommand;
 import org.apache.dolphinscheduler.remote.utils.ChannelUtils;
 import org.apache.dolphinscheduler.remote.utils.JsonSerializer;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
@@ -53,7 +53,7 @@ import org.slf4j.Logger;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SpringApplicationContext.class, TaskCallbackService.class, WorkerConfig.class, FileUtils.class,
-    JsonSerializer.class, JSONUtils.class, ThreadUtils.class, ExecutorService.class, ChannelUtils.class})
+        JsonSerializer.class, JSONUtils.class, ThreadUtils.class, ExecutorService.class, ChannelUtils.class})
 @Ignore
 public class TaskExecuteProcessorTest {
 
@@ -84,7 +84,7 @@ public class TaskExecuteProcessorTest {
         workerConfig.setListenPort(1234);
         command = new Command();
         command.setType(CommandType.TASK_EXECUTE_REQUEST);
-        ackCommand = new TaskExecuteAckCommand().convert2Command();
+        ackCommand = new TaskExecuteRunningCommand().convert2Command();
         taskRequestCommand = new TaskExecuteRequestCommand();
         alertClientService = PowerMockito.mock(AlertClientService.class);
         workerExecService = PowerMockito.mock(ExecutorService.class);
@@ -95,7 +95,7 @@ public class TaskExecuteProcessorTest {
         PowerMockito.when(ChannelUtils.toAddress(null)).thenReturn(null);
 
         taskCallbackService = PowerMockito.mock(TaskCallbackService.class);
-        PowerMockito.doNothing().when(taskCallbackService).sendAck(taskExecutionContext.getTaskInstanceId(), ackCommand);
+        PowerMockito.doNothing().when(taskCallbackService).send(taskExecutionContext.getTaskInstanceId(), ackCommand);
 
         PowerMockito.mockStatic(SpringApplicationContext.class);
         PowerMockito.when(SpringApplicationContext.getBean(TaskCallbackService.class))
@@ -125,10 +125,10 @@ public class TaskExecuteProcessorTest {
 
         PowerMockito.mockStatic(FileUtils.class);
         PowerMockito.when(FileUtils.getProcessExecDir(taskExecutionContext.getProjectCode(),
-                taskExecutionContext.getProcessDefineCode(),
-                taskExecutionContext.getProcessDefineVersion(),
-                taskExecutionContext.getProcessInstanceId(),
-                taskExecutionContext.getTaskInstanceId()))
+                        taskExecutionContext.getProcessDefineCode(),
+                        taskExecutionContext.getProcessDefineVersion(),
+                        taskExecutionContext.getProcessInstanceId(),
+                        taskExecutionContext.getTaskInstanceId()))
                 .thenReturn(taskExecutionContext.getExecutePath());
         PowerMockito.doNothing().when(FileUtils.class, "createWorkDirIfAbsent", taskExecutionContext.getExecutePath());
 


### PR DESCRIPTION
## Purpose of the pull request
this pr close issue: #7697
![image](https://user-images.githubusercontent.com/11962619/158414198-a827feea-408a-4941-8c45-fb5d339efa61.png)


## Brief change log

- change the command type: 
    - remove `TASK_EXECUTE_ACK`
    - add `TASK_EXECUTE_RUNNING`
    - change `DB_TASK_ACK` to `TASK_EXECUTE_RUNNING_ACK`
    - change `DB_TASK_RESPONSE` to `TASK_EXECUTE_RESPONSE_ACK`

- remove the task execute ack and add the running callback before really `task.handle()`, which will make the running state more acurrate, see `TaskExecuteProcessor` , `TaskExecuteThread`

 
## Verify this pull request
test run task concurrently is ok

