### PR TITLE
 [Improvement-#9680][task-plugin] add hive sql log listener

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/pom.xml
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.plugin.task.sql;
 
 import org.apache.dolphinscheduler.common.utils.LoggerUtils;

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
@@ -1,0 +1,61 @@
+package org.apache.dolphinscheduler.plugin.task.sql;
+
+import org.apache.dolphinscheduler.common.utils.LoggerUtils;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.hive.jdbc.HiveStatement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+
+/**
+ * hive log listener thread
+ */
+public class HiveSqlLogThread extends Thread{
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveSqlLogThread.class);
+    /**
+     * hive statement
+     */
+    private HiveStatement statement;
+    /**
+     * logger
+     */
+    private Logger logger;
+
+    private TaskExecutionContext taskExecutionContext;
+
+    public HiveSqlLogThread(Statement statement, Logger logger, TaskExecutionContext taskExecutionContext){
+        this.statement = (HiveStatement) statement;
+        this.logger = logger;
+        this.taskExecutionContext = taskExecutionContext;
+    }
+    @Override
+    public void run() {
+        if (statement == null){
+            LOGGER.info("hive statement is null,end this log query!");
+        }
+        try {
+            while (!statement.isClosed() && statement.hasMoreLogs()){
+                for (String log: statement.getQueryLog(true,500)){
+
+                    //hive mapreduce log
+                    logger.info(log);
+
+                    List<String> appIds = LoggerUtils.getAppIds(log, logger);
+
+
+                    //get sql task yarn's application_id
+                    if (!appIds.isEmpty()){
+                        taskExecutionContext.setAppIds(String.join(",", appIds));
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            logger.error("Failed to view hive log,exception:[{}]",e.getMessage());
+        }
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -177,6 +177,7 @@ public class SqlTask extends AbstractTaskExecutor {
         Connection connection = null;
         PreparedStatement stmt = null;
         ResultSet resultSet = null;
+        HiveSqlLogThread queryThread = null;
         try {
 
             // create connection
@@ -189,6 +190,15 @@ public class SqlTask extends AbstractTaskExecutor {
             // pre sql
             preSql(connection, preStatementsBinds);
             stmt = prepareStatementAndBind(connection, mainSqlBinds);
+
+
+            //hive log listener
+            if (DbType.HIVE == DbType.valueOf(sqlParameters.getType())) {
+                logger.info("execute sql type is [{}]",DbType.HIVE.getDescp());
+
+                queryThread = new HiveSqlLogThread(stmt, logger,taskExecutionContext);
+                queryThread.start();
+            }
 
             String result = null;
             // decide whether to executeQuery or executeUpdate based on sqlType

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
@@ -52,10 +52,12 @@ public class SqlTaskExecutionTest {
         Class.forName("org.apache.hive.jdbc.HiveDriver");
         ResultSet res = null;
         try{
-            if(con == null)
+            if(con == null) {
                 con = DriverManager.getConnection(url);
-            if(stmt == null)
+            }
+            if(stmt == null) {
                 stmt = con.createStatement();
+            }
             HiveSqlLogThread queryThread = new HiveSqlLogThread(stmt, LoggerFactory.getLogger("log test"), taskExecutionContext);
             queryThread.setName("sql log print");
             queryThread.start();

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
 import org.apache.dolphinscheduler.plugin.task.sql.HiveSqlLogThread;

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
@@ -1,0 +1,51 @@
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
+import org.apache.dolphinscheduler.plugin.task.sql.HiveSqlLogThread;
+import org.apache.dolphinscheduler.spi.utils.JSONUtils;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * sql task execution test
+ */
+public class SqlTaskExecutionTest {
+
+    public static Connection con = null;
+    public static Statement stmt = null;
+    @Test
+    public void hiveLogListener() throws IOException, ClassNotFoundException {
+        String taskJson="{\"type\":\"HIVE\",\"datasource\":1,\"sql\":\"select * from tmp.test_doris limit 10\",\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\",\"groupId\":null,\"localParams\":[],\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"dependence\":{},\"conditionResult\":{\"successNode\":[],\"failedNode\":[]},\"waitStartTimeout\":{},\"switchResult\":{}}";
+        TaskExecutionContext taskExecutionContext = new TaskExecutionContext();
+        taskExecutionContext.setTaskType("hive");
+        taskExecutionContext.setTaskParams(taskJson);
+        SqlParameters sqlParameters = JSONUtils.parseObject(taskExecutionContext.getTaskParams(), SqlParameters.class);
+        String type = sqlParameters.getType();
+        String sql = sqlParameters.getSql();
+        System.out.println(type);
+
+        // hive connection
+
+        String url= "jdbc:hive2://127.0.0.1:10000";
+        Class.forName("org.apache.hive.jdbc.HiveDriver");
+        ResultSet res = null;
+        try{
+            if(con == null)
+                con = DriverManager.getConnection(url);
+            if(stmt == null)
+                stmt = con.createStatement();
+            HiveSqlLogThread queryThread = new HiveSqlLogThread(stmt, LoggerFactory.getLogger("log test"), taskExecutionContext);
+            queryThread.setName("sql log print");
+            queryThread.start();
+            res = stmt.executeQuery(sql);
+        }catch (Exception e){
+           e.printStackTrace();
+        }
+
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/SqlTaskExecutionTest.java
@@ -19,6 +19,8 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
 import org.apache.dolphinscheduler.plugin.task.sql.HiveSqlLogThread;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +44,11 @@ public class SqlTaskExecutionTest {
         taskExecutionContext.setTaskType("hive");
         taskExecutionContext.setTaskParams(taskJson);
         SqlParameters sqlParameters = JSONUtils.parseObject(taskExecutionContext.getTaskParams(), SqlParameters.class);
+
+        Assert.assertNotNull(sqlParameters);
         String type = sqlParameters.getType();
         String sql = sqlParameters.getSql();
-        System.out.println(type);
+
 
         // hive connection
 
@@ -58,6 +62,8 @@ public class SqlTaskExecutionTest {
             if(stmt == null) {
                 stmt = con.createStatement();
             }
+            Assert.assertNotNull(stmt);
+
             HiveSqlLogThread queryThread = new HiveSqlLogThread(stmt, LoggerFactory.getLogger("log test"), taskExecutionContext);
             queryThread.setName("sql log print");
             queryThread.start();


### PR DESCRIPTION
 [Improvement-#9680][task-plugin]  add hive sql log listener, print MapReduce progress log and obtain application_id allows developers to better track tasks