### PR TITLE
[Fix-9516] [Statistics] Statistics Manager shows data should belongs to current user

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
@@ -233,13 +233,16 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         Date end = null;
         Long[] projectCodeArray = getProjectCodesArrays(loginUser);
 
+        // admin can view all
+        int userId = loginUser.getUserType() == UserType.ADMIN_USER ? 0 : loginUser.getId();
+
         // count normal command state
-        Map<CommandType, Integer> normalCountCommandCounts = commandMapper.countCommandState(loginUser.getId(), start, end, projectCodeArray)
+        Map<CommandType, Integer> normalCountCommandCounts = commandMapper.countCommandState(userId, start, end, projectCodeArray)
                 .stream()
                 .collect(Collectors.toMap(CommandCount::getCommandType, CommandCount::getCount));
 
         // count error command state
-        Map<CommandType, Integer> errorCommandCounts = errorCommandMapper.countCommandState(start, end, projectCodeArray)
+        Map<CommandType, Integer> errorCommandCounts = errorCommandMapper.countCommandState(userId, start, end, projectCodeArray)
                 .stream()
                 .collect(Collectors.toMap(CommandCount::getCommandType, CommandCount::getCount));
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
@@ -260,14 +260,14 @@ public class DataAnalysisServiceTest {
         commandCounts.add(commandCount);
 
         Mockito.when(commandMapper.countCommandState(0, null, null, new Long[]{1L})).thenReturn(commandCounts);
-        Mockito.when(errorCommandMapper.countCommandState(null, null, new Long[]{1L})).thenReturn(commandCounts);
+        Mockito.when(errorCommandMapper.countCommandState(0, null, null, new Long[]{1L})).thenReturn(commandCounts);
 
         Map<String, Object> result = dataAnalysisServiceImpl.countCommandState(user);
         Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
 
         // when no command found then return all count are 0
         Mockito.when(commandMapper.countCommandState(anyInt(), any(), any(), any())).thenReturn(Collections.emptyList());
-        Mockito.when(errorCommandMapper.countCommandState(any(), any(), any())).thenReturn(Collections.emptyList());
+        Mockito.when(errorCommandMapper.countCommandState(anyInt(), any(), any(), any())).thenReturn(Collections.emptyList());
         Map<String, Object> result5 = dataAnalysisServiceImpl.countCommandState(user);
         assertThat(result5).containsEntry(Constants.STATUS, Status.SUCCESS);
         assertThat(result5.get(Constants.DATA_LIST)).asList().extracting("errorCount").allMatch(count -> count.equals(0));
@@ -281,7 +281,7 @@ public class DataAnalysisServiceTest {
         errorCommandCount.setCommandType(CommandType.START_PROCESS);
         errorCommandCount.setCount(5);
         Mockito.when(commandMapper.countCommandState(anyInt(), any(), any(), any())).thenReturn(Collections.singletonList(normalCommandCount));
-        Mockito.when(errorCommandMapper.countCommandState(any(), any(), any())).thenReturn(Collections.singletonList(errorCommandCount));
+        Mockito.when(errorCommandMapper.countCommandState(anyInt(), any(), any(), any())).thenReturn(Collections.singletonList(errorCommandCount));
 
         Map<String, Object> result6 = dataAnalysisServiceImpl.countCommandState(user);
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ErrorCommandMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ErrorCommandMapper.java
@@ -34,12 +34,14 @@ public interface ErrorCommandMapper extends BaseMapper<ErrorCommand> {
 
     /**
      * count command state
+     * @param userId
      * @param startTime startTime
      * @param endTime endTime
      * @param projectCodeArray projectCodeArray
      * @return CommandCount list
      */
     List<CommandCount> countCommandState(
+            @Param("userId") int userId,
             @Param("startTime") Date startTime,
             @Param("endTime") Date endTime,
             @Param("projectCodeArray") Long[] projectCodeArray);

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
@@ -22,7 +22,9 @@
         select cmd.command_type as command_type, count(1) as count
         from t_ds_command cmd, t_ds_process_definition process
         where cmd.process_definition_code = process.code
-        and process.user_id = #{userId}
+        <if test="userId != 0 ">
+            and process.user_id= #{userId}
+        </if>
         <if test="projectCodeArray != null and projectCodeArray.length != 0">
             and process.project_code in
             <foreach collection="projectCodeArray" index="index" item="i" open="(" close=")" separator=",">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
@@ -22,6 +22,7 @@
         select cmd.command_type as command_type, count(1) as count
         from t_ds_command cmd, t_ds_process_definition process
         where cmd.process_definition_code = process.code
+        and process.user_id = #{userId}
         <if test="projectCodeArray != null and projectCodeArray.length != 0">
             and process.project_code in
             <foreach collection="projectCodeArray" index="index" item="i" open="(" close=")" separator=",">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ErrorCommandMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ErrorCommandMapper.xml
@@ -22,6 +22,9 @@
         select cmd.command_type as command_type, count(1) as count
         from t_ds_error_command cmd, t_ds_process_definition process
         where cmd.process_definition_code = process.code
+        <if test="userId != 0 ">
+            and process.user_id= #{userId}
+        </if>
         <if test="projectCodeArray != null and projectCodeArray.length != 0">
             and process.project_code in
             <foreach collection="projectCodeArray" index="index" item="i" open="(" close=")" separator=",">

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ErrorCommandMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ErrorCommandMapperTest.java
@@ -77,6 +77,7 @@ public class ErrorCommandMapperTest extends BaseDaoTest {
         errorCommandMapper.updateById(errorCommand);
 
         List<CommandCount> commandCounts = errorCommandMapper.countCommandState(
+                0,
                 null,
                 null,
                 new Long[0]
@@ -86,6 +87,7 @@ public class ErrorCommandMapperTest extends BaseDaoTest {
         projectCodeArray[0] = processDefinition.getProjectCode();
         projectCodeArray[1] = 200L;
         List<CommandCount> commandCounts2 = errorCommandMapper.countCommandState(
+                0,
                 null,
                 null,
                 projectCodeArray


### PR DESCRIPTION
When querying command information, it is not restricted by the user ID condition. Actually this happens when the user doesn't create a task in project management

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This pull request add the current user ID to the query condition of the query command information

## Brief change log

dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
SQL countCommandState method adds user ID query conditions

## Verify this pull request

Manually verified the change by testing locally.
