### PR TITLE
[Feature][doc] Add how to change standalone database type (#9376)

### DIFF
--- a/docs/docs/en/development/development-environment-setup.md
+++ b/docs/docs/en/development/development-environment-setup.md
@@ -35,8 +35,9 @@ There are two ways to configure the DolphinScheduler development environment, st
 
 ## DolphinScheduler Standalone Quick Start
 
-> **_Note:_** Standalone server only for development and debugging, cause it use H2 Database, Zookeeper Testing Server which may not stable in production
-> Standalone is only supported in DolphinScheduler 1.3.9 and later versions
+> **_Note:_** Use standalone server only for development and debugging, because it uses H2 Database as default database and Zookeeper Testing Server which may not be stable in production.
+> Standalone is only supported in DolphinScheduler 1.3.9 and later versions.
+> Standalone server is able to connect to external databases like mysql and postgresql, see [Standalone Deployment](../guide/installation/standalone.md) for instructions.
 
 ### Git Branch Choose
 
@@ -54,12 +55,12 @@ Find the class `org.apache.dolphinscheduler.server.StandaloneServer` in Intellij
 Install frontend dependencies and run it
 
 ```shell
-cd dolphinscheduler-ui
-npm install
-npm run start
+cd dolphinscheduler-ui-next
+pnpm install
+pnpm run dev
 ```
 
-The browser access address http://localhost:12345/dolphinscheduler can login DolphinScheduler UI. The default username and password are **admin/dolphinscheduler123**
+The browser access address [http://localhost:3000](http://localhost:3000) can login DolphinScheduler UI. The default username and password are **admin/dolphinscheduler123**
 
 ## DolphinScheduler Normal Mode
 
@@ -151,9 +152,9 @@ There are three services that need to be started, including MasterServer, Worker
 Install frontend dependencies and run it
 
 ```shell
-cd dolphinscheduler-ui
-npm install
-npm run start
+cd dolphinscheduler-ui-next
+pnpm install
+pnpm run dev
 ```
 
-The browser access address http://localhost:12345/dolphinscheduler can login DolphinScheduler UI. The default username and password are **admin/dolphinscheduler123**
+The browser access address [http://localhost:3000](http://localhost:3000) can login DolphinScheduler UI. The default username and password are **admin/dolphinscheduler123**

--- a/docs/docs/en/guide/installation/standalone.md
+++ b/docs/docs/en/guide/installation/standalone.md
@@ -4,7 +4,8 @@ Standalone only for quick experience for DolphinScheduler.
 
 If you are a new hand and want to experience DolphinScheduler functions, we recommend you install follow [Standalone deployment](standalone.md). If you want to experience more complete functions and schedule massive tasks, we recommend you install follow [pseudo-cluster deployment](pseudo-cluster.md). If you want to deploy DolphinScheduler in production, we recommend you follow [cluster deployment](cluster.md) or [Kubernetes deployment](kubernetes.md).
 
-> **_Note:_** Standalone only recommends the usage of fewer than 20 workflows, because it uses H2 Database, ZooKeeper Testing Server, too many tasks may cause instability.
+> **_Note:_** Standalone only recommends the usage of fewer than 20 workflows, because it uses in-memory H2 Database in default, ZooKeeper Testing Server, too many tasks may cause instability.
+> When Standalone stops or restarts, in-memory H2 database will clear up. To use Standalone with external databases like mysql or postgresql, please see the last section `Database Configuration`.  
 
 ## Preparation
 
@@ -44,3 +45,35 @@ sh ./bin/dolphinscheduler-daemon.sh stop standalone-server
 > path `api-server/conf/application.yaml`
 
 [jdk]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
+
+### Database Configuration
+
+* Use mysql as an example to illustrate how to configure an external database:
+* First of all, follow the instructions in [pseudo-cluster deployment](pseudo-cluster.md) `Initialize the Database` section to create and initialize database
+* Modify `./standalone-server/bin/dolphinscheduler_env.sh` to use mysql, change username and password to yours:
+
+```shell
+export DATABASE=${DATABASE:-mysql}
+export SPRING_PROFILES_ACTIVE=${DATABASE}
+export SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver
+export SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+export SPRING_DATASOURCE_USERNAME={user}
+export SPRING_DATASOURCE_PASSWORD={password}
+```
+
+* Modify `./standalone-server/conf/application.yaml` to use mysql, change username and password to yours:
+
+```properties
+  sql:
+    init:
+      schema-locations: classpath:sql/dolphinscheduler_mysql.sql
+  datasource:
+    driver-class-name: com.mysql.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+    username: {user}
+    password: {password}
+```
+
+* Add mysql-connector-java driver to `./standalone-server/libs/standalone-server/`, see [pseudo-cluster deployment](pseudo-cluster.md) `Initialize the Database` section about where to download
+
+* Start standalone-server, now you are using mysql as database and it will not clear up your data when you stop or restart standalone-server.

--- a/docs/docs/en/guide/installation/standalone.md
+++ b/docs/docs/en/guide/installation/standalone.md
@@ -5,7 +5,7 @@ Standalone only for quick experience for DolphinScheduler.
 If you are a new hand and want to experience DolphinScheduler functions, we recommend you install follow [Standalone deployment](standalone.md). If you want to experience more complete functions and schedule massive tasks, we recommend you install follow [pseudo-cluster deployment](pseudo-cluster.md). If you want to deploy DolphinScheduler in production, we recommend you follow [cluster deployment](cluster.md) or [Kubernetes deployment](kubernetes.md).
 
 > **_Note:_** Standalone only recommends the usage of fewer than 20 workflows, because it uses in-memory H2 Database in default, ZooKeeper Testing Server, too many tasks may cause instability.
-> When Standalone stops or restarts, in-memory H2 database will clear up. To use Standalone with external databases like mysql or postgresql, please see the last section `Database Configuration`.  
+> When Standalone stops or restarts, in-memory H2 database will clear up. To use Standalone with external databases like mysql or postgresql, please see [`Database Configuration`](#database-configuration).    
 
 ## Preparation
 
@@ -50,28 +50,13 @@ sh ./bin/dolphinscheduler-daemon.sh stop standalone-server
 
 * Use mysql as an example to illustrate how to configure an external database:
 * First of all, follow the instructions in [pseudo-cluster deployment](pseudo-cluster.md) `Initialize the Database` section to create and initialize database
-* Modify `./standalone-server/bin/dolphinscheduler_env.sh` to use mysql, change username and password to yours:
+* Set the following environment variables in your terminal with your database username and password for {user} and {password}:
 
 ```shell
 export DATABASE=${DATABASE:-mysql}
 export SPRING_PROFILES_ACTIVE=${DATABASE}
-export SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver
-export SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
 export SPRING_DATASOURCE_USERNAME={user}
 export SPRING_DATASOURCE_PASSWORD={password}
-```
-
-* Modify `./standalone-server/conf/application.yaml` to use mysql, change username and password to yours:
-
-```properties
-  sql:
-    init:
-      schema-locations: classpath:sql/dolphinscheduler_mysql.sql
-  datasource:
-    driver-class-name: com.mysql.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
-    username: {user}
-    password: {password}
 ```
 
 * Add mysql-connector-java driver to `./standalone-server/libs/standalone-server/`, see [pseudo-cluster deployment](pseudo-cluster.md) `Initialize the Database` section about where to download

--- a/docs/docs/zh/development/development-environment-setup.md
+++ b/docs/docs/zh/development/development-environment-setup.md
@@ -52,12 +52,12 @@ DolphinScheduler 开发环境配置有两个方式，分别是standalone模式�
 安装前端依赖并运行前端组件
 
 ```shell
-cd dolphinscheduler-ui
-npm install
-npm run start
+cd dolphinscheduler-ui-next
+pnpm install
+pnpm run dev
 ```
 
-截止目前，前后端已成功运行起来，浏览器访问[http://localhost:8888](http://localhost:8888)，并使用默认账户密码 **admin/dolphinscheduler123** 即可完成登录
+截止目前，前后端已成功运行起来，浏览器访问[http://localhost:3000](http://localhost:3000)，并使用默认账户密码 **admin/dolphinscheduler123** 即可完成登录
 
 ## DolphinScheduler 普通开发模式
 
@@ -147,9 +147,9 @@ DolphinScheduler 的元数据存储在关系型数据库中，目前支持的关
 安装前端依赖并运行前端组件
 
 ```shell
-cd dolphinscheduler-ui
-npm install
-npm run start
+cd dolphinscheduler-ui-next
+pnpm install
+pnpm run dev
 ```
 
-截止目前，前后端已成功运行起来，浏览器访问[http://localhost:8888](http://localhost:8888)，并使用默认账户密码 **admin/dolphinscheduler123** 即可完成登录
+截止目前，前后端已成功运行起来，浏览器访问[http://localhost:3000](http://localhost:3000)，并使用默认账户密码 **admin/dolphinscheduler123** 即可完成登录

--- a/docs/docs/zh/guide/installation/standalone.md
+++ b/docs/docs/zh/guide/installation/standalone.md
@@ -4,7 +4,8 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 
 如果你是新手，想要体验 DolphinScheduler 的功能，推荐使用[Standalone](standalone.md)方式体检。如果你想体验更完整的功能，或者更大的任务量，推荐使用[伪集群部署](pseudo-cluster.md)。如果你是在生产中使用，推荐使用[集群部署](cluster.md)或者[kubernetes](kubernetes.md)
 
-> **_注意:_** Standalone仅建议20个以下工作流使用，因为其采用 H2 Database, Zookeeper Testing Server，任务过多可能导致不稳定
+> **_注意:_** Standalone仅建议20个以下工作流使用，因为其采用内存式的H2 Database, Zookeeper Testing Server，任务过多可能导致不稳定，并且如果重启或者停止standalone-server会导致内存中数据库里的数据清空。
+> 如果您要连接外部数据库，比如mysql或者postgresql，请看结尾处`配置数据库`
 
 ## 前置准备工作
 
@@ -40,3 +41,35 @@ sh ./bin/dolphinscheduler-daemon.sh stop standalone-server
 ```
 
 [jdk]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
+
+### 配置数据库
+
+* 这里以mysql为例介绍如何连接外部数据库
+* 首先，参照 [伪集群部署](pseudo-cluster.md) `初始化数据库` 创建并初始化数据库 
+* 修改 `./standalone-server/bin/dolphinscheduler_env.sh` 使用mysql，将{user}和{password}改为你的数据库用户名和密码:
+
+```shell
+export DATABASE=${DATABASE:-mysql}
+export SPRING_PROFILES_ACTIVE=${DATABASE}
+export SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver
+export SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+export SPRING_DATASOURCE_USERNAME={user}
+export SPRING_DATASOURCE_PASSWORD={password}
+```
+
+* 修改 `./standalone-server/conf/application.yaml` 使用mysql，将{user}和{password}改为你的数据库用户名和密码:
+
+```properties
+  sql:
+    init:
+      schema-locations: classpath:sql/dolphinscheduler_mysql.sql
+  datasource:
+    driver-class-name: com.mysql.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+    username: {user}
+    password: {password}
+```
+
+* 将mysql-connector-java驱动加到`./standalone-server/libs/standalone-server/`目录下, 下载方法见 [伪集群部署](pseudo-cluster.md) `初始化数据库` 一栏
+
+* 启动standalone-server，此时你已经连接上mysql，重启或者停止standalone-server并不会清空您数据库里的数据

--- a/docs/docs/zh/guide/installation/standalone.md
+++ b/docs/docs/zh/guide/installation/standalone.md
@@ -5,7 +5,7 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 如果你是新手，想要体验 DolphinScheduler 的功能，推荐使用[Standalone](standalone.md)方式体检。如果你想体验更完整的功能，或者更大的任务量，推荐使用[伪集群部署](pseudo-cluster.md)。如果你是在生产中使用，推荐使用[集群部署](cluster.md)或者[kubernetes](kubernetes.md)
 
 > **_注意:_** Standalone仅建议20个以下工作流使用，因为其采用内存式的H2 Database, Zookeeper Testing Server，任务过多可能导致不稳定，并且如果重启或者停止standalone-server会导致内存中数据库里的数据清空。
-> 如果您要连接外部数据库，比如mysql或者postgresql，请看结尾处`配置数据库`
+> 如果您要连接外部数据库，比如mysql或者postgresql，请看[配置数据库](#配置数据库)
 
 ## 前置准备工作
 
@@ -46,28 +46,13 @@ sh ./bin/dolphinscheduler-daemon.sh stop standalone-server
 
 * 这里以mysql为例介绍如何连接外部数据库
 * 首先，参照 [伪集群部署](pseudo-cluster.md) `初始化数据库` 创建并初始化数据库 
-* 修改 `./standalone-server/bin/dolphinscheduler_env.sh` 使用mysql，将{user}和{password}改为你的数据库用户名和密码:
+* 在你的命令行设定下列环境变量，将{user}和{password}改为你数据库的用户名和密码
 
 ```shell
 export DATABASE=${DATABASE:-mysql}
 export SPRING_PROFILES_ACTIVE=${DATABASE}
-export SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver
-export SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
 export SPRING_DATASOURCE_USERNAME={user}
 export SPRING_DATASOURCE_PASSWORD={password}
-```
-
-* 修改 `./standalone-server/conf/application.yaml` 使用mysql，将{user}和{password}改为你的数据库用户名和密码:
-
-```properties
-  sql:
-    init:
-      schema-locations: classpath:sql/dolphinscheduler_mysql.sql
-  datasource:
-    driver-class-name: com.mysql.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
-    username: {user}
-    password: {password}
 ```
 
 * 将mysql-connector-java驱动加到`./standalone-server/libs/standalone-server/`目录下, 下载方法见 [伪集群部署](pseudo-cluster.md) `初始化数据库` 一栏

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -195,3 +195,17 @@ spring:
   quartz:
     properties:
       org.quartz.jobStore.driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+
+---
+spring:
+  config:
+    activate:
+      on-profile: mysql
+  sql:
+     init:
+       schema-locations: classpath:sql/dolphinscheduler_mysql.sql
+  datasource:
+    driver-class-name: com.mysql.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+    username: {user}
+    password: {password}

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -207,5 +207,5 @@ spring:
   datasource:
     driver-class-name: com.mysql.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
-    username: {user}
-    password: {password}
+    username: root
+    password: root


### PR DESCRIPTION
## Purpose of the pull request
* Remind users of that default db for standalone-server is in-memory H2 db, which will clear up when the standalone-server restarts or stops.
* Add instructions about how to change standalone database type.
* This PR closes: #9376 

## Brief change log
* Already described above

## Verify this pull request
* Verified by manual test
