### PR TITLE
[Fix-8746][UI] Rectify the issue with affecting the original node's data when editing the form of the copied node.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/contextMenu.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/canvas/contextMenu.vue
@@ -45,6 +45,7 @@
   import { mapState, mapActions, mapMutations } from 'vuex'
   import { findComponentDownward, uuid } from '@/module/util/'
   import MenuItem from './menuItem.vue'
+  import _ from 'lodash'
 
   export default {
     name: 'dag-context-menu',
@@ -131,6 +132,10 @@
               code,
               name: taskName
             }
+            if (targetTask.taskParams) {
+              task.taskParams = _.cloneDeep(targetTask.taskParams)
+            }
+
             this.dagCanvas.addNode(code, this.currentTask.type, {
               x: targetNode.position.x + 100,
               y: targetNode.position.y + 100


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This PR will close #8746 .
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
The test results are as follows:

After copying a node:
![image](https://user-images.githubusercontent.com/4928204/157578277-71ec140c-3e6e-4e05-940e-cedef8bde50b.png)

When editing the form of the new task node, it seems like:
![image](https://user-images.githubusercontent.com/4928204/157578174-e78d5ab8-9b51-411e-90fa-3a3c1bda6588.png)

Now the original node data won't be affected, it seems like:
![image](https://user-images.githubusercontent.com/4928204/157578179-446f5a6d-8d4a-4b74-ab16-087dee70d7f8.png)

