### PR TITLE
[Fix-10338] Tenant does not belong to resource permission.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/constants/ApiFuncIdentificationConstant.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/constants/ApiFuncIdentificationConstant.java
@@ -154,10 +154,6 @@ public class ApiFuncIdentificationConstant {
     public static final String MONITOR_WORKER_VIEW = "monitor:workers:view";
     public static final String MONITOR_DATABASES_VIEW = "monitor:databases:view";
 
-    public static final String MONITOR_STATISTICS_VIEW = "monitor:statistics:view";
-    public static final String MONITOR_EVENT_LIST_VIEW = "monitor:event:view";
-    public static final String MONITOR_ALERT_LIST_VIEW = "monitor:alert:view";
-
     public final static Map<ExecuteType,String> map = new HashMap<ExecuteType,String>();
 
     static{

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/constants/ApiFuncIdentificationConstant.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/constants/ApiFuncIdentificationConstant.java
@@ -120,7 +120,7 @@ public class ApiFuncIdentificationConstant {
     public static final String DATASOURCE_PARAM_VIEW = "datasource:param-view";
 
     public static final String FILE_VIEW = "resources:file:view";
-    public static final String FOLDER_ONLINE_CREATE = "resources:folder:online-create";
+    public static final String FOLDER_ONLINE_CREATE = "resources:file:create";
     public static final String FILE_ONLINE_CREATE = "resources:file:online-create";
     public static final String FILE_UPLOAD = "resources:file:upload";
     public static final String FILE_UPDATE = "resources:file:update-content";
@@ -129,7 +129,7 @@ public class ApiFuncIdentificationConstant {
     public static final String FILE_DELETE = "resources:file:delete";
 
     public static final String UDF_FILE_VIEW = "resources:udf:view";
-    public static final String UDF_FOLDER_ONLINE_CREATE = "resources:udf-folder:online-create";
+    public static final String UDF_FOLDER_ONLINE_CREATE = "resources:udf:create";
     public static final String UDF_UPLOAD = "resources:udf:upload";
     public static final String UDF_UPDATE = "resources:udf:edit";
     public static final String UDF_DOWNLOAD = "resources:udf:download";

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -223,7 +223,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                                          int pid,
                                          String currentDir) {
         Result<Object> result = new Result<>();
-        String funcPermissionKey = type.equals(ResourceType.FILE) ? ApiFuncIdentificationConstant.FILE_ONLINE_CREATE : ApiFuncIdentificationConstant.UDF_FOLDER_ONLINE_CREATE;
+        String funcPermissionKey = type.equals(ResourceType.FILE) ? ApiFuncIdentificationConstant.FILE_UPLOAD : ApiFuncIdentificationConstant.UDF_UPLOAD;
         boolean canOperatorPermissions = canOperatorPermissions(loginUser, null, AuthorizationType.RESOURCE_FILE_ID, funcPermissionKey);
         if (!canOperatorPermissions){
             putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -135,7 +135,6 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
 
         result.put(Constants.DATA_LIST, tenant);
         putMsg(result, Status.SUCCESS);
-
         return result;
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -135,7 +135,6 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
 
         result.put(Constants.DATA_LIST, tenant);
         putMsg(result, Status.SUCCESS);
-        permissionPostHandle(AuthorizationType.TENANT, loginUser.getId(), Collections.singletonList(tenant.getId()),logger);
 
         return result;
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -132,7 +132,6 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
         if (PropertyUtils.getResUploadStartupState()) {
             storageOperate.createTenantDirIfNotExists(tenantCode);
         }
-
         result.put(Constants.DATA_LIST, tenant);
         putMsg(result, Status.SUCCESS);
         return result;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -138,7 +138,7 @@ public class ResourcesServiceTest {
     @Test
     public void testCreateResource() {
 
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_UPLOAD, serviceLogger)).thenReturn(true);
         PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
 
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(false);
@@ -180,7 +180,7 @@ public class ResourcesServiceTest {
         Assert.assertEquals(Status.RESOURCE_SUFFIX_FORBID_CHANGE.getMsg(), result.getMsg());
 
         //UDF_RESOURCE_SUFFIX_NOT_JAR
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.UDF_FOLDER_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.UDF_UPLOAD, serviceLogger)).thenReturn(true);
         PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
 
         mockMultipartFile = new MockMultipartFile("ResourcesServiceTest.pdf", "ResourcesServiceTest.pdf", "pdf", "test".getBytes());
@@ -190,7 +190,7 @@ public class ResourcesServiceTest {
         Assert.assertEquals(Status.UDF_RESOURCE_SUFFIX_NOT_JAR.getMsg(), result.getMsg());
 
         //FULL_FILE_NAME_TOO_LONG
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_UPLOAD, serviceLogger)).thenReturn(true);
         PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
 
         String tooLongFileName = getRandomStringWithLength(Constants.RESOURCE_FULL_NAME_MAX_LENGTH) + ".pdf";


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

Tenant does not belong to resource permission.

## Purpose of the pull request

close #10338 

## Verify this pull request
Manually verified the change by testing locally.
