### PR TITLE
[Fix-10400]Change K8s PostgreSQL Password Key Name

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
+++ b/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Create a database environment variables.
     secretKeyRef:
       {{- if .Values.postgresql.enabled }}
       name: {{ template "dolphinscheduler.postgresql.fullname" . }}
-      key: postgresql-password
+      key: postgres-password
       {{- else }}
       name: {{ include "dolphinscheduler.fullname" . }}-externaldb
       key: database-password


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Due `postgresql` upgrade and  postgresql-password has been changed. See  https://github.com/bitnami/charts/commit/50946fdff3d90522d0b87012f8b9bb73c4b6f12c#diff-00f2e1e3c249371477aae086aa0c058d3e8e34d7045398f5d558d34840cef2e1R16-R22

Fixed the PostgreSQL password key name

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

Manually verified the change by testing locally

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

- Part of #10400