### PR TITLE
[Fix-9906] After the serial wait execution strategy stops the running workflow instance, the instance will be woken up and executed if there is a wait instance.

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -667,7 +667,8 @@ public class WorkflowExecuteThread {
         try {
             logger.info("process:{} state {} change to {}", processInstance.getId(), processInstance.getState(), stateEvent.getExecutionStatus());
 
-            if (stateEvent.getExecutionStatus() == ExecutionStatus.STOP) {
+            // serial wait execution type needs to wake up the waiting process
+            if (stateEvent.getExecutionStatus() == ExecutionStatus.STOP && !processDefinition.getExecutionType().typeIsSerialWait()) {
                 this.updateProcessInstanceState(stateEvent);
                 return true;
             }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -667,10 +667,15 @@ public class WorkflowExecuteThread {
         try {
             logger.info("process:{} state {} change to {}", processInstance.getId(), processInstance.getState(), stateEvent.getExecutionStatus());
 
-            // serial wait execution type needs to wake up the waiting process
-            if (stateEvent.getExecutionStatus() == ExecutionStatus.STOP && !processDefinition.getExecutionType().typeIsSerialWait()) {
-                this.updateProcessInstanceState(stateEvent);
-                return true;
+            if (stateEvent.getExecutionStatus() == ExecutionStatus.STOP) {
+                // serial wait execution type needs to wake up the waiting process
+                if (processDefinition.getExecutionType().typeIsSerialWait()){
+                    endProcess();
+                    return true;
+                } else {
+                    this.updateProcessInstanceState(stateEvent);
+                    return true;
+                }
             }
 
             if (processComplementData()) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThread.java
@@ -672,10 +672,9 @@ public class WorkflowExecuteThread {
                 if (processDefinition.getExecutionType().typeIsSerialWait()){
                     endProcess();
                     return true;
-                } else {
-                    this.updateProcessInstanceState(stateEvent);
-                    return true;
                 }
+                this.updateProcessInstanceState(stateEvent);
+                return true;
             }
 
             if (processComplementData()) {

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/WorkflowExecuteThreadTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/WorkflowExecuteThreadTest.java
@@ -164,7 +164,7 @@ public class WorkflowExecuteThreadTest {
             List<TaskInstance> taskInstances = (List<TaskInstance>) method.invoke(workflowExecuteThread, JSONUtils.toJsonString(cmdParam));
             Assert.assertEquals(4, taskInstances.size());
 
-            cmdParam.put(CMD_PARAM_RECOVERY_START_NODE_STRING, "");
+            cmdParam.put(CMD_PARAM_RECOVERY_START_NODE_STRING, "1");
             List<TaskInstance> taskInstanceEmpty = (List<TaskInstance>) method.invoke(workflowExecuteThread, JSONUtils.toJsonString(cmdParam));
             Assert.assertTrue(taskInstanceEmpty.isEmpty());
 


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

After the serial wait execution strategy stops the running workflow instance, the instance will be woken up and executed if there is a wait instance.

## Brief change log

close #9906 

## Verify this pull request

Manually verified the change by testing locally.
