### PR TITLE
[Fix][Script] Fix wrong type of variable workersGroupMap, which will …

### DIFF
--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -21,19 +21,14 @@ workDir=`cd ${workDir};pwd`
 
 source ${workDir}/env/install_env.sh
 
-txt=""
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # Mac OSX
-    txt="''"
-fi
-
 workersGroup=(${workers//,/ })
 for workerGroup in ${workersGroup[@]}
 do
   echo $workerGroup;
   worker=`echo $workerGroup|awk -F':' '{print $1}'`
-  groupsName=`echo $workerGroup|awk -F':' '{print $2}'`
-  workersGroupMap+=([$worker]=$groupsName)
+  group=`echo $workerGroup|awk -F':' '{print $2}'`
+  workerNames+=($worker)
+  groupNames+=(${group:-default})
 done
 
 hostsArr=(${ips//,/ })
@@ -47,17 +42,23 @@ do
   echo "scp dirs to $host/$installPath starting"
 	ssh -p $sshPort $host  "cd $installPath/; rm -rf bin/ conf/ lib/ script/ sql/ ui/"
 
+  for i in ${!workerNames[@]}; do
+    if [[ ${workerNames[$i]} == $host ]]; then
+      workerIndex=$i
+      break
+    fi
+  done
+  # set worker groups in application.yaml
+  [[ -n ${workerIndex} ]] && sed -i "s/- default/- ${groupNames[$workerIndex]}/" worker-server/conf/application.yaml
+
   for dsDir in bin master-server worker-server alert-server api-server ui
   do
-    # if worker in workersGroupMap
-    if [[ "${workersGroupMap[${host}]}" ]]; then
-      echo "export WORKER_GROUPS_0=${workersGroupMap[${host}]}" >> worker-server/bin/dolphinscheduler_env.sh
-    fi
-
     echo "start to scp $dsDir to $host/$installPath"
     # Use quiet mode to reduce command line output
     scp -q -P $sshPort -r $workDir/../$dsDir  $host:$installPath
   done
+  # restore worker groups to default
+  [[ -n ${workerIndex} ]] && sed -i "s/- ${groupNames[$workerIndex]}/- default/" worker-server/conf/application.yaml
 
   echo "scp dirs to $host/$installPath complete"
 done

--- a/script/start-all.sh
+++ b/script/start-all.sh
@@ -26,8 +26,7 @@ for workerGroup in ${workersGroup[@]}
 do
   echo $workerGroup;
   worker=`echo $workerGroup|awk -F':' '{print $1}'`
-  groupName=`echo $workerGroup|awk -F':' '{print $2}'`
-  workersGroupMap+=([$worker]=$groupName)
+  workerNames+=($worker)
 done
 
 mastersHost=(${masters//,/ })
@@ -38,7 +37,7 @@ do
 
 done
 
-for worker in ${!workersGroupMap[*]}
+for worker in ${workerNames[@]}
 do
   echo "$worker worker server is starting"
 

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -41,8 +41,7 @@ workersGroup=(${workers//,/ })
 for workerGroup in ${workersGroup[@]}
 do
   worker=`echo $workerGroup|awk -F':' '{print $1}'`
-  groupName=`echo $workerGroup|awk -F':' '{print $2}'`
-  workersGroupMap+=([$worker]=$groupName)
+  workerNames+=($worker)
 done
 
 StateRunning="Running"
@@ -55,7 +54,7 @@ do
 done
 
 # 2.worker server check state
-for worker in ${!workersGroupMap[*]}
+for worker in ${workerNames[@]}
 do
   workerState=`ssh -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server;"`
   echo "$worker  $workerState"

--- a/script/stop-all.sh
+++ b/script/stop-all.sh
@@ -26,8 +26,7 @@ for workerGroup in ${workersGroup[@]}
 do
   echo $workerGroup;
   worker=`echo $workerGroup|awk -F':' '{print $1}'`
-  groupName=`echo $workerGroup|awk -F':' '{print $2}'`
-  workersGroupMap+=([$worker]=$groupName)
+  workerNames+=($worker)
 done
 
 mastersHost=(${masters//,/ })
@@ -38,7 +37,7 @@ do
 
 done
 
-for worker in ${!workersGroupMap[*]}
+for worker in ${workerNames[@]}
 do
   echo "$worker worker server is stopping"
   ssh -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh stop worker-server;"


### PR DESCRIPTION
…result in failing to start all workers.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

Fix wrong type of variable workersGroupMap, which will result in failing to start all workers. Also fix the same issue in scp-hosts.sh, status-all.sh and stop-all.sh.

This PR will close: [ISSUE-8004](https://github.com/apache/dolphinscheduler/issues/8004)

## Brief change log

- script/scp-hosts.sh
- script/start-all.sh
- script/status-all.sh
- script/stop-all.sh

## Verify this pull request


This pull request is code cleanup without any test coverage.


