### PR TITLE
[Feature-8985][UI-Next] Add a new option of 'thisMonthBegin into the options of the month select for the dependent task.

### DIFF
--- a/dolphinscheduler-ui-next/src/locales/modules/en_US.ts
+++ b/dolphinscheduler-ui-next/src/locales/modules/en_US.ts
@@ -847,6 +847,7 @@ const project = {
     last_saturday: 'LastSaturday',
     last_sunday: 'LastSunday',
     this_month: 'ThisMonth',
+    this_month_begin: 'ThisMonthBegin',
     last_month: 'LastMonth',
     last_month_begin: 'LastMonthBegin',
     last_month_end: 'LastMonthEnd',

--- a/dolphinscheduler-ui-next/src/locales/modules/zh_CN.ts
+++ b/dolphinscheduler-ui-next/src/locales/modules/zh_CN.ts
@@ -837,6 +837,7 @@ const project = {
     last_saturday: '上周六',
     last_sunday: '上周日',
     this_month: '本月',
+    this_month_begin: '本月初',
     last_month: '上月',
     last_month_begin: '上月初',
     last_month_end: '上月末',

--- a/dolphinscheduler-ui-next/src/views/projects/task/components/node/fields/use-dependent.ts
+++ b/dolphinscheduler-ui-next/src/views/projects/task/components/node/fields/use-dependent.ts
@@ -142,6 +142,10 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
         label: t('project.node.this_month')
       },
       {
+        value: 'thisMonthBegin',
+        label: t('project.node.this_month_begin')
+      },
+      {
         value: 'lastMonth',
         label: t('project.node.last_month')
       },


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This PR will close #8985 .
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
The test results are illustrated below:

<img width="580" alt="image" src="https://user-images.githubusercontent.com/4928204/159101093-609bb748-1e84-4ab3-b190-0de3380592e4.png">

<img width="571" alt="image" src="https://user-images.githubusercontent.com/4928204/159101094-aa09b9cf-964a-4f0a-abaa-264497ef7c7b.png">



