### PR TITLE
[fix-10608] [worker] move setting of TaskExecutionContext to finally block

### DIFF
--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
@@ -262,6 +262,7 @@ public class TaskCallbackService {
         // add response cache
         ResponseCache.get().cache(taskExecutionContext.getTaskInstanceId(), command.convert2Command(), Event.RESULT);
         send(taskExecutionContext.getTaskInstanceId(), command.convert2Command());
+        logger.info("task execute response command : {}", command);
     }
 
     public void sendTaskKillResponseCommand(TaskExecutionContext taskExecutionContext) {


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
fix #10608 
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- move setting to finally
- add log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
