### PR TITLE
Add mysql registry plugin

### DIFF
--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-scheduler-quartz</artifactId>
         </dependency>
 

--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -62,11 +62,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-registry-zookeeper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+            <artifactId>dolphinscheduler-registry-all</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>

--- a/dolphinscheduler-master/pom.xml
+++ b/dolphinscheduler-master/pom.xml
@@ -53,6 +53,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-scheduler-quartz</artifactId>
         </dependency>
 

--- a/dolphinscheduler-master/pom.xml
+++ b/dolphinscheduler-master/pom.xml
@@ -49,11 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-registry-zookeeper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+            <artifactId>dolphinscheduler-registry-all</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>

--- a/dolphinscheduler-registry/dolphinscheduler-registry-all/pom.xml
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-all/pom.xml
@@ -19,35 +19,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>dolphinscheduler</artifactId>
         <groupId>org.apache.dolphinscheduler</groupId>
+        <artifactId>dolphinscheduler-registry</artifactId>
         <version>dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>dolphinscheduler-registry</artifactId>
-    <packaging>pom</packaging>
+
+    <artifactId>dolphinscheduler-registry-all</artifactId>
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-registry-zookeeper</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
-
-    <modules>
-        <module>dolphinscheduler-registry-api</module>
-        <module>dolphinscheduler-registry-plugins</module>
-        <module>dolphinscheduler-registry-all</module>
-    </modules>
 </project>

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
@@ -12,11 +12,21 @@ You can directly execute the sql script `src/main/resources/mysql_registry_init.
 
 2. Open the config
 
-You need to set the registry type to mysql in master/worker/api's appplication.yml
+You need to set the registry properties in master/worker/api's appplication.yml
 
 ```yaml
 registry:
   type: mysql
+  term-refresh-interval: 2000
+  term-expire-times: 3
+  mysql-datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler
+    username: root
+    password: root
+    maximum-pool-size: 5
+    connection-timeout: 9000
+    idle-timeout: 600000
 ```
 
 After do this two steps, you can start your DolphinScheduler cluster, your cluster will use mysql as registry centery to

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
@@ -29,5 +29,8 @@ registry:
     idle-timeout: 600000
 ```
 
-After do this two steps, you can start your DolphinScheduler cluster, your cluster will use mysql as registry centery to
+After do this two steps, you can start your DolphinScheduler cluster, your cluster will use mysql as registry center to
 store server metadata.
+
+NOTE: You need to add `mysql-connector-java.jar` into DS classpath, since this plugin will not bundle this driver in distribution. 
+You can get the detail about <a href="https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/guide/installation/pseudo-cluster.html">Initialize the Database</a>

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
@@ -16,7 +16,7 @@ You need to set the registry type to mysql in master/worker/api's appplication.y
 
 ```yaml
 registry:
-  type: zookeeper
+  type: mysql
 ```
 
 After do this two steps, you can start your DolphinScheduler cluster, your cluster will use mysql as registry centery to

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
@@ -17,11 +17,11 @@ You need to set the registry properties in master/worker/api's appplication.yml
 ```yaml
 registry:
   type: mysql
-  term-refresh-interval: 2000
+  term-refresh-interval: 2s
   term-expire-times: 3
-  mysql-datasource:
+  hikari-config:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler
+    jdbc-url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler
     username: root
     password: root
     maximum-pool-size: 5

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This module is the mysql registry plugin module, this plugin will use mysql as the registry center.
+
+# How to use
+
+If you want to set the registry center as mysql, you need to do the below two steps:
+
+1. Initialize the mysql table
+
+You can directly execute the sql script `src/main/resources/mysql_registry_init.sql`.
+
+2. Open the config
+
+You need to set the registry type to mysql in master/worker/api's appplication.yml
+
+```yaml
+registry:
+  type: zookeeper
+```
+
+After do this two steps, you can start your DolphinScheduler cluster, your cluster will use mysql as registry centery to
+store server metadata.

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/pom.xml
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/pom.xml
@@ -39,17 +39,17 @@
             <artifactId>dolphinscheduler-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-dao</artifactId>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/pom.xml
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/pom.xml
@@ -17,21 +17,40 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.dolphinscheduler</groupId>
-        <artifactId>dolphinscheduler-registry</artifactId>
+        <artifactId>dolphinscheduler-registry-plugins</artifactId>
         <version>dev-SNAPSHOT</version>
     </parent>
-    <artifactId>dolphinscheduler-registry-plugins</artifactId>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
 
-    <modules>
-        <module>dolphinscheduler-registry-zookeeper</module>
-        <module>dolphinscheduler-registry-mysql</module>
-    </modules>
+    <artifactId>dolphinscheduler-registry-mysql</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-registry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-dao</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlOperator.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlOperator.java
@@ -125,6 +125,15 @@ public class MysqlOperator {
         }
     }
 
+    public void deleteEphemeralData(long ephemeralNodeId) throws SQLException {
+        String sql = "DELETE from t_ds_mysql_registry_data where `id` = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, ephemeralNodeId);
+            preparedStatement.execute();
+        }
+    }
+
     public void deletePersistentData(String key) throws SQLException {
         String sql = "DELETE from t_ds_mysql_registry_data where `key` = ? and type = ?";
         try (Connection connection = dataSource.getConnection();
@@ -269,7 +278,7 @@ public class MysqlOperator {
         try (Connection connection = dataSource.getConnection();
              PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             preparedStatement.setLong(1, ephemeralDateId);
-            return preparedStatement.executeUpdate() > 1;
+            return preparedStatement.executeUpdate() > 0;
         }
     }
 
@@ -278,7 +287,7 @@ public class MysqlOperator {
         try (Connection connection = dataSource.getConnection();
              PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             preparedStatement.setLong(1, mysqlRegistryLock.getId());
-            return preparedStatement.executeUpdate() > 1;
+            return preparedStatement.executeUpdate() > 0;
         }
     }
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlOperator.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlOperator.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql;
+
+import org.apache.dolphinscheduler.common.utils.NetUtils;
+import org.apache.dolphinscheduler.plugin.registry.mysql.model.DataType;
+import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryData;
+import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryLock;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Used to CRUD from mysql
+ */
+public class MysqlOperator {
+
+    private static final Logger logger = LoggerFactory.getLogger(MysqlOperator.class);
+
+    private final DataSource dataSource;
+
+    public MysqlOperator(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void healthCheck() throws SQLException {
+        String sql = "select 1 from t_ds_mysql_registry_data";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            // if no exception, the healthCheck success
+            preparedStatement.executeQuery();
+        }
+    }
+
+    public List<MysqlRegistryData> queryAllMysqlRegistryData() throws SQLException {
+        String sql = "select id, `key`, data, type, createTime, lastUpdateTime from t_ds_mysql_registry_data";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            ResultSet resultSet = preparedStatement.executeQuery();
+            List<MysqlRegistryData> result = new ArrayList<>(resultSet.getFetchSize());
+            while (resultSet.next()) {
+                MysqlRegistryData mysqlRegistryData = MysqlRegistryData.builder()
+                        .id(resultSet.getLong(1))
+                        .key(resultSet.getString(2))
+                        .data(resultSet.getString(3))
+                        .type(resultSet.getInt(4))
+                        .createTime(resultSet.getTimestamp(5))
+                        .lastUpdateTime(resultSet.getTimestamp(6))
+                        .build();
+                result.add(mysqlRegistryData);
+            }
+            return result;
+        }
+    }
+
+    public long insertOrUpdateEphemeralData(String key, String value) throws SQLException {
+        String sql = "INSERT INTO t_ds_mysql_registry_data (`key`, data, type, createTime, lastUpdateTime) VALUES (?, ?, ?, current_timestamp, current_timestamp)" +
+                "ON DUPLICATE KEY UPDATE data=?, lastUpdateTime=current_timestamp";
+        // put a ephemeralData
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            preparedStatement.setString(1, key);
+            preparedStatement.setString(2, value);
+            preparedStatement.setInt(3, DataType.EPHEMERAL.getTypeValue());
+            preparedStatement.setString(4, value);
+            int insertCount = preparedStatement.executeUpdate();
+            ResultSet generatedKeys = preparedStatement.getGeneratedKeys();
+            if (insertCount < 1 || !generatedKeys.next()) {
+                throw new SQLException("Insert ephemeral data error");
+            }
+            return generatedKeys.getLong(1);
+        }
+    }
+
+    public void insertOrUpdatePersistentData(String key, String value) throws SQLException {
+        String sql = "INSERT INTO t_ds_mysql_registry_data (`key`, data, type, createTime, lastUpdateTime) VALUES (?, ?, ?, current_timestamp, current_timestamp)" +
+                "ON DUPLICATE KEY UPDATE data=?, lastUpdateTime=current_timestamp";
+        // put a persistent Data
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            preparedStatement.setString(2, value);
+            preparedStatement.setInt(3, DataType.PERSISTENT.getTypeValue());
+            preparedStatement.setString(4, value);
+            preparedStatement.executeUpdate();
+        }
+    }
+
+    public void deleteEphemeralData(String key) throws SQLException {
+        String sql = "DELETE from t_ds_mysql_registry_data where `key` = ? and type = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            preparedStatement.setInt(2, DataType.EPHEMERAL.getTypeValue());
+            preparedStatement.execute();
+        }
+    }
+
+    public void deletePersistentData(String key) throws SQLException {
+        String sql = "DELETE from t_ds_mysql_registry_data where `key` = ? and type = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            preparedStatement.setInt(2, DataType.PERSISTENT.getTypeValue());
+            preparedStatement.execute();
+        }
+    }
+
+    public void clearExpireLock() {
+        String sql = "delete from t_ds_mysql_registry_lock where current_timestamp - lastTerm > ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, MysqlRegistryConstant.TERM_EXPIRE_TIME / 1000);
+            preparedStatement.executeUpdate();
+        } catch (Exception ex) {
+            logger.warn("Clear expire lock from mysql registry error", ex);
+        }
+    }
+
+    public void clearExpireEphemeralDate() {
+        String sql = "delete from t_ds_mysql_registry_data where current_timestamp - lastUpdateTime > ? and type = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, MysqlRegistryConstant.TERM_EXPIRE_TIME / 1000);
+            preparedStatement.setInt(2, DataType.EPHEMERAL.getTypeValue());
+            preparedStatement.executeUpdate();
+        } catch (Exception ex) {
+            logger.warn("Clear expire ephemeral data from mysql registry error", ex);
+        }
+    }
+
+    public MysqlRegistryData getData(String key) throws SQLException {
+        String sql = "SELECT id, `key`, data, type, createTime, lastUpdateTime FROM t_ds_mysql_registry_data WHERE `key` = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            if (resultSet == null) {
+                return null;
+            }
+            return MysqlRegistryData.builder()
+                    .id(resultSet.getLong(1))
+                    .key(resultSet.getString(2))
+                    .data(resultSet.getString(3))
+                    .type(resultSet.getInt(4))
+                    .createTime(resultSet.getTimestamp(5))
+                    .lastUpdateTime(resultSet.getTimestamp(6))
+                    .build();
+        }
+    }
+
+    public List<String> getChildren(String key) throws SQLException {
+        String sql = "SELECT `key` from t_ds_mysql_registry_data where `key` like ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key + "%");
+            ResultSet resultSet = preparedStatement.executeQuery();
+            List<String> result = new ArrayList<>(resultSet.getFetchSize());
+            while (resultSet.next()) {
+                String fullPath = resultSet.getString(1);
+                if (fullPath.length() > key.length()) {
+                    result.add(StringUtils.substringBefore(fullPath.substring(key.length() + 1), "/"));
+                }
+            }
+            return result;
+        }
+    }
+
+    public boolean existKey(String key) throws SQLException {
+        String sql = "SELECT 1 FROM t_ds_mysql_registry_data WHERE `key` = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Try to acquire the target Lock, if cannot acquire, return null.
+     */
+    public MysqlRegistryLock tryToAcquireLock(String key) throws SQLException {
+        String sql = "INSERT INTO t_ds_mysql_registry_lock (`key`, host, lastTerm, lastUpdateTime, createTime) VALUES (?, ?, current_timestamp, current_timestamp, current_timestamp)";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            Timestamp now = new Timestamp(System.currentTimeMillis());
+            preparedStatement.setString(1, key);
+            // todo: if we start multiple master in one instance with the same ip,
+            //  then only one master can get the lock at the same time.
+            preparedStatement.setString(2, NetUtils.getHost());
+            preparedStatement.executeUpdate();
+            ResultSet resultSet = preparedStatement.getGeneratedKeys();
+            if (resultSet.next()) {
+                long newLockId = resultSet.getLong(1);
+                return getLockById(newLockId);
+            }
+            return null;
+        } catch (SQLIntegrityConstraintViolationException e) {
+            // duplicate exception
+            return null;
+        }
+    }
+
+    public MysqlRegistryLock getLockById(long lockId) throws SQLException {
+        String sql = "SELECT `id`, `key`, host, lastTerm, lastUpdateTime, createTime FROM t_ds_mysql_registry_lock WHERE id = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, lockId);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                return MysqlRegistryLock.builder()
+                        .id(resultSet.getLong(1))
+                        .key(resultSet.getString(2))
+                        .host(resultSet.getString(3))
+                        .lastTerm(resultSet.getTimestamp(4))
+                        .lastUpdateTime(resultSet.getTimestamp(5))
+                        .createTime(resultSet.getTimestamp(6))
+                        .build();
+            }
+            return null;
+        }
+    }
+
+    // release the lock
+    public boolean releaseLock(long lockId) throws SQLException {
+        String sql = "DELETE FROM t_ds_mysql_registry_lock WHERE id = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, lockId);
+            int i = preparedStatement.executeUpdate();
+            return i > 0;
+        }
+    }
+
+    public boolean updateEphemeralDateTerm(Long ephemeralDateId) throws SQLException {
+        String sql = "update t_ds_mysql_registry_data set `lastUpdateTime` = current_timestamp where `id` = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, ephemeralDateId);
+            return preparedStatement.executeUpdate() > 1;
+        }
+    }
+
+    public boolean updateLockTerm(MysqlRegistryLock mysqlRegistryLock) throws SQLException {
+        String sql = "update t_ds_mysql_registry_lock set `lastTerm` = current_timestamp and `lastUpdateTime` = current_timestamp where `id` = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setLong(1, mysqlRegistryLock.getId());
+            return preparedStatement.executeUpdate() > 1;
+        }
+    }
+
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
@@ -53,14 +53,12 @@ public class MysqlRegistry implements Registry {
     private final MysqlOperator mysqlOperator;
 
     public MysqlRegistry(MysqlRegistryProperties mysqlRegistryProperties) {
-        MysqlRegistryConstant.TERM_REFRESH_INTERVAL = mysqlRegistryProperties.getTermRefreshInterval();
-        MysqlRegistryConstant.TERM_EXPIRE_TIMES = mysqlRegistryProperties.getTermExpireTimes();
-        this.mysqlOperator = new MysqlOperator(mysqlRegistryProperties.getMysqlDatasource());
+        this.mysqlOperator = new MysqlOperator(mysqlRegistryProperties);
         mysqlOperator.clearExpireLock();
         mysqlOperator.clearExpireEphemeralDate();
-        this.ephemeralDateManager = new EphemeralDateManager(mysqlOperator);
-        this.subscribeDataManager = new SubscribeDataManager(mysqlOperator);
-        this.registryLockManager = new RegistryLockManager(mysqlOperator);
+        this.ephemeralDateManager = new EphemeralDateManager(mysqlRegistryProperties, mysqlOperator);
+        this.subscribeDataManager = new SubscribeDataManager(mysqlRegistryProperties, mysqlOperator);
+        this.registryLockManager = new RegistryLockManager(mysqlRegistryProperties, mysqlOperator);
         LOGGER.info("Initialize Mysql Registry...");
     }
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql;
+
+import org.apache.dolphinscheduler.plugin.registry.mysql.task.EphemeralDateManager;
+import org.apache.dolphinscheduler.plugin.registry.mysql.task.RegistryLockManager;
+import org.apache.dolphinscheduler.plugin.registry.mysql.task.SubscribeDataManager;
+import org.apache.dolphinscheduler.registry.api.ConnectionListener;
+import org.apache.dolphinscheduler.registry.api.Registry;
+import org.apache.dolphinscheduler.registry.api.RegistryException;
+import org.apache.dolphinscheduler.registry.api.SubscribeListener;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Collection;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * This is one of the implementation of {@link Registry}, with this implementation, you need to rely on mysql database to
+ * store the DolphinScheduler master/worker's metadata and do the server registry/unRegistry.
+ */
+@Component
+@ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "mysql")
+public class MysqlRegistry implements Registry {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(MysqlRegistry.class);
+
+    private final EphemeralDateManager ephemeralDateManager;
+    private final SubscribeDataManager subscribeDataManager;
+    private final RegistryLockManager registryLockManager;
+    private final MysqlOperator mysqlOperator;
+
+    public MysqlRegistry(DataSource dataSource, MysqlRegistryProperties mysql) {
+        this.mysqlOperator = new MysqlOperator(dataSource);
+        this.ephemeralDateManager = new EphemeralDateManager(mysqlOperator);
+        this.subscribeDataManager = new SubscribeDataManager(mysqlOperator);
+        this.registryLockManager = new RegistryLockManager(mysqlOperator);
+        LOGGER.info("Initialize Mysql Registry...");
+    }
+
+    @PostConstruct
+    public void start() {
+        LOGGER.info("Starting Mysql Registry...");
+        // start a mysql connect check
+        ephemeralDateManager.start();
+        subscribeDataManager.start();
+        registryLockManager.start();
+        LOGGER.info("Started Mysql Registry...");
+    }
+
+    @Override
+    public boolean subscribe(String path, SubscribeListener listener) {
+        // new a schedule thread to query the path, if the path
+        subscribeDataManager.addListener(path, listener);
+        return true;
+    }
+
+    @Override
+    public void unsubscribe(String path) {
+        subscribeDataManager.removeListener(path);
+    }
+
+    @Override
+    public void addConnectionStateListener(ConnectionListener listener) {
+        // check the current connection
+        ephemeralDateManager.addConnectionListener(listener);
+    }
+
+    @Override
+    public String get(String key) {
+        // get the key value
+        try {
+            return subscribeDataManager.getData(key);
+        } catch (SQLException e) {
+            throw new RegistryException(String.format("Get key: %s error", key), e);
+        }
+    }
+
+    @Override
+    public void put(String key, String value, boolean deleteOnDisconnect) {
+        try {
+            if (deleteOnDisconnect) {
+                // when put a ephemeralData will new a scheduler thread to update it
+                long ephemeralDataId = mysqlOperator.insertOrUpdateEphemeralData(key, value);
+                ephemeralDateManager.addEphemeralDateId(ephemeralDataId);
+            } else {
+                mysqlOperator.insertOrUpdatePersistentData(key, value);
+            }
+        } catch (Exception ex) {
+            throw new RegistryException(String.format("put key:%s, value:%s error", key, value), ex);
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        try {
+            mysqlOperator.deleteEphemeralData(key);
+            mysqlOperator.deletePersistentData(key);
+        } catch (Exception e) {
+            throw new RegistryException(String.format("Delete key: %s error", key), e);
+        }
+    }
+
+    @Override
+    public Collection<String> children(String key) {
+        try {
+            return mysqlOperator.getChildren(key);
+        } catch (SQLException e) {
+            throw new RegistryException(String.format("Get key: %s children error", key), e);
+        }
+    }
+
+    @Override
+    public boolean exists(String key) {
+        try {
+            return mysqlOperator.existKey(key);
+        } catch (Exception e) {
+            throw new RegistryException(String.format("Check key: %s exist error", key), e);
+        }
+    }
+
+    @Override
+    public boolean acquireLock(String key) {
+        try {
+            registryLockManager.acquireLock(key);
+            return true;
+        } catch (RegistryException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RegistryException(String.format("Acquire lock: %s error", key), e);
+        }
+    }
+
+    @Override
+    public boolean releaseLock(String key) {
+        registryLockManager.releaseLock(key);
+        return true;
+    }
+
+    @Override
+    public Duration getSessionTimeout() {
+        throw new UnsupportedOperationException("Not support session timeout at Mysql Registry");
+    }
+
+    @Override
+    public void close() {
+        LOGGER.info("Closing Mysql Registry...");
+        // remove the current Ephemeral node, if can connect to mysql
+        try (EphemeralDateManager closed1 = ephemeralDateManager;
+             SubscribeDataManager close2 = subscribeDataManager;
+             RegistryLockManager close3 = registryLockManager) {
+        }
+        LOGGER.info("Closed Mysql Registry...");
+    }
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
@@ -172,6 +172,8 @@ public class MysqlRegistry implements Registry {
         try (EphemeralDateManager closed1 = ephemeralDateManager;
              SubscribeDataManager close2 = subscribeDataManager;
              RegistryLockManager close3 = registryLockManager) {
+        } catch (SQLException e) {
+            throw new RegistryException("Close Mysql Registry error", e);
         }
         LOGGER.info("Closed Mysql Registry...");
     }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
@@ -17,12 +17,14 @@
 
 package org.apache.dolphinscheduler.plugin.registry.mysql;
 
-import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
 
-@NoArgsConstructor
+@UtilityClass
 public final class MysqlRegistryConstant {
 
     public static long TERM_REFRESH_INTERVAL = 2_000L;
 
-    public static long TERM_EXPIRE_TIME = TERM_REFRESH_INTERVAL * 3;
+    public static int TERM_EXPIRE_TIMES = 3;
+
+    public static final long LOCK_ACQUIRE_INTERVAL = 1_000;
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
@@ -25,10 +25,6 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public final class MysqlRegistryConstant {
 
-    public static long TERM_REFRESH_INTERVAL = 2_000L;
-
-    public static int TERM_EXPIRE_TIMES = 3;
-
     public static final long LOCK_ACQUIRE_INTERVAL = 1_000;
 
     public static final String LOCK_OWNER = NetUtils.getHost() + "_" + OSUtils.getProcessID();

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public final class MysqlRegistryConstant {
+
+    public static long TERM_REFRESH_INTERVAL = 2_000L;
+
+    public static long TERM_EXPIRE_TIME = TERM_REFRESH_INTERVAL * 3;
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryConstant.java
@@ -17,6 +17,9 @@
 
 package org.apache.dolphinscheduler.plugin.registry.mysql;
 
+import org.apache.dolphinscheduler.common.utils.NetUtils;
+import org.apache.dolphinscheduler.common.utils.OSUtils;
+
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -27,4 +30,6 @@ public final class MysqlRegistryConstant {
     public static int TERM_EXPIRE_TIMES = 3;
 
     public static final long LOCK_ACQUIRE_INTERVAL = 1_000;
+
+    public static final String LOCK_OWNER = NetUtils.getHost() + "_" + OSUtils.getProcessID();
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryProperties.java
@@ -21,12 +21,34 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import lombok.Data;
+
+@Data
 @Configuration
 @ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "mysql")
 @ConfigurationProperties(prefix = "registry")
 public class MysqlRegistryProperties {
 
-    // todo:
-    private int lockTermExpireTime;
+    /**
+     * Used to schedule refresh the ephemeral data/ lock.
+     */
+    private long termRefreshInterval = MysqlRegistryConstant.TERM_REFRESH_INTERVAL;
+    /**
+     * Used to calculate the expire time,
+     * e.g. if you set 2, and latest two refresh error, then the ephemeral data/lock will be expire.
+     */
+    private int termExpireTimes = MysqlRegistryConstant.TERM_EXPIRE_TIMES;
+    private MysqlDatasourceProperties mysqlDatasource;
+
+    @Data
+    public static final class MysqlDatasourceProperties {
+        private String driverClassName;
+        private String url;
+        private String username;
+        private String password;
+        private int maximumPoolSize;
+        private long connectionTimeout;
+        private long idleTimeout;
+    }
 
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryProperties.java
@@ -17,9 +17,13 @@
 
 package org.apache.dolphinscheduler.plugin.registry.mysql;
 
+import java.time.Duration;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+
+import com.zaxxer.hikari.HikariConfig;
 
 import lombok.Data;
 
@@ -32,23 +36,12 @@ public class MysqlRegistryProperties {
     /**
      * Used to schedule refresh the ephemeral data/ lock.
      */
-    private long termRefreshInterval = MysqlRegistryConstant.TERM_REFRESH_INTERVAL;
+    private Duration termRefreshInterval = Duration.ofSeconds(2);
     /**
      * Used to calculate the expire time,
      * e.g. if you set 2, and latest two refresh error, then the ephemeral data/lock will be expire.
      */
-    private int termExpireTimes = MysqlRegistryConstant.TERM_EXPIRE_TIMES;
-    private MysqlDatasourceProperties mysqlDatasource;
-
-    @Data
-    public static final class MysqlDatasourceProperties {
-        private String driverClassName;
-        private String url;
-        private String username;
-        private String password;
-        private int maximumPoolSize;
-        private long connectionTimeout;
-        private long idleTimeout;
-    }
+    private int termExpireTimes = 3;
+    private HikariConfig hikariConfig;
 
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistryProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "mysql")
+@ConfigurationProperties(prefix = "registry")
+public class MysqlRegistryProperties {
+
+    // todo:
+    private int lockTermExpireTime;
+
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/DataType.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/DataType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql.model;
+
+public enum DataType {
+    EPHEMERAL(1),
+    PERSISTENT(2),
+    ;
+    private final int typeValue;
+
+    DataType(int typeValue) {
+        this.typeValue = typeValue;
+    }
+
+    public int getTypeValue() {
+        return typeValue;
+    }
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/MysqlRegistryData.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/MysqlRegistryData.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql.model;
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MysqlRegistryData {
+
+    private long id;
+    private String key;
+    private String data;
+    private int type;
+    private Date createTime;
+    private Date lastUpdateTime;
+
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/MysqlRegistryLock.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/MysqlRegistryLock.java
@@ -38,7 +38,7 @@ public class MysqlRegistryLock {
     /**
      * acquire lock host.
      */
-    private String host;
+    private String lockOwner;
     /**
      * The last term, if the (currentTime - lastTerm) > termExpire time, the lock will be expired.
      */

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/MysqlRegistryLock.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/model/MysqlRegistryLock.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql.model;
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MysqlRegistryLock {
+
+    private long id;
+    /**
+     * The lock key.
+     */
+    private String key;
+    /**
+     * acquire lock host.
+     */
+    private String host;
+    /**
+     * The last term, if the (currentTime - lastTerm) > termExpire time, the lock will be expired.
+     */
+    private Date lastTerm;
+    /**
+     * The lock last update time.
+     */
+    private Date lastUpdateTime;
+    /**
+     * The lock create time.
+     */
+    private Date createTime;
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
@@ -76,10 +76,13 @@ public class EphemeralDateManager implements AutoCloseable {
     }
 
     @Override
-    public void close() {
-        scheduledExecutorService.shutdownNow();
+    public void close() throws SQLException {
         ephemeralDateIds.clear();
         connectionListeners.clear();
+        scheduledExecutorService.shutdownNow();
+        for (Long ephemeralDateId : ephemeralDateIds) {
+            mysqlOperator.deleteEphemeralData(ephemeralDateId);
+        }
     }
 
     // Use this task to refresh ephemeral term and check the connect state.

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
@@ -63,7 +63,7 @@ public class EphemeralDateManager implements AutoCloseable {
     public void start() {
         this.scheduledExecutorService.scheduleWithFixedDelay(
                 new EphemeralDateTermRefreshTask(mysqlOperator, connectionListeners, ephemeralDateIds),
-                registryProperties.getTermExpireTimes(),
+                registryProperties.getTermRefreshInterval().toMillis(),
                 registryProperties.getTermRefreshInterval().toMillis(),
                 TimeUnit.MILLISECONDS);
     }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
@@ -148,11 +148,8 @@ public class EphemeralDateManager implements AutoCloseable {
         }
 
         private void updateEphemeralDateTerm() throws SQLException {
-            // todo: batch update
-            for (Long ephemeralDateId : ephemeralDateIds) {
-                if (!mysqlOperator.updateEphemeralDateTerm(ephemeralDateId)) {
-                    LOGGER.warn("Update mysql registry ephemeral data: {} term error", ephemeralDateId);
-                }
+            if (!mysqlOperator.updateEphemeralDataTerm(ephemeralDateIds)) {
+                LOGGER.warn("Update mysql registry ephemeral data: {} term error", ephemeralDateIds);
             }
         }
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql.task;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
+import org.apache.dolphinscheduler.registry.api.ConnectionListener;
+import org.apache.dolphinscheduler.registry.api.ConnectionState;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * This thread is used to check the connect state to mysql.
+ */
+public class EphemeralDateManager implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EphemeralDateManager.class);
+
+    private final MysqlOperator mysqlOperator;
+    private final List<ConnectionListener> connectionListeners = Collections.synchronizedList(new ArrayList<>());
+    private final Set<Long> ephemeralDateIds = Collections.synchronizedSet(new HashSet<>());
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    public EphemeralDateManager(MysqlOperator mysqlOperator) {
+        this.mysqlOperator = checkNotNull(mysqlOperator);
+        this.scheduledExecutorService = Executors.newScheduledThreadPool(
+                1,
+                new ThreadFactoryBuilder().setNameFormat("EphemeralDateTermRefreshThread").setDaemon(true).build());
+        mysqlOperator.clearExpireEphemeralDate();
+    }
+
+    public void start() {
+        this.scheduledExecutorService.scheduleWithFixedDelay(
+                new EphemeralDateTermRefreshTask(mysqlOperator, connectionListeners, ephemeralDateIds),
+                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                TimeUnit.MILLISECONDS);
+    }
+
+    public void addConnectionListener(ConnectionListener connectionListener) {
+        connectionListeners.add(connectionListener);
+    }
+
+    public void addEphemeralDateId(Long ephemeralDateId) {
+        ephemeralDateIds.add(ephemeralDateId);
+    }
+
+    @Override
+    public void close() {
+        scheduledExecutorService.shutdownNow();
+        ephemeralDateIds.clear();
+        connectionListeners.clear();
+    }
+
+    // Use this task to refresh ephemeral term and check the connect state.
+    private static class EphemeralDateTermRefreshTask implements Runnable {
+        private final List<ConnectionListener> connectionListeners;
+        private final Set<Long> ephemeralDateIds;
+        private final MysqlOperator mysqlOperator;
+        private ConnectionState connectionState;
+
+        public EphemeralDateTermRefreshTask(MysqlOperator mysqlOperator,
+                                            List<ConnectionListener> connectionListeners,
+                                            Set<Long> ephemeralDateIds) {
+            this.mysqlOperator = checkNotNull(mysqlOperator);
+            this.connectionListeners = checkNotNull(connectionListeners);
+            this.ephemeralDateIds = checkNotNull(ephemeralDateIds);
+        }
+
+        @Override
+        public void run() {
+            try {
+                ConnectionState currentConnectionState = getConnectionState();
+                if (currentConnectionState == connectionState) {
+                    // no state change
+                    return;
+                }
+                if (connectionState == null) {
+                    // first time connect
+                    if (currentConnectionState == ConnectionState.CONNECTED) {
+                        connectionState = ConnectionState.CONNECTED;
+                        triggerListener(ConnectionState.CONNECTED);
+                    }
+                } else {
+                    // already connect before
+                    if (connectionState == ConnectionState.CONNECTED && currentConnectionState == ConnectionState.DISCONNECTED) {
+                        connectionState = ConnectionState.DISCONNECTED;
+                        triggerListener(ConnectionState.DISCONNECTED);
+                    } else if (connectionState == ConnectionState.DISCONNECTED && currentConnectionState == ConnectionState.CONNECTED) {
+                        connectionState = ConnectionState.CONNECTED;
+                        triggerListener(ConnectionState.RECONNECTED);
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.error("Mysql Registry connect state check task execute failed", e);
+                connectionState = ConnectionState.DISCONNECTED;
+                triggerListener(ConnectionState.DISCONNECTED);
+            }
+        }
+
+        private ConnectionState getConnectionState() {
+            try {
+                if (ephemeralDateIds.isEmpty()) {
+                    mysqlOperator.healthCheck();
+                } else {
+                    updateEphemeralDateTerm();
+                }
+                mysqlOperator.clearExpireEphemeralDate();
+                return ConnectionState.CONNECTED;
+            } catch (Exception ex) {
+                return ConnectionState.DISCONNECTED;
+            }
+        }
+
+        private void updateEphemeralDateTerm() throws SQLException {
+            // todo: batch update
+            for (Long ephemeralDateId : ephemeralDateIds) {
+                mysqlOperator.updateEphemeralDateTerm(ephemeralDateId);
+            }
+        }
+
+        private void triggerListener(ConnectionState connectionState) {
+            for (ConnectionListener connectionListener : connectionListeners) {
+                connectionListener.onUpdate(connectionState);
+            }
+        }
+    }
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/EphemeralDateManager.java
@@ -20,7 +20,7 @@ package org.apache.dolphinscheduler.plugin.registry.mysql.task;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
-import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryProperties;
 import org.apache.dolphinscheduler.registry.api.ConnectionListener;
 import org.apache.dolphinscheduler.registry.api.ConnectionState;
 
@@ -47,11 +47,13 @@ public class EphemeralDateManager implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(EphemeralDateManager.class);
 
     private final MysqlOperator mysqlOperator;
+    private final MysqlRegistryProperties registryProperties;
     private final List<ConnectionListener> connectionListeners = Collections.synchronizedList(new ArrayList<>());
     private final Set<Long> ephemeralDateIds = Collections.synchronizedSet(new HashSet<>());
     private final ScheduledExecutorService scheduledExecutorService;
 
-    public EphemeralDateManager(MysqlOperator mysqlOperator) {
+    public EphemeralDateManager(MysqlRegistryProperties registryProperties, MysqlOperator mysqlOperator) {
+        this.registryProperties = registryProperties;
         this.mysqlOperator = checkNotNull(mysqlOperator);
         this.scheduledExecutorService = Executors.newScheduledThreadPool(
                 1,
@@ -61,8 +63,8 @@ public class EphemeralDateManager implements AutoCloseable {
     public void start() {
         this.scheduledExecutorService.scheduleWithFixedDelay(
                 new EphemeralDateTermRefreshTask(mysqlOperator, connectionListeners, ephemeralDateIds),
-                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
-                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                registryProperties.getTermExpireTimes(),
+                registryProperties.getTermRefreshInterval().toMillis(),
                 TimeUnit.MILLISECONDS);
     }
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/RegistryLockManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/RegistryLockManager.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql.task;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
+import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryLock;
+import org.apache.dolphinscheduler.registry.api.RegistryException;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public class RegistryLockManager implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(RegistryLockManager.class);
+
+    private final MysqlOperator mysqlOperator;
+    private final Map<String, MysqlRegistryLock> lockHoldMap;
+    private final ScheduledExecutorService lockTermUpdateThreadPool;
+
+    public RegistryLockManager(MysqlOperator mysqlOperator) {
+        this.mysqlOperator = mysqlOperator;
+        mysqlOperator.clearExpireLock();
+        this.lockHoldMap = new ConcurrentHashMap<>();
+        this.lockTermUpdateThreadPool = Executors.newScheduledThreadPool(
+                1,
+                new ThreadFactoryBuilder().setNameFormat("MysqlRegistryLockTermRefreshThread").setDaemon(true).build());
+    }
+
+    public void start() {
+        lockTermUpdateThreadPool.scheduleWithFixedDelay(
+                new LockTermRefreshTask(lockHoldMap, mysqlOperator),
+                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Acquire the lock, if cannot get the lock will await.
+     */
+    public void acquireLock(String lockKey) throws RegistryException {
+        // maybe we can use the computeIf absent
+        lockHoldMap.computeIfAbsent(lockKey, key -> {
+            MysqlRegistryLock mysqlRegistryLock;
+            try {
+                while ((mysqlRegistryLock = mysqlOperator.tryToAcquireLock(lockKey)) == null) {
+                    logger.debug("Acquire the lock {} failed try again", key);
+                    // acquire failed, wait and try again
+                    Thread.sleep(1_000L);
+                }
+            } catch (InterruptedException | SQLException e) {
+                // We clear the interrupt status
+                throw new RegistryException("Acquire the lock error", e);
+            }
+            return mysqlRegistryLock;
+        });
+    }
+
+    public void releaseLock(String lockKey) {
+        MysqlRegistryLock mysqlRegistryLock = lockHoldMap.get(lockKey);
+        if (mysqlRegistryLock != null) {
+            // the lock is unExit
+            try {
+                mysqlOperator.releaseLock(mysqlRegistryLock.getId());
+                lockHoldMap.remove(lockKey);
+            } catch (SQLException e) {
+                throw new RegistryException(String.format("Release lock: %s error", lockKey), e);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        lockTermUpdateThreadPool.shutdownNow();
+        lockHoldMap.clear();
+    }
+
+    /**
+     * This task is used to refresh the lock held by the current server.
+     */
+    static class LockTermRefreshTask implements Runnable {
+        private final Map<String, MysqlRegistryLock> lockHoldMap;
+        private final MysqlOperator mysqlOperator;
+
+        private LockTermRefreshTask(Map<String, MysqlRegistryLock> lockHoldMap, MysqlOperator mysqlOperator) {
+            this.lockHoldMap = checkNotNull(lockHoldMap);
+            this.mysqlOperator = checkNotNull(mysqlOperator);
+        }
+
+        public void run() {
+            try {
+                for (Map.Entry<String, MysqlRegistryLock> entry : lockHoldMap.entrySet()) {
+                    // update the lock term
+                    mysqlOperator.updateLockTerm(entry.getValue());
+                }
+                mysqlOperator.clearExpireLock();
+            } catch (Exception e) {
+                logger.debug("Update lock term error", e);
+            }
+        }
+    }
+}
+

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/RegistryLockManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/RegistryLockManager.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.plugin.registry.mysql.task;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
 import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryLock;
@@ -72,9 +73,9 @@ public class RegistryLockManager implements AutoCloseable {
                 while ((mysqlRegistryLock = mysqlOperator.tryToAcquireLock(lockKey)) == null) {
                     logger.debug("Acquire the lock {} failed try again", key);
                     // acquire failed, wait and try again
-                    Thread.sleep(1_000L);
+                    ThreadUtils.sleep(1_000L);
                 }
-            } catch (InterruptedException | SQLException e) {
+            } catch (SQLException e) {
                 // We clear the interrupt status
                 throw new RegistryException("Acquire the lock error", e);
             }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/RegistryLockManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/RegistryLockManager.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.plugin.registry.mysql.task;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryProperties;
 import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryLock;
 import org.apache.dolphinscheduler.registry.api.RegistryException;
 
@@ -43,10 +44,12 @@ public class RegistryLockManager implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(RegistryLockManager.class);
 
     private final MysqlOperator mysqlOperator;
+    private final MysqlRegistryProperties registryProperties;
     private final Map<String, MysqlRegistryLock> lockHoldMap;
     private final ScheduledExecutorService lockTermUpdateThreadPool;
 
-    public RegistryLockManager(MysqlOperator mysqlOperator) {
+    public RegistryLockManager(MysqlRegistryProperties registryProperties, MysqlOperator mysqlOperator) {
+        this.registryProperties = registryProperties;
         this.mysqlOperator = mysqlOperator;
         this.lockHoldMap = new ConcurrentHashMap<>();
         this.lockTermUpdateThreadPool = Executors.newSingleThreadScheduledExecutor(
@@ -56,8 +59,8 @@ public class RegistryLockManager implements AutoCloseable {
     public void start() {
         lockTermUpdateThreadPool.scheduleWithFixedDelay(
                 new LockTermRefreshTask(lockHoldMap, mysqlOperator),
-                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
-                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                registryProperties.getTermRefreshInterval().toMillis(),
+                registryProperties.getTermRefreshInterval().toMillis(),
                 TimeUnit.MILLISECONDS);
     }
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/SubscribeDataManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/SubscribeDataManager.java
@@ -17,8 +17,6 @@
 
 package org.apache.dolphinscheduler.plugin.registry.mysql.task;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
 import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryData;
@@ -41,6 +39,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Used to refresh if the subscribe path has been changed.
  */
@@ -62,7 +62,7 @@ public class SubscribeDataManager implements AutoCloseable {
 
     public void start() {
         dataSubscribeCheckThreadPool.scheduleWithFixedDelay(
-                new RegistrySubscribeDataCheckTask(mysqlRegistryDataMap, dataSubScribeMap, mysqlOperator),
+                new RegistrySubscribeDataCheckTask(dataSubScribeMap, mysqlOperator, mysqlRegistryDataMap),
                 MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
                 MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
                 TimeUnit.MILLISECONDS);
@@ -76,7 +76,7 @@ public class SubscribeDataManager implements AutoCloseable {
         dataSubScribeMap.remove(path);
     }
 
-    public String getData(String path) throws SQLException {
+    public String getData(String path) {
         MysqlRegistryData mysqlRegistryData = mysqlRegistryDataMap.get(path);
         if (mysqlRegistryData == null) {
             return null;
@@ -90,20 +90,12 @@ public class SubscribeDataManager implements AutoCloseable {
         dataSubScribeMap.clear();
     }
 
+    @RequiredArgsConstructor
     static class RegistrySubscribeDataCheckTask implements Runnable {
 
         private final Map<String, List<SubscribeListener>> dataSubScribeMap;
         private final MysqlOperator mysqlOperator;
         private final Map<String, MysqlRegistryData> mysqlRegistryDataMap;
-
-        public RegistrySubscribeDataCheckTask(
-                Map<String, MysqlRegistryData> mysqlRegistryDataMap,
-                Map<String, List<SubscribeListener>> dataSubScribeMap,
-                MysqlOperator mysqlOperator) {
-            this.mysqlRegistryDataMap = checkNotNull(mysqlRegistryDataMap);
-            this.dataSubScribeMap = checkNotNull(dataSubScribeMap);
-            this.mysqlOperator = checkNotNull(mysqlOperator);
-        }
 
         @Override
         public void run() {

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/SubscribeDataManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/SubscribeDataManager.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.mysql.task;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
+import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryData;
+import org.apache.dolphinscheduler.registry.api.Event;
+import org.apache.dolphinscheduler.registry.api.SubscribeListener;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * Used to refresh if the subscribe path has been changed.
+ */
+public class SubscribeDataManager implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscribeDataManager.class);
+
+    private final MysqlOperator mysqlOperator;
+    private final Map<String, List<SubscribeListener>> dataSubScribeMap = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService dataSubscribeCheckThreadPool;
+    private final Map<String, MysqlRegistryData> mysqlRegistryDataMap = new ConcurrentHashMap<>();
+
+    public SubscribeDataManager(MysqlOperator mysqlOperator) {
+        this.mysqlOperator = mysqlOperator;
+        this.dataSubscribeCheckThreadPool = Executors.newScheduledThreadPool(
+                1,
+                new ThreadFactoryBuilder().setNameFormat("MysqlRegistrySubscribeDataCheckThread").setDaemon(true).build());
+    }
+
+    public void start() {
+        dataSubscribeCheckThreadPool.scheduleWithFixedDelay(
+                new RegistrySubscribeDataCheckTask(mysqlRegistryDataMap, dataSubScribeMap, mysqlOperator),
+                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                TimeUnit.MILLISECONDS);
+    }
+
+    public void addListener(String path, SubscribeListener subscribeListener) {
+        dataSubScribeMap.computeIfAbsent(path, k -> new ArrayList<>()).add(subscribeListener);
+    }
+
+    public void removeListener(String path) {
+        dataSubScribeMap.remove(path);
+    }
+
+    public String getData(String path) throws SQLException {
+        MysqlRegistryData mysqlRegistryData = mysqlRegistryDataMap.get(path);
+        if (mysqlRegistryData == null) {
+            return null;
+        }
+        return mysqlRegistryData.getData();
+    }
+
+    @Override
+    public void close() {
+        dataSubscribeCheckThreadPool.shutdownNow();
+        dataSubScribeMap.clear();
+    }
+
+    static class RegistrySubscribeDataCheckTask implements Runnable {
+
+        private final Map<String, List<SubscribeListener>> dataSubScribeMap;
+        private final MysqlOperator mysqlOperator;
+        private final Map<String, MysqlRegistryData> mysqlRegistryDataMap;
+
+        public RegistrySubscribeDataCheckTask(
+                Map<String, MysqlRegistryData> mysqlRegistryDataMap,
+                Map<String, List<SubscribeListener>> dataSubScribeMap,
+                MysqlOperator mysqlOperator) {
+            this.mysqlRegistryDataMap = checkNotNull(mysqlRegistryDataMap);
+            this.dataSubScribeMap = checkNotNull(dataSubScribeMap);
+            this.mysqlOperator = checkNotNull(mysqlOperator);
+        }
+
+        @Override
+        public void run() {
+            // query the full data from database, and update the mysqlRegistryDataMap
+            try {
+                Map<String, MysqlRegistryData> currentMysqlDataMap = mysqlOperator.queryAllMysqlRegistryData()
+                        .stream()
+                        .collect(Collectors.toMap(MysqlRegistryData::getKey, Function.identity()));
+                // find the different
+                List<MysqlRegistryData> addedData = new ArrayList<>();
+                List<MysqlRegistryData> deletedData = new ArrayList<>();
+                List<MysqlRegistryData> updatedData = new ArrayList<>();
+                for (Map.Entry<String, MysqlRegistryData> entry : currentMysqlDataMap.entrySet()) {
+                    MysqlRegistryData newData = entry.getValue();
+                    MysqlRegistryData oldData = mysqlRegistryDataMap.get(entry.getKey());
+                    if (oldData == null) {
+                        addedData.add(newData);
+                    } else {
+                        if (!entry.getValue().getLastUpdateTime().equals(oldData.getLastUpdateTime())) {
+                            updatedData.add(newData);
+                        }
+                    }
+                }
+                for (Map.Entry<String, MysqlRegistryData> entry : mysqlRegistryDataMap.entrySet()) {
+                    if (!currentMysqlDataMap.containsKey(entry.getKey())) {
+                        deletedData.add(entry.getValue());
+                    }
+                }
+                mysqlRegistryDataMap.clear();
+                mysqlRegistryDataMap.putAll(currentMysqlDataMap);
+                // trigger listener
+                for (Map.Entry<String, List<SubscribeListener>> entry : dataSubScribeMap.entrySet()) {
+                    String subscribeKey = entry.getKey();
+                    List<SubscribeListener> subscribeListeners = entry.getValue();
+                    triggerListener(addedData, subscribeKey, subscribeListeners, Event.Type.ADD);
+                    triggerListener(deletedData, subscribeKey, subscribeListeners, Event.Type.REMOVE);
+                    triggerListener(updatedData, subscribeKey, subscribeListeners, Event.Type.UPDATE);
+                }
+            } catch (Exception e) {
+                LOGGER.error("Query data from mysql registry error");
+            }
+        }
+
+        private void triggerListener(List<MysqlRegistryData> dataList,
+                                     String subscribeKey,
+                                     List<SubscribeListener> subscribeListeners,
+                                     Event.Type type) {
+            for (MysqlRegistryData data : dataList) {
+                if (data.getKey().startsWith(subscribeKey)) {
+                    subscribeListeners.forEach(subscribeListener ->
+                            subscribeListener.notify(new Event(data.getKey(), data.getKey(), data.getData(), type)));
+                }
+            }
+        }
+
+    }
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/SubscribeDataManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/task/SubscribeDataManager.java
@@ -18,12 +18,11 @@
 package org.apache.dolphinscheduler.plugin.registry.mysql.task;
 
 import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlOperator;
-import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryConstant;
+import org.apache.dolphinscheduler.plugin.registry.mysql.MysqlRegistryProperties;
 import org.apache.dolphinscheduler.plugin.registry.mysql.model.MysqlRegistryData;
 import org.apache.dolphinscheduler.registry.api.Event;
 import org.apache.dolphinscheduler.registry.api.SubscribeListener;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +48,13 @@ public class SubscribeDataManager implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(SubscribeDataManager.class);
 
     private final MysqlOperator mysqlOperator;
+    private final MysqlRegistryProperties registryProperties;
     private final Map<String, List<SubscribeListener>> dataSubScribeMap = new ConcurrentHashMap<>();
     private final ScheduledExecutorService dataSubscribeCheckThreadPool;
     private final Map<String, MysqlRegistryData> mysqlRegistryDataMap = new ConcurrentHashMap<>();
 
-    public SubscribeDataManager(MysqlOperator mysqlOperator) {
+    public SubscribeDataManager(MysqlRegistryProperties registryProperties, MysqlOperator mysqlOperator) {
+        this.registryProperties = registryProperties;
         this.mysqlOperator = mysqlOperator;
         this.dataSubscribeCheckThreadPool = Executors.newScheduledThreadPool(
                 1,
@@ -63,8 +64,8 @@ public class SubscribeDataManager implements AutoCloseable {
     public void start() {
         dataSubscribeCheckThreadPool.scheduleWithFixedDelay(
                 new RegistrySubscribeDataCheckTask(dataSubScribeMap, mysqlOperator, mysqlRegistryDataMap),
-                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
-                MysqlRegistryConstant.TERM_REFRESH_INTERVAL,
+                registryProperties.getTermRefreshInterval().toMillis(),
+                registryProperties.getTermRefreshInterval().toMillis(),
                 TimeUnit.MILLISECONDS);
     }
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP TABLE IF EXISTS `t_ds_mysql_registry_data`;
+CREATE TABLE `t_ds_mysql_registry_data`
+(
+    `id`             bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+    `key`            varchar(200) NOT NULL COMMENT 'key, like zookeeper node path',
+    `data`           varchar(200) NOT NULL COMMENT 'data, like zookeeper node value',
+    `type`           tinyint(4)   NOT NULL COMMENT '1: empth, 2: persistent node',
+    `createTime`     timestamp    NULL COMMENT 'create time',
+    `lastUpdateTime` timestamp    NULL COMMENT 'last update time',
+    PRIMARY KEY (`id`),
+    unique (`key`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+
+DROP TABLE IF EXISTS `t_ds_mysql_registry_lock`;
+CREATE TABLE `t_ds_mysql_registry_lock`
+(
+    `id`             bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+    `key`            varchar(200) NOT NULL COMMENT 'lock path',
+    `host`           varchar(100) NOT NULL COMMENT 'get lock address',
+    `lastTerm`       timestamp    NOT NULL COMMENT 'last term time',
+    `lastUpdateTime` timestamp    NULL COMMENT 'last update time',
+    `createTime`     timestamp    NULL COMMENT 'lock create time',
+    PRIMARY KEY (`id`),
+    unique (`key`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
@@ -20,12 +20,12 @@ SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS `t_ds_mysql_registry_data`;
 CREATE TABLE `t_ds_mysql_registry_data`
 (
-    `id`             bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
-    `key`            varchar(200) NOT NULL COMMENT 'key, like zookeeper node path',
-    `data`           varchar(200) NOT NULL COMMENT 'data, like zookeeper node value',
-    `type`           tinyint(4)   NOT NULL COMMENT '1: ephemeral node, 2: persistent node',
-    `lastUpdateTime` timestamp    NULL COMMENT 'last update time',
-    `createTime`     timestamp    NULL COMMENT 'create time',
+    `id`               bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+    `key`              varchar(200) NOT NULL COMMENT 'key, like zookeeper node path',
+    `data`             varchar(200) NOT NULL COMMENT 'data, like zookeeper node value',
+    `type`             tinyint(4)   NOT NULL COMMENT '1: ephemeral node, 2: persistent node',
+    `last_update_time` timestamp    NULL COMMENT 'last update time',
+    `create_time`      timestamp    NULL COMMENT 'create time',
     PRIMARY KEY (`id`),
     unique (`key`)
 ) ENGINE = InnoDB
@@ -35,12 +35,12 @@ CREATE TABLE `t_ds_mysql_registry_data`
 DROP TABLE IF EXISTS `t_ds_mysql_registry_lock`;
 CREATE TABLE `t_ds_mysql_registry_lock`
 (
-    `id`             bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
-    `key`            varchar(200) NOT NULL COMMENT 'lock path',
-    `host`           varchar(100) NOT NULL COMMENT 'get lock address',
-    `lastTerm`       timestamp    NOT NULL COMMENT 'last term time',
-    `lastUpdateTime` timestamp    NULL COMMENT 'last update time',
-    `createTime`     timestamp    NULL COMMENT 'lock create time',
+    `id`               bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+    `key`              varchar(200) NOT NULL COMMENT 'lock path',
+    `host`             varchar(100) NOT NULL COMMENT 'get lock address',
+    `last_term`        timestamp    NOT NULL COMMENT 'last term time',
+    `last_update_time` timestamp    NULL COMMENT 'last update time',
+    `create_time`      timestamp    NULL COMMENT 'lock create time',
     PRIMARY KEY (`id`),
     unique (`key`)
 ) ENGINE = InnoDB

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
@@ -23,9 +23,9 @@ CREATE TABLE `t_ds_mysql_registry_data`
     `id`             bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
     `key`            varchar(200) NOT NULL COMMENT 'key, like zookeeper node path',
     `data`           varchar(200) NOT NULL COMMENT 'data, like zookeeper node value',
-    `type`           tinyint(4)   NOT NULL COMMENT '1: empth, 2: persistent node',
-    `createTime`     timestamp    NULL COMMENT 'create time',
+    `type`           tinyint(4)   NOT NULL COMMENT '1: ephemeral node, 2: persistent node',
     `lastUpdateTime` timestamp    NULL COMMENT 'last update time',
+    `createTime`     timestamp    NULL COMMENT 'create time',
     PRIMARY KEY (`id`),
     unique (`key`)
 ) ENGINE = InnoDB

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
@@ -37,7 +37,7 @@ CREATE TABLE `t_ds_mysql_registry_lock`
 (
     `id`               bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
     `key`              varchar(200) NOT NULL COMMENT 'lock path',
-    `host`             varchar(100) NOT NULL COMMENT 'get lock address',
+    `lock_owner`       varchar(100) NOT NULL COMMENT 'the lock owner, ip_processId',
     `last_term`        timestamp    NOT NULL COMMENT 'last term time',
     `last_update_time` timestamp    NULL COMMENT 'last update time',
     `create_time`      timestamp    NULL COMMENT 'lock create time',

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
@@ -23,8 +23,6 @@ import org.apache.dolphinscheduler.registry.api.ConnectionListener;
 import org.apache.dolphinscheduler.registry.api.Event;
 import org.apache.dolphinscheduler.registry.api.Registry;
 import org.apache.dolphinscheduler.registry.api.RegistryException;
-import org.apache.dolphinscheduler.registry.api.RegistryProperties;
-import org.apache.dolphinscheduler.registry.api.RegistryProperties.ZookeeperProperties;
 import org.apache.dolphinscheduler.registry.api.SubscribeListener;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -59,14 +57,14 @@ import com.google.common.base.Strings;
 @Component
 @ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "zookeeper")
 public final class ZookeeperRegistry implements Registry {
-    private final ZookeeperProperties properties;
+    private final ZookeeperRegistryProperties.ZookeeperProperties properties;
     private final CuratorFramework client;
 
     private final Map<String, TreeCache> treeCacheMap = new ConcurrentHashMap<>();
 
     private static final ThreadLocal<Map<String, InterProcessMutex>> threadLocalLockMap = new ThreadLocal<>();
 
-    public ZookeeperRegistry(RegistryProperties registryProperties) {
+    public ZookeeperRegistry(ZookeeperRegistryProperties registryProperties) {
         properties = registryProperties.getZookeeper();
 
         final ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
@@ -27,16 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "zookeeper")
 @ConfigurationProperties(prefix = "registry")
 public class ZookeeperRegistryProperties {
-    private Type type;
     private ZookeeperProperties zookeeper = new ZookeeperProperties();
-
-    public Type getType() {
-        return type;
-    }
-
-    public void setType(Type type) {
-        this.type = type;
-    }
 
     public ZookeeperProperties getZookeeper() {
         return zookeeper;
@@ -44,10 +35,6 @@ public class ZookeeperRegistryProperties {
 
     public void setZookeeper(ZookeeperProperties zookeeper) {
         this.zookeeper = zookeeper;
-    }
-
-    public enum Type {
-        ZOOKEEPER
     }
 
     public static final class ZookeeperProperties {

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.plugin.registry.zookeeper;
 
 import java.time.Duration;

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
@@ -1,33 +1,15 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
- */
-
-package org.apache.dolphinscheduler.registry.api;
+package org.apache.dolphinscheduler.plugin.registry.zookeeper;
 
 import java.time.Duration;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "zookeeper")
 @ConfigurationProperties(prefix = "registry")
-public class RegistryProperties {
+public class ZookeeperRegistryProperties {
     private Type type;
     private ZookeeperProperties zookeeper = new ZookeeperProperties();
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/test/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryTest.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/test/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryTest.java
@@ -18,7 +18,6 @@
 package org.apache.dolphinscheduler.plugin.registry.zookeeper;
 
 import org.apache.dolphinscheduler.registry.api.Event;
-import org.apache.dolphinscheduler.registry.api.RegistryProperties;
 import org.apache.dolphinscheduler.registry.api.SubscribeListener;
 
 import org.apache.curator.test.TestingServer;
@@ -48,7 +47,7 @@ public class ZookeeperRegistryTest {
     public void before() throws Exception {
         server = new TestingServer(true);
 
-        RegistryProperties p = new RegistryProperties();
+        ZookeeperRegistryProperties p = new ZookeeperRegistryProperties();
         p.getZookeeper().setConnectString(server.getConnectString());
         registry = new ZookeeperRegistry(p);
         registry.start();

--- a/dolphinscheduler-worker/pom.xml
+++ b/dolphinscheduler-worker/pom.xml
@@ -61,6 +61,10 @@
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-registry-zookeeper</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>

--- a/dolphinscheduler-worker/pom.xml
+++ b/dolphinscheduler-worker/pom.xml
@@ -59,11 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-registry-zookeeper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-registry-mysql</artifactId>
+            <artifactId>dolphinscheduler-registry-all</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
+                <artifactId>dolphinscheduler-registry-all</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-dao</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -856,13 +861,6 @@
                 <version>${aws.sdk.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -1233,6 +1231,12 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <hibernate.validator.version>6.2.2.Final</hibernate.validator.version>
         <aws.sdk.version>1.12.160</aws.sdk.version>
         <joda-time.version>2.10.13</joda-time.version>
+        <lombok.version>1.18.20</lombok.version>
         <docker.hub>apache</docker.hub>
         <docker.repo>${project.name}</docker.repo>
         <docker.tag>${project.version}</docker.tag>
@@ -383,6 +384,11 @@
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-registry-zookeeper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dolphinscheduler</groupId>
+                <artifactId>dolphinscheduler-registry-mysql</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -848,6 +854,13 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
                 <version>${aws.sdk.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
## Purpose of the pull request
close #10408 
Add new registry plugin - mysql. If user don't have a zookeeper cluster, they can still use DolphinScheduler.

todo: add doc

## Brief change log
- Add a new module `dolphinscheduler-registry-mysql`.
- Add dependency `dolphinscheduler-registry-mysql` to api/master/worker


## Verify this pull request
Change the registry.type to mysql and start a ds cluster.

