### PR TITLE
[Fix-9984] Fix db-init-job failed when deploy on k8s by helm

### DIFF
--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/CreateDolphinScheduler.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/CreateDolphinScheduler.java
@@ -30,7 +30,8 @@ import org.springframework.stereotype.Component;
 @ComponentScan(
     includeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = CreateDolphinScheduler.CreateRunner.class)
-    }, useDefaultFilters = false
+    },
+    useDefaultFilters = false
 )
 public class CreateDolphinScheduler {
     public static void main(String[] args) {

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/CreateDolphinScheduler.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/CreateDolphinScheduler.java
@@ -22,9 +22,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.stereotype.Component;
 
 @SpringBootApplication
+@ComponentScan(
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = CreateDolphinScheduler.CreateRunner.class)
+    }, useDefaultFilters = false
+)
 public class CreateDolphinScheduler {
     public static void main(String[] args) {
         SpringApplication.run(CreateDolphinScheduler.class, args);

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/InitDolphinScheduler.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/InitDolphinScheduler.java
@@ -30,7 +30,8 @@ import org.springframework.stereotype.Component;
 @ComponentScan(
     includeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = InitDolphinScheduler.InitRunner.class)
-    }, useDefaultFilters = false
+    },
+    useDefaultFilters = false
 )
 public class InitDolphinScheduler {
     public static void main(String[] args) {

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/InitDolphinScheduler.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/InitDolphinScheduler.java
@@ -22,9 +22,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.stereotype.Component;
 
 @SpringBootApplication
+@ComponentScan(
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = InitDolphinScheduler.InitRunner.class)
+    }, useDefaultFilters = false
+)
 public class InitDolphinScheduler {
     public static void main(String[] args) {
         SpringApplication.run(InitDolphinScheduler.class, args);

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/UpgradeDolphinScheduler.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/UpgradeDolphinScheduler.java
@@ -30,7 +30,8 @@ import org.springframework.stereotype.Component;
 @ComponentScan(
     includeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UpgradeDolphinScheduler.UpgradeRunner.class)
-    }, useDefaultFilters = false
+    },
+    useDefaultFilters = false
 )
 public class UpgradeDolphinScheduler {
     public static void main(String[] args) {

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/UpgradeDolphinScheduler.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/UpgradeDolphinScheduler.java
@@ -22,9 +22,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.stereotype.Component;
 
 @SpringBootApplication
+@ComponentScan(
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UpgradeDolphinScheduler.UpgradeRunner.class)
+    }, useDefaultFilters = false
+)
 public class UpgradeDolphinScheduler {
     public static void main(String[] args) {
         SpringApplication.run(UpgradeDolphinScheduler.class, args);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
This pull request fix  db-init-job failed when to deploy on k8s by helm.

When you helm install dolphinscheduler on k8s and occured this bug. The detail can see #9963.

And the reason why is there are three class SpringBootApplication ```CreateDolphinScheduler InitDolphinScheduler and UpgradeDolphinScheduler``` in tools-modules. And they are in the same pkg. When you run any class SpringBootApplication will auto-scan all their runner classes by ```@Component```.  The SQL file will running twice. And the table t_ds_process_instance can't dropped because of foreign_key.
```
cannot drop table t_ds_process_instance because other objects depend on it
Detail: constraint foreign_key_instance_id on table t_ds_task_instance depends on table t_ds_process_instance
``` 

So there is a problem.

The solution is to configure to only scan itself and run only runner itself.

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

* Change dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/CreateDolphinScheduler.java
* Change dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/InitDolphinScheduler.java
* Change dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/UpgradeDolphinScheduler.java

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request
* I have test local

close #9963 part of #9984 