### PR TITLE
[BUG][UT] Fix DateUtilsTest failed due to timezone inconsistent

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
@@ -45,6 +45,7 @@ public final class DateUtils {
     static final long C6 = C5 * 24L;
 
     private static final Logger logger = LoggerFactory.getLogger(DateUtils.class);
+    private static final DateTimeFormatter YYYY_MM_DD_HH_MM_SS = DateTimeFormatter.ofPattern(Constants.YYYY_MM_DD_HH_MM_SS);
 
     private DateUtils() {
         throw new UnsupportedOperationException("Construct DateUtils");
@@ -58,10 +59,7 @@ public final class DateUtils {
      */
     private static LocalDateTime date2LocalDateTime(Date date) {
         String timezone = ThreadLocalContext.getTimezoneThreadLocal().get();
-        ZoneId zoneId = ZoneId.systemDefault();
-        if (StringUtils.isNotEmpty(timezone)) {
-            zoneId = ZoneId.of(timezone);
-        }
+        ZoneId zoneId = StringUtils.isNotEmpty(timezone) ? ZoneId.of(timezone) : ZoneId.systemDefault();
         return date2LocalDateTime(date, zoneId);
     }
 
@@ -84,10 +82,7 @@ public final class DateUtils {
      */
     private static Date localDateTime2Date(LocalDateTime localDateTime) {
         String timezone = ThreadLocalContext.getTimezoneThreadLocal().get();
-        ZoneId zoneId = ZoneId.systemDefault();
-        if (StringUtils.isNotEmpty(timezone)) {
-            zoneId = ZoneId.of(timezone);
-        }
+        ZoneId zoneId = StringUtils.isNotEmpty(timezone) ? ZoneId.of(timezone) : ZoneId.systemDefault();
         return localDateTime2Date(localDateTime, zoneId);
     }
 
@@ -100,15 +95,6 @@ public final class DateUtils {
     private static Date localDateTime2Date(LocalDateTime localDateTime, ZoneId zoneId) {
         Instant instant = localDateTime.atZone(zoneId).toInstant();
         return Date.from(instant);
-    }
-
-    /**
-     * get current date str
-     *
-     * @return date string
-     */
-    public static String getCurrentTime() {
-        return getCurrentTime(Constants.YYYY_MM_DD_HH_MM_SS);
     }
 
     /**
@@ -129,10 +115,12 @@ public final class DateUtils {
      * @return date string
      */
     public static String format(Date date, String format, String timezone) {
-        if (StringUtils.isEmpty(timezone)) {
-            return format(date2LocalDateTime(date), format);
-        }
-        return format(date2LocalDateTime(date, ZoneId.of(timezone)), format);
+        return format(date, DateTimeFormatter.ofPattern(format), timezone);
+    }
+
+    public static String format(Date date, DateTimeFormatter dateTimeFormatter, String timezone) {
+        LocalDateTime localDateTime = StringUtils.isEmpty(timezone) ? date2LocalDateTime(date) : date2LocalDateTime(date, ZoneId.of(timezone));
+        return format(localDateTime, dateTimeFormatter);
     }
 
     /**
@@ -143,7 +131,11 @@ public final class DateUtils {
      * @return date string
      */
     public static String format(LocalDateTime localDateTime, String format) {
-        return localDateTime.format(DateTimeFormatter.ofPattern(format));
+        return format(localDateTime, DateTimeFormatter.ofPattern(format));
+    }
+
+    public static String format(LocalDateTime localDateTime, DateTimeFormatter dateTimeFormatter) {
+        return localDateTime.format(dateTimeFormatter);
     }
 
     /**
@@ -153,7 +145,7 @@ public final class DateUtils {
      * @return date string
      */
     public static String dateToString(Date date) {
-        return format(date, Constants.YYYY_MM_DD_HH_MM_SS, null);
+        return format(date, YYYY_MM_DD_HH_MM_SS, null);
     }
 
     /**
@@ -164,7 +156,7 @@ public final class DateUtils {
      * @return date string
      */
     public static String dateToString(Date date, String timezone) {
-        return format(date, Constants.YYYY_MM_DD_HH_MM_SS, timezone);
+        return format(date, YYYY_MM_DD_HH_MM_SS, timezone);
     }
 
     /**
@@ -176,8 +168,12 @@ public final class DateUtils {
      * @return date
      */
     public static Date parse(String date, String format, String timezone) {
+        return parse(date, DateTimeFormatter.ofPattern(format), timezone);
+    }
+
+    public static Date parse(String date, DateTimeFormatter dateTimeFormatter, String timezone) {
         try {
-            LocalDateTime ldt = LocalDateTime.parse(date, DateTimeFormatter.ofPattern(format));
+            LocalDateTime ldt = LocalDateTime.parse(date, dateTimeFormatter);
             if (StringUtils.isEmpty(timezone)) {
                 return localDateTime2Date(ldt);
             }
@@ -195,7 +191,7 @@ public final class DateUtils {
      * @return yyyy-MM-dd HH:mm:ss format
      */
     public static Date stringToDate(String date) {
-        return parse(date, Constants.YYYY_MM_DD_HH_MM_SS, null);
+        return parse(date, YYYY_MM_DD_HH_MM_SS, null);
     }
 
     /**
@@ -206,7 +202,7 @@ public final class DateUtils {
      * @return yyyy-MM-dd HH:mm:ss format
      */
     public static Date stringToDate(String date, String timezone) {
-        return parse(date, Constants.YYYY_MM_DD_HH_MM_SS, timezone);
+        return parse(date, YYYY_MM_DD_HH_MM_SS, timezone);
     }
 
     /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
@@ -26,10 +26,23 @@ import java.util.TimeZone;
 
 import javax.management.timer.Timer;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class DateUtilsTest {
+
+    @Before
+    public void before() {
+        ThreadLocalContext.getTimezoneThreadLocal().remove();
+    }
+
+    @After
+    public void after() {
+        ThreadLocalContext.getTimezoneThreadLocal().remove();
+    }
+
     @Test
     public void format2Readable() throws ParseException {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -120,14 +133,16 @@ public class DateUtilsTest {
     public void getStartOfDay() {
         Date d1 = DateUtils.stringToDate("2019-01-31 11:59:59");
         Date curr = DateUtils.getStartOfDay(d1);
-        Assert.assertEquals(DateUtils.dateToString(curr), "2019-01-31 00:00:00");
+        String expected = new SimpleDateFormat("yyyy-MM-dd").format(d1) + " 00:00:00";
+        Assert.assertEquals(DateUtils.dateToString(curr), expected);
     }
 
     @Test
     public void getEndOfDay() {
         Date d1 = DateUtils.stringToDate("2019-01-31 11:00:59");
         Date curr = DateUtils.getEndOfDay(d1);
-        Assert.assertEquals(DateUtils.dateToString(curr), "2019-01-31 23:59:59");
+        String expected = new SimpleDateFormat("yyyy-MM-dd").format(d1) + " 23:59:59";
+        Assert.assertEquals(DateUtils.dateToString(curr), expected);
     }
 
     @Test
@@ -212,17 +227,17 @@ public class DateUtilsTest {
 
     @Test
     public void testTimezone() {
+
         String time = "2019-01-28 00:00:00";
         ThreadLocalContext.timezoneThreadLocal.set("UTC");
         Date utcDate = DateUtils.stringToDate(time);
-
         Assert.assertEquals(time, DateUtils.dateToString(utcDate));
 
         ThreadLocalContext.timezoneThreadLocal.set("Asia/Shanghai");
         Date shanghaiDate = DateUtils.stringToDate(time);
-
         Assert.assertEquals(time, DateUtils.dateToString(shanghaiDate));
 
         Assert.assertEquals(Timer.ONE_HOUR * 8, utcDate.getTime() - shanghaiDate.getTime());
+
     }
 }


### PR DESCRIPTION
## Purpose of the pull request
The UT in `DateUtilsTest` may fail in some case.
This is caused by the timezone cache in ThreadLocalContext

see https://github.com/apache/dolphinscheduler/runs/5500361419?check_suite_focus=true
```java
Error:  Failures: 
Error:    DateUtilsTest.getEndOfDay:130 expected:<2019-0[2-01 07]:59:59> but was:<2019-0[1-31 23]:59:59>
Error:    DateUtilsTest.testTransformToTimezone:204 expected:<2022-03-11 [02]:06:24> but was:<2022-03-11 [10]:06:24>
Error:    DateUtilsTest.testWeek:56 expected:<Mon Jan 28 16:00:00 UTC 2019> but was:<Sun Jan 27 16:00:00 UTC 2019>

```

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
