### PR TITLE
Open checkstyle, change checkstyle severity from info to warning

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -65,7 +65,7 @@ jobs:
           ./mvnw -B clean install \
           -Dmaven.test.skip \
           -Dmaven.javadoc.skip \
-          -Dmaven.checkstyle.skip \
+          -Dcheckstyle.skip=true \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
       - name: Export Docker Images

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
           ./mvnw -B clean install \
           -Dmaven.test.skip \
           -Dmaven.javadoc.skip \
-          -Dmaven.checkstyle.skip \
+          -Dcheckstyle.skip=true \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
       - name: Export Docker Images

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -56,7 +56,7 @@ jobs:
           ./mvnw -B clean deploy \
           -Dmaven.test.skip \
           -Dmaven.javadoc.skip \
-          -Dmaven.checkstyle.skip \
+          -Dcheckstyle.skip=true \
           -Dmaven.deploy.skip \
           -Ddocker.tag=${{ github.sha }} \
           -Ddocker.hub=${{ env.HUB }} \

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -137,7 +137,7 @@ jobs:
           ./mvnw -B clean install \
           -Dmaven.test.skip \
           -Dmaven.javadoc.skip \
-          -Dmaven.checkstyle.skip \
+          -Dcheckstyle.skip=true \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
       - name: Export Docker Images

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -71,7 +71,7 @@ jobs:
           key: ${{ runner.os }}-maven
 
       - name: Run Unit tests
-        run: ./mvnw clean verify -B -Dmaven.test.skip=false
+        run: ./mvnw clean verify -B -Dmaven.test.skip=false -Dcheckstyle.skip=true
       - name: Upload coverage report to codecov
         run: CODECOV_TOKEN="09c2663f-b091-4258-8a47-c981827eb29a" bash <(curl -s https://codecov.io/bash)
 

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -21,7 +21,9 @@
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="info"/>
+    <property name="severity" value="warning"/>
+
+    <module name="SuppressWarningsFilter"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
 
@@ -40,6 +42,9 @@
     </module>
 
     <module name="TreeWalker">
+
+        <module name="SuppressWarningsHolder"/>
+
         <module name="OuterTypeFilename">
             <property name="severity" value="error"/>
         </module>


### PR DESCRIPTION
## Purpose of the pull request

Right now, the checkstyle is unused, since we set severity level to info,  this means when someone break the checkstyle rule, the will be a info log, the CI/checkstyle task will still pass.

todo: We need to config a checkstyle task on ci.

## Brief change log
Change checkstyle severity to warning.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
