### PR TITLE
[Improvement]Delete the getSession in the Registry interface 

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/Registry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/Registry.java
@@ -43,6 +43,4 @@ public interface Registry extends Closeable {
     boolean acquireLock(String key);
 
     boolean releaseLock(String key);
-
-    Duration getSessionTimeout();
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/java/org/apache/dolphinscheduler/plugin/registry/mysql/MysqlRegistry.java
@@ -156,10 +156,6 @@ public class MysqlRegistry implements Registry {
         return true;
     }
 
-    @Override
-    public Duration getSessionTimeout() {
-        throw new UnsupportedOperationException("Not support session timeout at Mysql Registry");
-    }
 
     @Override
     public void close() {

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
@@ -233,11 +233,6 @@ public final class ZookeeperRegistry implements Registry {
     }
 
     @Override
-    public Duration getSessionTimeout() {
-        return properties.getSessionTimeout();
-    }
-
-    @Override
     public void close() {
         treeCacheMap.values().forEach(CloseableUtils::closeQuietly);
         CloseableUtils.closeQuietly(client);

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/registry/RegistryClient.java
@@ -310,8 +310,4 @@ public class RegistryClient {
             }
         }
     }
-
-    public Duration getSessionTimeout() {
-        return registry.getSessionTimeout();
-    }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Close #10626 [Improvment][Registry] getSessionTime() that has not been used in the project in the Registry 

## Brief change log

Delete the getSessionTimeout from the registry interface
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

