### PR TITLE
[fix] File overwrite when specific value set to installPath

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -31,7 +31,7 @@ if [ ! -d $installPath ];then
 # so we should check its value. Here use command `realpath` to get the related path, and it will skip if your shell env
 # without command `realpath`.
 elif [[ -z "${installPath// }" || "${installPath// }" == "/" || ( $(command -v realpath) && $(realpath -s "${installPath}") == "/" ) ]]; then
-  echo "Parameter installPath can not be empty, use in root path or related path of root path, currently use ${installPath}."
+  echo "Parameter installPath can not be empty, use in root path or related path of root path, currently use ${installPath}"
   exit 1
 fi
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -28,9 +28,10 @@ if [ ! -d $installPath ];then
   sudo mkdir -p $installPath
   sudo chown -R $deployUser:$deployUser $installPath
 # If install Path equal to "/" or related path is "/" or is empty, will cause directory "/bin" be overwrite or file adding,
-# so we should check its value
-elif [[ -z "${installPath// }" || "${installPath// }" == "/" || $(realpath -s "${installPath}") == "/" ]]; then
-  echo "Parameter ${installPath} can not be empty or use in root path"
+# so we should check its value. Here use command `realpath` to get the related path, and it will skip if your shell env
+# without command `realpath`.
+elif [[ -z "${installPath// }" || "${installPath// }" == "/" || ( $(command -v realpath) && $(realpath -s "${installPath}") == "/" ) ]]; then
+  echo "Parameter installPath can not be empty, use in root path or related path of root path, currently use ${installPath}."
   exit 1
 fi
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -24,12 +24,12 @@ source ${workDir}/env/dolphinscheduler_env.sh
 
 echo "1.create directory"
 
-if [ ! -d $installPath ];then
-  sudo mkdir -p $installPath
-  sudo chown -R $deployUser:$deployUser $installPath
 # If install Path equal to "/" or related path is "/" or is empty, will cause directory "/bin" be overwrite or file adding,
 # so we should check its value. Here use command `realpath` to get the related path, and it will skip if your shell env
 # without command `realpath`.
+if [ ! -d $installPath ];then
+  sudo mkdir -p $installPath
+  sudo chown -R $deployUser:$deployUser $installPath
 elif [[ -z "${installPath// }" || "${installPath// }" == "/" || ( $(command -v realpath) && $(realpath -s "${installPath}") == "/" ) ]]; then
   echo "Parameter installPath can not be empty, use in root path or related path of root path, currently use ${installPath}"
   exit 1

--- a/script/install.sh
+++ b/script/install.sh
@@ -27,6 +27,11 @@ echo "1.create directory"
 if [ ! -d $installPath ];then
   sudo mkdir -p $installPath
   sudo chown -R $deployUser:$deployUser $installPath
+# If install Path equal to "/" or related path is "/" or is empty, will cause directory "/bin" be overwrite or file adding,
+# so we should check its value
+elif [[ -z "${installPath// }" || "${installPath// }" == "/" || $(realpath -s "${installPath}") == "/" ]]; then
+  echo "Parameter ${installPath} can not be empty or use in root path"
+  exit 1
 fi
 
 echo "2.scp resources"

--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -40,8 +40,6 @@ do
   fi
 
   echo "scp dirs to $host/$installPath starting"
-	ssh -p $sshPort $host  "cd $installPath/; rm -rf bin/ master-server/ worker-server/ alert-server/ api-server/ ui/ tools/"
-
   for i in ${!workerNames[@]}; do
     if [[ ${workerNames[$i]} == $host ]]; then
       workerIndex=$i


### PR DESCRIPTION
When our `installPath` in file `install_env.sh` set to `/`
or empty or related path to `/` some system specific directory
, like `/bin` and `libs`, will be overwritten, and it is not expect