### PR TITLE
[Bug][Master] Deduplicate the classpath jars in start.sh of the stand…

### DIFF
--- a/dolphinscheduler-standalone-server/src/main/dist-bin/start.sh
+++ b/dolphinscheduler-standalone-server/src/main/dist-bin/start.sh
@@ -30,7 +30,10 @@ fi
 CP=$DOLPHINSCHEDULER_HOME/libs/standalone-server/*
 for d in alert-server api-server master-server worker-server; do
   for f in $DOLPHINSCHEDULER_HOME/../$d/libs/*.jar; do
-    CP=$CP:$f
+    JAR_FILE_NAME=${f##*/}
+    if [[ ! $CP =~ $JAR_FILE_NAME ]];then
+      CP=$CP:$f
+    fi
   done
 done
 


### PR DESCRIPTION
…alone server

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

Fixed argument list too long error when starting standalone server by deduplicating the classpath jars as the startup command line inside start.sh of the standalone server.

Issue link: [ISSUE-9575](https://github.com/apache/dolphinscheduler/issues/9575)

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->

- dolphinscheduler-standalone-server/src/main/dist-bin/start.sh

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

