### PR TITLE
Modify the bug, Added disk available capacity monitoring,and delete The case where only one log can be deleted from an instance

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HeartBeat.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HeartBeat.java
@@ -218,7 +218,6 @@ public class HeartBeat {
         StringBuilder builder = new StringBuilder(100);
         builder.append(cpuUsage).append(COMMA);
         builder.append(memoryUsage).append(COMMA);
-        builder.append(diskAvailable).append(COMMA);
         builder.append(loadAverage).append(COMMA);
         builder.append(availablePhysicalMemorySize).append(Constants.COMMA);
         builder.append(maxCpuloadAvg).append(Constants.COMMA);
@@ -229,7 +228,8 @@ public class HeartBeat {
         builder.append(processId).append(COMMA);
         builder.append(workerHostWeight).append(COMMA);
         builder.append(workerExecThreadCount).append(COMMA);
-        builder.append(workerWaitingTaskCount);
+        builder.append(workerWaitingTaskCount).append(COMMA);
+        builder.append(diskAvailable);
 
         return builder.toString();
     }
@@ -245,18 +245,18 @@ public class HeartBeat {
         HeartBeat heartBeat = new HeartBeat();
         heartBeat.cpuUsage = Double.parseDouble(parts[0]);
         heartBeat.memoryUsage = Double.parseDouble(parts[1]);
-        heartBeat.diskAvailable = Double.parseDouble(parts[2]);
-        heartBeat.loadAverage = Double.parseDouble(parts[3]);
-        heartBeat.availablePhysicalMemorySize = Double.parseDouble(parts[4]);
-        heartBeat.maxCpuloadAvg = Double.parseDouble(parts[5]);
-        heartBeat.reservedMemory = Double.parseDouble(parts[6]);
-        heartBeat.startupTime = Long.parseLong(parts[7]);
-        heartBeat.reportTime = Long.parseLong(parts[8]);
-        heartBeat.serverStatus = Integer.parseInt(parts[9]);
-        heartBeat.processId = Integer.parseInt(parts[10]);
-        heartBeat.workerHostWeight = Integer.parseInt(parts[11]);
-        heartBeat.workerExecThreadCount = Integer.parseInt(parts[12]);
-        heartBeat.workerWaitingTaskCount = Integer.parseInt(parts[13]);
+        heartBeat.loadAverage = Double.parseDouble(parts[2]);
+        heartBeat.availablePhysicalMemorySize = Double.parseDouble(parts[3]);
+        heartBeat.maxCpuloadAvg = Double.parseDouble(parts[4]);
+        heartBeat.reservedMemory = Double.parseDouble(parts[5]);
+        heartBeat.startupTime = Long.parseLong(parts[6]);
+        heartBeat.reportTime = Long.parseLong(parts[7]);
+        heartBeat.serverStatus = Integer.parseInt(parts[8]);
+        heartBeat.processId = Integer.parseInt(parts[9]);
+        heartBeat.workerHostWeight = Integer.parseInt(parts[10]);
+        heartBeat.workerExecThreadCount = Integer.parseInt(parts[11]);
+        heartBeat.workerWaitingTaskCount = Integer.parseInt(parts[12]);
+        heartBeat.diskAvailable = Double.parseDouble(parts[13]);
         return heartBeat;
     }
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
@@ -87,11 +87,10 @@ public class OSUtils {
      * get disk usage
      * Keep 2 decimal
      *
-     * @return disk free space  (GB)
+     * @return disk free size, unit: GB
      */
     public static double diskAvailable() {
         File file = new File(".");
-        long totalSpace = file.getTotalSpace(); //total disk space in bytes.
         long freeSpace = file.getFreeSpace(); //unallocated / free disk space in bytes.
 
         double diskAvailable = freeSpace / 1024.0 / 1024 / 1024;

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HeartBeatTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HeartBeatTest.java
@@ -55,13 +55,12 @@ public class HeartBeatTest {
 
     @Test
     public void testDecodeHeartBeat() throws Exception {
-        String heartBeatInfo = "0.35,0.58,5.86,3.09,6.47,5.0,1.0,1634033006749,1634033006857,1,29732,1,199,200";
+        String heartBeatInfo = "0.35,0.58,3.09,6.47,5.0,1.0,1634033006749,1634033006857,1,29732,1,199,200,65.86";
         HeartBeat heartBeat = HeartBeat.decodeHeartBeat(heartBeatInfo);
 
         double delta = 0.001;
         assertEquals(0.35, heartBeat.getCpuUsage(), delta);
         assertEquals(0.58, heartBeat.getMemoryUsage(), delta);
-        assertEquals(5.86, heartBeat.getDiskAvailable(), delta);
         assertEquals(3.09, heartBeat.getLoadAverage(), delta);
         assertEquals(6.47, heartBeat.getAvailablePhysicalMemorySize(), delta);
         assertEquals(5.0, heartBeat.getMaxCpuloadAvg(), delta);
@@ -72,6 +71,7 @@ public class HeartBeatTest {
         assertEquals(29732, heartBeat.getProcessId());
         assertEquals(199, heartBeat.getWorkerExecThreadCount());
         assertEquals(200, heartBeat.getWorkerWaitingTaskCount());
+        assertEquals(65.86, heartBeat.getDiskAvailable(), delta);
     }
 
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
@@ -41,6 +41,8 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
     List<TaskInstance> findValidTaskListByProcessId(@Param("processInstanceId") Integer processInstanceId,
                                                     @Param("flag") Flag flag);
 
+    List<TaskInstance> findAllTaskListByProcessId(@Param("processInstanceId") Integer processInstanceId);
+
     List<TaskInstance> queryByHostAndStatus(@Param("host") String host,
                                             @Param("states") int[] stateArray);
 

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -54,6 +54,13 @@
         and flag = #{flag}
         order by start_time desc
     </select>
+    <select id="findAllTaskListByProcessId" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
+        select
+        <include refid="baseSql"/>
+        from t_ds_task_instance
+        WHERE process_instance_id = #{processInstanceId}
+        order by start_time desc
+    </select>
     <select id="queryByHostAndStatus" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
         select
         <include refid="baseSql"/>

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -428,7 +428,7 @@ public class ProcessService {
      * @param processInstanceId processInstanceId
      */
     public void removeTaskLogFile(Integer processInstanceId) {
-        List<TaskInstance> taskInstanceList = findValidTaskListByProcessId(processInstanceId);
+        List<TaskInstance> taskInstanceList = findAllTaskListByProcessId(processInstanceId);
         if (CollectionUtils.isEmpty(taskInstanceList)) {
             return;
         }
@@ -1619,6 +1619,16 @@ public class ProcessService {
     }
 
     /**
+     * find all task list by process definition id
+     *
+     * @param processInstanceId processInstanceId
+     * @return task instance list
+     */
+    public List<TaskInstance> findAllTaskListByProcessId(Integer processInstanceId) {
+        return taskInstanceMapper.findAllTaskListByProcessId(processInstanceId);
+    }
+
+    /**
      * find previous task list by work process id
      *
      * @param processInstanceId processInstanceId
@@ -1671,7 +1681,6 @@ public class ProcessService {
      */
     public int deleteWorkProcessMapByParentId(int parentWorkProcessId) {
         return processInstanceMapMapper.deleteByParentProcessId(parentWorkProcessId);
-
     }
 
     /**


### PR DESCRIPTION
Modify the bug

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->
https://github.com/apache/dolphinscheduler/pull/10030
Through version 3.0.0, E2E test results, found a bug, so fix it  
Therefore, the function added last time is modified again
If yes, please merge to 2.0.6-prepare


problem: https://github.com/apache/dolphinscheduler/issues/10316
Delete The case where only one log can be deleted from an instance
Do the repair


<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
