### PR TITLE
[hotfix][docker] Removed extra equals in mail user in docker.md

### DIFF
--- a/docs/docs/en/guide/start/docker.md
+++ b/docs/docs/en/guide/start/docker.md
@@ -977,7 +977,7 @@ Configure the mail service port for `alert-server`, default value `empty`.
 
 Configure the mail sender for `alert-server`, default value `empty`.
 
-**`MAIL_USER=`**
+**`MAIL_USER`**
 
 Configure the user name of the mail service for `alert-server`, default value `empty`.
 


### PR DESCRIPTION

## Purpose of the pull request

Removed extra equal after mail_user in docker doc

## Brief change log

Updated `MAIL_USER=` to 'MAIL_USER` in the docker.md

## Verify this pull request

This pull request is code cleanup without any test coverage.
