### PR TITLE
[Bug-9793] [Script] dolphinscheduler-daemon.sh overwrite_server_env may causing standalone server start failed

### DIFF
--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -42,7 +42,9 @@ BIN_ENV_FILE="${DOLPHINSCHEDULER_HOME}/bin/env/dolphinscheduler_env.sh"
 function overwrite_server_env() {
   local server=$1
   local server_env_file="${DOLPHINSCHEDULER_HOME}/${server}/conf/dolphinscheduler_env.sh"
-  if [ -f "${BIN_ENV_FILE}" ]; then
+  if [ "$server" = "standalone-server" ]; then
+    echo "standalone-server skip overwrite_server_env"
+  elif [ -f "${BIN_ENV_FILE}" ]; then
     echo "Overwrite ${server}/conf/dolphinscheduler_env.sh using bin/env/dolphinscheduler_env.sh."
     cp "${BIN_ENV_FILE}" "${server_env_file}"
   else


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This pr will close #9793 