### PR TITLE
[Cherry-Pick][Fix][UI] Limit task group resource capacity to only positive integers.

### DIFF
--- a/dolphinscheduler-ui/src/locales/modules/en_US.ts
+++ b/dolphinscheduler-ui/src/locales/modules/en_US.ts
@@ -306,8 +306,6 @@ const resource = {
     name: 'Task group name',
     project_name: 'Project name',
     resource_pool_size: 'Resource pool size',
-    resource_pool_size_be_a_number:
-      'The size of the task group resource pool should be more than 1',
     resource_used_pool_size: 'Used resource',
     desc: 'Task group desc',
     status: 'Task group status',
@@ -317,6 +315,7 @@ const resource = {
     please_enter_desc: 'Please enter task group description',
     please_enter_resource_pool_size:
       'Please enter task group resource pool size',
+    positive_integer_tips: 'should be a positive integer',
     please_select_project: 'Please select a project',
     create_time: 'Create time',
     update_time: 'Update time',

--- a/dolphinscheduler-ui/src/locales/modules/zh_CN.ts
+++ b/dolphinscheduler-ui/src/locales/modules/zh_CN.ts
@@ -312,7 +312,7 @@ const resource = {
     please_enter_name: '请输入任务组名称',
     please_enter_desc: '请输入任务组描述',
     please_enter_resource_pool_size: '请输入资源容量大小',
-    resource_pool_size_be_a_number: '资源容量大小必须大于等于1的数值',
+    positive_integer_tips: '应为正整数',
     please_select_project: '请选择项目',
     create_time: '创建时间',
     update_time: '更新时间',

--- a/dolphinscheduler-ui/src/views/resource/task-group/option/components/form-modal.tsx
+++ b/dolphinscheduler-ui/src/views/resource/task-group/option/components/form-modal.tsx
@@ -16,7 +16,7 @@
  */
 
 import { defineComponent, PropType, toRefs, onMounted, ref, Ref } from 'vue'
-import { NForm, NFormItem, NInput, NSelect } from 'naive-ui'
+import { NForm, NFormItem, NInput, NSelect, NInputNumber } from 'naive-ui'
 import { useForm } from '../use-form'
 import Modal from '@/components/modal'
 import { createTaskGroup, updateTaskGroup } from '@/service/modules/task-group'
@@ -133,8 +133,10 @@ const FormModal = defineComponent({
             label={t('resource.task_group_option.resource_pool_size')}
             path='groupSize'
           >
-            <NInput
+            <NInputNumber
               v-model:value={this.formData.groupSize}
+              style={{width: '100%'}}
+              min={1}
               placeholder={t(
                 'resource.task_group_option.please_enter_resource_pool_size'
               )}

--- a/dolphinscheduler-ui/src/views/resource/task-group/option/use-form.ts
+++ b/dolphinscheduler-ui/src/views/resource/task-group/option/use-form.ts
@@ -53,6 +53,12 @@ export function useForm() {
               t('resource.task_group_option.please_enter_resource_pool_size')
             )
           }
+          if (!/^[1-9]\d*$/.test(state.formData.groupSize)) {
+            return new Error(
+              t('resource.task_group_option.resource_pool_size') +
+                t('resource.task_group_option.positive_integer_tips')
+            )
+          }
         }
       },
       projectCode: {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
ref https://github.com/apache/dolphinscheduler/pull/10158
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
