### PR TITLE
[Improve] no need to subscribe the dev mailing list when asking questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -25,7 +25,7 @@ body:
       value: |
         Please make sure what you are reporting is indeed a bug with reproducible steps, if you want to ask questions
         or share ideas, you can head to our
-        [Discussions](https://github.com/apache/dolphinscheduler/discussions) tab, you also can [subscribe to our mailing list](mailto:dev-subscribe@dolphinscheduler.apache.org) and send 
+        [Discussions](https://github.com/apache/dolphinscheduler/discussions) tab, you can also [subscribe to our mailing list](mailto:dev-subscribe@dolphinscheduler.apache.org) and send 
         emails to [our mailing list](mailto:dev@dolphinscheduler.apache.org)
 
         For better global communication, Please write in English.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,9 +24,9 @@ body:
     attributes:
       value: |
         Please make sure what you are reporting is indeed a bug with reproducible steps, if you want to ask questions
-        or share ideas, please [subscribe to our mailing list](mailto:dev-subscribe@dolphinscheduler.apache.org) and sent
-        emails to [our mailing list](mailto:dev@dolphinscheduler.apache.org), you can also head to our
-        [Discussion](https://github.com/apache/dolphinscheduler/discussions) tab.
+        or share ideas, you can head to our
+        [Discussions](https://github.com/apache/dolphinscheduler/discussions) tab, you also can [subscribe to our mailing list](mailto:dev-subscribe@dolphinscheduler.apache.org) and send 
+        emails to [our mailing list](mailto:dev@dolphinscheduler.apache.org)
 
         For better global communication, Please write in English.
 
@@ -98,7 +98,7 @@ body:
         Which version of Apache DolphinScheduler are you running? We only accept bugs report from the LTS projects.
       options:
         - dev
-        - 3.0.0-prepare
+        - 3.0.0-alpha
         - 2.0.5
         - 2.0.3
         - 2.0.2


### PR DESCRIPTION
there is no need to subscribe the dev mailing list when users only ask usage questions

