### PR TITLE
[Improvement-9338][API] show more create datasource exception message

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -337,8 +337,11 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
             putMsg(result, Status.SUCCESS);
             return result;
         } catch (Exception e) {
-            logger.error("datasource test connection error, dbType:{}, connectionParam:{}, message:{}.", type, connectionParam, e.getMessage());
-            return new Result<>(Status.CONNECTION_TEST_FAILURE.getCode(), e.getMessage());
+            String message = Optional.of(e).map(Throwable::getCause)
+                    .map(Throwable::getMessage)
+                    .orElse(e.getMessage());
+            logger.error("datasource test connection error, dbType:{}, connectionParam:{}, message:{}.", type, connectionParam, message);
+            return new Result<>(Status.CONNECTION_TEST_FAILURE.getCode(), message);
         }
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
This pull request fix Execption message miss, modify file dolphinscheduler-api\src\main\java\org\apache\dolphinscheduler\api\service\impl\DataSourceServiceImpl.java

Because of org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient#checkClient method convert sqlException to RuntimeException, org.apache.dolphinscheduler.api.service.impl.DataSourceServiceImpl#checkConnection method can't get right exception message.
![image](https://user-images.githubusercontent.com/19678580/161385207-f7df734f-451d-40c7-b856-e6220227c8b7.png)

This pull request is code cleanup without any test coverage.