### PR TITLE
[Feature][UI Next][V1.0.0-Beta] Change the css style usage of the blue number flopper in the alarm center to css variables.

### DIFF
--- a/dolphinscheduler-ui-next/src/views/monitor/servers/db/index.module.scss
+++ b/dolphinscheduler-ui-next/src/views/monitor/servers/db/index.module.scss
@@ -37,5 +37,5 @@
 
 .connections {
   @include base;
-  color: dodgerblue;
+  color: var(--n-color-target);
 }

--- a/dolphinscheduler-ui-next/src/views/monitor/servers/master/index.module.scss
+++ b/dolphinscheduler-ui-next/src/views/monitor/servers/master/index.module.scss
@@ -29,14 +29,15 @@
 
 .load-average {
   @include base;
-  color: dodgerblue;
+  color: var(--n-color-target);
 }
 
 .link-btn {
-  color: #579cd8;
+  color: var(--n-color-target);
   cursor: pointer;
 
   &:hover {
-    color: #80bef7;
+    color: var(--n-color-target);
+    opacity: 0.8;
   }
 }

--- a/dolphinscheduler-ui-next/src/views/monitor/servers/worker/index.module.scss
+++ b/dolphinscheduler-ui-next/src/views/monitor/servers/worker/index.module.scss
@@ -29,14 +29,15 @@
 
 .load-average {
   @include base;
-  color: dodgerblue;
+  color: var(--n-color-target);
 }
 
 .link-btn {
-  color: #579cd8;
+  color: var(--n-color-target);
   cursor: pointer;
 
   &:hover {
-    color: #80bef7;
+    color: var(--n-color-target);
+    opacity: 0.8;
   }
 }

--- a/dolphinscheduler-ui-next/src/views/monitor/statistics/statistics/index.module.scss
+++ b/dolphinscheduler-ui-next/src/views/monitor/statistics/statistics/index.module.scss
@@ -21,5 +21,5 @@
   justify-content: center;
   align-items: center;
   min-height: 160px;
-  color: dodgerblue;
+  color: var(--n-color-target);
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
close [#9510](https://github.com/apache/dolphinscheduler/issues/9510)
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
