### PR TITLE
[Fix-9124,9127][Task]Fix the exception of task getting external resource data during execu…

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTaskChannel.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTaskChannel.java
@@ -44,6 +44,6 @@ public class DataxTaskChannel implements TaskChannel {
 
     @Override
     public ResourceParametersHelper getResources(String parameters) {
-        return null;
+        return JSONUtils.parseObject(parameters, DataxParameters.class).getResources();
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-procedure/src/main/java/org/apache/dolphinscheduler/plugin/task/procedure/ProcedureTaskChannel.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-procedure/src/main/java/org/apache/dolphinscheduler/plugin/task/procedure/ProcedureTaskChannel.java
@@ -44,6 +44,6 @@ public class ProcedureTaskChannel implements TaskChannel {
 
     @Override
     public ResourceParametersHelper getResources(String parameters) {
-        return null;
+        return JSONUtils.parseObject(parameters, ProcedureParameters.class).getResources();
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTaskChannel.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTaskChannel.java
@@ -45,6 +45,6 @@ public class SqoopTaskChannel implements TaskChannel {
 
     @Override
     public ResourceParametersHelper getResources(String parameters) {
-        return null;
+        return JSONUtils.parseObject(parameters, SqoopParameters.class).getResources();
     }
 }


### PR DESCRIPTION
…tion

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

this pr closes: #9124 #9127 

When the task is executed (such as sql task), the data source or UDF information needs to be used, but the data source ID is stored in the task parameter. At this time, the data source link data needs to be completed according to the ID.

As we all know, the worker node is not connected to the database and cannot obtain other information of the data source based on the data source ID. This part of the operation can only be handled by the master.

Current processing flow:

1.The master calls getResources, and obtains the type and ID of the external resource that needs to be filled according to the task parameters

2.master BaseTaskProcessor.setTaskResourceInfo queries the system library according to the results returned in the previous part, fills in the external resource link data, and stores it in the TaskExecutionContext.resourceParametersHelper property

3.When the task is executed, get the external resource link data from taskExecutionContext.getResourceParametersHelper()

---

在task执行时候（例如sql任务），需要使用数据源或UDF信息，但是task 参数里面存储的是数据源ID, 这个时候就需要根据ID补齐数据源链接数据。

众所周知，worker 节点是没有连接数据库，不能根据数据源ID去获取数据源其他信息，这部分操作只能由master来负责。

当前的处理流程： 

1.master  调用getResources, 根据任务参数获取需要填充外部资源的类型和ID
2.master BaseTaskProcessor.setTaskResourceInfo根据上部分返回的结果查询系统库，填充外部资源链接数据，存放到TaskExecutionContext.resourceParametersHelper属性
3.task 执行时，从taskExecutionContext.getResourceParametersHelper()中获取外部资源链接数据


## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
