### PR TITLE
Add ingress annotations

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/ingress.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/ingress.yaml
@@ -28,6 +28,10 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "dolphinscheduler.fullname" . }}
     {{- include "dolphinscheduler.common.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   rules:
   - host: {{ .Values.ingress.host }}

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -403,6 +403,7 @@ ingress:
   enabled: false
   host: "dolphinscheduler.org"
   path: "/dolphinscheduler"
+  annotations: {}
   tls:
     enabled: false
     secretName: "dolphinscheduler-tls"


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This PR adds ingress annotations and is related to Issue #9486 


## Brief change log
- Add  ingress metadata annotations in ingress.yaml
- Add default annotations to ingress 

## Verify this pull request

Manually tested this pr by deploying DolphinScheduler to Azure CN K8S (AKS)  with values.yaml.
```
ingress:
  enabled: true
  path: "/dolphinscheduler"
  annotations:
    nginx.ingress.kubernetes.io/whitelist-source-range: 10.0.0.0/14
```

And ip within the whitelist is allowed to access dolpinscheduler.
We're using nginx-ingress.

Here's ingress 
```
(base) [root@master ~]# kubectl describe ingress dolphinscheduler
Name:             dolphinscheduler
Namespace:        flag-qa
Address:          10.240.0.5
Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
Rules:
  Host        Path  Backends
  ----        ----  --------
  *           
              /dolphinscheduler   dolphinscheduler-api:api-port (10.244.0.64:12345)
Annotations:  meta.helm.sh/release-name: dolphinscheduler
              meta.helm.sh/release-namespace: flag-qa
              nginx.ingress.kubernetes.io/whitelist-source-range:
                10.0.0.0/14
Events:       <none>

```
