### PR TITLE
[Fix-9938][master] Fix 9938 query environment config set to task instance

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -1115,6 +1115,12 @@ public class WorkflowExecuteRunnable implements Runnable {
     private TaskInstance createTaskInstance(ProcessInstance processInstance, TaskNode taskNode) {
         TaskInstance taskInstance = findTaskIfExists(taskNode.getCode(), taskNode.getVersion());
         if (taskInstance != null) {
+            if (!taskInstance.getEnvironmentCode().equals(-1L)) {
+                Environment environment = processService.findEnvironmentByCode(taskInstance.getEnvironmentCode());
+                if (Objects.nonNull(environment) && StringUtils.isNotEmpty(environment.getConfig())) {
+                    taskInstance.setEnvironmentConfig(environment.getConfig());
+                }
+            }
             return taskInstance;
         }
 


### PR DESCRIPTION
check exists task environment code if not default query environment config set to task instance

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
close https://github.com/apache/dolphinscheduler/issues/9938
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
