### PR TITLE
[Feature-8635][Task-Plugin]Add support for Clickhouse as the DataX target TargetDataBase 

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/datax.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/datax.vue
@@ -59,7 +59,7 @@
           <m-datasource
             ref="refDt"
             @on-dsData="_onDtData"
-            :supportType="['MYSQL','POSTGRESQL', 'ORACLE', 'SQLSERVER']"
+            :supportType="['MYSQL','POSTGRESQL', 'ORACLE', 'SQLSERVER', 'CLICKHOUSE']"
             :data="{ type:dtType,datasource:datatarget }">
           </m-datasource>
         </div>


### PR DESCRIPTION

## Purpose of the pull request

Add support for Clickhouse as the DataX target TargetDataBase 
fix [#8635](https://github.com/apache/dolphinscheduler/issues/8635)

## Brief change log

Add string 'CLICKHOUSE' to datax.vue

## Verify this pull request

This pull request is code cleanup without any test coverage.
I run the dataX task MySQL -> ClickHouse in the local test, which can run through
