### PR TITLE
[Cherry-pick-2.0.6][Bug-8790][Api]fix Duplicate key TaskDefinition

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -2261,23 +2261,6 @@ public class ProcessService {
             taskDefinitionLog.setOperateTime(now);
             taskDefinitionLog.setOperator(operator.getId());
             taskDefinitionLog.setResourceIds(getResourceIds(taskDefinitionLog));
-            if (taskDefinitionLog.getCode() > 0 && taskDefinitionLog.getVersion() > 0) {
-                TaskDefinitionLog definitionCodeAndVersion = taskDefinitionLogMapper
-                        .queryByDefinitionCodeAndVersion(taskDefinitionLog.getCode(), taskDefinitionLog.getVersion());
-                if (definitionCodeAndVersion != null) {
-                    if (!taskDefinitionLog.equals(definitionCodeAndVersion)) {
-                        taskDefinitionLog.setUserId(definitionCodeAndVersion.getUserId());
-                        Integer version = taskDefinitionLogMapper.queryMaxVersionForDefinition(taskDefinitionLog.getCode());
-                        taskDefinitionLog.setVersion(version + 1);
-                        taskDefinitionLog.setCreateTime(definitionCodeAndVersion.getCreateTime());
-                        updateTaskDefinitionLogs.add(taskDefinitionLog);
-                    }
-                    continue;
-                }
-            }
-            taskDefinitionLog.setUserId(operator.getId());
-            taskDefinitionLog.setVersion(Constants.VERSION_FIRST);
-            taskDefinitionLog.setCreateTime(now);
             if (taskDefinitionLog.getCode() == 0) {
                 try {
                     taskDefinitionLog.setCode(CodeGenerateUtils.getInstance().genCode());
@@ -2286,7 +2269,27 @@ public class ProcessService {
                     return Constants.DEFINITION_FAILURE;
                 }
             }
-            newTaskDefinitionLogs.add(taskDefinitionLog);
+            if (taskDefinitionLog.getVersion() == 0) {
+                // init first version
+                taskDefinitionLog.setVersion(Constants.VERSION_FIRST);
+            }
+            TaskDefinitionLog definitionCodeAndVersion = taskDefinitionLogMapper
+                    .queryByDefinitionCodeAndVersion(taskDefinitionLog.getCode(), taskDefinitionLog.getVersion());
+            if (definitionCodeAndVersion == null) {
+                taskDefinitionLog.setUserId(operator.getId());
+                taskDefinitionLog.setCreateTime(now);
+                newTaskDefinitionLogs.add(taskDefinitionLog);
+                continue;
+            }
+            if (taskDefinitionLog.equals(definitionCodeAndVersion)) {
+                // do nothing if equals
+                continue;
+            }
+            taskDefinitionLog.setUserId(definitionCodeAndVersion.getUserId());
+            Integer version = taskDefinitionLogMapper.queryMaxVersionForDefinition(taskDefinitionLog.getCode());
+            taskDefinitionLog.setVersion(version + 1);
+            taskDefinitionLog.setCreateTime(definitionCodeAndVersion.getCreateTime());
+            updateTaskDefinitionLogs.add(taskDefinitionLog);
         }
         int insertResult = 0;
         int updateResult = 0;
@@ -2304,7 +2307,7 @@ public class ProcessService {
                 }
             }
         }
-        if (!newTaskDefinitionLogs.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(newTaskDefinitionLogs)) {
             insertResult += taskDefinitionLogMapper.batchInsert(newTaskDefinitionLogs);
             if (Boolean.TRUE.equals(syncDefine)) {
                 updateResult += taskDefinitionMapper.batchInsert(newTaskDefinitionLogs);


### PR DESCRIPTION
## Purpose of the pull request
this pr close #8790
associate pr: #8986

## Brief change log
the logic of `saveTaskDefine`

## Verify this pull request
  - Manually verified the change by testing locally.
