### PR TITLE
[Feature][dolphinscheduler-ui]Exporting monitor status data into different types of files

### DIFF
--- a/dolphinscheduler-ui/src/views/monitor/servers/master/index.tsx
+++ b/dolphinscheduler-ui/src/views/monitor/servers/master/index.tsx
@@ -27,6 +27,7 @@ import MasterModal from './master-modal'
 import type { Ref } from 'vue'
 import type { RowData } from 'naive-ui/es/data-table/src/interface'
 import type { MasterNode } from '@/service/modules/monitor/types'
+import jsPDF from 'jspdf'
 
 const master = defineComponent({
   name: 'master',
@@ -45,6 +46,114 @@ const master = defineComponent({
       showModalRef.value = false
     }
 
+    const exportToFile = (data: any) => {
+      function convertToFileData(jsonData: any) {
+        const array = []
+        let str = ''
+        array.push(['Info', 'Value'])
+        for (const i in jsonData) {
+          if (i === 'resInfo') {
+            const resInfoJsonData = JSON.parse(jsonData[i])
+            for (const j in resInfoJsonData) {
+              array.push([i + '.' + j, resInfoJsonData[j]])
+            }
+          } else {
+            array.push([i, jsonData[i]])
+          }
+        }
+        for (let k = 0; k < array.length; k++) {
+          let line = ''
+          for (const index in array[k]) {
+            if (line != '') line += ','
+            line += array[k][index]
+          }
+          str += line + '\r\n'
+        }
+        return str
+      }
+
+      function padTo2Digits(num: number) {
+        return num.toString().padStart(2, '0')
+      }
+
+      function formatDate(date: Date) {
+        return (
+          [
+            padTo2Digits(date.getMonth() + 1),
+            padTo2Digits(date.getDate()),
+            date.getFullYear()
+          ].join('-') +
+          ' ' +
+          [
+            padTo2Digits(date.getHours()),
+            padTo2Digits(date.getMinutes()),
+            padTo2Digits(date.getSeconds())
+          ].join('-')
+        )
+      }
+
+      const fileData = convertToFileData(data)
+      const now = formatDate(new Date())
+
+      // Export to CSV file
+      const uriCSV = 'data:text/csv;charset=utf-8,' + escape(fileData)
+      const csvLink = document.createElement('a')
+      csvLink.id = 'exportCSV'
+      csvLink.href = uriCSV
+      csvLink.download = now.toLocaleString() + '.csv'
+      if (document.getElementById('exportCSV') === null) {
+        // @ts-ignore
+        document
+          .getElementById('exportToFile')
+          .insertAdjacentElement('beforeend', csvLink)
+        // @ts-ignore
+        document.getElementById('exportCSV').append('Export to CSV')
+        // @ts-ignore
+        document.getElementById('exportToFile').append(' ')
+      }
+
+      // Export to TXT file
+      const uriTXT = 'data:text/txt;charset=utf-8,' + escape(fileData)
+      const txtLink = document.createElement('a')
+      txtLink.id = 'exportTXT'
+      txtLink.href = uriTXT
+      txtLink.download = now.toLocaleString() + '.txt'
+      if (document.getElementById('exportTXT') === null) {
+        // @ts-ignore
+        document
+          .getElementById('exportToFile')
+          .insertAdjacentElement('beforeend', txtLink)
+        // @ts-ignore
+        document.getElementById('exportTXT').append('Export to TXT')
+        // @ts-ignore
+        document.getElementById('exportToFile').append(' ')
+      }
+
+      // Export to PDF file
+      function exportToPDF() {
+        const doc = new jsPDF()
+        doc.text(fileData, 10, 10)
+        doc.save(now.toLocaleString() + '.pdf')
+        return false
+      }
+
+      const pdfLink = document.createElement('a')
+      pdfLink.id = 'exportPDF'
+      pdfLink.href = '#'
+      if (document.getElementById('exportPDF') === null) {
+        // @ts-ignore
+        document
+          .getElementById('exportToFile')
+          .insertAdjacentElement('beforeend', pdfLink)
+        // @ts-ignore
+        document.getElementById('exportPDF').append('Export to PDF')
+        // @ts-ignore
+        document.getElementById('exportPDF').onclick = exportToPDF
+        // @ts-ignore
+        document.getElementById('exportToFile').append(' ')
+      }
+    }
+
     onMounted(() => {
       getTableMaster()
     })
@@ -54,13 +163,20 @@ const master = defineComponent({
       ...toRefs(variables),
       clickDetails,
       onConfirmModal,
+      exportToFile,
       showModalRef,
       zkDirectoryRef
     }
   },
   render() {
-    const { t, clickDetails, onConfirmModal, showModalRef, zkDirectoryRef } =
-      this
+    const {
+      t,
+      clickDetails,
+      onConfirmModal,
+      exportToFile,
+      showModalRef,
+      zkDirectoryRef
+    } = this
 
     return this.data.length < 1 ? (
       <Result
@@ -139,6 +255,15 @@ const master = defineComponent({
                     </Card>
                   </NGi>
                 </NGrid>
+                <NSpace>
+                  <span
+                    class={styles['link-btn']}
+                    onClick={() => exportToFile(item)}
+                  >
+                    {t('Download Monitor Status')}
+                  </span>
+                  <div id='exportToFile'></div>
+                </NSpace>
               </NSpace>
             )
           })}


### PR DESCRIPTION
## Purpose of the pull request
Create a new feature at Monitor Master page to export and download monitor status in different types of files.
<img width="1270" alt="Screen Shot 2022-06-01 at 8 55 38 PM" src="https://user-images.githubusercontent.com/73679778/171549948-333a6c88-dbb8-40a8-88cb-81e07c2326ca.png">

## Brief change log
Add exportToFile function to dolphinscheduler-ui/src/views/monitor/servers/master/index.tsx

## Verify this pull request
Manually verified the change by testing locally.
