### PR TITLE
[Fix] Fix the jmod issues, support 11 and later versions  #10232

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
@@ -136,9 +136,26 @@
             <scope>test</scope>
         </dependency>
 
+
+
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <argLine>
+                        ${add.opens.java.base.jdk.internal.loader}
+                        ${add.exports.java.xml.jdk.xml.internal}
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
@@ -152,7 +152,7 @@
                 <configuration>
                     <argLine>
                         ${add.opens.java.base.jdk.internal.loader}
-                        ${add.exports.java.xml.jdk.xml.internal}
+                        ${add.opens.java.xml.jdk.xml.internal}
                     </argLine>
                 </configuration>
             </plugin>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/pom.xml
@@ -330,18 +330,20 @@
     <build>
         <plugins>
             <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven-compiler-plugin.version}</version>
-                    <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                        <testSource>${java.version}</testSource>
-                        <testTarget>${java.version}</testTarget>
-                        <compilerArgument>
-                            ${compiler.args}
-                        </compilerArgument>
-                    </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <testSource>${java.version}</testSource>
+                    <testTarget>${java.version}</testTarget>
+                    <compilerArgs>
+                        <arg>
+                            ${add.exports.java.security.jgss.sun.security.krb5}
+                        </arg>
+                    </compilerArgs>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/pom.xml
@@ -327,4 +327,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <testSource>${java.version}</testSource>
+                        <testTarget>${java.version}</testTarget>
+                        <compilerArgument>
+                            ${compiler.args}
+                        </compilerArgument>
+                    </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <spring.version>5.3.12</spring.version>
         <spring.boot.version>2.5.6</spring.boot.version>
         <java.version>1.8</java.version>
+        <compiler.args></compiler.args>
         <logback.version>1.2.3</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
         <quartz.version>2.3.2</quartz.version>
@@ -1219,6 +1220,26 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>jmod</id>
+            <properties>
+                <java.version>11</java.version>
+                <add.exports.java.security.jgss.sun.security.krb5>
+                    --add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                </add.exports.java.security.jgss.sun.security.krb5>
+
+                <add.exports.java.xml.jdk.xml.internal>
+                    --add-opens=java.xml/jdk.xml.internal=ALL-UNNAMED
+                </add.exports.java.xml.jdk.xml.internal>
+
+                <add.opens.java.base.jdk.internal.loader>
+                    --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
+                </add.opens.java.base.jdk.internal.loader>
+            </properties>
+            <activation>
+                <jdk>[11,17]</jdk>
+            </activation>
+        </profile>
         <profile>
             <id>docker</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <add.exports.java.security.jgss.sun.security.krb5></add.exports.java.security.jgss.sun.security.krb5>
         <add.opens.java.base.jdk.internal.loader></add.opens.java.base.jdk.internal.loader>
         <add.exports.java.xml.jdk.xml.internal></add.exports.java.xml.jdk.xml.internal>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.11</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
         <quartz.version>2.3.2</quartz.version>
         <jackson.version>2.10.5</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,9 @@
         <spring.version>5.3.12</spring.version>
         <spring.boot.version>2.5.6</spring.boot.version>
         <java.version>1.8</java.version>
-        <compiler.args></compiler.args>
+        <add.exports.java.security.jgss.sun.security.krb5></add.exports.java.security.jgss.sun.security.krb5>
+        <add.opens.java.base.jdk.internal.loader></add.opens.java.base.jdk.internal.loader>
+        <add.exports.java.xml.jdk.xml.internal></add.exports.java.xml.jdk.xml.internal>
         <logback.version>1.2.3</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
         <quartz.version>2.3.2</quartz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <spring.version>5.3.12</spring.version>
         <spring.boot.version>2.5.6</spring.boot.version>
         <java.version>1.8</java.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.2.3</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
         <quartz.version>2.3.2</quartz.version>
         <jackson.version>2.10.5</jackson.version>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

The official website document only indicates that developers use the 1.8+ version for development, but it does not point out that the version after 1.9+ should be incompatible with jmod, so I fixed this problem and support the 11+ version. The reason why version 1.9 is not supported is because it will require developers to modify the --release parameter of IDEA configuration. I think this is not friendly to developers. It is better to suggest that they upgrade to 11 for development.

## Brief change log

Added a profile configuration to the root POM file

## Verify this pull request



This change added tests and can be verified as follows:

mvn test -Pjmod
(or)
run the application in IDEA
