### PR TITLE
[fix] Deploy scp-hosts use fullpath avoid dangling

### DIFF
--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -47,7 +47,7 @@ do
     fi
   done
   # set worker groups in application.yaml
-  [[ -n ${workerIndex} ]] && sed -i "s/- default/- ${groupNames[$workerIndex]}/" ../worker-server/conf/application.yaml
+  [[ -n ${workerIndex} ]] && sed -i "s/- default/- ${groupNames[$workerIndex]}/" $workDir/../worker-server/conf/application.yaml
 
   for dsDir in bin master-server worker-server alert-server api-server ui tools
   do
@@ -56,7 +56,7 @@ do
     scp -q -P $sshPort -r $workDir/../$dsDir  $host:$installPath
   done
   # restore worker groups to default
-  [[ -n ${workerIndex} ]] && sed -i "s/- ${groupNames[$workerIndex]}/- default/" ../worker-server/conf/application.yaml
+  [[ -n ${workerIndex} ]] && sed -i "s/- ${groupNames[$workerIndex]}/- default/" $workDir/../worker-server/conf/application.yaml
 
   echo "scp dirs to $host/$installPath complete"
 done


### PR DESCRIPTION
This path fix error modify worker application.yaml when
running `scp-hosts.sh` script in different directory. Currently
setting only work when running `scp-hosts.sh` in path
`<DOLPHINSCHEDULER_HOME>/bin` using command `./scp-hosts.sh`.
And will fail when we run script in directory
`<DOLPHINSCHEDULER_HOME>` using command `./bin/scp-hosts.sh`

ref: #10209 and #10208
