### PR TITLE
[python] Recover python release properties

### DIFF
--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -70,9 +70,6 @@
     <profiles>
         <profile>
             <id>release</id>
-            <properties>
-                <python.sign.skip>false</python.sign.skip>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -30,6 +30,12 @@
 
     <profiles>
         <profile>
+            <id>release</id>
+            <properties>
+                <python.sign.skip>false</python.sign.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>python</id>
             <build>
                 <plugins>

--- a/dolphinscheduler-standalone-server/pom.xml
+++ b/dolphinscheduler-standalone-server/pom.xml
@@ -51,11 +51,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-python</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>${curator.test}</version>


### PR DESCRIPTION
This patch recovers the properties `python.sign.skip=false`
when the combined profile `release,python` is used.

also close: #9433
