### PR TITLE
[python] Separate py from main dist and auto add gpg sign

### DIFF
--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -28,6 +28,7 @@
     <name>${project.artifactId}</name>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <python.sign.skip>false</python.sign.skip>
     </properties>
 
     <dependencies>

--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -70,9 +70,9 @@
     <profiles>
         <profile>
             <id>release</id>
-              <properties>
+            <properties>
                 <python.sign.skip>false</python.sign.skip>
-              </properties>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -28,7 +28,6 @@
     <name>${project.artifactId}</name>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <python.sign.skip>false</python.sign.skip>
     </properties>
 
     <dependencies>
@@ -71,6 +70,9 @@
     <profiles>
         <profile>
             <id>release</id>
+              <properties>
+                <python.sign.skip>false</python.sign.skip>
+              </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -104,6 +104,20 @@
                                 </configuration>
                             </execution>
 
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>python</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+
                             <execution>
                                 <id>python</id>
                                 <phase>package</phase>

--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -105,7 +105,7 @@
             </build>
         </profile>
         <profile>
-            <id>release</id>
+            <id>python</id>
             <build>
                 <plugins>
                     <plugin>
@@ -119,7 +119,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>python3</executable>
+                                    <executable>python</executable>
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>
                                         <argument>-m</argument>
@@ -138,7 +138,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>python3</executable>
+                                    <executable>python</executable>
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>
                                         <argument>setup.py</argument>
@@ -153,11 +153,43 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>python3</executable>
+                                    <executable>python</executable>
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>
                                         <argument>-m</argument>
                                         <argument>build</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>sign-source</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <!-- We use `bash -c` here cause plugin exec-maven-plugin do not support wildcard-->
+                                        <argument>gpg --armor --sign dist/*.tar.gz</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>sign-wheel</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <!-- We use `bash -c` here cause plugin exec-maven-plugin do not support wildcard-->
+                                        <argument>gpg --armor --sign dist/*.whl</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -168,6 +168,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>${python.sign.skip}</skip>
                                     <executable>bash</executable>
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>
@@ -184,6 +185,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>${python.sign.skip}</skip>
                                     <executable>bash</executable>
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,8 @@
         <docker.tag>${project.version}</docker.tag>
         <docker.build.skip>true</docker.build.skip>
         <docker.push.skip>true</docker.push.skip>
+
+        <python.sign.skip>true</python.sign.skip>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
* Add new profile `python` to separate build python
  package from `release`. Now someone who does not interested
  in python api could build package without python environment
* Add auto gpg asc sign when run `mvn instal -Ppython`

close: #8671