### PR TITLE
[ci] Dead link check all markdown file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo npm install -g markdown-link-check@3.10.0
-      # NOTE: Change command to ` find . -not -path "*/node_modules/*" -not -path "*/.tox/*" -name "*.md"` if you want to run check locally
+      # NOTE: Change command from `find . -name "*.md"` to `find . -not -path "*/node_modules/*" -not -path "*/.tox/*" -name "*.md"`
+      # if you want to run check locally
       - run: |
           for file in $(find . -name "*.md"); do
             markdown-link-check -c .dlc.json -q "$file"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo npm install -g markdown-link-check@3.10.0
+      # NOTE: Change command to ` find . -not -path "*/node_modules/*" -not -path "*/.tox/*" -name "*.md"` if you want to run check locally
       - run: |
-          for file in $(find ./docs -name "*.md"); do
+          for file in $(find . -name "*.md"); do
             markdown-link-check -c .dlc.json -q "$file"
           done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,8 @@ name: Docs
 on:
   pull_request:
     paths:
+      - '.github/workflows/docs.yml'
+      - '**/*.md'
       - 'docs/**'
 
 concurrency:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,4 +1,4 @@
 # DolphinScheduler for Docker and Kubernetes
 
-* [Start Up DolphinScheduler with Docker](https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/guide/installation/docker.html)
+* [Start Up DolphinScheduler with Docker](https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/guide/start/docker.html)
 * [Start Up DolphinScheduler with Kubernetes](https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/guide/installation/kubernetes.html)


### PR DESCRIPTION
there are 162 markdown files in dir `docs`
and all file in project is 175 files, so I
think check all file will not add too much
load for our ci, but it could discovered
the dead link in time to avoid some thing
like #9998

