### PR TITLE
[CI] Enable CI to remove unexpected files in /docs/img dir

### DIFF
--- a/docs/img_utils.py
+++ b/docs/img_utils.py
@@ -32,16 +32,6 @@ root_dir: Path = Path(__file__).parent
 img_dir: Path = root_dir.joinpath("img")
 doc_dir: Path = root_dir.joinpath("docs")
 
-expect_img_types: Set = {
-    "jpg",
-    "png",
-}
-
-
-def build_pattern() -> re.Pattern:
-    """Build current document image regexp pattern."""
-    return re.compile(f"(/img.*?\\.({'|'.join(expect_img_types)}))")
-
 
 def get_files_recurse(path: Path) -> Set:
     """Get all files recursively from given :param:`path`."""
@@ -68,14 +58,14 @@ def get_paths_rel_path(paths: Set[Path], rel: Path) -> Set:
     return {f"/{path.relative_to(rel)}" for path in paths}
 
 
-def get_docs_img_path(paths: Set[Path], pattern: re.Pattern) -> Set:
+def get_docs_img_path(paths: Set[Path]) -> Set:
     """Get all img syntax from given :param:`paths` using the regexp from :param:`pattern`."""
     res = set()
     for path in paths:
         content = path.read_text()
-        find = pattern.findall(content)
+        find = re.findall(r"/img[\w./-]*", content)
         if find:
-            res |= {item[0] for item in find}
+            res |= {item for item in find}
     return res
 
 
@@ -102,16 +92,6 @@ def diff_two_set(first: Set, second: Set) -> Tuple[set, set]:
     return first.difference(second), second.difference(first)
 
 
-def check_diff_img_type() -> Tuple[set, set]:
-    """Check images difference type.
-
-    :return: Tuple[(actual - expect), (expect - actual)]
-    """
-    img = get_files_recurse(img_dir)
-    img_suffix = get_paths_uniq_suffix(img)
-    return diff_two_set(img_suffix, expect_img_types)
-
-
 def check_diff_img() -> Tuple[set, set]:
     """Check images difference files.
 
@@ -120,20 +100,12 @@ def check_diff_img() -> Tuple[set, set]:
     img = get_files_recurse(img_dir)
     docs = get_files_recurse(doc_dir)
     img_rel_path = get_paths_rel_path(img, root_dir)
-    pat = build_pattern()
-    docs_rel_path = get_docs_img_path(docs, pat)
+    docs_rel_path = get_docs_img_path(docs)
     return diff_two_set(docs_rel_path, img_rel_path)
 
 
 def check() -> None:
     """Runner for `check` sub command."""
-    img_type_act, img_type_exp = check_diff_img_type()
-    assert not img_type_act and not img_type_exp, (
-        f"Images type assert failed: \n"
-        f"* difference actual types to expect is: {img_type_act if img_type_act else 'None'}\n"
-        f"* difference expect types to actual is: {img_type_exp if img_type_exp else 'None'}\n"
-    )
-
     img_docs, img_img = check_diff_img()
     assert not img_docs and not img_img, (
         f"Images assert failed: \n"

--- a/docs/img_utils.py
+++ b/docs/img_utils.py
@@ -61,9 +61,10 @@ def get_paths_rel_path(paths: Set[Path], rel: Path) -> Set:
 def get_docs_img_path(paths: Set[Path]) -> Set:
     """Get all img syntax from given :param:`paths` using the regexp from :param:`pattern`."""
     res = set()
+    pattern = re.compile(r"/img[\w./-]*")
     for path in paths:
         content = path.read_text()
-        find = re.findall(r"/img[\w./-]*", content)
+        find = pattern.findall(content)
         if find:
             res |= {item for item in find}
     return res


### PR DESCRIPTION
## Purpose of the pull request
* Enable CI to automatically remove unexpected files in dolphinscheduler/docs/img dir
* This PR closes: #9321

## Brief change log
* Remove hard-coded `expect_img_types`, in case developers use other image types such as svg, etc.
* Optimize regex expression to match the paths of image files in docs.
* Remove `check_diff_img_type()` because it is fully covered by another check `check_diff_img()`.

## Verify this pull request
* Tested by running dolphinscheduler/docs/img_utils.py locally.