### PR TITLE
[Fix] Change the default value of the parameter 'block-until-connecte…

### DIFF
--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -81,7 +81,7 @@ registry:
       max-retries: 5
     session-timeout: 30s
     connection-timeout: 9s
-    block-until-connected: 600ms
+    block-until-connected: 5000ms
     digest: ~
 
 master:


### PR DESCRIPTION
## Purpose of the pull request

Change the default value of the parameter 'block-until-connected' for registry. 
600ms may be too short that sometimes it cause exception like "RegistryException: zookeeper connect timeout".

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
