### PR TITLE
[Bug][Master] Global taskRetryCheckList clear conflict to killAllTasks in WorkflowExecuteThread

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -1332,12 +1332,10 @@ public class WorkflowExecuteThread implements Runnable {
             readyToSubmitTaskQueue.clear();
         }
 
-        boolean needStopProcessInstance = false;
         for (int taskId : activeTaskProcessorMaps.keySet()) {
             if (taskRetryCheckList.containsKey(taskId)) {
                 taskRetryCheckList.remove(taskId);
                 logger.info("task id {} removed from taskRetryCheckList", taskId);
-                needStopProcessInstance = true;
             }
 
             TaskInstance taskInstance = processService.findTaskInstanceById(taskId);
@@ -1355,9 +1353,7 @@ public class WorkflowExecuteThread implements Runnable {
             }
         }
 
-        if (needStopProcessInstance) {
-            this.addProcessStopEvent(processInstance);
-        }
+        this.addProcessStopEvent(processInstance);
     }
 
     public boolean workFlowFinish() {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -1332,7 +1332,14 @@ public class WorkflowExecuteThread implements Runnable {
             readyToSubmitTaskQueue.clear();
         }
 
+        boolean needStopProcessInstance = false;
         for (int taskId : activeTaskProcessorMaps.keySet()) {
+            if (taskRetryCheckList.containsKey(taskId)) {
+                taskRetryCheckList.remove(taskId);
+                logger.info("task id {} removed from taskRetryCheckList", taskId);
+                needStopProcessInstance = true;
+            }
+
             TaskInstance taskInstance = processService.findTaskInstanceById(taskId);
             if (taskInstance == null || taskInstance.getState().typeIsFinished()) {
                 continue;
@@ -1348,8 +1355,7 @@ public class WorkflowExecuteThread implements Runnable {
             }
         }
 
-        if (taskRetryCheckList.size() > 0) {
-            this.taskRetryCheckList.clear();
+        if (needStopProcessInstance) {
             this.addProcessStopEvent(processInstance);
         }
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

The Object taskInstanceRetryCheckList is shared among all WorkflowExecuteThreads, so when taskInstanceRetryCheckList is cleared by one WorkflowExecuteThread, all other WorkflowExecuteThreads may lose their track of checking dependent tasks, causing other dependent tasks stuck.

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

When executing killAllTasks, the WorkflowExecuteThread only remove those tasks belonging to itself from the global taskInstanceRetryCheckList reference.

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
