### PR TITLE
[Fix-10076] queryUserByToken use server timezone

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptor.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptor.java
@@ -37,6 +37,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.util.Date;
+
 /**
  * login interceptor, must log in first
  */
@@ -71,7 +73,7 @@ public class LoginHandlerInterceptor implements HandlerInterceptor {
                 return false;
             }
         } else {
-            user = userMapper.queryUserByToken(token);
+            user = userMapper.queryUserByToken(token, new Date());
             if (user == null) {
                 response.setStatus(HttpStatus.SC_UNAUTHORIZED);
                 logger.info("user token has expired");

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptorTest.java
@@ -45,6 +45,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
+
 @ActiveProfiles(value = {ProfileType.H2})
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ApiApplicationServer.class)
@@ -81,7 +83,7 @@ public class LoginHandlerInterceptorTest {
         // test token
         String token = "123456";
         when(request.getHeader("token")).thenReturn(token);
-        when(userMapper.queryUserByToken(token)).thenReturn(mockUser);
+        when(userMapper.queryUserByToken(token, new Date())).thenReturn(mockUser);
         Assert.assertTrue(interceptor.preHandle(request, response, null));
 
         // test disable user

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.api.interceptor;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.ApiApplicationServer;
@@ -83,7 +85,7 @@ public class LoginHandlerInterceptorTest {
         // test token
         String token = "123456";
         when(request.getHeader("token")).thenReturn(token);
-        when(userMapper.queryUserByToken(token, new Date())).thenReturn(mockUser);
+        when(userMapper.queryUserByToken(eq(token), any(Date.class))).thenReturn(mockUser);
         Assert.assertTrue(interceptor.preHandle(request, response, null));
 
         // test disable user

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/UserMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/UserMapper.java
@@ -21,6 +21,7 @@ import org.apache.dolphinscheduler.dao.entity.User;
 
 import org.apache.ibatis.annotations.Param;
 
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.cache.annotation.CacheConfig;
@@ -83,7 +84,7 @@ public interface UserMapper extends BaseMapper<User> {
     /**
      * user page
      *
-     * @param page page
+     * @param page     page
      * @param userName userName
      * @return user IPage
      */
@@ -126,9 +127,10 @@ public interface UserMapper extends BaseMapper<User> {
      * query user by token
      *
      * @param token token
+     * @param now   now date
      * @return user
      */
-    User queryUserByToken(@Param("token") String token);
+    User queryUserByToken(@Param("token") String token, @Param("now") Date now);
 
     /**
      * query user by queue name

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/UserMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/UserMapper.xml
@@ -97,7 +97,7 @@
             <property name="alias" value="u"/>
         </include>
         from t_ds_user u ,t_ds_access_token t
-        where u.id = t.user_id and token=#{token} and t.expire_time > NOW()
+        where u.id = t.user_id and token=#{token} and t.expire_time > #{now}
     </select>
     <select id="queryUserListByQueue" resultType="org.apache.dolphinscheduler.dao.entity.User">
         select

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/UserMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/UserMapperTest.java
@@ -303,7 +303,7 @@ public class UserMapperTest extends BaseDaoTest {
         //insertOneAccessToken
         AccessToken accessToken = insertOneAccessToken(user);
         //queryUserByToken
-        User userToken = userMapper.queryUserByToken(accessToken.getToken());
+        User userToken = userMapper.queryUserByToken(accessToken.getToken(), new Date());
         Assert.assertEquals(userToken, user);
 
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
close #10076 
test method `org.apache.dolphinscheduler.dao.mapper.UserMapperTest#testQueryUserByToken`
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
