### PR TITLE
[python] Change distribute name avoid confusion with main pkg

### DIFF
--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -92,6 +92,37 @@
                                     </arguments>
                                 </configuration>
                             </execution>
+                            <!-- Rename Python dist package to avoid confusion with dolphinscheduler main package -->
+                            <execution>
+                                <id>python-pkg-rename-tar</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>mv apache-dolphinscheduler-*.tar.gz apache-dolphinscheduler-python-${project.version}.tar.gz</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>python-pkg-rename-whl</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>mv apache_dolphinscheduler-*py3-none-any.whl apache_dolphinscheduler-python-${project.version}-py3-none-any.whl</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>sign-source</id>
                                 <phase>prepare-package</phase>

--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -104,7 +104,7 @@
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>
                                         <argument>-c</argument>
-                                        <argument>mv apache-dolphinscheduler-*.tar.gz apache-dolphinscheduler-python-${project.version}.tar.gz</argument>
+                                        <argument>mv dist/apache-dolphinscheduler-*.tar.gz dist/apache-dolphinscheduler-python-${project.version}.tar.gz</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -119,7 +119,7 @@
                                     <workingDirectory>${project.basedir}/pydolphinscheduler</workingDirectory>
                                     <arguments>
                                         <argument>-c</argument>
-                                        <argument>mv apache_dolphinscheduler-*py3-none-any.whl apache_dolphinscheduler-python-${project.version}-py3-none-any.whl</argument>
+                                        <argument>mv dist/apache_dolphinscheduler-*py3-none-any.whl dist/apache_dolphinscheduler-python-${project.version}-py3-none-any.whl</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
rename them and add `python` suffix in the end
close: #9121
