### PR TITLE
 [fix][deploy]fix run on kubernetes bug

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
+++ b/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
@@ -112,7 +112,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified zookkeeper quorum.
 */}}
 {{- define "dolphinscheduler.zookeeper.quorum" -}}
-{{- $port := default "2181" (.Values.zookeeper.service.port | toString) -}}
+{{- $port := default "2181" .Values.zookeeper.service.port | toString -}}
 {{- printf "%s:%s" (include "dolphinscheduler.zookeeper.fullname" .) $port -}}
 {{- end -}}
 

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -52,6 +52,8 @@ externalDatabase:
 ## If not exists external registry, the zookeeper registry will be used by default.
 zookeeper:
   enabled: true
+  service:
+    port: 2181 
   fourlwCommandsWhitelist: "srvr,ruok,wchs,cons"
   persistence:
     enabled: false


### PR DESCRIPTION
## Purpose of the pull request
Fix the problem that the "REGISTRY_ZOOKEEPER_CONNECT_STRING" variable zookeeper port number is "nil"
Use the default zookeeper error reporting

`2022-06-08 17:42:00.525 org.apache.zookeeper.ZooKeeper:[442] - Initiating client connection, connectString=dolphinscheduler-zookeeper:<nil> sessionTimeout=30000 watcher=org.apache.curator.ConnectionState@4ac8768e`
![image](https://user-images.githubusercontent.com/16237905/172783047-846fe1be-1233-4738-a576-910de51d03e0.png)
After repair：
` helm install dolphinscheduler .  --dry-run`
![image](https://user-images.githubusercontent.com/16237905/172781072-2770291f-3cc8-4f2c-a66d-aed1059bfba5.png)

## Brief change log
Fix the problem that the "REGISTRY_ZOOKEEPER_CONNECT_STRING" variable zookeeper port number is "nil"