### PR TITLE
[Bug-8810] [master] add try catch to onSuccess method in the WorkflowExecuteThreadPool

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
@@ -121,11 +121,17 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
 
             @Override
             public void onSuccess(Object result) {
-                if (workflowExecuteThread.workFlowFinish()) {
-                    stateWheelExecuteThread.removeProcess4TimeoutCheck(workflowExecuteThread.getProcessInstance());
-                    processInstanceExecCacheManager.removeByProcessInstanceId(processInstanceId);
-                    notifyProcessChanged(workflowExecuteThread.getProcessInstance());
-                    logger.info("process instance {} finished.", processInstanceId);
+                // if an exception occurs, first, the error message cannot be printed in the log;
+                // secondly, the `multiThreadFilterMap` cannot be remove the `workflowExecuteThread`, resulting in the state of process instance cannot be changed and memory leak
+                try {
+                    if (workflowExecuteThread.workFlowFinish()) {
+                        stateWheelExecuteThread.removeProcess4TimeoutCheck(workflowExecuteThread.getProcessInstance());
+                        processInstanceExecCacheManager.removeByProcessInstanceId(processInstanceId);
+                        notifyProcessChanged(workflowExecuteThread.getProcessInstance());
+                        logger.info("process instance {} finished.", processInstanceId);
+                    }
+                } catch (Exception e) {
+                    logger.error("handle events {} success, but notify changed error", processInstanceId, e);
                 }
                 multiThreadFilterMap.remove(workflowExecuteThread.getKey());
             }


### PR DESCRIPTION
This closes #8810

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
