### PR TITLE
[Bug][Api-Server]Fix bug when user without tenant uploads file in resource center

### DIFF
--- a/docs/docs/en/guide/resource/file-manage.md
+++ b/docs/docs/en/guide/resource/file-manage.md
@@ -4,7 +4,11 @@ When third party jars are used in the scheduling process or user defined scripts
 
 ![file-manage](/img/new_ui/dev/resource/file-manage.png)
 
-## Basic Operator
+> **_Note:_**
+>
+> * When you manage files as `admin`, remember to set up `tenant` for `admin` first. 
+
+## Basic Operations
 
 ### Create a File
 

--- a/docs/docs/zh/guide/resource/file-manage.md
+++ b/docs/docs/zh/guide/resource/file-manage.md
@@ -2,6 +2,10 @@
 
 当在调度过程中需要使用到第三方的 jar 或者用户需要自定义脚本的情况，可以通过在该页面完成相关操作。可创建的文件类型包括：`txt/log/sh/conf/py/java` 等。并且可以对文件进行编辑、重命名、下载和删除等操作。
 
+> **_注意：_**
+>
+> * 当您以`admin`身份等入并操作文件时，需要先给`admin`设置租户
+
 ## 基础操作
 
 ![file-manage](/img/new_ui/dev/resource/file-manage.png)

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -200,16 +200,6 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         return currentDir.equals(FOLDER_SEPARATOR) ? String.format(FORMAT_SS, currentDir, name) : String.format(FORMAT_S_S, currentDir, name);
     }
 
-    private Result<Object> verifyTenant(User loginUser) {
-        Result<Object> result = new Result<>();
-        putMsg(result, Status.SUCCESS);
-        Tenant tenant = tenantMapper.queryById(loginUser.getTenantId());
-        if (tenant == null) {
-            putMsg(result, Status.CURRENT_LOGIN_USER_TENANT_NOT_EXIST);
-        }
-        return result;
-    }
-
     /**
      * create resource
      *
@@ -248,8 +238,9 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             return result;
         }
 
-        result = verifyTenant(loginUser);
-        if (!result.getCode().equals(Status.SUCCESS.getCode())) {
+        // make sure login user has tenant
+        String tenantCode = getTenantCode(loginUser.getId(), result);
+        if (StringUtils.isEmpty(tenantCode)) {
             return result;
         }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -200,6 +200,16 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         return currentDir.equals(FOLDER_SEPARATOR) ? String.format(FORMAT_SS, currentDir, name) : String.format(FORMAT_S_S, currentDir, name);
     }
 
+    private Result<Object> verifyTenant(User loginUser) {
+        Result<Object> result = new Result<>();
+        putMsg(result, Status.SUCCESS);
+        Tenant tenant = tenantMapper.queryById(loginUser.getTenantId());
+        if (tenant == null) {
+            putMsg(result, Status.CURRENT_LOGIN_USER_TENANT_NOT_EXIST);
+        }
+        return result;
+    }
+
     /**
      * create resource
      *
@@ -234,6 +244,11 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         }
 
         result = verifyPid(loginUser, pid);
+        if (!result.getCode().equals(Status.SUCCESS.getCode())) {
+            return result;
+        }
+
+        result = verifyTenant(loginUser);
         if (!result.getCode().equals(Status.SUCCESS.getCode())) {
             return result;
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -695,7 +695,14 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             return false;
         }
         // query tenant
-        String tenantCode = tenantMapper.queryById(loginUser.getTenantId()).getTenantCode();
+        Tenant tenant = tenantMapper.queryById(loginUser.getTenantId());
+        // this could happen when user logs in as admin
+        if (tenant == null) {
+            logger.error("fail to acquire tenant, please set tenant for login user/admin first");
+            return false;
+        }
+
+        String tenantCode = tenant.getTenantCode();
         // random file name
         String localFilename = FileUtils.getUploadFilename(tenantCode, UUID.randomUUID().toString());
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -710,14 +710,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             return false;
         }
         // query tenant
-        Tenant tenant = tenantMapper.queryById(loginUser.getTenantId());
-        // this could happen when user logs in as admin
-        if (tenant == null) {
-            logger.error("fail to acquire tenant, please set tenant for login user/admin first");
-            return false;
-        }
-
-        String tenantCode = tenant.getTenantCode();
+        String tenantCode = tenantMapper.queryById(loginUser.getTenantId()).getTenantCode();
         // random file name
         String localFilename = FileUtils.getUploadFilename(tenantCode, UUID.randomUUID().toString());
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -148,6 +148,8 @@ public class ResourcesServiceTest {
         //CURRENT_LOGIN_USER_TENANT_NOT_EXIST
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test.pdf", "test.pdf", "pdf", "test".getBytes());
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
+        Mockito.when(userMapper.selectById(1)).thenReturn(getUser());
+        Mockito.when(tenantMapper.queryById(1)).thenReturn(null);
         Result result = resourcesService.createResource(user, "ResourcesServiceTest", "ResourcesServiceTest", ResourceType.FILE, mockMultipartFile, -1, "/");
         logger.info(result.toString());
         Assert.assertEquals(Status.CURRENT_LOGIN_USER_TENANT_NOT_EXIST.getMsg(), result.getMsg());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -144,13 +144,25 @@ public class ResourcesServiceTest {
         User user = new User();
         user.setId(1);
         user.setUserType(UserType.GENERAL_USER);
+
+        //CURRENT_LOGIN_USER_TENANT_NOT_EXIST
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test.pdf", "test.pdf", "pdf", "test".getBytes());
+        PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
+        Result result = resourcesService.createResource(user, "ResourcesServiceTest", "ResourcesServiceTest", ResourceType.FILE, mockMultipartFile, -1, "/");
+        logger.info(result.toString());
+        Assert.assertEquals(Status.CURRENT_LOGIN_USER_TENANT_NOT_EXIST.getMsg(), result.getMsg());
+        //set tenant for user
+        user.setTenantId(1);
+        Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
+
         //HDFS_NOT_STARTUP
-        Result result = resourcesService.createResource(user, "ResourcesServiceTest", "ResourcesServiceTest", ResourceType.FILE, null, -1, "/");
+        PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(false);
+        result = resourcesService.createResource(user, "ResourcesServiceTest", "ResourcesServiceTest", ResourceType.FILE, null, -1, "/");
         logger.info(result.toString());
         Assert.assertEquals(Status.STORAGE_NOT_STARTUP.getMsg(), result.getMsg());
 
         //RESOURCE_FILE_IS_EMPTY
-        MockMultipartFile mockMultipartFile = new MockMultipartFile("test.pdf", "".getBytes());
+        mockMultipartFile = new MockMultipartFile("test.pdf", "".getBytes());
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
         result = resourcesService.createResource(user, "ResourcesServiceTest", "ResourcesServiceTest", ResourceType.FILE, mockMultipartFile, -1, "/");
         logger.info(result.toString());


### PR DESCRIPTION
## Purpose of the pull request
* Make error msg more instructive when user logged in as `admin` tries to manage files in `resource center` without setting up `tenant`. In this way, user will no more get a `NullPointerException` here.

* Add a reminder in docs.

* This PR closes: #10293 

## Brief change log
* Already described above.

## Verify this pull request
* Verified by manual test and unit test.
