### PR TITLE
[hotfix] Fix database initialize late in standalone.

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/SpringConnectionFactory.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/SpringConnectionFactory.java
@@ -24,8 +24,11 @@ import org.apache.ibatis.type.JdbcType;
 
 import java.util.Properties;
 
+import javax.annotation.Resource;
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -40,6 +43,12 @@ import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 
 @Configuration
 public class SpringConnectionFactory {
+
+    /**
+     * Inject this field to make sure the database is initialized, this can solve the table not found issue #8432.
+     */
+    @Autowired(required = false)
+    public DataSourceScriptDatabaseInitializer dataSourceScriptDatabaseInitializer;
 
     @Bean
     public PaginationInterceptor paginationInterceptor() {


### PR DESCRIPTION
## Purpose of the pull request
When I start StandaloneServer, find the master will throw exception:
```java
[ERROR] 2022-05-30 18:37:34.967 +0800 org.apache.dolphinscheduler.server.master.registry.ServerNodeManager:[221] - WorkerNodeInfoAndGroupDbSyncTask error:
org.springframework.jdbc.BadSqlGrammarException: 
### Error querying database.  Cause: org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "t_ds_worker_group" not found; SQL statement:
select *
        from t_ds_worker_group
        order by update_time desc [42102-200]
### The error may exist in file [/Users/ruanwenjun/Project/Github/dolphinscheduler/dolphinscheduler-dao/target/classes/org/apache/dolphinscheduler/dao/mapper/WorkerGroupMapper.xml]
### The error may involve org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper.queryAllWorkerGroup
### The error occurred while executing a query
### SQL: select *         from t_ds_worker_group         order by update_time desc
### Cause: org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "t_ds_worker_group" not found; SQL statement:
select *
        from t_ds_worker_group
        order by update_time desc [42102-200]
; bad SQL grammar []; nested exception is org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "t_ds_worker_group" not found; SQL statement:
select *
        from t_ds_worker_group
        order by update_time desc [42102-200]
```

This is caused by the h2 database is not initialized when we query the work group.

## Brief change log
Inject the DataSourceScriptDatabaseInitializer to make sure the database is initialized after we can get connector.

## Verify this pull request
Start StandaloneServer, find there is no exception.
