### PR TITLE
[Fix-10051][Alert]Fix Alert Server UT

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertServer.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertServer.java
@@ -31,7 +31,6 @@ import javax.annotation.PreDestroy;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.event.ApplicationReadyEvent;

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/test/java/org/apache/dolphinscheduler/alert/AlertServerTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/test/java/org/apache/dolphinscheduler/alert/AlertServerTest.java
@@ -56,8 +56,8 @@ public class AlertServerTest extends TestCase {
     public void testStart() {
 
         Mockito.when(pluginDao.checkPluginDefineTableExist()).thenReturn(true);
-        
-        Mockito.when(alertConfig.getPort()).thenReturn(50053);
+
+        Mockito.when(alertConfig.getPort()).thenReturn(50052);
 
         Mockito.doNothing().when(alertSenderService).start();
 
@@ -67,7 +67,7 @@ public class AlertServerTest extends TestCase {
     
         NettyServerConfig nettyServerConfig = Whitebox.getInternalState(nettyRemotingServer, "serverConfig");
         
-        Assert.assertEquals(50053, nettyServerConfig.getListenPort());
+        Assert.assertEquals(50052, nettyServerConfig.getListenPort());
 
     }
 }


### PR DESCRIPTION
Remove this unused import && Change the Alert Server UT Netty port, which will be [50052](https://github.com/apache/dolphinscheduler/blob/3.0.0-alpha-release/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application.yaml#L56) and [this](https://github.com/apache/dolphinscheduler/blob/3.0.0-alpha-release/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertConfig.java#L24)