### PR TITLE
[Fix-9593] Storage Management StorageOperate No Instance

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
@@ -1,36 +1,32 @@
 package org.apache.dolphinscheduler.common.storage;
 
 import org.apache.dolphinscheduler.common.enums.ResUploadType;
-import org.apache.dolphinscheduler.common.utils.HadoopUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
-
 /**
  * @author Storage Operate Manager
  */
-@Component
 public class StorageOperateManager {
 
-    /**
-      * default storage
-     */
-    @Autowired
-    private HadoopUtils hadoopUtils;
-
-    public static Map<ResUploadType, StorageOperate> storageOperateMap = new HashMap<>(3);
+    public static Map<ResUploadType, StorageOperate> STORAGE_OPERATE_MAP = new HashMap<>(ResUploadType.values().length);
 
     static {
         ServiceLoader<StorageOperate> load = ServiceLoader.load(StorageOperate.class);
         for (StorageOperate storageOperate : load) {
-            storageOperateMap.put(storageOperate.returnStorageType(), storageOperate);
+            STORAGE_OPERATE_MAP.put(storageOperate.returnStorageType(), storageOperate);
         }
     }
 
-    public StorageOperate storageOperate(ResUploadType resUploadType){
-        return storageOperateMap.getOrDefault(resUploadType, hadoopUtils);
+    public static StorageOperate storageOperate(ResUploadType resUploadType) {
+        if (Objects.isNull(resUploadType)){
+            resUploadType = ResUploadType.HDFS;
+        }
+        StorageOperate storageOperate = STORAGE_OPERATE_MAP.get(resUploadType);
+        if (Objects.isNull(storageOperate)){
+            storageOperate = STORAGE_OPERATE_MAP.get(ResUploadType.HDFS);
+        }
+        return storageOperate;
     }
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dolphinscheduler.common.storage;
 
 import org.apache.dolphinscheduler.common.enums.ResUploadType;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
@@ -17,8 +17,8 @@
 package org.apache.dolphinscheduler.common.storage;
 
 import org.apache.dolphinscheduler.common.enums.ResUploadType;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.util.EnumMap;
 import java.util.Objects;
 import java.util.ServiceLoader;
 /**
@@ -26,22 +26,22 @@ import java.util.ServiceLoader;
  */
 public class StorageOperateManager {
 
-    public static Map<ResUploadType, StorageOperate> STORAGE_OPERATE_MAP = new HashMap<>(ResUploadType.values().length);
+    public static final EnumMap<ResUploadType, StorageOperate> OPERATE_MAP = new EnumMap<>(ResUploadType.class);
 
     static {
         ServiceLoader<StorageOperate> load = ServiceLoader.load(StorageOperate.class);
         for (StorageOperate storageOperate : load) {
-            STORAGE_OPERATE_MAP.put(storageOperate.returnStorageType(), storageOperate);
+            OPERATE_MAP.put(storageOperate.returnStorageType(), storageOperate);
         }
     }
 
-    public static StorageOperate storageOperate(ResUploadType resUploadType) {
+    public static StorageOperate getStorageOperate(ResUploadType resUploadType) {
         if (Objects.isNull(resUploadType)){
             resUploadType = ResUploadType.HDFS;
         }
-        StorageOperate storageOperate = STORAGE_OPERATE_MAP.get(resUploadType);
+        StorageOperate storageOperate = OPERATE_MAP.get(resUploadType);
         if (Objects.isNull(storageOperate)){
-            storageOperate = STORAGE_OPERATE_MAP.get(ResUploadType.HDFS);
+            storageOperate = OPERATE_MAP.get(ResUploadType.HDFS);
         }
         return storageOperate;
     }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/storage/StorageOperateManager.java
@@ -1,0 +1,36 @@
+package org.apache.dolphinscheduler.common.storage;
+
+import org.apache.dolphinscheduler.common.enums.ResUploadType;
+import org.apache.dolphinscheduler.common.utils.HadoopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * @author Storage Operate Manager
+ */
+@Component
+public class StorageOperateManager {
+
+    /**
+      * default storage
+     */
+    @Autowired
+    private HadoopUtils hadoopUtils;
+
+    public static Map<ResUploadType, StorageOperate> storageOperateMap = new HashMap<>(3);
+
+    static {
+        ServiceLoader<StorageOperate> load = ServiceLoader.load(StorageOperate.class);
+        for (StorageOperate storageOperate : load) {
+            storageOperateMap.put(storageOperate.returnStorageType(), storageOperate);
+        }
+    }
+
+    public StorageOperate storageOperate(ResUploadType resUploadType){
+        return storageOperateMap.getOrDefault(resUploadType, hadoopUtils);
+    }
+}

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.client.cli.RMAdminCLI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -55,6 +56,7 @@ import static org.apache.dolphinscheduler.common.Constants.*;
  * hadoop utils
  * single instance
  */
+@Component
 public class HadoopUtils implements Closeable, StorageOperate {
 
     private static final Logger logger = LoggerFactory.getLogger(HadoopUtils.class);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/S3Utils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/S3Utils.java
@@ -36,6 +36,7 @@ import org.apache.dolphinscheduler.spi.enums.ResourceType;
 import org.jets3t.service.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import java.io.*;
 import java.util.Collections;
@@ -45,6 +46,7 @@ import java.util.stream.Stream;
 
 import static org.apache.dolphinscheduler.common.Constants.*;
 
+@Component
 public class S3Utils implements Closeable, StorageOperate {
 
     private static final Logger logger = LoggerFactory.getLogger(S3Utils.class);

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/storage/StorageOperateManagerTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/storage/StorageOperateManagerTest.java
@@ -1,0 +1,30 @@
+package org.apache.dolphinscheduler.common.storage;
+
+import org.apache.dolphinscheduler.common.enums.ResUploadType;
+import org.apache.dolphinscheduler.common.utils.HadoopUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+
+/**
+ * @author StorageOperateManagerTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class StorageOperateManagerTest {
+
+    @Mock
+    private HadoopUtils hadoopUtils;
+
+    @Test
+    public void testManager() {
+        Map<ResUploadType, StorageOperate> storageOperateMap = StorageOperateManager.STORAGE_OPERATE_MAP;
+        storageOperateMap.put(ResUploadType.HDFS, hadoopUtils);
+
+        StorageOperate storageOperate = StorageOperateManager.storageOperate(ResUploadType.HDFS);
+        Assert.assertNotNull(storageOperate);
+    }
+}

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/storage/StorageOperateManagerTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/storage/StorageOperateManagerTest.java
@@ -22,9 +22,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Map;
+import java.util.EnumMap;
 
 /**
  * @author StorageOperateManagerTest
@@ -37,10 +38,13 @@ public class StorageOperateManagerTest {
 
     @Test
     public void testManager() {
-        Map<ResUploadType, StorageOperate> storageOperateMap = StorageOperateManager.STORAGE_OPERATE_MAP;
+        StorageOperateManager mock = Mockito.mock(StorageOperateManager.class);
+        Assert.assertNotNull(mock);
+
+        EnumMap<ResUploadType, StorageOperate> storageOperateMap = StorageOperateManager.OPERATE_MAP;
         storageOperateMap.put(ResUploadType.HDFS, hadoopUtils);
 
-        StorageOperate storageOperate = StorageOperateManager.storageOperate(ResUploadType.HDFS);
+        StorageOperate storageOperate = StorageOperateManager.getStorageOperate(ResUploadType.HDFS);
         Assert.assertNotNull(storageOperate);
     }
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/storage/StorageOperateManagerTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/storage/StorageOperateManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dolphinscheduler.common.storage;
 
 import org.apache.dolphinscheduler.common.enums.ResUploadType;

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -18,6 +18,8 @@
 package org.apache.dolphinscheduler.server.worker.processor;
 
 import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.ResUploadType;
+import org.apache.dolphinscheduler.common.storage.StorageOperateManager;
 import org.apache.dolphinscheduler.common.utils.CommonUtils;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
@@ -84,6 +86,12 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
      */
     @Autowired
     private WorkerManagerThread workerManager;
+
+    /**
+     * storage Operate Manager
+     */
+    @Autowired
+    private StorageOperateManager storageOperateManager;
 
     @Override
     public void process(Channel channel, Command command) {
@@ -161,7 +169,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
         }
 
         // submit task to manager
-        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager));
+        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager, storageOperateManager.storageOperate(ResUploadType.HDFS)));
         if (!offer) {
             logger.error("submit task to manager error, queue is full, queue size is {}, taskInstanceId: {}",
                     workerManager.getDelayQueueSize(), taskExecutionContext.getTaskInstanceId());

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -163,7 +163,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
         }
 
         // submit task to manager
-        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager, StorageOperateManager.storageOperate(ResUploadType.HDFS)));
+        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager, StorageOperateManager.getStorageOperate(ResUploadType.HDFS)));
         if (!offer) {
             logger.error("submit task to manager error, queue is full, queue size is {}, taskInstanceId: {}",
                     workerManager.getDelayQueueSize(), taskExecutionContext.getTaskInstanceId());

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -87,12 +87,6 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
     @Autowired
     private WorkerManagerThread workerManager;
 
-    /**
-     * storage Operate Manager
-     */
-    @Autowired
-    private StorageOperateManager storageOperateManager;
-
     @Override
     public void process(Channel channel, Command command) {
         Preconditions.checkArgument(CommandType.TASK_EXECUTE_REQUEST == command.getType(),
@@ -169,7 +163,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
         }
 
         // submit task to manager
-        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager, storageOperateManager.storageOperate(ResUploadType.HDFS)));
+        boolean offer = workerManager.offer(new TaskExecuteThread(taskExecutionContext, taskCallbackService, alertClientService, taskPluginManager, StorageOperateManager.storageOperate(ResUploadType.HDFS)));
         if (!offer) {
             logger.error("submit task to manager error, queue is full, queue size is {}, taskInstanceId: {}",
                     workerManager.getDelayQueueSize(), taskExecutionContext.getTaskInstanceId());

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/TaskExecuteThread.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/TaskExecuteThread.java
@@ -115,11 +115,13 @@ public class TaskExecuteThread implements Runnable, Delayed {
     public TaskExecuteThread(TaskExecutionContext taskExecutionContext,
                              TaskCallbackService taskCallbackService,
                              AlertClientService alertClientService,
-                             TaskPluginManager taskPluginManager) {
+                             TaskPluginManager taskPluginManager,
+                             StorageOperate storageOperate) {
         this.taskExecutionContext = taskExecutionContext;
         this.taskCallbackService = taskCallbackService;
         this.alertClientService = alertClientService;
         this.taskPluginManager = taskPluginManager;
+        this.storageOperate = storageOperate;
     }
 
     @Override


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Instantiate StorageOperate in TaskExecuteProcessor class.

## Brief change log

close #9593 
Add StorageOperateManager and Instantiate StorageOperate in TaskExecuteProcessor class.

## Verify this pull request

Manually verified the change by testing locally.
