### PR TITLE
[Fix-10730][UI] fix bug about the environment name display

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -22,14 +22,13 @@ import type { IEnvironmentNameOption, IJsonItem } from '../types'
 
 export function useEnvironmentName(
   model: { [field: string]: any },
-  isCreate: boolean
+  unusedIsCreate: boolean
 ): IJsonItem {
   const { t } = useI18n()
 
   let environmentList = [] as IEnvironmentNameOption[]
   const options = ref([] as IEnvironmentNameOption[])
   const loading = ref(false)
-  const value = ref()
 
   const getEnvironmentList = async () => {
     if (loading.value) return
@@ -53,16 +52,6 @@ export function useEnvironmentName(
     if (!option?.workerGroups?.length) return false
     return option.workerGroups.indexOf(model.workerGroup) !== -1
   }
-
-  watch(
-    () => options.value.length,
-    () => {
-      if (isCreate && options.value.length === 1 && !value.value) {
-        model.environmentCode = options.value[0].value
-      }
-      if (options.value.length === 0) model.environmentCode = null
-    }
-  )
 
   watch(
     () => model.workerGroup,

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-worker-group.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-worker-group.ts
@@ -19,8 +19,7 @@ import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { queryAllWorkerGroups } from '@/service/modules/worker-groups'
 import type { IJsonItem } from '../types'
-
-export function useWorkerGroup(): IJsonItem {
+export function useWorkerGroup(model: { [field: string]: any }): IJsonItem {
   const { t } = useI18n()
 
   const options = ref([] as { label: string; value: string }[])
@@ -34,6 +33,8 @@ export function useWorkerGroup(): IJsonItem {
     loading.value = false
   }
 
+  const resetEnvironment = () => (model.environmentCode = null)
+
   onMounted(() => {
     getWorkerGroups()
   })
@@ -43,7 +44,8 @@ export function useWorkerGroup(): IJsonItem {
     span: 12,
     name: t('project.node.worker_group'),
     props: {
-      loading: loading
+      loading: loading,
+      'on-update:value': () => resetEnvironment()
     },
     options: options,
     validate: {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-conditions.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-conditions.ts
@@ -71,7 +71,7 @@ export function useConditions({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-data-quality.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-data-quality.ts
@@ -81,7 +81,7 @@ export function useDataQuality({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-datax.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-datax.ts
@@ -75,7 +75,7 @@ export function useDataX({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-dependent.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-dependent.ts
@@ -72,7 +72,7 @@ export function useDependent({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-dinky.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-dinky.ts
@@ -67,7 +67,7 @@ export function useDinky({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-dvc.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-dvc.ts
@@ -68,7 +68,7 @@ export function useDvc({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-emr.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-emr.ts
@@ -68,7 +68,7 @@ export function useEmr({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-flink.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-flink.ts
@@ -77,7 +77,7 @@ export function useFlink({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-http.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-http.ts
@@ -74,7 +74,7 @@ export function useHttp({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-jupyter.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-jupyter.ts
@@ -69,7 +69,7 @@ export function useJupyter({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-k8s.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-k8s.ts
@@ -68,7 +68,7 @@ export function useK8s({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-mlflow.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-mlflow.ts
@@ -78,7 +78,7 @@ export function useMlflow({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-mr.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-mr.ts
@@ -68,7 +68,7 @@ export function useMr({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-openmldb.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-openmldb.ts
@@ -71,7 +71,7 @@ export function useOpenmldb({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-pigeon.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-pigeon.ts
@@ -67,7 +67,7 @@ export function usePigeon({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-procedure.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-procedure.ts
@@ -71,7 +71,7 @@ export function useProcedure({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-python.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-python.ts
@@ -71,7 +71,7 @@ export function usePython({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sea-tunnel.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sea-tunnel.ts
@@ -75,7 +75,7 @@ export function useSeaTunnel({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-shell.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-shell.ts
@@ -70,7 +70,7 @@ export function useShell({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-spark.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-spark.ts
@@ -76,7 +76,7 @@ export function useSpark({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sql.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sql.ts
@@ -76,7 +76,7 @@ export function useSql({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sqoop.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sqoop.ts
@@ -89,7 +89,7 @@ export function useSqoop({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sub-process.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-sub-process.ts
@@ -70,7 +70,7 @@ export function useSubProcess({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useTimeoutAlarm(model),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-switch.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-switch.ts
@@ -71,7 +71,7 @@ export function useSwitch({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !data?.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-zeppelin.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-zeppelin.ts
@@ -67,7 +67,7 @@ export function useZeppelin({
       Fields.useRunFlag(),
       Fields.useDescription(),
       Fields.useTaskPriority(),
-      Fields.useWorkerGroup(),
+      Fields.useWorkerGroup(model),
       Fields.useEnvironmentName(model, !model.id),
       ...Fields.useTaskGroup(model, projectCode),
       ...Fields.useFailed(),


### PR DESCRIPTION

## Purpose of the pull request
close #10730 

## Brief change log
1. When selecting the workGroup just empty the environment code.
2. Delete the environmentCode operation in use-environment-name.ts. So just pure trigger from workGroup can change the default environmentCode.
3. not that good: The environmentCode will not has default. 

## Verify this pull request
This pull request is code cleanup without any test coverage.
