### PR TITLE
[doc] Dir development should not ref other dirs content

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Run Dev Relative Reference
+        run: python img_utils.py -v dev-syntax
       - name: Run Image Check
         run: python img_utils.py -v check
   dead-link:

--- a/docs/docs/en/development/development-environment-setup.md
+++ b/docs/docs/en/development/development-environment-setup.md
@@ -37,7 +37,7 @@ There are two ways to configure the DolphinScheduler development environment, st
 
 > **_Note:_** Use standalone server only for development and debugging, because it uses H2 Database as default database and Zookeeper Testing Server which may not be stable in production.
 > Standalone is only supported in DolphinScheduler 1.3.9 and later versions.
-> Standalone server is able to connect to external databases like mysql and postgresql, see [Standalone Deployment](../guide/installation/standalone.md) for instructions.
+> Standalone server is able to connect to external databases like mysql and postgresql, see [Standalone Deployment](https://dolphinscheduler.apache.org/en-us/docs/dev/user_doc/guide/installation/standalone.html) for instructions.
 
 ### Git Branch Choose
 

--- a/docs/img_utils.py
+++ b/docs/img_utils.py
@@ -31,6 +31,8 @@ log.addHandler(logging.StreamHandler())
 root_dir: Path = Path(__file__).parent
 img_dir: Path = root_dir.joinpath("img")
 doc_dir: Path = root_dir.joinpath("docs")
+dev_en_dir: Path = doc_dir.joinpath("en", "development")
+dev_zh_dir: Path = doc_dir.joinpath("zh", "development")
 
 
 def get_files_recurse(path: Path) -> Set:
@@ -122,6 +124,17 @@ def prune() -> None:
     del_empty_dir_recurse(img_dir)
 
 
+def dev_syntax() -> None:
+    """Check temp whether temporary do not support syntax in development."""
+    pattern = re.compile("(\\(\\.\\.[\\w./-]+\\))")
+    dev_files_path = get_files_recurse(dev_en_dir) | get_files_recurse(dev_zh_dir)
+    get_files_recurse(dev_en_dir)
+    for path in dev_files_path:
+        content = path.read_text()
+        find = pattern.findall(content)
+        assert not find, f"File {str(path)} contain temporary not support syntax: {find}."
+
+
 def build_argparse() -> argparse.ArgumentParser:
     """Build argparse.ArgumentParser with specific configuration."""
     parser = argparse.ArgumentParser(prog="img_utils")
@@ -149,6 +162,11 @@ def build_argparse() -> argparse.ArgumentParser:
         "prune", help="Remove img in directory `img` but not use in directory `docs`."
     )
     parser_prune.set_defaults(func=prune)
+
+    parser_prune = subparsers.add_parser(
+        "dev-syntax", help="Check whether temporary does not support syntax in development directory."
+    )
+    parser_prune.set_defaults(func=dev_syntax)
 
     # TODO Add subcommand `reorder`
     return parser


### PR DESCRIPTION
For now, development dir deploy in other place instead
of docs dir https://dolphinscheduler.apache.org/en-us/development/development-environment-setup.html
so could not ref markdown doc from other docs dir
