### PR TITLE
[Improve] Add LDAP user not exsitst action config

### DIFF
--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -226,7 +226,7 @@ security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP 
 security.authentication.ldap.password|password|LDAP password
 security.authentication.ldap.user.identity.attribute|uid|LDAP user identity attribute 
 security.authentication.ldap.user.email.attribute|mail|LDAP user email attribute
-security.authentication.ldap.user.not.exist.action|CREATION|action when LDAP user is not exist
+security.authentication.ldap.user.not.exist.action|CREATE|action when LDAP user is not exist. Default CREATE: automatically create user when user not exist, DENY: deny log-in when user not exist
 
 ### master.properties [master-service log config]
 

--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -226,6 +226,7 @@ security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP 
 security.authentication.ldap.password|password|LDAP password
 security.authentication.ldap.user.identity.attribute|uid|LDAP user identity attribute 
 security.authentication.ldap.user.email.attribute|mail|LDAP user email attribute
+security.authentication.ldap.user.not.exist.action|CREATION|action when LDAP user is not exist
 
 ### master.properties [master-service log config]
 

--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -221,12 +221,12 @@ spring.messages.basename|i18n/messages| i18n config
 security.authentication.type|PASSWORD| authentication type
 security.authentication.ldap.user.admin|read-only-admin|admin user account when you log-in with LDAP
 security.authentication.ldap.urls|ldap://ldap.forumsys.com:389/|LDAP urls
-security.authentication.ldap.base.dn|dc=example,dc=com|LDAP base dn
+security.authentication.ldap.base-dn|dc=example,dc=com|LDAP base dn
 security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP username
 security.authentication.ldap.password|password|LDAP password
-security.authentication.ldap.user.identity.attribute|uid|LDAP user identity attribute 
-security.authentication.ldap.user.email.attribute|mail|LDAP user email attribute
-security.authentication.ldap.user.not.exist.action|CREATE|action when LDAP user is not exist. Default CREATE: automatically create user when user not exist, DENY: deny log-in when user not exist
+security.authentication.ldap.user.identity-attribute|uid|LDAP user identity attribute 
+security.authentication.ldap.user.email-attribute|mail|LDAP user email attribute
+security.authentication.ldap.user.not-exist-action|CREATE|action when LDAP user is not exist. Default CREATE: automatically create user when user not exist, DENY: deny log-in when user not exist
 
 ### master.properties [master-service log config]
 

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -217,7 +217,7 @@ security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP�
 security.authentication.ldap.password|password|LDAP密码
 security.authentication.ldap.user.identity.attribute|uid|LDAP用户身份标识字段名
 security.authentication.ldap.user.email.attribute|mail|LDAP邮箱字段名
-
+security.authentication.ldap.user.not.exist.action|CREATION|当LDAP用户不存在时执行的操作
 
 ## 6.master.properties [Master服务配置]
 |参数 |默认值| 描述| 

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -217,7 +217,7 @@ security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP�
 security.authentication.ldap.password|password|LDAP密码
 security.authentication.ldap.user.identity.attribute|uid|LDAP用户身份标识字段名
 security.authentication.ldap.user.email.attribute|mail|LDAP邮箱字段名
-security.authentication.ldap.user.not.exist.action|CREATION|当LDAP用户不存在时执行的操作
+security.authentication.ldap.user.not.exist.action|CREATE|当LDAP用户不存在时执行的操作。CREATE：当用户不存在时自动新建用户, DENY：当用户不存在时拒绝登陆
 
 ## 6.master.properties [Master服务配置]
 |参数 |默认值| 描述| 

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -212,12 +212,12 @@ spring.messages.basename|i18n/messages|i18n配置
 security.authentication.type|PASSWORD|权限校验类型
 security.authentication.ldap.user.admin|read-only-admin|LDAP登陆时，系统管理员账号
 security.authentication.ldap.urls|ldap://ldap.forumsys.com:389/|LDAP urls
-security.authentication.ldap.base.dn|dc=example,dc=com|LDAP base dn
+security.authentication.ldap.base-dn|dc=example,dc=com|LDAP base dn
 security.authentication.ldap.username|cn=read-only-admin,dc=example,dc=com|LDAP账号
 security.authentication.ldap.password|password|LDAP密码
-security.authentication.ldap.user.identity.attribute|uid|LDAP用户身份标识字段名
-security.authentication.ldap.user.email.attribute|mail|LDAP邮箱字段名
-security.authentication.ldap.user.not.exist.action|CREATE|当LDAP用户不存在时执行的操作。CREATE：当用户不存在时自动新建用户, DENY：当用户不存在时拒绝登陆
+security.authentication.ldap.user.identity-attribute|uid|LDAP用户身份标识字段名
+security.authentication.ldap.user.email-attribute|mail|LDAP邮箱字段名
+security.authentication.ldap.user.not-exist-action|CREATE|当LDAP用户不存在时执行的操作。CREATE：当用户不存在时自动新建用户, DENY：当用户不存在时拒绝登陆
 
 ## 6.master.properties [Master服务配置]
 |参数 |默认值| 描述| 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/LdapUserNotExistActionType.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/LdapUserNotExistActionType.java
@@ -24,7 +24,7 @@ import com.baomidou.mybatisplus.annotation.EnumValue;
  */
 public enum LdapUserNotExistActionType {
 
-    CREATION(0, "automatically create user when user not exist"),
+    CREATE(0, "automatically create user when user not exist"),
     DENY(1, "deny log-in when user not exist"),
     ;
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/LdapUserNotExistActionType.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/LdapUserNotExistActionType.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.security;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+
+/**
+ * ldap user not exist action type
+ */
+public enum LdapUserNotExistActionType {
+
+    CREATION(0, "automatically create user when user not exist"),
+    DENY(1, "deny log-in when user not exist"),
+    ;
+
+    LdapUserNotExistActionType(int code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    @EnumValue
+    private final int code;
+    private final String desc;
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.api.security.impl.ldap;
 
-import org.apache.dolphinscheduler.api.security.LdapUserNotExistActionType;
 import org.apache.dolphinscheduler.api.security.impl.AbstractAuthenticator;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -37,10 +36,8 @@ public class LdapAuthenticator extends AbstractAuthenticator {
         if (ldapEmail != null) {
             //check if user exist
             user = usersService.getUserByUserName(userId);
-            if (user == null) {
-                if(ldapService.createIfUserNotExists()){
-                    user = usersService.createUser(ldapService.getUserType(userId), userId, ldapEmail);
-                }
+            if (user == null && ldapService.createIfUserNotExists()) {
+                user = usersService.createUser(ldapService.getUserType(userId), userId, ldapEmail);
             }
         }
         return user;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.api.security.impl.ldap;
 
+import org.apache.dolphinscheduler.api.security.LdapUserNotExistActionType;
 import org.apache.dolphinscheduler.api.security.impl.AbstractAuthenticator;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -37,7 +38,10 @@ public class LdapAuthenticator extends AbstractAuthenticator {
             //check if user exist
             user = usersService.getUserByUserName(userId);
             if (user == null) {
-                user = usersService.createUser(ldapService.getUserType(userId), userId, ldapEmail);
+                LdapUserNotExistActionType type = ldapService.getLdapUserNotExistAction();
+                if(type == LdapUserNotExistActionType.CREATION){
+                    user = usersService.createUser(ldapService.getUserType(userId), userId, ldapEmail);
+                }
             }
         }
         return user;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
@@ -39,7 +39,7 @@ public class LdapAuthenticator extends AbstractAuthenticator {
             user = usersService.getUserByUserName(userId);
             if (user == null) {
                 LdapUserNotExistActionType type = ldapService.getLdapUserNotExistAction();
-                if(type == LdapUserNotExistActionType.CREATION){
+                if(type == LdapUserNotExistActionType.CREATE){
                     user = usersService.createUser(ldapService.getUserType(userId), userId, ldapEmail);
                 }
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
@@ -43,3 +43,4 @@ public class LdapAuthenticator extends AbstractAuthenticator {
         return user;
     }
 }
+

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
@@ -38,8 +38,7 @@ public class LdapAuthenticator extends AbstractAuthenticator {
             //check if user exist
             user = usersService.getUserByUserName(userId);
             if (user == null) {
-                LdapUserNotExistActionType type = ldapService.getLdapUserNotExistAction();
-                if(type == LdapUserNotExistActionType.CREATE){
+                if(ldapService.createIfUserNotExists()){
                     user = usersService.createUser(ldapService.getUserType(userId), userId, ldapEmail);
                 }
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticator.java
@@ -43,4 +43,3 @@ public class LdapAuthenticator extends AbstractAuthenticator {
         return user;
     }
 }
-

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
@@ -145,4 +145,8 @@ public class LdapService {
 
         return LdapUserNotExistActionType.valueOf(ldapUserNotExistAction);
     }
+
+    public boolean createIfUserNotExists(){
+        return getLdapUserNotExistAction() == LdapUserNotExistActionType.CREATE;
+    }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
@@ -17,7 +17,11 @@
 
 package org.apache.dolphinscheduler.api.security.impl.ldap;
 
+import org.apache.dolphinscheduler.api.security.AuthenticationType;
+import org.apache.dolphinscheduler.api.security.LdapUserNotExistActionType;
 import org.apache.dolphinscheduler.common.enums.UserType;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Properties;
 
@@ -62,6 +66,9 @@ public class LdapService {
 
     @Value("${security.authentication.ldap.user.email.attribute:null}")
     private String ldapEmailAttribute;
+
+    @Value("${security.authentication.ldap.user.not.exist.action:CREATION}")
+    private String ldapUserNotExistAction;
 
     /***
      * get user type by configured admin userId
@@ -129,5 +136,14 @@ public class LdapService {
         env.put(Context.SECURITY_CREDENTIALS, ldapPrincipalPassword);
         env.put(Context.PROVIDER_URL, ldapUrls);
         return env;
+    }
+
+    public LdapUserNotExistActionType getLdapUserNotExistAction(){
+        if (StringUtils.isBlank(ldapUserNotExistAction)) {
+            logger.info("security.authentication.ldap.user.not.exist.action configuration is empty, the default value 'CREATION'");
+            return LdapUserNotExistActionType.CREATION;
+        }
+
+        return LdapUserNotExistActionType.valueOf(ldapUserNotExistAction);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.api.security.impl.ldap;
 
-import org.apache.dolphinscheduler.api.security.AuthenticationType;
 import org.apache.dolphinscheduler.api.security.LdapUserNotExistActionType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 
@@ -67,7 +66,7 @@ public class LdapService {
     @Value("${security.authentication.ldap.user.email.attribute:null}")
     private String ldapEmailAttribute;
 
-    @Value("${security.authentication.ldap.user.not.exist.action:CREATION}")
+    @Value("${security.authentication.ldap.user.not.exist.action:CREATE}")
     private String ldapUserNotExistAction;
 
     /***
@@ -140,8 +139,8 @@ public class LdapService {
 
     public LdapUserNotExistActionType getLdapUserNotExistAction(){
         if (StringUtils.isBlank(ldapUserNotExistAction)) {
-            logger.info("security.authentication.ldap.user.not.exist.action configuration is empty, the default value 'CREATION'");
-            return LdapUserNotExistActionType.CREATION;
+            logger.info("security.authentication.ldap.user.not.exist.action configuration is empty, the default value 'CREATE'");
+            return LdapUserNotExistActionType.CREATE;
         }
 
         return LdapUserNotExistActionType.valueOf(ldapUserNotExistAction);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapService.java
@@ -51,7 +51,7 @@ public class LdapService {
     @Value("${security.authentication.ldap.urls:null}")
     private String ldapUrls;
 
-    @Value("${security.authentication.ldap.base.dn:null}")
+    @Value("${security.authentication.ldap.base-dn:null}")
     private String ldapBaseDn;
 
     @Value("${security.authentication.ldap.username:null}")
@@ -60,13 +60,13 @@ public class LdapService {
     @Value("${security.authentication.ldap.password:null}")
     private String ldapPrincipalPassword;
 
-    @Value("${security.authentication.ldap.user.identity.attribute:null}")
+    @Value("${security.authentication.ldap.user.identity-attribute:null}")
     private String ldapUserIdentifyingAttribute;
 
-    @Value("${security.authentication.ldap.user.email.attribute:null}")
+    @Value("${security.authentication.ldap.user.email-attribute:null}")
     private String ldapEmailAttribute;
 
-    @Value("${security.authentication.ldap.user.not.exist.action:CREATE}")
+    @Value("${security.authentication.ldap.user.not-exist-action:CREATE}")
     private String ldapUserNotExistAction;
 
     /***

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -143,6 +143,8 @@ security:
       password: password
       user.identity.attribute: uid
       user.email.attribute: mail
+      # action when ldap user is not exist (supported types: CREATION,DENY)
+      user.not.exist.action: CREATION
 
 # Override by profile
 

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -143,8 +143,8 @@ security:
       password: password
       user.identity.attribute: uid
       user.email.attribute: mail
-      # action when ldap user is not exist (supported types: CREATION,DENY)
-      user.not.exist.action: CREATION
+      # action when ldap user is not exist (supported types: CREATE,DENY)
+      user.not.exist.action: CREATE
 
 # Override by profile
 

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -134,17 +134,18 @@ security:
     type: PASSWORD
     # IF you set type `LDAP`, below config will be effective
     ldap:
-      # admin userId
-      user.admin: read-only-admin
       # ldap server config
       urls: ldap://ldap.forumsys.com:389/
-      base.dn: dc=example,dc=com
+      base-dn: dc=example,dc=com
       username: cn=read-only-admin,dc=example,dc=com
       password: password
-      user.identity.attribute: uid
-      user.email.attribute: mail
-      # action when ldap user is not exist (supported types: CREATE,DENY)
-      user.not.exist.action: CREATE
+      user:
+        # admin userId when you use LDAP login
+        admin: read-only-admin
+        identity-attribute: uid
+        email-attribute: mail
+        # action when ldap user is not exist (supported types: CREATE,DENY)
+        not-exist-action: CREATE
 
 # Override by profile
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
@@ -23,7 +23,6 @@ import org.apache.dolphinscheduler.api.security.impl.ldap.LdapService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = {
@@ -47,5 +46,8 @@ public class SecurityConfigLDAPTest extends AbstractControllerTest {
     public void testLdapUserNotExistAction() {
         LdapUserNotExistActionType authenticator = ldapService.getLdapUserNotExistAction();
         Assert.assertEquals(LdapUserNotExistActionType.CREATE, authenticator);
+
+        boolean isCreateAction = ldapService.createIfUserNotExists();
+        Assert.assertEquals(Boolean.TRUE, isCreateAction);
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
@@ -46,6 +46,6 @@ public class SecurityConfigLDAPTest extends AbstractControllerTest {
     @Test
     public void testLdapUserNotExistAction() {
         LdapUserNotExistActionType authenticator = ldapService.getLdapUserNotExistAction();
-        Assert.assertEquals(authenticator, LdapUserNotExistActionType.CREATION);
+        Assert.assertEquals(LdapUserNotExistActionType.CREATE, authenticator);
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
@@ -51,3 +51,4 @@ public class SecurityConfigLDAPTest extends AbstractControllerTest {
         Assert.assertEquals(Boolean.TRUE, isCreateAction);
     }
 }
+

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
@@ -18,10 +18,12 @@
 package org.apache.dolphinscheduler.api.security;
 
 import org.apache.dolphinscheduler.api.controller.AbstractControllerTest;
+import org.apache.dolphinscheduler.api.security.impl.ldap.LdapService;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = {
@@ -32,9 +34,18 @@ public class SecurityConfigLDAPTest extends AbstractControllerTest {
     @Autowired
     private SecurityConfig securityConfig;
 
+    @Autowired
+    private LdapService ldapService;
+
     @Test
     public void testAuthenticator() {
         Authenticator authenticator = securityConfig.authenticator();
         Assert.assertNotNull(authenticator);
+    }
+
+    @Test
+    public void testLdapUserNotExistAction() {
+        LdapUserNotExistActionType authenticator = ldapService.getLdapUserNotExistAction();
+        Assert.assertEquals(authenticator, LdapUserNotExistActionType.CREATION);
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
@@ -53,12 +53,12 @@ import org.springframework.test.context.TestPropertySource;
                 "security.authentication.type=LDAP",
                 "security.authentication.ldap.user.admin=read-only-admin",
                 "security.authentication.ldap.urls=ldap://ldap.forumsys.com:389/",
-                "security.authentication.ldap.base.dn=dc=example,dc=com",
+                "security.authentication.ldap.base-dn=dc=example,dc=com",
                 "security.authentication.ldap.username=cn=read-only-admin,dc=example,dc=com",
                 "security.authentication.ldap.password=password",
-                "security.authentication.ldap.user.identity.attribute=uid",
-                "security.authentication.ldap.user.email.attribute=mail",
-                "security.authentication.ldap.user.not.exist.action=CREATE",
+                "security.authentication.ldap.user.identity-attribute=uid",
+                "security.authentication.ldap.user.email-attribute=mail",
+                "security.authentication.ldap.user.not-exist-action=CREATE",
         })
 public class LdapAuthenticatorTest extends AbstractControllerTest {
     private static Logger logger = LoggerFactory.getLogger(LdapAuthenticatorTest.class);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
@@ -110,11 +110,13 @@ public class LdapAuthenticatorTest extends AbstractControllerTest {
 
         // test username pwd correct and user not exist, config user not exist action deny, so login denied
         when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.DENY);
+        when(ldapService.createIfUserNotExists()).thenReturn(false);
         Result<Map<String, String>> result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.USER_NAME_PASSWD_ERROR.getCode(), (int) result.getCode());
 
         // test username pwd correct and user not exist, config user not exist action create, so login success
         when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.CREATE);
+        when(ldapService.createIfUserNotExists()).thenReturn(true);
         result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         logger.info(result.toString());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
@@ -58,7 +58,7 @@ import org.springframework.test.context.TestPropertySource;
                 "security.authentication.ldap.password=password",
                 "security.authentication.ldap.user.identity.attribute=uid",
                 "security.authentication.ldap.user.email.attribute=mail",
-                "security.authentication.ldap.user.not.exist.action=CREATION",
+                "security.authentication.ldap.user.not.exist.action=CREATE",
         })
 public class LdapAuthenticatorTest extends AbstractControllerTest {
     private static Logger logger = LoggerFactory.getLogger(LdapAuthenticatorTest.class);
@@ -114,7 +114,7 @@ public class LdapAuthenticatorTest extends AbstractControllerTest {
         Assert.assertEquals(Status.USER_NAME_PASSWD_ERROR.getCode(), (int) result.getCode());
 
         // test username pwd correct and user not exist, config user not exist action creation, so login success
-        when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.CREATION);
+        when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.CREATE);
         result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         logger.info(result.toString());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
@@ -113,13 +113,13 @@ public class LdapAuthenticatorTest extends AbstractControllerTest {
         Result<Map<String, String>> result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.USER_NAME_PASSWD_ERROR.getCode(), (int) result.getCode());
 
-        // test username pwd correct and user not exist, config user not exist action creation, so login success
+        // test username pwd correct and user not exist, config user not exist action create, so login success
         when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.CREATE);
         result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         logger.info(result.toString());
 
-        // test username pwd correct and user not exist, config action creation but can't create session, so login failed
+        // test username pwd correct and user not exist, config action create but can't create session, so login failed
         when(sessionService.createSession(Mockito.any(User.class), Mockito.eq(ip))).thenReturn(null);
         result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.LOGIN_SESSION_FAILED.getCode(), (int) result.getCode());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.controller.AbstractControllerTest;
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.security.LdapUserNotExistActionType;
 import org.apache.dolphinscheduler.api.service.SessionService;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.api.utils.Result;
@@ -30,6 +31,7 @@ import org.apache.dolphinscheduler.dao.entity.Session;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -56,6 +58,7 @@ import org.springframework.test.context.TestPropertySource;
                 "security.authentication.ldap.password=password",
                 "security.authentication.ldap.user.identity.attribute=uid",
                 "security.authentication.ldap.user.email.attribute=mail",
+                "security.authentication.ldap.user.not.exist.action=CREATION",
         })
 public class LdapAuthenticatorTest extends AbstractControllerTest {
     private static Logger logger = LoggerFactory.getLogger(LdapAuthenticatorTest.class);
@@ -98,23 +101,30 @@ public class LdapAuthenticatorTest extends AbstractControllerTest {
         mockSession.setIp(ip);
         mockSession.setUserId(1);
         mockSession.setLastLoginTime(new Date());
-
     }
 
     @Test
     public void testAuthenticate() {
-        when(sessionService.createSession(Mockito.any(User.class), Mockito.eq(ip))).thenReturn(mockSession.getId());
         when(ldapService.ldapLogin(ldapUid, ldapUserPwd)).thenReturn(ldapEmail);
+        when(sessionService.createSession(Mockito.any(User.class), Mockito.eq(ip))).thenReturn(mockSession.getId());
 
-        Result result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
+        // test username pwd correct and user not exist, config user not exist action deny, so login denied
+        when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.DENY);
+        Result<Map<String, String>> result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
+        Assert.assertEquals(Status.USER_NAME_PASSWD_ERROR.getCode(), (int) result.getCode());
+
+        // test username pwd correct and user not exist, config user not exist action creation, so login success
+        when(ldapService.getLdapUserNotExistAction()).thenReturn(LdapUserNotExistActionType.CREATION);
+        result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
         logger.info(result.toString());
 
+        // test username pwd correct and user not exist, config action creation but can't create session, so login failed
         when(sessionService.createSession(Mockito.any(User.class), Mockito.eq(ip))).thenReturn(null);
-
         result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.LOGIN_SESSION_FAILED.getCode(), (int) result.getCode());
 
+        // test username pwd error, login failed
         when(ldapService.ldapLogin(ldapUid, ldapUserPwd)).thenReturn(null);
         result = ldapAuthenticator.authenticate(ldapUid, ldapUserPwd, ip);
         Assert.assertEquals(Status.USER_NAME_PASSWD_ERROR.getCode(), (int) result.getCode());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
@@ -42,12 +42,12 @@ import org.springframework.test.context.junit4.SpringRunner;
                 "security.authentication.type=LDAP",
                 "security.authentication.ldap.user.admin=read-only-admin",
                 "security.authentication.ldap.urls=ldap://ldap.forumsys.com:389/",
-                "security.authentication.ldap.base.dn=dc=example,dc=com",
+                "security.authentication.ldap.base-dn=dc=example,dc=com",
                 "security.authentication.ldap.username=cn=read-only-admin,dc=example,dc=com",
                 "security.authentication.ldap.password=password",
-                "security.authentication.ldap.user.identity.attribute=uid",
-                "security.authentication.ldap.user.email.attribute=mail",
-                "security.authentication.ldap.user.not.exist.action=CREATE",
+                "security.authentication.ldap.user.identity-attribute=uid",
+                "security.authentication.ldap.user.email-attribute=mail",
+                "security.authentication.ldap.user.not-exist-action=CREATE",
         })
 public class LdapServiceTest {
     @Autowired

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
@@ -47,6 +47,7 @@ import org.springframework.test.context.junit4.SpringRunner;
                 "security.authentication.ldap.password=password",
                 "security.authentication.ldap.user.identity.attribute=uid",
                 "security.authentication.ldap.user.email.attribute=mail",
+                "security.authentication.ldap.user.not.exist.action=CREATION",
         })
 public class LdapServiceTest {
     @Autowired

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapServiceTest.java
@@ -47,7 +47,7 @@ import org.springframework.test.context.junit4.SpringRunner;
                 "security.authentication.ldap.password=password",
                 "security.authentication.ldap.user.identity.attribute=uid",
                 "security.authentication.ldap.user.email.attribute=mail",
-                "security.authentication.ldap.user.not.exist.action=CREATION",
+                "security.authentication.ldap.user.not.exist.action=CREATE",
         })
 public class LdapServiceTest {
     @Autowired

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -101,8 +101,8 @@ security:
       password: password
       user.identity.attribute: uid
       user.email.attribute: mail
-      # action when ldap user is not exist (supported types: CREATION,DENY)
-      user.not.exist.action: CREATION
+      # action when ldap user is not exist (supported types: CREATE,DENY)
+      user.not.exist.action: CREATE
 
 master:
   listen-port: 5678

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -92,17 +92,18 @@ security:
     type: PASSWORD
     # IF you set type `LDAP`, below config will be effective
     ldap:
-      # admin userId
-      user.admin: read-only-admin
       # ldap server config
       urls: ldap://ldap.forumsys.com:389/
-      base.dn: dc=example,dc=com
+      base-dn: dc=example,dc=com
       username: cn=read-only-admin,dc=example,dc=com
       password: password
-      user.identity.attribute: uid
-      user.email.attribute: mail
-      # action when ldap user is not exist (supported types: CREATE,DENY)
-      user.not.exist.action: CREATE
+      user:
+        # admin userId when you use LDAP login
+        admin: read-only-admin
+        identity-attribute: uid
+        email-attribute: mail
+        # action when ldap user is not exist (supported types: CREATE,DENY)
+        not-exist-action: CREATE
 
 master:
   listen-port: 5678

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -101,6 +101,8 @@ security:
       password: password
       user.identity.attribute: uid
       user.email.attribute: mail
+      # action when ldap user is not exist (supported types: CREATION,DENY)
+      user.not.exist.action: CREATION
 
 master:
   listen-port: 5678


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

When you log in with LDAP and are not a ds user, it will create a new user automatedly. 

But in my option, LDAP login is the same as user-password log-in, if you are not a ds user, your login will be denied.

I think we can add a new config field, user can choose if they log in with LDAP and are not a ds user, which will create a new user or be denied.

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

  modified:   dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/SecurityConfigLDAPTest.java
  modified:   dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/security/impl/ldap/LdapAuthenticatorTest.java

part of #10425 