### PR TITLE
[Feature-8591][Python] Add pre-commit to run basic test before commit

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/.flake8
+++ b/dolphinscheduler-python/pydolphinscheduler/.flake8
@@ -36,5 +36,5 @@ ignore =
     # Conflict to Black
     W503   # W503: Line breaks before binary operators
 per-file-ignores =
-    src/pydolphinscheduler/side/__init__.py:F401
-    src/pydolphinscheduler/tasks/__init__.py:F401
+    */pydolphinscheduler/side/__init__.py:F401
+    */pydolphinscheduler/tasks/__init__.py:F401

--- a/dolphinscheduler-python/pydolphinscheduler/.pre-commit-config.yaml
+++ b/dolphinscheduler-python/pydolphinscheduler/.pre-commit-config.yaml
@@ -17,6 +17,11 @@
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+default_stages: [commit, push]
+default_language_version:
+  # force all python hooks to run python3
+  python: python3
 repos:
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
@@ -27,8 +32,16 @@ repos:
     rev: 22.1.0
     hooks:
       - id: black
-        args: [ --line-length=79 ]
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
+        additional_dependencies: [
+            'flake8-docstrings>=1.6',
+            'flake8-black>=0.2',
+        ]
+        # pre-commit run in the root, so we have to point out the full path of configuration
+        args: [
+            --config, 
+            dolphinscheduler-python/pydolphinscheduler/.flake8
+        ]

--- a/dolphinscheduler-python/pydolphinscheduler/.pre-commit-config.yaml
+++ b/dolphinscheduler-python/pydolphinscheduler/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+      - id: black
+        args: [ --line-length=79 ]
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8

--- a/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
+++ b/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
@@ -69,6 +69,10 @@ maybe you could follow [Black-integration][black-editor] to configure them in yo
 Our Python API CI would automatically run code style checker and unittest when you submit pull request in
 GitHub, you could also run static check locally.
 
+We recommend [pre-commit](https://pre-commit.com/) to do the checker mentioned above before you develop locally. 
+You should install `pre-commit` in your development environment and then run `pre-commit install` to set up 
+the git hooks scripts.
+
 ```shell
 # We recommend you run isort and Black before Flake8, because Black could auto fix some code style issue
 # but Flake8 just hint when code style not match pep8

--- a/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
+++ b/dolphinscheduler-python/pydolphinscheduler/DEVELOP.md
@@ -116,8 +116,15 @@ Our Python API CI would automatically run code style checker and unittest when y
 GitHub, you could also run static check locally.
 
 We recommend [pre-commit](https://pre-commit.com/) to do the checker mentioned above before you develop locally. 
-You should install `pre-commit` in your development environment and then run `pre-commit install` to set up 
-the git hooks scripts.
+You should install `pre-commit` by running
+
+```shell
+python -m pip install pre-commit 
+```
+
+in your development environment and then run `pre-commit install` to set up the git hooks scripts. After finish
+above steps, each time you run `git commit` or `git push` would run pre-commit check to make basic check before
+you create pull requests in GitHub.
 
 ```shell
 # We recommend you run isort and Black before Flake8, because Black could auto fix some code style issue


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Add pre-commit to run basic test before commit

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log


  1. add `.pre-commit-config.yaml` in the pydolphinscheduler module and configured basic check rules like `isort`, `black`, `flake8`
  2. add some instructions in `DEVELOP.MD`

this close #8591


<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
