### PR TITLE
[Fix-8544][API] The folder's size can't be updated when creating, updating or deleting a resource file int the folder.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -21,9 +21,6 @@ import static org.apache.dolphinscheduler.common.Constants.ALIAS;
 import static org.apache.dolphinscheduler.common.Constants.CONTENT;
 import static org.apache.dolphinscheduler.common.Constants.JAR;
 
-import com.baomidou.mybatisplus.extension.api.R;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import org.apache.dolphinscheduler.api.dto.resources.ResourceComponent;
 import org.apache.dolphinscheduler.api.dto.resources.filter.ResourceFilter;
 import org.apache.dolphinscheduler.api.dto.resources.visitor.ResourceTreeVisitor;
@@ -36,7 +33,6 @@ import org.apache.dolphinscheduler.api.utils.RegexUtils;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ProgramType;
-import org.apache.dolphinscheduler.spi.enums.ResourceType;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.common.utils.HadoopUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
@@ -53,6 +49,7 @@ import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UdfFuncMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.utils.ResourceProcessDefinitionUtils;
+import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
 import org.apache.commons.beanutils.BeanMap;
 import org.apache.commons.collections.CollectionUtils;
@@ -84,6 +81,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 
 /**
@@ -259,7 +257,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             String[] splits = resource.getFullName().split("/");
             for (int i = 1; i < splits.length; i++) {
                 String parentFullName = Joiner.on("/").join(Arrays.copyOfRange(splits, 0, i));
-                if(StringUtils.isNotBlank(parentFullName)) {
+                if (StringUtils.isNotBlank(parentFullName)) {
                     List<Resource> resources = resourcesMapper.queryResource(parentFullName, resource.getType().ordinal());
                     if (CollectionUtils.isNotEmpty(resources)) {
                         Resource parentResource = resources.get(0);
@@ -268,7 +266,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                         } else {
                             parentResource.setSize(0L);
                         }
-                        resourcesMapper.updateById(parentResource);
+//                        resourcesMapper.updateById(parentResource);
                     }
                 }
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -266,7 +266,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                         } else {
                             parentResource.setSize(0L);
                         }
-//                        resourcesMapper.updateById(parentResource);
+                        resourcesMapper.updateById(parentResource);
                     }
                 }
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -21,6 +21,9 @@ import static org.apache.dolphinscheduler.common.Constants.ALIAS;
 import static org.apache.dolphinscheduler.common.Constants.CONTENT;
 import static org.apache.dolphinscheduler.common.Constants.JAR;
 
+import com.baomidou.mybatisplus.extension.api.R;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import org.apache.dolphinscheduler.api.dto.resources.ResourceComponent;
 import org.apache.dolphinscheduler.api.dto.resources.filter.ResourceFilter;
 import org.apache.dolphinscheduler.api.dto.resources.visitor.ResourceTreeVisitor;
@@ -221,6 +224,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
 
         try {
             resourcesMapper.insert(resource);
+            updateParentResourceSize(resource, resource.getSize());
             putMsg(result, Status.SUCCESS);
             Map<Object, Object> dataMap = new BeanMap(resource);
             Map<String, Object> resultMap = new HashMap<>();
@@ -242,6 +246,33 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             throw new ServiceException(String.format("upload resource: %s file: %s failed.", name, file.getOriginalFilename()));
         }
         return result;
+    }
+
+    /**
+     * update the folder's size of the resource
+     *
+     * @param resource the current resource
+     * @param size size
+     */
+    private void updateParentResourceSize(Resource resource, long size) {
+        if (resource.getSize() > 0) {
+            String[] splits = resource.getFullName().split("/");
+            for (int i = 1; i < splits.length; i++) {
+                String parentFullName = Joiner.on("/").join(Arrays.copyOfRange(splits, 0, i));
+                if(StringUtils.isNotBlank(parentFullName)) {
+                    List<Resource> resources = resourcesMapper.queryResource(parentFullName, resource.getType().ordinal());
+                    if (CollectionUtils.isNotEmpty(resources)) {
+                        Resource parentResource = resources.get(0);
+                        if (parentResource.getSize() + size >= 0) {
+                            parentResource.setSize(parentResource.getSize() + size);
+                        } else {
+                            parentResource.setSize(0L);
+                        }
+                        resourcesMapper.updateById(parentResource);
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -360,6 +391,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
 
         // updateResource data
         Date now = new Date();
+        long originFileSize = resource.getSize();
 
         resource.setAlias(name);
         resource.setFileName(name);
@@ -445,6 +477,8 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                     throw new ServiceException(String.format("delete resource: %s failed.", originFullName));
                 }
             }
+
+            updateParentResourceSize(resource, resource.getSize() - originFileSize);
             return result;
         }
 
@@ -727,11 +761,15 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         String hdfsFilename = HadoopUtils.getHdfsFileName(resource.getType(), tenantCode, resource.getFullName());
 
         //delete data in database
+        resourcesMapper.selectBatchIds(Arrays.asList(needDeleteResourceIdArray)).forEach(item -> {
+            updateParentResourceSize(item, item.getSize() * -1);
+        });
         resourcesMapper.deleteIds(needDeleteResourceIdArray);
         resourceUserMapper.deleteResourceUserArray(0, needDeleteResourceIdArray);
 
         //delete file on hdfs
         HadoopUtils.getInstance().delete(hdfsFilename, true);
+
         putMsg(result, Status.SUCCESS);
 
         return result;
@@ -941,6 +979,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         Resource resource = new Resource(pid,name,fullName,false,desc,name,loginUser.getId(),type,content.getBytes().length,now,now);
 
         resourcesMapper.insert(resource);
+        updateParentResourceSize(resource, resource.getSize());
 
         putMsg(result, Status.SUCCESS);
         Map<Object, Object> dataMap = new BeanMap(resource);
@@ -1035,9 +1074,12 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         if (StringUtils.isEmpty(tenantCode)) {
             return  result;
         }
+        long originFileSize = resource.getSize();
         resource.setSize(content.getBytes().length);
         resource.setUpdateTime(new Date());
         resourcesMapper.updateById(resource);
+
+        updateParentResourceSize(resource, resource.getSize() - originFileSize);
 
         result = uploadContentToHdfs(resource.getFullName(), tenantCode, content);
         if (!result.getCode().equals(Status.SUCCESS.getCode())) {

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -19,10 +19,10 @@
 data.basedir.path=/tmp/dolphinscheduler
 
 # resource storage type: HDFS, S3, NONE
-resource.storage.type=hdfs
+resource.storage.type=NONE
 
 # resource store on HDFS/S3 path, resource file will store to this hadoop hdfs path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
-resource.upload.path=/user/calvin/dolphinscheduler
+resource.upload.path=/dolphinscheduler
 
 # whether to startup kerberos
 hadoop.security.authentication.startup.state=false
@@ -43,10 +43,10 @@ kerberos.expire.time=2
 #resource.view.suffixs=txt,log,sh,bat,conf,cfg,py,java,sql,xml,hql,properties,json,yml,yaml,ini,js
 
 # if resource.storage.type=HDFS, the user must have the permission to create directories under the HDFS root path
-hdfs.root.user=calvin
+hdfs.root.user=hdfs
 
 # if resource.storage.type=S3, the value like: s3a://dolphinscheduler; if resource.storage.type=HDFS and namenode HA is enabled, you need to copy core-site.xml and hdfs-site.xml to conf dir
-fs.defaultFS=hdfs://zp-data-hadoop-qa-001:8020
+fs.defaultFS=hdfs://mycluster:8020
 
 # if resource.storage.type=S3, s3 endpoint
 fs.s3a.endpoint=http://192.168.xx.xx:9010

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -19,10 +19,10 @@
 data.basedir.path=/tmp/dolphinscheduler
 
 # resource storage type: HDFS, S3, NONE
-resource.storage.type=NONE
+resource.storage.type=hdfs
 
 # resource store on HDFS/S3 path, resource file will store to this hadoop hdfs path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
-resource.upload.path=/dolphinscheduler
+resource.upload.path=/user/calvin/dolphinscheduler
 
 # whether to startup kerberos
 hadoop.security.authentication.startup.state=false
@@ -43,10 +43,10 @@ kerberos.expire.time=2
 #resource.view.suffixs=txt,log,sh,bat,conf,cfg,py,java,sql,xml,hql,properties,json,yml,yaml,ini,js
 
 # if resource.storage.type=HDFS, the user must have the permission to create directories under the HDFS root path
-hdfs.root.user=hdfs
+hdfs.root.user=calvin
 
 # if resource.storage.type=S3, the value like: s3a://dolphinscheduler; if resource.storage.type=HDFS and namenode HA is enabled, you need to copy core-site.xml and hdfs-site.xml to conf dir
-fs.defaultFS=hdfs://mycluster:8020
+fs.defaultFS=hdfs://zp-data-hadoop-qa-001:8020
 
 # if resource.storage.type=S3, s3 endpoint
 fs.s3a.endpoint=http://192.168.xx.xx:9010

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/DolphinSchedulerManager.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/DolphinSchedulerManager.java
@@ -99,12 +99,13 @@ public class DolphinSchedulerManager {
             }
             // The target version of the upgrade
             String schemaVersion = "";
+            String currentVersion = version;
             for (String schemaDir : schemaList) {
                 schemaVersion = schemaDir.split("_")[0];
                 if (SchemaUtils.isAGreatVersion(schemaVersion, version)) {
                     logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
                     logger.info("Begin upgrading DolphinScheduler's table structure");
-                    upgradeDao.upgradeDolphinScheduler(schemaDir);
+//                    upgradeDao.upgradeDolphinScheduler(schemaDir);
                     if ("1.3.0".equals(schemaVersion)) {
                         upgradeDao.upgradeDolphinSchedulerWorkerGroup();
                     } else if ("1.3.2".equals(schemaVersion)) {
@@ -114,6 +115,10 @@ public class DolphinSchedulerManager {
                     }
                     version = schemaVersion;
                 }
+            }
+
+            if (SchemaUtils.isAGreatVersion("2.0.6", currentVersion) && SchemaUtils.isAGreatVersion(SchemaUtils.getSoftVersion(), currentVersion)) {
+                upgradeDao.upgradeDolphinSchedulerResourceFileSize();
             }
         }
 

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/DolphinSchedulerManager.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/DolphinSchedulerManager.java
@@ -77,6 +77,7 @@ public class DolphinSchedulerManager {
         logger.info("Start initializing the DolphinScheduler manager table structure");
         upgradeDao.initSchema();
     }
+
     public void upgradeDolphinScheduler() throws IOException {
         // Gets a list of all upgrades
         List<String> schemaList = SchemaUtils.getAllSchemaList();
@@ -105,7 +106,7 @@ public class DolphinSchedulerManager {
                 if (SchemaUtils.isAGreatVersion(schemaVersion, version)) {
                     logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
                     logger.info("Begin upgrading DolphinScheduler's table structure");
-//                    upgradeDao.upgradeDolphinScheduler(schemaDir);
+                    // upgradeDao.upgradeDolphinScheduler(schemaDir);
                     if ("1.3.0".equals(schemaVersion)) {
                         upgradeDao.upgradeDolphinSchedulerWorkerGroup();
                     } else if ("1.3.2".equals(schemaVersion)) {

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/DolphinSchedulerManager.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/DolphinSchedulerManager.java
@@ -106,7 +106,7 @@ public class DolphinSchedulerManager {
                 if (SchemaUtils.isAGreatVersion(schemaVersion, version)) {
                     logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
                     logger.info("Begin upgrading DolphinScheduler's table structure");
-                    // upgradeDao.upgradeDolphinScheduler(schemaDir);
+                     upgradeDao.upgradeDolphinScheduler(schemaDir);
                     if ("1.3.0".equals(schemaVersion)) {
                         upgradeDao.upgradeDolphinSchedulerWorkerGroup();
                     } else if ("1.3.2".equals(schemaVersion)) {

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ResourceDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ResourceDao.java
@@ -96,7 +96,7 @@ public class ResourceDao {
                 if (StringUtils.isNotBlank(fullName) && !isDirectory) {
                     String[] splits = fullName.split("/");
                     for (int i = 1; i < splits.length; i++) {
-                        String parentFullName = Joiner.on("/").join(Arrays.copyOfRange(splits,0, splits.length - 1));
+                        String parentFullName = Joiner.on("/").join(Arrays.copyOfRange(splits,0, splits.length - i));
                         if (Strings.isNotEmpty(parentFullName)) {
                             long size = resourceSizeMap.getOrDefault(parentFullName, 0L);
                             resourceSizeMap.put(parentFullName, size + fileSize);
@@ -121,7 +121,7 @@ public class ResourceDao {
 
         String sql = "UPDATE t_ds_resources SET size=? where type=? and full_name=? and is_directory = true";
         try {
-            for(Map.Entry<String, Long> entry : resourceSizeMap.entrySet()) {
+            for (Map.Entry<String, Long> entry : resourceSizeMap.entrySet()) {
                 PreparedStatement pstmt = conn.prepareStatement(sql);
                 pstmt.setLong(1, entry.getValue());
                 pstmt.setInt(2, type);

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ResourceDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ResourceDao.java
@@ -18,15 +18,21 @@
 package org.apache.dolphinscheduler.tools.datasource.dao;
 
 import org.apache.dolphinscheduler.common.utils.ConnectionUtils;
+import org.apache.dolphinscheduler.spi.utils.StringUtils;
+
+import org.apache.directory.api.util.Strings;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
 
 /**
  * resource dao
@@ -64,6 +70,70 @@ public class ResourceDao {
         }
 
         return resourceMap;
+    }
+
+    /**
+     * list all resources by the type
+     *
+     * @param conn connection
+     * @return map that key is full_name and value is the folder's size
+     */
+    private Map<String, Long> listAllResourcesByFileType(Connection conn, int type) {
+        Map<String, Long> resourceSizeMap = new HashMap<>();
+
+        String sql = String.format("SELECT full_name, type, size, is_directory FROM t_ds_resources where type = %d", type);
+        ResultSet rs = null;
+        PreparedStatement pstmt = null;
+        try {
+            pstmt = conn.prepareStatement(sql);
+            rs = pstmt.executeQuery();
+
+            while (rs.next()) {
+                String fullName = rs.getString("full_name");
+                Boolean isDirectory = rs.getBoolean("is_directory");
+                long fileSize = rs.getLong("size");
+
+                if (StringUtils.isNotBlank(fullName) && !isDirectory) {
+                    String[] splits = fullName.split("/");
+                    for (int i = 1; i < splits.length; i++) {
+                        String parentFullName = Joiner.on("/").join(Arrays.copyOfRange(splits,0, splits.length - 1));
+                        if (Strings.isNotEmpty(parentFullName)) {
+                            long size = resourceSizeMap.getOrDefault(parentFullName, 0L);
+                            resourceSizeMap.put(parentFullName, size + fileSize);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            throw new RuntimeException("sql: " + sql, e);
+        }
+        return resourceSizeMap;
+    }
+
+    /**
+     * update the folder's size
+     *
+     * @param conn connection
+     */
+    public void updateResourceFolderSizeByFileType(Connection conn, int type) {
+        Map<String, Long> resourceSizeMap = listAllResourcesByFileType(conn, type);
+
+        String sql = "UPDATE t_ds_resources SET size=? where type=? and full_name=? and is_directory = true";
+        try {
+            for(Map.Entry<String, Long> entry : resourceSizeMap.entrySet()) {
+                PreparedStatement pstmt = conn.prepareStatement(sql);
+                pstmt.setLong(1, entry.getValue());
+                pstmt.setInt(2, type);
+                pstmt.setString(3, entry.getKey());
+                pstmt.executeUpdate();
+            }
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            throw new RuntimeException("sql: " + sql, e);
+        } finally {
+            ConnectionUtils.releaseResource(conn);
+        }
     }
 
 }

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/UpgradeDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/UpgradeDao.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.tools.datasource.dao;
 
+import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.P;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_CONDITIONS;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_DEPENDENT;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SUB_PROCESS;
@@ -170,6 +171,21 @@ public abstract class UpgradeDao {
     public void upgradeDolphinSchedulerTo200(String schemaDir) {
         processDefinitionJsonSplit();
         upgradeDolphinSchedulerDDL(schemaDir, "dolphinscheduler_ddl_post.sql");
+    }
+
+    /**
+     * upgrade DolphinScheduler to 2.0.6
+     */
+    public void upgradeDolphinSchedulerResourceFileSize() {
+        ResourceDao resourceDao = new ResourceDao();
+        try {
+            // update the size of the folder that is the type of file.
+            resourceDao.updateResourceFolderSizeByFileType(dataSource.getConnection(), 0);
+            // update the size of the folder that is the type of udf.
+            resourceDao.updateResourceFolderSizeByFileType(dataSource.getConnection(), 1);
+        } catch (Exception ex) {
+            logger.error("Failed to upgrade because of failing to update the folder's size of resource files.");
+        }
     }
 
     /**

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/UpgradeDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/UpgradeDao.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.tools.datasource.dao;
 
-import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.P;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_CONDITIONS;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_DEPENDENT;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SUB_PROCESS;
@@ -27,7 +26,6 @@ import org.apache.dolphinscheduler.common.enums.ConditionType;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.enums.Priority;
 import org.apache.dolphinscheduler.common.enums.TimeoutFlag;
-import org.apache.dolphinscheduler.plugin.task.api.parameters.TaskTimeoutParameter;
 import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.common.utils.ConnectionUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
@@ -43,6 +41,7 @@ import org.apache.dolphinscheduler.dao.upgrade.ScheduleDao;
 import org.apache.dolphinscheduler.dao.upgrade.SchemaUtils;
 import org.apache.dolphinscheduler.dao.upgrade.WorkerGroupDao;
 import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.TaskTimeoutParameter;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 
 import org.apache.commons.collections.CollectionUtils;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This PR will close #8544 .
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

When creating, updating or deleting a resource file in a folder, the folder's size wouldn't be updated. Because the back-end service didn't handle that.
First of all I add the function to update the folder's size when creating, updating or deleting a resource file in a folder.
Second I add  the repairing mechanisms to repair that issue of the previous version when users choose to upgrade the system from the version below '2.0.6'.

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.* 

The test results are as follows:
![image](https://user-images.githubusercontent.com/4928204/159611140-21cb8925-7e4f-40e6-9411-cb073ded93da.png)

![image](https://user-images.githubusercontent.com/4928204/159611152-87305ad1-eda6-42a5-8a34-45a5f47e5124.png)

