### PR TITLE
[Fix-10425]Recovery LDAP Config

### DIFF
--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -219,7 +219,13 @@ spring.messages.encoding|UTF-8| message encoding
 spring.jackson.time-zone|GMT+8| time zone
 spring.messages.basename|i18n/messages| i18n config
 security.authentication.type|PASSWORD| authentication type
-
+security.authentication.ldap.user.admin|read-only-admin|admin user account when you log-in with LDAP
+security.authentication.ldap.urls|ldap://ldap.forumsys.com:389/|LDAP urls
+security.authentication.ldap.base.dn|dc=example,dc=com|LDAP base dn
+security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP username
+security.authentication.ldap.password|password|LDAP password
+security.authentication.ldap.user.identity.attribute|uid|LDAP user identity attribute 
+security.authentication.ldap.user.email.attribute|mail|LDAP user email attribute
 
 ### master.properties [master-service log config]
 

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -210,6 +210,13 @@ spring.messages.encoding|UTF-8|请求编码
 spring.jackson.time-zone|GMT+8|设置时区
 spring.messages.basename|i18n/messages|i18n配置
 security.authentication.type|PASSWORD|权限校验类型
+security.authentication.ldap.user.admin|read-only-admin|LDAP登陆时，系统管理员账号
+security.authentication.ldap.urls|ldap://ldap.forumsys.com:389/|LDAP urls
+security.authentication.ldap.base.dn|dc=example,dc=com|LDAP base dn
+security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP账号
+security.authentication.ldap.password|password|LDAP密码
+security.authentication.ldap.user.identity.attribute|uid|LDAP用户身份标识字段名
+security.authentication.ldap.user.email.attribute|mail|LDAP邮箱字段名
 
 
 ## 6.master.properties [Master服务配置]
@@ -383,7 +390,7 @@ singleYarnIp="yarnIp1"
 resourceUploadPath="/dolphinscheduler"
 
 
-# HDFS/S3  操作用户
+# HDFS/S3  操作用户 
 hdfsRootUser="hdfs"
 
 # 以下为 kerberos 配置

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
@@ -45,22 +45,22 @@ public class LdapService {
     @Value("${security.authentication.ldap.user.admin:null}")
     private String adminUserId;
 
-    @Value("${ldap.urls:null}")
+    @Value("${security.authentication.ldap.urls:null}")
     private String ldapUrls;
 
-    @Value("${ldap.base.dn:null}")
+    @Value("${security.authentication.ldap.base.dn:null}")
     private String ldapBaseDn;
 
-    @Value("${ldap.username:null}")
+    @Value("${security.authentication.ldap.username:null}")
     private String ldapSecurityPrincipal;
 
-    @Value("${ldap.password:null}")
+    @Value("${security.authentication.ldap.password:null}")
     private String ldapPrincipalPassword;
 
-    @Value("${ldap.user.identity.attribute:null}")
+    @Value("${security.authentication.ldap.user.identity.attribute:null}")
     private String ldapUserIdentifyingAttribute;
 
-    @Value("${ldap.user.email.attribute:null}")
+    @Value("${security.authentication.ldap.user.email.attribute:null}")
     private String ldapEmailAttribute;
 
     /***

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -128,6 +128,22 @@ python-gateway:
   # (0 = infinite), and socket server would never close even though no requests accept
   read-timeout: 0
 
+security:
+  authentication:
+    # Authentication types (supported types: PASSWORD,LDAP)
+    type: PASSWORD
+    # IF you set type `LDAP`, below config will be effective
+    ldap:
+      # admin userId
+      user.admin: read-only-admin
+      # ldap server config
+      urls: ldap://ldap.forumsys.com:389/
+      base.dn: dc=example,dc=com
+      username: cn=read-only-admin,dc=example,dc=com
+      password: password
+      user.identity.attribute: uid
+      user.email.attribute: mail
+
 # Override by profile
 
 ---

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
@@ -49,12 +49,12 @@ import org.springframework.test.context.TestPropertySource;
         properties = {
                 "security.authentication.type=LDAP",
                 "security.authentication.ldap.user.admin=read-only-admin",
-                "ldap.urls=ldap://ldap.forumsys.com:389/",
-                "ldap.base.dn=dc=example,dc=com",
-                "ldap.username=cn=read-only-admin,dc=example,dc=com",
-                "ldap.password=password",
-                "ldap.user.identity.attribute=uid",
-                "ldap.user.email.attribute=mail",
+                "security.authentication.ldap.urls=ldap://ldap.forumsys.com:389/",
+                "security.authentication.ldap.base.dn=dc=example,dc=com",
+                "security.authentication.ldap.username=cn=read-only-admin,dc=example,dc=com",
+                "security.authentication.ldap.password=password",
+                "security.authentication.ldap.user.identity.attribute=uid",
+                "security.authentication.ldap.user.email.attribute=mail",
         })
 public class LdapAuthenticatorTest extends AbstractControllerTest {
     private static Logger logger = LoggerFactory.getLogger(LdapAuthenticatorTest.class);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
@@ -41,12 +41,12 @@ import org.springframework.test.context.junit4.SpringRunner;
         properties = {
                 "security.authentication.type=LDAP",
                 "security.authentication.ldap.user.admin=read-only-admin",
-                "ldap.urls=ldap://ldap.forumsys.com:389/",
-                "ldap.base.dn=dc=example,dc=com",
-                "ldap.username=cn=read-only-admin,dc=example,dc=com",
-                "ldap.password=password",
-                "ldap.user.identity.attribute=uid",
-                "ldap.user.email.attribute=mail",
+                "security.authentication.ldap.urls=ldap://ldap.forumsys.com:389/",
+                "security.authentication.ldap.base.dn=dc=example,dc=com",
+                "security.authentication.ldap.username=cn=read-only-admin,dc=example,dc=com",
+                "security.authentication.ldap.password=password",
+                "security.authentication.ldap.user.identity.attribute=uid",
+                "security.authentication.ldap.user.email.attribute=mail",
         })
 public class LdapServiceTest {
     @Autowired

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -86,6 +86,22 @@ registry:
     block-until-connected: 600ms
     digest: ~
 
+security:
+  authentication:
+    # Authentication types (supported types: PASSWORD,LDAP)
+    type: PASSWORD
+    # IF you set type `LDAP`, below config will be effective
+    ldap:
+      # admin userId
+      user.admin: read-only-admin
+      # ldap server config
+      urls: ldap://ldap.forumsys.com:389/
+      base.dn: dc=example,dc=com
+      username: cn=read-only-admin,dc=example,dc=com
+      password: password
+      user.identity.attribute: uid
+      user.email.attribute: mail
+
 master:
   listen-port: 5678
   # master fetch command num


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Due to https://github.com/apache/dolphinscheduler/commit/4114cb07f64950f88ffb4aa8a4ecc4815f32d76b#diff-f2f54230647b5ed6920efc032cd61c4dc2acd8f728ad0f43aef1e8fd3f9793ed , dev branch has no LDAP config in the YAML file. I recovery LDAP config.

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

dolphinscheduler-api/src/main/resources/application.yaml
dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
dolphinscheduler-standalone-server/src/main/resources/application.yaml

## Verify this pull request


This pull request is already covered by existing tests, such as *(please describe tests)*.

dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

part of #10425 