### PR TITLE
[Fix-10196] When creating a task group, the description information is not required, but I not can click confirm before entering the description information

### DIFF
--- a/dolphinscheduler-ui/src/views/resource/task-group/option/components/form-modal.tsx
+++ b/dolphinscheduler-ui/src/views/resource/task-group/option/components/form-modal.tsx
@@ -101,11 +101,7 @@ const FormModal = defineComponent({
         show={show}
         onConfirm={onConfirm}
         onCancel={onCancel}
-        confirmDisabled={
-          !this.formData.name ||
-          !this.formData.groupSize ||
-          !this.formData.description
-        }
+        confirmDisabled={!this.formData.name || !this.formData.groupSize}
         confirmLoading={this.saving}
       >
         <NForm rules={this.rules} ref='formRef'>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request


## Brief change log

close [#10196](https://github.com/apache/dolphinscheduler/issues/10196)

## Verify this pull request

Manually verified the change by testing locally.
