### PR TITLE
[python] Change name to_string to __str__ and add __repr__

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
+++ b/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
@@ -113,6 +113,11 @@ When you add a new package in pydolphinscheduler, you should also add the packag
 `dolphinscheduler-dist/release-docs/licenses/python-api-licenses`, and also add a short description to
 `dolphinscheduler-dist/release-docs/LICENSE`.
 
+## Update `UPDATING.md` when public class, method or interface is be changed
+
+When you change public class, method or interface, you should change the [UPDATING.md](./UPDATING.md) to notice
+users who may use it in other way.
+
 <!-- content -->
 [py4j]: https://www.py4j.org/index.html
 [pycharm]: https://www.jetbrains.com/pycharm

--- a/dolphinscheduler-python/pydolphinscheduler/UPDATING.md
+++ b/dolphinscheduler-python/pydolphinscheduler/UPDATING.md
@@ -24,4 +24,5 @@ It started after version 2.0.5 released
 
 ## dev
 
+* Change `yaml_parser.py` method `to_string` to magic method `__str__` make it more pythonic.
 * Use package ``ruamel.yaml`` replace ``pyyaml`` for write yaml file with comment.

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/configuration.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/configuration.py
@@ -53,7 +53,7 @@ def init_config_file() -> None:
             "in %s, if you wan to overwrite the exists configure please remove the exists file manually.",
             str(config_path()),
         )
-    file.write(content=get_configs().to_string(), to_path=str(config_path()))
+    file.write(content=str(get_configs()), to_path=str(config_path()))
 
 
 def get_single_config(key: str) -> Any:
@@ -115,7 +115,7 @@ def set_single_config(key: str, value: Any) -> None:
             "Configuration path %s do not exists. Can not set configuration.", key
         )
     config[key] = value
-    file.write(content=config.to_string(), to_path=str(config_path()), overwrite=True)
+    file.write(content=str(config), to_path=str(config_path()), overwrite=True)
 
 
 # Start Common Configuration Settings

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/utils/yaml_parser.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/utils/yaml_parser.py
@@ -59,6 +59,7 @@ class YamlParser:
     """
 
     def __init__(self, content: str, delimiter: Optional[str] = "."):
+        self._content = content
         self.src_parser = content
         self._delimiter = delimiter
 
@@ -159,7 +160,7 @@ class YamlParser:
         else:
             return val
 
-    def to_string(self) -> str:
+    def __str__(self) -> str:
         """Transfer :class:`YamlParser` to string object.
 
         It is useful when users want to output the :class:`YamlParser` object they change just now.
@@ -167,3 +168,6 @@ class YamlParser:
         buf = io.StringIO()
         self._yaml.dump(self.src_parser, buf)
         return buf.getvalue()
+
+    def __repr__(self) -> str:
+        return f"YamlParser({str(self)})"

--- a/dolphinscheduler-python/pydolphinscheduler/tests/utils/test_yaml_parser.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/utils/test_yaml_parser.py
@@ -73,7 +73,7 @@ name:
   mark:
     name_mark:
       key: value
-    """
+"""
 ]
 
 with open(path_default_config_yaml, "r") as f:
@@ -237,13 +237,20 @@ name:
         ),
     ],
 )
-def test_yaml_parser_to_string(src: str, setter: Dict, expect: str):
+def test_yaml_parser_str_repr(src: str, setter: Dict, expect: str):
     """Test function :func:`YamlParser.to_string`."""
     yaml_parser = YamlParser(src)
+
+    # Equal before change
+    assert f"YamlParser({src})" == repr(yaml_parser)
+    assert src == str(yaml_parser)
+
     for key, val in setter.items():
         yaml_parser[key] = val
 
-    assert expect == yaml_parser.to_string()
+    # Equal after changed
+    assert expect == str(yaml_parser)
+    assert f"YamlParser({expect})" == repr(yaml_parser)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Change `yaml_parser.py` method `to_string` to magic method
  `__str__` make it more pythonic.
* Add some tests to magic method `__str__` and `__repr__`
