### PR TITLE
[doc] Fix syntax error cause website not work correctly

### DIFF
--- a/docs/configs/docsdev.js
+++ b/docs/configs/docsdev.js
@@ -245,7 +245,6 @@ export default {
                                 title: 'Script',
                                 link: '/en-us/docs/dev/user_doc/guide/alert/script.html',
                             },
-                            ,
                             {
                                 title: 'Http',
                                 link: '/en-us/docs/dev/user_doc/guide/alert/http.html',


### PR DESCRIPTION
In https://github.com/apache/dolphinscheduler/pull/9792 we change docsdev.js with unexpected syntax which will cause the error of the website build