### PR TITLE
[fix] Process definition length too long when copy or import

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -1844,7 +1844,6 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 processDefinition.setId(0);
                 processDefinition.setUserId(loginUser.getId());
                 processDefinition.setName(getNewName(processDefinition.getName(), COPY_SUFFIX));
-                processDefinition.setName(getNewName(processDefinition.getName(), "_copy_"));
                 final Date date = new Date();
                 processDefinition.setCreateTime(date);
                 processDefinition.setUpdateTime(date);
@@ -1886,7 +1885,8 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
      */
     private String getNewName(String originalName, String suffix) {
         StringBuilder newName = new StringBuilder();
-        if (originalName.contains(suffix)) {
+        String regex = String.format(".*%s\\d{17}$", suffix);
+        if (originalName.matches(regex)) {
             //replace timestamp of originalName
             return newName.append(originalName, 0, originalName.lastIndexOf(suffix))
                     .append(suffix)

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -32,8 +32,10 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_TREE_VIEW;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_UPDATE;
 import static org.apache.dolphinscheduler.common.Constants.CMD_PARAM_SUB_PROCESS_DEFINE_CODE;
+import static org.apache.dolphinscheduler.common.Constants.COPY_SUFFIX;
 import static org.apache.dolphinscheduler.common.Constants.DEFAULT_WORKER_GROUP;
 import static org.apache.dolphinscheduler.common.Constants.EMPTY_STRING;
+import static org.apache.dolphinscheduler.common.Constants.IMPORT_SUFFIX;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.COMPLEX_TASK_TYPES;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SQL;
 
@@ -1011,7 +1013,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         if (index > 0) {
             processDefinitionName = processDefinitionName.substring(0, index);
         }
-        processDefinitionName = getNewName(processDefinitionName, "_import_");
+        processDefinitionName = getNewName(processDefinitionName, IMPORT_SUFFIX);
 
         ProcessDefinition processDefinition;
         List<TaskDefinitionLog> taskDefinitionList = new ArrayList<>();
@@ -1207,8 +1209,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
 
         // generate import processDefinitionName
         String processDefinitionName = recursionProcessDefinitionName(projectCode, processDefinition.getName(), 1);
-        String importProcessDefinitionName = getNewName(processDefinitionName, "_import_");
-
+        String importProcessDefinitionName = getNewName(processDefinitionName, IMPORT_SUFFIX);
         //unique check
         Map<String, Object> checkResult = verifyProcessDefinitionName(loginUser, projectCode, importProcessDefinitionName);
         if (Status.SUCCESS.equals(checkResult.get(Constants.STATUS))) {
@@ -1843,6 +1844,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 }
                 processDefinition.setId(0);
                 processDefinition.setUserId(loginUser.getId());
+                processDefinition.setName(getNewName(processDefinition.getName(), COPY_SUFFIX));
                 processDefinition.setName(getNewName(processDefinition.getName(), "_copy_"));
                 final Date date = new Date();
                 processDefinition.setCreateTime(date);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -1883,7 +1883,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
      * @param suffix "_copy_" or "_import_"
      * @return
      */
-    private String getNewName(String originalName, String suffix) {
+    public String getNewName(String originalName, String suffix) {
         StringBuilder newName = new StringBuilder();
         String regex = String.format(".*%s\\d{17}$", suffix);
         if (originalName.matches(regex)) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -115,7 +115,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1888,20 +1887,16 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
     private String getNewName(String originalName, String suffix) {
         StringBuilder newName = new StringBuilder();
         if (originalName.contains(suffix)) {
-            final String originalTimeStamp = originalName.substring(originalName.lastIndexOf(suffix) + suffix.length());
-            try {
-                SimpleDateFormat dateFormat = new SimpleDateFormat(Constants.YYYYMMDDHHMMSSSSS);
-                dateFormat.parse(originalTimeStamp);
-                //replace timestamp in originalName
-                newName.append(originalName, 0, originalName.lastIndexOf(suffix))
-                        .append(suffix)
-                        .append(DateUtils.getCurrentTimeStamp());
-                return newName.toString();
-            } catch (Exception e) {
-                logger.error("error while parse last timestamp in {}", originalName);
-            }
+            //replace timestamp of originalName
+            return newName.append(originalName, 0, originalName.lastIndexOf(suffix))
+                    .append(suffix)
+                    .append(DateUtils.getCurrentTimeStamp())
+                    .toString();
         }
-        return newName.append(originalName).append(suffix).append(DateUtils.getCurrentTimeStamp()).toString();
+        return newName.append(originalName)
+                .append(suffix)
+                .append(DateUtils.getCurrentTimeStamp())
+                .toString();
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
@@ -763,7 +763,7 @@ public class ProcessDefinitionServiceTest {
     }
 
     @Test
-    public void TestGetNewProcessName() {
+    public void testGetNewProcessName() {
         String processName1 = "test_copy_" + DateUtils.getCurrentTimeStamp();
         final String newName1 = processDefinitionService.getNewName(processName1, Constants.COPY_SUFFIX);
         Assert.assertEquals(2, newName1.split(Constants.COPY_SUFFIX).length);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
@@ -41,6 +41,7 @@ import org.apache.dolphinscheduler.common.enums.ReleaseState;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.enums.WarningType;
 import org.apache.dolphinscheduler.common.graph.DAG;
+import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.DagData;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
@@ -759,6 +760,19 @@ public class ProcessDefinitionServiceTest {
         result = processDefinitionService.importSqlProcessDefinition(loginUser, projectCode, mockMultipartFile);
 
         Assert.assertEquals(result.get(Constants.STATUS), Status.SUCCESS);
+    }
+
+    @Test
+    public void TestGetNewProcessName() {
+        String processName1 = "test_copy_" + DateUtils.getCurrentTimeStamp();
+        final String newName1 = processDefinitionService.getNewName(processName1, Constants.COPY_SUFFIX);
+        Assert.assertEquals(2, newName1.split(Constants.COPY_SUFFIX).length);
+        String processName2 = "wf_copy_all_ods_data_to_d";
+        final String newName2 = processDefinitionService.getNewName(processName2, Constants.COPY_SUFFIX);
+        Assert.assertEquals(3, newName2.split(Constants.COPY_SUFFIX).length);
+        String processName3 = "test_import_" + DateUtils.getCurrentTimeStamp();
+        final String newName3 = processDefinitionService.getNewName(processName3, Constants.IMPORT_SUFFIX);
+        Assert.assertEquals(2, newName3.split(Constants.IMPORT_SUFFIX).length);
     }
 
     /**

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -215,6 +215,10 @@ public final class Constants {
      * date format of yyyyMMddHHmmssSSS
      */
     public static final String YYYYMMDDHHMMSSSSS = "yyyyMMddHHmmssSSS";
+
+    public static final String IMPORT_SUFFIX = "_import_";
+
+    public static final String COPY_SUFFIX = "_copy_";
     /**
      * http connect time out
      */


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
Fix workflow name or  task name exceed the length limit when copying or importing workflows

close #10622
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
If the name of the workflow or task contains `_copy_` or `_import_`, and the last timestamp can be formatted, the new name only replaces the timestamp of original name
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
