### PR TITLE
[Fix-9617]New task group project name drop-down data is displayed according to user type.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ProjectController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ProjectController.java
@@ -287,7 +287,7 @@ public class ProjectController extends BaseController {
     @ApiException(LOGIN_USER_QUERY_PROJECT_LIST_PAGING_ERROR)
     @AccessLogAnnotation(ignoreRequestArgs = "loginUser")
     public Result queryAllProjectList(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser) {
-        Map<String, Object> result = projectService.queryAllProjectList();
+        Map<String, Object> result = projectService.queryAllProjectList(loginUser);
         return returnDataList(result);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
@@ -138,10 +138,10 @@ public interface ProjectService {
 
     /**
      * query all project list that have one or more process definitions.
-     *
+     * @param loginUser
      * @return project list
      */
-    Map<String, Object> queryAllProjectList();
+    Map<String, Object> queryAllProjectList(User loginUser);
 
     /**
      * query authorized and user create project list by user id

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
 import java.util.*;
 
 import static org.apache.dolphinscheduler.api.utils.CheckUtils.checkDesc;
@@ -500,13 +501,13 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
 
     /**
      * query all project list
-     *
+     * @param user
      * @return project list
      */
     @Override
-    public Map<String, Object> queryAllProjectList() {
+    public Map<String, Object> queryAllProjectList(User user) {
         Map<String, Object> result = new HashMap<>();
-        List<Project> projects = projectMapper.queryAllProject();
+        List<Project> projects = projectMapper.queryAllProject(user.getUserType() == UserType.ADMIN_USER ? 0 : user.getId());
 
         result.put(Constants.DATA_LIST, projects);
         putMsg(result, Status.SUCCESS);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -38,7 +38,13 @@ import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.dolphinscheduler.api.utils.CheckUtils.checkDesc;
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -38,7 +38,6 @@ import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.util.*;
 
 import static org.apache.dolphinscheduler.api.utils.CheckUtils.checkDesc;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProjectControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProjectControllerTest.java
@@ -137,9 +137,11 @@ public class ProjectControllerTest {
 
     @Test
     public void testQueryAllProjectList() {
+        User user = new User();
+        user.setId(0);
         Map<String, Object> result = new HashMap<>();
         putMsg(result, Status.SUCCESS);
-        Mockito.when(projectService.queryAllProjectList()).thenReturn(result);
+        Mockito.when(projectService.queryAllProjectList(user)).thenReturn(result);
         Result response = projectController.queryAllProjectList(user);
         Assert.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -345,9 +345,11 @@ public class ProjectServiceTest {
 
     @Test
     public void testQueryAllProjectList() {
-        Mockito.when(projectMapper.queryAllProject()).thenReturn(getList());
+        Mockito.when(projectMapper.queryAllProject(0)).thenReturn(getList());
 
-        Map<String, Object> result = projectService.queryAllProjectList();
+        User user = new User();
+        user.setId(0);
+        Map<String, Object> result = projectService.queryAllProjectList(user);
         logger.info(result.toString());
         List<Project> projects = (List<Project>) result.get(Constants.DATA_LIST);
         Assert.assertTrue(CollectionUtils.isNotEmpty(projects));

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.java
@@ -123,7 +123,8 @@ public interface ProjectMapper extends BaseMapper<Project> {
 
     /**
      * query all project
+     * @param userId
      * @return projectList
      */
-    List<Project> queryAllProject();
+    List<Project> queryAllProject(@Param("userId") int userId);
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -164,5 +164,9 @@
         select
         <include refid="baseSql"/>
         from t_ds_project
+        where 1=1
+        <if test="userId != 0">
+            and user_id = #{userId}
+        </if>
     </select>
 </mapper>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

New task group project name drop-down data is displayed according to user type.

## Brief change log

close #9617 

## Verify this pull request

Manually verified the change by testing locally.
