### PR TITLE
[Fix-8281][DataSource]Mysql jdbc connect failed.

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/client/CommonDataSourceClient.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/client/CommonDataSourceClient.java
@@ -40,7 +40,6 @@ public class CommonDataSourceClient implements DataSourceClient {
     private static final Logger logger = LoggerFactory.getLogger(CommonDataSourceClient.class);
 
     public static final String COMMON_USER = "root";
-    public static final String COMMON_PASSWORD = "123456";
     public static final String COMMON_VALIDATION_QUERY = "select 1";
 
     protected final BaseConnectionParam baseConnectionParam;
@@ -73,17 +72,10 @@ public class CommonDataSourceClient implements DataSourceClient {
         if (StringUtils.isBlank(baseConnectionParam.getUser())) {
             setDefaultUsername(baseConnectionParam);
         }
-        if (StringUtils.isBlank(baseConnectionParam.getPassword())) {
-            setDefaultPassword(baseConnectionParam);
-        }
     }
 
     protected void setDefaultUsername(BaseConnectionParam baseConnectionParam) {
         baseConnectionParam.setUser(COMMON_USER);
-    }
-
-    protected void setDefaultPassword(BaseConnectionParam baseConnectionParam) {
-        baseConnectionParam.setPassword(COMMON_PASSWORD);
     }
 
     protected void checkValidationQuery(BaseConnectionParam baseConnectionParam) {

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/client/CommonDataSourceClientTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/client/CommonDataSourceClientTest.java
@@ -70,11 +70,6 @@ public class CommonDataSourceClientTest {
         PowerMockito.doNothing().when(commonDataSourceClient).setDefaultUsername(Mockito.any(BaseConnectionParam.class));
         commonDataSourceClient.setDefaultUsername(baseConnectionParam);
         Mockito.verify(commonDataSourceClient).setDefaultUsername(Mockito.any(BaseConnectionParam.class));
-
-        PowerMockito.doNothing().when(commonDataSourceClient).setDefaultPassword(Mockito.any(BaseConnectionParam.class));
-        commonDataSourceClient.setDefaultPassword(baseConnectionParam);
-        Mockito.verify(commonDataSourceClient).setDefaultPassword(Mockito.any(BaseConnectionParam.class));
-
     }
 
     @Test


### PR DESCRIPTION

## Purpose of the pull request

Fixes #8281

When the database itself does not have a password, it should not be forced to the default value of 123456

## Brief change log

Fixes #8281 Purpose of the pull request

## Verify this pull request

This pull request is code cleanup without any test coverage.
