### PR TITLE
[Feature][Metrics] Enable prometheus to collect metrics in standalone mode demo 

### DIFF
--- a/dolphinscheduler-meter/src/main/resources/grafana-demo/prometheus.yml
+++ b/dolphinscheduler-meter/src/main/resources/grafana-demo/prometheus.yml
@@ -29,3 +29,9 @@ scrape_configs:
           - 'host.docker.internal:1235' # Change the address to the address of DolphinScheduler worker server
           - 'host.docker.internal:50053' # Change the address to the address of DolphinScheduler alert server
           - 'host.docker.internal:8080' # Change the address to the DolphinScheduler standalone server
+  - job_name: 'DolphinScheduler-Standalone'
+    metrics_path: '/dolphinscheduler/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+          - 'host.docker.internal:12345' # Change the address to the DolphinScheduler standalone server

--- a/dolphinscheduler-meter/src/main/resources/grafana-demo/prometheus.yml
+++ b/dolphinscheduler-meter/src/main/resources/grafana-demo/prometheus.yml
@@ -28,7 +28,6 @@ scrape_configs:
           - 'host.docker.internal:5679' # Change the address to the address of DolphinScheduler master server
           - 'host.docker.internal:1235' # Change the address to the address of DolphinScheduler worker server
           - 'host.docker.internal:50053' # Change the address to the address of DolphinScheduler alert server
-          - 'host.docker.internal:8080' # Change the address to the DolphinScheduler standalone server
   - job_name: 'DolphinScheduler-Standalone'
     metrics_path: '/dolphinscheduler/actuator/prometheus'
     scrape_interval: 5s


### PR DESCRIPTION
## Purpose of the pull request
* Enable prometheus to collect metrics in standalone mode demo so that developers / users could try / test metrics in standalone mode more conveniently.
* This PR closes: #10395 

## Brief change log
* Already described above.

## Verify this pull request
* Verified by manual test.
![metrics](https://user-images.githubusercontent.com/34905992/172984658-b93852c1-a2a6-4e8d-858f-706bfbe6fafd.png)
