### PR TITLE
[Fix] Change the default value of the parameter 'block-until-connecte…

### DIFF
--- a/dolphinscheduler-server/src/main/resources/config/install_config.conf
+++ b/dolphinscheduler-server/src/main/resources/config/install_config.conf
@@ -105,6 +105,9 @@ registryServers="192.168.xx.xx:2181,192.168.xx.xx:2181,192.168.xx.xx:2181"
 # Registry Namespace
 registryNamespace="dolphinscheduler"
 
+# Registry connect wait
+registryBlockUntilConnectedWait=5000
+
 # ---------------------------------------------------------
 # Worker Task Server
 # ---------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ sed -i ${txt} "s@^#*registry.plugin.dir=.*@registry.plugin.dir=${installPath}/${
 sed -i ${txt} "s@^#*registry.plugin.name=.*@registry.plugin.name=${registryPluginName}@g" conf/registry.properties
 sed -i ${txt} "s@^#*registry.servers=.*@registry.servers=${registryServers}@g" conf/registry.properties
 sed -i ${txt} "s@^#*registry.namespace=.*@registry.namespace=${registryNamespace}@g" conf/registry.properties
+sed -i ${txt} "s@^#*registry.block.until.connected.wait=.*@registry.block.until.connected.wait=${registryBlockUntilConnectedWait}@g" conf/registry.properties
 
 # 2.create directory
 echo "2.create directory"


### PR DESCRIPTION
## Purpose of the pull request
Change the default value of the parameter 'block-until-connected' for registry. 
600ms may be too short that sometimes it cause exception like "RegistryException: zookeeper connect timeout".

## Brief change log


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
