### PR TITLE
[Fix&Feature] Fix the OSUtilsTest.loadAverage test case in windows, and support os windows to get loadAverage in OSUtils.loadAverage #10280

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
@@ -116,11 +116,18 @@ public class OSUtils {
     public static double loadAverage() {
         double loadAverage;
         try {
-            OperatingSystemMXBean osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
-            loadAverage = osBean.getSystemLoadAverage();
+            if(SystemUtils.IS_OS_WINDOWS){
+                loadAverage = ManagementFactory.getPlatformMXBean(com.sun.management.OperatingSystemMXBean.class).getProcessCpuLoad();
+            }else{
+                loadAverage = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class).getSystemLoadAverage();
+            }
         } catch (Exception e) {
             logger.error("get operation system load average exception, try another method ", e);
-            loadAverage = hal.getProcessor().getSystemLoadAverage(1)[0];
+            if (SystemUtils.IS_OS_WINDOWS){
+                loadAverage = ManagementFactory.getPlatformMXBean(com.sun.management.OperatingSystemMXBean.class).getSystemCpuLoad();
+            }else{
+                loadAverage = hal.getProcessor().getSystemLoadAverage(1)[0];
+            }
             if (Double.isNaN(loadAverage)) {
                 return NEGATIVE_ONE;
             }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

- [x] Fixed #10280 
## Purpose of the pull request

In this pull request, I fixed the problem that the OSUtils.loadAverage method could not get the CPU information under Windows. In addition, I found that many test cases cannot run on the Windows system,  I think we should give some tips to developers in the official website documentation

## Brief change log

Use com.sun.management.OperatingSystemMXBean#getProcessCpuLoad(); instead of java.lang.management.OperatingSystemMXBean#.getSystemLoadAverage(); to get cpu load information on windows

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
