### PR TITLE
[Bug][Script] Remove deprecated arg in remove-zk-node.sh

### DIFF
--- a/script/remove-zk-node.sh
+++ b/script/remove-zk-node.sh
@@ -39,7 +39,7 @@ export JAVA_HOME=$JAVA_HOME
 export DOLPHINSCHEDULER_CONF_DIR=$DOLPHINSCHEDULER_HOME/conf
 export DOLPHINSCHEDULER_LIB_JARS=$DOLPHINSCHEDULER_HOME/api-server/libs/*
 
-export DOLPHINSCHEDULER_OPTS="-Xmx1g -Xms1g -Xss512k -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:LargePageSizeInBytes=128m -XX:+UseFastAccessorMethods -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 "
+export DOLPHINSCHEDULER_OPTS="-Xmx1g -Xms1g -Xss512k -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:LargePageSizeInBytes=128m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 "
 export STOP_TIMEOUT=5
 
 CLASS=org.apache.zookeeper.ZooKeeperMain


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

* `UseFastAccessorMethods` has been deprecated since JDK 9 and may cause `remove-zk-node.sh` failure.
* This PR closes: #10787 

## Brief change log

* Remove `UseFastAccessorMethods` arg in script `remove-zk-node.sh`.

## Verify this pull request

* Verified by manual test. 


