### PR TITLE
[Fix-10317] [ui] Fix the tips of startTimeout in the jupyter form

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-jupyter.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-jupyter.ts
@@ -146,7 +146,7 @@ export function useJupyter(model: { [field: string]: any }): IJsonItem[] {
       field: 'startTimeout',
       name: t('project.node.jupyter_start_timeout'),
       props: {
-        placeholder: t('project.node.zeppelin_note_id_tips')
+        placeholder: t('project.node.jupyter_start_timeout_tips')
       }
       //       validate: {
       //         trigger: ['input', 'blur'],


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Fix the tips of startTimeout in the jupyter form

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

close [#10317](https://github.com/apache/dolphinscheduler/issues/10317)