### PR TITLE
[Fix-9854][api] Query access token for specified user failed

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
@@ -33,9 +33,9 @@
     </select>
 
     <select id="queryAccessTokenByUser" resultType="org.apache.dolphinscheduler.dao.entity.AccessToken">
-        select `id`, `user_id`, `token`, `expire_time`, `create_time`, `update_time`
-        from `t_ds_access_token`
-        where `user_id` = #{userId}
+        select id, user_id, token, expire_time, create_time, update_time
+        from t_ds_access_token
+        where user_id = #{userId}
     </select>
 
     <delete id="deleteAccessTokenByUserId">


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

When storing metadata through the **PostgreSQL** database, fix query access token for specified user failed! The exception log is as follows:
![image](https://user-images.githubusercontent.com/62897740/165965430-9196558a-10ec-48e8-babd-66930b91c10e.png)

The issue is refer to https://github.com/apache/dolphinscheduler/issues/9854



<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

dolphinscheduler-dao/src/main/resources/org.apache.dolphinscheduler.dao.mapper/AccessTokenMapper.xml -> queryAccessTokenByUser block and remove to '`'.  The original SQL statement is as follows：
![image](https://user-images.githubusercontent.com/62897740/165965725-d77bd3f9-220e-4b2a-be22-de6b796a431e.png)


<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
