### PR TITLE
[Bug] [API-9558]fix homepage task instance count method to use submit time to recount

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataAnalysisService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataAnalysisService.java
@@ -17,8 +17,12 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.ibatis.annotations.Param;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -75,4 +79,17 @@ public interface DataAnalysisService {
      */
     Map<String, Object> countQueueState(User loginUser);
 
+    /**
+     * Statistics task instance group by given project codes list
+     * <p>
+     * We only need project codes to determine whether the task instance belongs to the user or not.
+     *
+     * @param startTime    Statistics start time
+     * @param endTime      Statistics end time
+     * @param projectCodes Project codes list to filter
+     * @return List of ExecuteStatusCount
+     */
+    List<ExecuteStatusCount> countTaskInstanceAllStatesByProjectCodes(@Param("startTime") Date startTime,
+                                                                      @Param("endTime") Date endTime,
+                                                                      @Param("projectCodes") Long[] projectCodes);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataAnalysisService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataAnalysisService.java
@@ -29,10 +29,10 @@ public interface DataAnalysisService {
     /**
      * statistical task instance status data
      *
-     * @param loginUser login user
+     * @param loginUser   login user
      * @param projectCode project code
-     * @param startDate start date
-     * @param endDate end date
+     * @param startDate   start date
+     * @param endDate     end date
      * @return task state count data
      */
     Map<String, Object> countTaskStateByProject(User loginUser, long projectCode, String startDate, String endDate);
@@ -40,20 +40,20 @@ public interface DataAnalysisService {
     /**
      * statistical process instance status data
      *
-     * @param loginUser login user
+     * @param loginUser   login user
      * @param projectCode project code
-     * @param startDate start date
-     * @param endDate end date
+     * @param startDate   start date
+     * @param endDate     end date
      * @return process instance state count data
      */
     Map<String, Object> countProcessInstanceStateByProject(User loginUser, long projectCode, String startDate, String endDate);
 
     /**
      * statistics the process definition quantities of a certain person
-     *
+     * <p>
      * We only need projects which users have permission to see to determine whether the definition belongs to the user or not.
      *
-     * @param loginUser login user
+     * @param loginUser   login user
      * @param projectCode project code
      * @return definition count data
      */

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
@@ -313,6 +313,6 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
                 .countTaskInstanceStateByProjectCodesAndStatesBySubmitTime(startTime, endTime, projectCodes, needRecountState);
         startTimeStates.orElseGet(ArrayList::new).addAll(recounts);
 
-        return startTimeStates.orElseGet(ArrayList::new);
+        return startTimeStates.get();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
@@ -313,6 +313,6 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
                 .countTaskInstanceStateByProjectCodesAndStatesBySubmitTime(startTime, endTime, projectCodes, needRecountState);
         startTimeStates.orElseGet(ArrayList::new).addAll(recounts);
 
-        return startTimeStates.get();
+        return startTimeStates.orElse(null);
     }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
@@ -56,7 +56,7 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
                       @Param("taskIds") int[] taskIds);
 
     /**
-     * Statistics task instance group by given project codes list
+     * Statistics task instance group by given project codes list by start time
      * <p>
      * We only need project codes to determine whether the task instance belongs to the user or not.
      *
@@ -70,7 +70,7 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
                                                                   @Param("projectCodes") Long[] projectCodes);
 
     /**
-     * Statistics task instance group by given project codes list
+     * Statistics task instance group by given project codes list by submit time
      * <p>
      * We only need project codes to determine whether the task instance belongs to the user or not.
      *
@@ -79,10 +79,10 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
      * @param projectCodes Project codes list to filter
      * @return List of ExecuteStatusCount
      */
-    List<ExecuteStatusCount> countTaskInstanceStateByProjectCodesAndStates(@Param("startTime") Date startTime,
-                                                                       @Param("endTime") Date endTime,
-                                                                       @Param("projectCodes") Long[] projectCodes,
-                                                                       @Param("states") int[] states);
+    List<ExecuteStatusCount> countTaskInstanceStateByProjectCodesAndStatesBySubmitTime(@Param("startTime") Date startTime,
+                                                                                       @Param("endTime") Date endTime,
+                                                                                       @Param("projectCodes") Long[] projectCodes,
+                                                                                       @Param("states") List<ExecutionStatus> states);
 
     IPage<TaskInstance> queryTaskInstanceListPaging(IPage<TaskInstance> page,
                                                     @Param("projectCode") Long projectCode,

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
@@ -17,18 +17,16 @@
 
 package org.apache.dolphinscheduler.dao.mapper;
 
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ExecutionStatus;
-
 import org.apache.ibatis.annotations.Param;
 
 import java.util.Date;
 import java.util.List;
-
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.baomidou.mybatisplus.core.metadata.IPage;
 
 /**
  * task instance mapper interface
@@ -71,6 +69,21 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
                                                                   @Param("endTime") Date endTime,
                                                                   @Param("projectCodes") Long[] projectCodes);
 
+    /**
+     * Statistics task instance group by given project codes list
+     * <p>
+     * We only need project codes to determine whether the task instance belongs to the user or not.
+     *
+     * @param startTime    Statistics start time
+     * @param endTime      Statistics end time
+     * @param projectCodes Project codes list to filter
+     * @return List of ExecuteStatusCount
+     */
+    int countTaskInstanceStateByProjectCodesAndState(@Param("startTime") Date startTime,
+                                                     @Param("endTime") Date endTime,
+                                                     @Param("projectCodes") Long[] projectCodes,
+                                                     @Param("state") int state);
+
     IPage<TaskInstance> queryTaskInstanceListPaging(IPage<TaskInstance> page,
                                                     @Param("projectCode") Long projectCode,
                                                     @Param("processInstanceId") Integer processInstanceId,
@@ -84,5 +97,5 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
                                                     @Param("endTime") Date endTime
     );
 
-    List<TaskInstance> loadAllInfosNoRelease(@Param("processInstanceId") int processInstanceId,@Param("status") int status);
+    List<TaskInstance> loadAllInfosNoRelease(@Param("processInstanceId") int processInstanceId, @Param("status") int status);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
@@ -79,10 +79,10 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
      * @param projectCodes Project codes list to filter
      * @return List of ExecuteStatusCount
      */
-    int countTaskInstanceStateByProjectCodesAndState(@Param("startTime") Date startTime,
-                                                     @Param("endTime") Date endTime,
-                                                     @Param("projectCodes") Long[] projectCodes,
-                                                     @Param("state") int state);
+    List<ExecuteStatusCount> countTaskInstanceStateByProjectCodesAndStates(@Param("startTime") Date startTime,
+                                                                       @Param("endTime") Date endTime,
+                                                                       @Param("projectCodes") Long[] projectCodes,
+                                                                       @Param("states") int[] states);
 
     IPage<TaskInstance> queryTaskInstanceListPaging(IPage<TaskInstance> page,
                                                     @Param("projectCode") Long projectCode,

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -89,17 +89,17 @@
         </if>
         group by t.state
     </select>
-    <select id="countTaskInstanceStateByProjectCodesAndStates" resultType="org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount">
+    <select id="countTaskInstanceStateByProjectCodesAndStatesBySubmitTime" resultType="org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount">
         select
         state, count(0) as count
         from t_ds_task_instance t
         left join t_ds_task_definition_log d on d.code=t.task_code and d.version=t.task_definition_version
         left join t_ds_project p on p.code=d.project_code
         where 1=1
-        <if test="states != null and states.length != 0">
+        <if test="states != null and states.size != 0">
             and t.state in
             <foreach collection="states" index="index" item="state" open="(" separator="," close=")">
-                #{state}
+                #{state.code}
             </foreach>
         </if>
         <if test="projectCodes != null and projectCodes.length != 0">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -89,6 +89,26 @@
         </if>
         group by t.state
     </select>
+    <select id="countTaskInstanceStateByProjectCodesAndState" resultType="int">
+        select
+        count(0)
+        from t_ds_task_instance t
+        left join t_ds_task_definition_log d on d.code=t.task_code and d.version=t.task_definition_version
+        left join t_ds_project p on p.code=d.project_code
+        where 1=1 and t.state=#{state}
+        <if test="projectCodes != null and projectCodes.length != 0">
+            and d.project_code in
+            <foreach collection="projectCodes" index="index" item="i" open="(" separator="," close=")">
+                #{i}
+            </foreach>
+        </if>
+        <if test="startTime != null">
+            and t.submit_time <![CDATA[ > ]]> #{startTime}
+        </if>
+        <if test="endTime != null">
+            and t.submit_time <![CDATA[ <= ]]> #{endTime}
+        </if>
+    </select>
     <select id="queryByInstanceIdAndName" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
         select
         <include refid="baseSql"/>

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -89,13 +89,19 @@
         </if>
         group by t.state
     </select>
-    <select id="countTaskInstanceStateByProjectCodesAndState" resultType="int">
+    <select id="countTaskInstanceStateByProjectCodesAndStates" resultType="org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount">
         select
-        count(0)
+        state, count(0) as count
         from t_ds_task_instance t
         left join t_ds_task_definition_log d on d.code=t.task_code and d.version=t.task_definition_version
         left join t_ds_project p on p.code=d.project_code
-        where 1=1 and t.state=#{state}
+        where 1=1
+        <if test="states != null and states.length != 0">
+            and t.state in
+            <foreach collection="states" index="index" item="state" open="(" separator="," close=")">
+                #{state}
+            </foreach>
+        </if>
         <if test="projectCodes != null and projectCodes.length != 0">
             and d.project_code in
             <foreach collection="projectCodes" index="index" item="i" open="(" separator="," close=")">
@@ -108,6 +114,7 @@
         <if test="endTime != null">
             and t.submit_time <![CDATA[ <= ]]> #{endTime}
         </if>
+        group by t.state
     </select>
     <select id="queryByInstanceIdAndName" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
         select

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/enums/ExecutionStatus.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/enums/ExecutionStatus.java
@@ -45,6 +45,7 @@ public enum ExecutionStatus {
      * 14 serial wait
      * 15 ready block
      * 16 block
+     * 17 dispatch
      */
     SUBMITTED_SUCCESS(0, "submit success"),
     RUNNING_EXECUTION(1, "running"),
@@ -108,7 +109,7 @@ public enum ExecutionStatus {
      */
     public boolean typeIsFinished() {
         return typeIsSuccess() || typeIsFailure() || typeIsCancel() || typeIsPause()
-            || typeIsStop() || typeIsBlock();
+                || typeIsStop() || typeIsBlock();
     }
 
     /**


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix homepage task instance count method to use submit time to recount special state
close #9558 
## Brief change log

fix homepage task instance count method to use submit time to recount special state
close #9558 
## Verify this pull request

I have tested locally.