### PR TITLE
[fix-9785][UI Next][dev] dynamic change height in viewlog when full s…

### DIFF
--- a/dolphinscheduler-ui-next/src/components/log-modal/index.tsx
+++ b/dolphinscheduler-ui-next/src/components/log-modal/index.tsx
@@ -156,7 +156,12 @@ export default defineComponent({
           }
         ])}
       >
-        <NLog rows={30} log={this.logRef} loading={this.logLoadingRef} />
+        <NLog
+          rows={30}
+          log={this.logRef}
+          loading={this.logLoadingRef}
+          style={{ height: isFullscreen ? 'calc(100vh - 140px)' : '525px' }}
+        />
       </Modal>
     )
   }


### PR DESCRIPTION
## Purpose of the pull request
to solve the scrollable height in viewlog modal.
I added this issue [https://github.com/apache/dolphinscheduler/issues/9785](https://github.com/apache/dolphinscheduler/issues/9785)

## Brief change log
i just changed the height in NLog component. and it worked fine.
`<NLog
          rows={30}
          log={this.logRef}
          loading={this.logLoadingRef}
          style={{ height: isFullscreen ? 'calc(100vh - 140px)' : '525px' }}
        />`
`525px`: NLog has the default certain heigth
`calc(100vh - 140px)` : when screen full, the heigth should be the viewport heigth exclude header height,footer height and padding bottom in NModal
## Verify this pull request
This pull request is code cleanup without any test coverage.

