### PR TITLE
[Fix-9015][UI Next][V1.0.0-Alpha] Worked out this issue about failing to assign another project to an existing task group.

### DIFF
--- a/dolphinscheduler-ui-next/src/views/resource/task-group/option/components/form-modal.tsx
+++ b/dolphinscheduler-ui-next/src/views/resource/task-group/option/components/form-modal.tsx
@@ -115,18 +115,21 @@ const FormModal = defineComponent({
               placeholder={t('resource.task_group_option.please_enter_name')}
             />
           </NFormItem>
-          <NFormItem
-            label={t('resource.task_group_option.project_name')}
-            path='projectCode'
-          >
-            <NSelect
+          { this.status === 0 && (
+              <NFormItem
+              label={t('resource.task_group_option.project_name')}
+              path='projectCode'
+              >
+              <NSelect
               options={projectOptions}
               v-model:value={this.formData.projectCode}
               placeholder={t(
-                'resource.task_group_option.please_select_project'
+              'resource.task_group_option.please_select_project'
               )}
-            />
-          </NFormItem>
+              />
+              </NFormItem>
+            )
+          }
           <NFormItem
             label={t('resource.task_group_option.resource_pool_size')}
             path='groupSize'


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This PR will close #9015 .

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
I found that the back-end api couldn't support to modify the project name of an existing task group. So I decide to take it out from the editing form of the task group.

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 
The test result are as follows:
When editing an existing task group, the form won't support to modify the project of the task group.
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/4928204/159117948-dc3676ee-91be-4d46-8ed5-c62d35e9b26d.png">
But if you want to create a new task group, the form still supports to pick a project for the task group.
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/4928204/159117952-4afb3672-66b6-4c60-bf27-c0c6fc35f0b3.png">
