### PR TITLE
[doc] change document structure

### DIFF
--- a/docs/configs/docsdev.js
+++ b/docs/configs/docsdev.js
@@ -51,27 +51,6 @@ export default {
                 ],
             },
             {
-                title: 'Installation',
-                children: [
-                    {
-                        title: 'Standalone Deployment',
-                        link: '/en-us/docs/dev/user_doc/guide/installation/standalone.html',
-                    },
-                    {
-                        title: 'Pseudo Cluster Deployment',
-                        link: '/en-us/docs/dev/user_doc/guide/installation/pseudo-cluster.html',
-                    },
-                    {
-                        title: 'Cluster Deployment',
-                        link: '/en-us/docs/dev/user_doc/guide/installation/cluster.html',
-                    },
-                    {
-                        title: 'Kubernetes Deployment',
-                        link: '/en-us/docs/dev/user_doc/guide/installation/kubernetes.html',
-                    },
-                ],
-            },
-            {
                 title: 'Introduction to Functions',
                 children: [
                     {
@@ -268,10 +247,6 @@ export default {
                         ],
                     },
                     {
-                        title: 'Data Quality',
-                        link: '/en-us/docs/dev/user_doc/guide/data-quality.html',
-                    },
-                    {
                         title: 'Resource',
                         children: [
                             {
@@ -310,8 +285,8 @@ export default {
                         ],
                     },
                     {
-                        title: 'Open API',
-                        link: '/en-us/docs/dev/user_doc/guide/open-api.html',
+                        title: 'Data Quality',
+                        link: '/en-us/docs/dev/user_doc/guide/data-quality.html',
                     },
                     {
                         title: 'Flink',
@@ -324,6 +299,27 @@ export default {
                     {
                         title: 'Expansion and Reduction',
                         link: '/en-us/docs/dev/user_doc/guide/expansion-reduction.html',
+                    },
+                ],
+            },
+            {
+                title: 'Installation',
+                children: [
+                    {
+                        title: 'Standalone Deployment',
+                        link: '/en-us/docs/dev/user_doc/guide/installation/standalone.html',
+                    },
+                    {
+                        title: 'Pseudo Cluster Deployment',
+                        link: '/en-us/docs/dev/user_doc/guide/installation/pseudo-cluster.html',
+                    },
+                    {
+                        title: 'Cluster Deployment',
+                        link: '/en-us/docs/dev/user_doc/guide/installation/cluster.html',
+                    },
+                    {
+                        title: 'Kubernetes Deployment',
+                        link: '/en-us/docs/dev/user_doc/guide/installation/kubernetes.html',
                     },
                 ],
             },
@@ -353,6 +349,19 @@ export default {
                     {
                         title: 'Cache',
                         link: '/en-us/docs/dev/user_doc/architecture/cache.html',
+                    },
+                ],
+            },
+            {
+                title: 'API',
+                children: [
+                    {
+                        title: 'Open API',
+                        link: '/en-us/docs/dev/user_doc/guide/open-api.html',
+                    },
+                    {
+                        title: 'PyDolphinScheduler',
+                        link: '/python/index.html',
                     },
                 ],
             },
@@ -406,27 +415,6 @@ export default {
                     {
                         title: 'Docker部署(Docker)',
                         link: '/zh-cn/docs/dev/user_doc/guide/start/docker.html',
-                    },
-                ],
-            },
-            {
-                title: '部署指南',
-                children: [
-                    {
-                        title: '单机部署(Standalone)',
-                        link: '/zh-cn/docs/dev/user_doc/guide/installation/standalone.html',
-                    },
-                    {
-                        title: '伪集群部署(Pseudo-Cluster)',
-                        link: '/zh-cn/docs/dev/user_doc/guide/installation/pseudo-cluster.html',
-                    },
-                    {
-                        title: '集群部署(Cluster)',
-                        link: '/zh-cn/docs/dev/user_doc/guide/installation/cluster.html',
-                    },
-                    {
-                        title: 'Kubernetes部署(Kubernetes)',
-                        link: '/zh-cn/docs/dev/user_doc/guide/installation/kubernetes.html',
                     },
                 ],
             },
@@ -627,10 +615,6 @@ export default {
                         ],
                     },
                     {
-                        title: '数据质量',
-                        link: '/zh-cn/docs/dev/user_doc/guide/data-quality.html',
-                    },
-                    {
                         title: '资源中心',
                         children: [
                             {
@@ -660,7 +644,7 @@ export default {
                         link: '/zh-cn/docs/dev/user_doc/guide/security.html',
                     },
                     {
-                        title: '常见操作',
+                        title: '常用指引',
                         children: [
                             {
                                 title: '通用设置',
@@ -669,8 +653,8 @@ export default {
                         ],
                     },
                     {
-                        title: 'API调用',
-                        link: '/zh-cn/docs/dev/user_doc/guide/open-api.html',
+                        title: '数据质量',
+                        link: '/zh-cn/docs/dev/user_doc/guide/data-quality.html',
                     },
                     {
                         title: 'Flink调用',
@@ -683,6 +667,27 @@ export default {
                     {
                         title: '扩/缩容',
                         link: '/zh-cn/docs/dev/user_doc/guide/expansion-reduction.html',
+                    },
+                ],
+            },
+            {
+                title: '部署指南',
+                children: [
+                    {
+                        title: '单机部署(Standalone)',
+                        link: '/zh-cn/docs/dev/user_doc/guide/installation/standalone.html',
+                    },
+                    {
+                        title: '伪集群部署(Pseudo-Cluster)',
+                        link: '/zh-cn/docs/dev/user_doc/guide/installation/pseudo-cluster.html',
+                    },
+                    {
+                        title: '集群部署(Cluster)',
+                        link: '/zh-cn/docs/dev/user_doc/guide/installation/cluster.html',
+                    },
+                    {
+                        title: 'Kubernetes部署(Kubernetes)',
+                        link: '/zh-cn/docs/dev/user_doc/guide/installation/kubernetes.html',
                     },
                 ],
             },
@@ -712,6 +717,19 @@ export default {
                     {
                         title: '缓存',
                         link: '/zh-cn/docs/dev/user_doc/architecture/cache.html',
+                    },
+                ],
+            },
+            {
+                title: 'API',
+                children: [
+                    {
+                        title: 'API调用',
+                        link: '/zh-cn/docs/dev/user_doc/guide/open-api.html',
+                    },
+                    {
+                        title: 'PyDolphinScheduler',
+                        link: '/python/index.html',
                     },
                 ],
             },

--- a/docs/configs/site.js
+++ b/docs/configs/site.js
@@ -58,16 +58,6 @@ export default {
             text: 'Older Versions',
             link: '/en-us/docs/release/history-versions.html',
           },
-          {
-            key: 'pythonAPI',
-            text: 'PyDolphinScheduler',
-            link: '/python/index.html',
-          },
-          {
-            key: 'docsdev',
-            text: 'dev',
-            link: '/en-us/docs/dev/user_doc/about/introduction.html',
-          },
         ],
       },
       {


### PR DESCRIPTION
This patch change the structure and make it more sense

* Remove dev doc in tab Docs, and for now you could only see it in
  history-version page
* Move PyDolphinScheduler from tab DOCS to sidebar and combine with open
  API
* Move installation after Functions
* Move data quality after HOW-TOS
