### PR TITLE
[dolphinscheduler-api][task-group-controller] Corrected notes for create, update and queryTaskGroupByStatus

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskGroupController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskGroupController.java
@@ -71,7 +71,7 @@ public class TaskGroupController extends BaseController {
      * @param name        project id
      * @return result and msg code
      */
-    @ApiOperation(value = "create", notes = "CREATE_TAKS_GROUP_NOTE")
+    @ApiOperation(value = "create", notes = "CREATE_TASK_GROUP_NOTE")
     @ApiImplicitParams({
         @ApiImplicitParam(name = "name", value = "NAME", dataType = "String"),
         @ApiImplicitParam(name = "projectCode", value = "PROJECT_CODE", type = "Long"),
@@ -102,7 +102,7 @@ public class TaskGroupController extends BaseController {
      * @param name        project id
      * @return result and msg code
      */
-    @ApiOperation(value = "update", notes = "UPDATE_TAKS_GROUP_NOTE")
+    @ApiOperation(value = "update", notes = "UPDATE_TASK_GROUP_NOTE")
     @ApiImplicitParams({
         @ApiImplicitParam(name = "id", value = "id", dataType = "Int"),
         @ApiImplicitParam(name = "name", value = "NAME", dataType = "String"),
@@ -159,7 +159,7 @@ public class TaskGroupController extends BaseController {
      * @param pageSize  page size
      * @return queue list
      */
-    @ApiOperation(value = "queryTaskGroupByStatus", notes = "QUERY_TASK_GROUP_LIST_BY_STSATUS_NOTES")
+    @ApiOperation(value = "queryTaskGroupByStatus", notes = "QUERY_TASK_GROUP_LIST_BY_STATUS_NOTES")
     @ApiImplicitParams({
         @ApiImplicitParam(name = "pageNo", value = "PAGE_NO", required = true, dataType = "Int", example = "1"),
         @ApiImplicitParam(name = "pageSize", value = "PAGE_SIZE", required = true, dataType = "Int", example = "20"),


### PR DESCRIPTION

## Purpose of the pull request

- The notes in create, update and queryTaskGroupByStatus has spelling mistakes (TAKS, and STSATUS) (`CREATE_TAKS_GROUP_NOTE`, `UPDATE_TAKS_GROUP_NOTE`, `QUERY_TASK_GROUP_LIST_BY_STSATUS_NOTES`).

## Brief change log

- Update the corresponding notes.

## Verify this pull request

This pull request is already covered by existing test in the module.  
