### PR TITLE
[Fix#9923] The alarm instance management interface is always in the loading state

### DIFF
--- a/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
+++ b/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
@@ -29,7 +29,6 @@ import type {
   IJsonItem,
   IRecord
 } from './types'
-import utils from '@/utils'
 
 export function useForm() {
   const { t } = useI18n()

--- a/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
+++ b/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
@@ -29,6 +29,7 @@ import type {
   IJsonItem,
   IRecord
 } from './types'
+import utils from '@/utils'
 
 export function useForm() {
   const { t } = useI18n()
@@ -72,12 +73,17 @@ export function useForm() {
   const getUiPluginsByType = async () => {
     if (state.pluginsLoading) return
     state.pluginsLoading = true
-    const plugins = await queryUiPluginsByType({ pluginType: 'ALERT' })
-    state.uiPlugins = plugins.map((plugin: IPlugin) => ({
-      label: plugin.pluginName,
-      value: plugin.id
-    }))
-    state.pluginsLoading = false
+    try {
+      const plugins = await queryUiPluginsByType({ pluginType: 'ALERT' })
+      state.uiPlugins = plugins.map((plugin: IPlugin) => ({
+        label: plugin.pluginName,
+        value: plugin.id
+      }))
+    } catch (e) {
+      utils.log.error(e)
+    } finally {
+      state.pluginsLoading = false
+    }
   }
 
   const changePlugin = async (pluginId: IPluginId) => {

--- a/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
+++ b/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
@@ -80,8 +80,6 @@ export function useForm() {
         value: plugin.id
       }))
     } catch (e) {
-      utils.log.error(e)
-    } finally {
       state.pluginsLoading = false
     }
   }

--- a/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
+++ b/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
@@ -81,6 +81,7 @@ export function useForm() {
     } catch (e) {
       state.pluginsLoading = false
     }
+    state.pluginsLoading = false
   }
 
   const changePlugin = async (pluginId: IPluginId) => {

--- a/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
+++ b/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
@@ -78,10 +78,10 @@ export function useForm() {
         label: plugin.pluginName,
         value: plugin.id
       }))
+      state.pluginsLoading = false
     } catch (e) {
       state.pluginsLoading = false
     }
-    state.pluginsLoading = false
   }
 
   const changePlugin = async (pluginId: IPluginId) => {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

## Brief change log

close [#9923](https://github.com/apache/dolphinscheduler/issues/9923) also close #10207

## Verify this pull request

Manually verified the change by testing locally
