### PR TITLE
[Python] Supports creating or editing resources.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -566,6 +566,9 @@ public class PythonGateway {
             logger.error(msg);
             throw new IllegalArgumentException(msg);
         }
+        if (!fullName.startsWith("/")) {
+            fullName = "/" + fullName;
+        }
         String resourceSuffix = fullName.substring(fullName.indexOf(".") + 1);
         String fileNameWithSuffix = fullName.substring(fullName.lastIndexOf("/") + 1);
         String resourceDir = fullName.replace(fileNameWithSuffix, "");

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -569,21 +569,11 @@ public class PythonGateway {
         if (!fullName.startsWith("/")) {
             fullName = "/" + fullName;
         }
-        String resourceSuffix = fullName.substring(fullName.indexOf(".") + 1);
-        String fileNameWithSuffix = fullName.substring(fullName.lastIndexOf("/") + 1);
-        String resourceDir = fullName.replace(fileNameWithSuffix, "");
-        String resourceName = fileNameWithSuffix.replace("." + resourceSuffix, "");
-        Result<Object> existResult = resourceService.queryResource(user, fullName, null, ResourceType.FILE);
-        if (existResult.getCode() == Status.SUCCESS.getCode()) {
-            Resource resource = (Resource) existResult.getData();
-            return this.updateResoure(user, resource.getId(), fullName, resourceContent);
-        } else if (existResult.getCode() == Status.RESOURCE_NOT_EXIST.getCode()) {
-            Result<Object> onlineCreateResourceResult = resourceService.onlineCreateResourceWithDir(
-                    user, resourceName, resourceSuffix, description, resourceContent, resourceDir);
-            if (onlineCreateResourceResult.getCode() == Status.SUCCESS.getCode()) {
-                Map<String, Object> resultMap = (Map<String, Object>) onlineCreateResourceResult.getData();
-                return (int) resultMap.get("id");
-            }
+        Result<Object> createResult = resourceService.onlineCreateOrUpdateResourceWithDir(
+                user, fullName, description, resourceContent);
+        if (createResult.getCode() == Status.SUCCESS.getCode()) {
+            Map<String, Object> resultMap = (Map<String, Object>) createResult.getData();
+            return (int) resultMap.get("id");
         }
         String msg = String.format("Can not create or update resource: %s", fullName);
         logger.error(msg);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -552,17 +552,24 @@ public class PythonGateway {
      * If the folder is not already created, it will be
      *
      * @param userName user who create or update resource
-     * @param resourceDir The folder where the resource resides.
-     * @param resourceName The name of resource.Do not include file suffixes.
-     * @param resourceSuffix suffix of resource
+     * @param fullName The fullname of resource.Includes path and suffix.
      * @param description description of resource
      * @param resourceContent content of resource
      * @return id of resource
      */
     public Integer createOrUpdateResource(
-            String userName, String resourceDir, String resourceName, String resourceSuffix, String description, String resourceContent) {
+            String userName, String fullName, String description, String resourceContent) {
         User user = usersService.queryUser(userName);
-        String fullName = resourceDir + "/" + resourceName + "." + resourceSuffix;
+        int suffixLabelIndex = fullName.indexOf(".");
+        if (suffixLabelIndex == -1) {
+            String msg = String.format("The suffix of file can not be empty: %s", fullName);
+            logger.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        String resourceSuffix = fullName.substring(fullName.indexOf(".") + 1);
+        String fileNameWithSuffix = fullName.substring(fullName.lastIndexOf("/") + 1);
+        String resourceDir = fullName.replace(fileNameWithSuffix, "");
+        String resourceName = fileNameWithSuffix.replace("." + resourceSuffix, "");
         Result<Object> existResult = resourceService.queryResource(user, fullName, null, ResourceType.FILE);
         if (existResult.getCode() == Status.SUCCESS.getCode()) {
             Resource resource = (Resource) existResult.getData();

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -559,35 +559,7 @@ public class PythonGateway {
      */
     public Integer createOrUpdateResource(
             String userName, String fullName, String description, String resourceContent) {
-        User user = usersService.queryUser(userName);
-        int suffixLabelIndex = fullName.indexOf(".");
-        if (suffixLabelIndex == -1) {
-            String msg = String.format("The suffix of file can not be empty: %s", fullName);
-            logger.error(msg);
-            throw new IllegalArgumentException(msg);
-        }
-        if (!fullName.startsWith("/")) {
-            fullName = "/" + fullName;
-        }
-        Result<Object> createResult = resourceService.onlineCreateOrUpdateResourceWithDir(
-                user, fullName, description, resourceContent);
-        if (createResult.getCode() == Status.SUCCESS.getCode()) {
-            Map<String, Object> resultMap = (Map<String, Object>) createResult.getData();
-            return (int) resultMap.get("id");
-        }
-        String msg = String.format("Can not create or update resource: %s", fullName);
-        logger.error(msg);
-        throw new IllegalArgumentException(msg);
-    }
-
-    private int updateResoure(User user, int resourceId, String resourceFullName, String resourceContent) {
-        Result<Object> updateResult = resourceService.updateResourceContent(user, resourceId, resourceContent);
-        if (updateResult.getCode() != Status.SUCCESS.getCode()) {
-            String msg = String.format("Can not update resource %s", resourceFullName);
-            logger.error(msg);
-            throw new IllegalArgumentException(msg);
-        }
-        return resourceId;
+        return resourceService.createOrUpdateResource(userName, fullName, description, resourceContent);
     }
 
     @PostConstruct

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -181,6 +181,18 @@ public interface ResourcesService {
     Result<Object> onlineCreateOrUpdateResourceWithDir(User loginUser, String fileFullName, String desc, String content);
 
     /**
+     * create or update resource.
+     * If the folder is not already created, it will be
+     *
+     * @param userName user who create or update resource
+     * @param fullName The fullname of resource.Includes path and suffix.
+     * @param description description of resource
+     * @param resourceContent content of resource
+     * @return id of resource
+     */
+    Integer createOrUpdateResource(String userName, String fullName, String description, String resourceContent);
+
+    /**
      * updateProcessInstance resource
      *
      * @param resourceId resource id

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -173,14 +173,12 @@ public interface ResourcesService {
      * If the folder is not already created, it will be
      *
      * @param loginUser user who create or update resource
-     * @param currentDirectory The folder where the resource resides.
-     * @param fileName The name of resource.Do not include file suffixes.
-     * @param fileSuffix suffix of resource
+     * @param fileFullName The full name of resource.Includes path and suffix.
      * @param desc description of resource
      * @param content content of resource
      * @return create result code
      */
-    Result<Object> onlineCreateResourceWithDir(User loginUser, String fileName, String fileSuffix, String desc, String content, String currentDirectory);
+    Result<Object> onlineCreateOrUpdateResourceWithDir(User loginUser, String fileFullName, String desc, String content);
 
     /**
      * updateProcessInstance resource

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -169,6 +169,20 @@ public interface ResourcesService {
     Result<Object> onlineCreateResource(User loginUser, ResourceType type, String fileName, String fileSuffix, String desc, String content,int pid,String currentDirectory);
 
     /**
+     * create or update resource.
+     * If the folder is not already created, it will be
+     *
+     * @param loginUser user who create or update resource
+     * @param currentDirectory The folder where the resource resides.
+     * @param fileName The name of resource.Do not include file suffixes.
+     * @param fileSuffix suffix of resource
+     * @param desc description of resource
+     * @param content content of resource
+     * @return create result code
+     */
+    Result<Object> onlineCreateResourceWithDir(User loginUser, String fileName, String fileSuffix, String desc, String content, String currentDirectory);
+
+    /**
      * updateProcessInstance resource
      *
      * @param resourceId resource id

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1129,7 +1129,6 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
      * @return create result code
      */
     @Override
-    @Transactional
     public Result<Object> onlineCreateOrUpdateResourceWithDir(User loginUser, String fileFullName, String desc, String content) {
         if (checkResourceExists(fileFullName, ResourceType.FILE.ordinal())) {
             Resource resource = resourcesMapper.queryResource(fileFullName, ResourceType.FILE.ordinal()).get(0);
@@ -1165,6 +1164,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     }
 
     @Override
+    @Transactional
     public Integer createOrUpdateResource(String userName, String fullName, String description, String resourceContent) {
         User user = userMapper.queryByUserNameAccurately(userName);
         int suffixLabelIndex = fullName.indexOf(".");

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1147,22 +1147,22 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
 
     private int queryOrCreateDirId(User user, int pid, String currentDir, String dirName) {
         String dirFullName = currentDir + "/" + dirName;
-        Result<Object> dirResult = this.queryResource(user, dirFullName, null, ResourceType.FILE);
-        if (dirResult.getCode() == Status.SUCCESS.getCode()) {
-            Resource dirResource = (Resource) dirResult.getData();
-            return dirResource.getId();
-        } else if (dirResult.getCode() == Status.RESOURCE_NOT_EXIST.getCode()) {
+        if (checkResourceExists(dirFullName, ResourceType.FILE.ordinal())) {
+            List<Resource> resourceList = resourcesMapper.queryResource(dirFullName, ResourceType.FILE.ordinal());
+            return resourceList.get(0).getId();
+        } else {
             // create dir
             Result<Object> createDirResult = this.createDirectory(
                     user, dirName, "", ResourceType.FILE, pid, currentDir);
             if (createDirResult.getCode() == Status.SUCCESS.getCode()) {
                 Map<String, Object> resultMap = (Map<String, Object>) createDirResult.getData();
                 return (int) resultMap.get("id");
+            } else {
+                String msg = String.format("Can not create dir %s", dirFullName);
+                logger.error(msg);
+                throw new IllegalArgumentException(msg);
             }
         }
-        String msg = String.format("Can not create dir %s", dirFullName);
-        logger.error(msg);
-        throw new IllegalArgumentException(msg);
     }
 
     private void permissionPostHandle(ResourceType resourceType, User loginUser, Integer resourceId) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1170,7 +1170,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         User user = userMapper.queryByUserNameAccurately(userName);
         int suffixLabelIndex = fullName.indexOf(".");
         if (suffixLabelIndex == -1) {
-            String msg = String.format("The suffix of file can not be empty: %s", fullName);
+            String msg = String.format("The suffix of file can not be empty : %s", fullName);
             logger.error(msg);
             throw new IllegalArgumentException(msg);
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -89,7 +89,7 @@ import static org.apache.dolphinscheduler.common.Constants.EMPTY_STRING;
 import static org.apache.dolphinscheduler.common.Constants.FOLDER_SEPARATOR;
 import static org.apache.dolphinscheduler.common.Constants.FORMAT_SS;
 import static org.apache.dolphinscheduler.common.Constants.FORMAT_S_S;
-import static org.apache.dolphinscheduler.common.Constants.JAR;;
+import static org.apache.dolphinscheduler.common.Constants.JAR;
 
 /**
  * resources service impl

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -83,7 +83,13 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
-import static org.apache.dolphinscheduler.common.Constants.*;
+import static org.apache.dolphinscheduler.common.Constants.ALIAS;
+import static org.apache.dolphinscheduler.common.Constants.CONTENT;
+import static org.apache.dolphinscheduler.common.Constants.EMPTY_STRING;
+import static org.apache.dolphinscheduler.common.Constants.FOLDER_SEPARATOR;
+import static org.apache.dolphinscheduler.common.Constants.FORMAT_SS;
+import static org.apache.dolphinscheduler.common.Constants.FORMAT_S_S;
+import static org.apache.dolphinscheduler.common.Constants.JAR;;
 
 /**
  * resources service impl

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1183,7 +1183,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             Map<String, Object> resultMap = (Map<String, Object>) createResult.getData();
             return (int) resultMap.get("id");
         }
-        String msg = String.format("Can not create or update resource: %s", fullName);
+        String msg = String.format("Can not create or update resource : %s", fullName);
         logger.error(msg);
         throw new IllegalArgumentException(msg);
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1153,7 +1153,8 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
             return dirResource.getId();
         } else if (dirResult.getCode() == Status.RESOURCE_NOT_EXIST.getCode()) {
             // create dir
-            Result<Object> createDirResult = this.createDirectory(user, dirName, "", ResourceType.FILE, pid, currentDir);
+            Result<Object> createDirResult = this.createDirectory(
+                    user, dirName, "", ResourceType.FILE, pid, currentDir);
             if (createDirResult.getCode() == Status.SUCCESS.getCode()) {
                 Map<String, Object> resultMap = (Map<String, Object>) createDirResult.getData();
                 return (int) resultMap.get("id");

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1170,7 +1170,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         User user = userMapper.queryByUserNameAccurately(userName);
         int suffixLabelIndex = fullName.indexOf(".");
         if (suffixLabelIndex == -1) {
-            String msg = String.format("The suffix of file can not be empty : %s", fullName);
+            String msg = String.format("The suffix of file can not be empty: %s", fullName);
             logger.error(msg);
             throw new IllegalArgumentException(msg);
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -1129,6 +1129,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
      * @return create result code
      */
     @Override
+    @Transactional
     public Result<Object> onlineCreateOrUpdateResourceWithDir(User loginUser, String fileFullName, String desc, String content) {
         if (checkResourceExists(fileFullName, ResourceType.FILE.ordinal())) {
             Resource resource = resourcesMapper.queryResource(fileFullName, ResourceType.FILE.ordinal()).get(0);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -100,8 +100,6 @@ public class PythonGatewayTest {
     @Test
     public void testCreateResource() {
         User user = getTestUser();
-        Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
-
         String resourceDir = "/dir1/dir2/";
         String resourceName = "test";
         String resourceSuffix = "py";
@@ -110,14 +108,9 @@ public class PythonGatewayTest {
         String resourceFullName = resourceDir + resourceName + "." + resourceSuffix;
 
         int resourceId = 3;
-        Result<Object> createResourceResult = new Result<>();
-        createResourceResult.setCode(Status.SUCCESS.getCode());
-        Map<String, Object> resourceMap = new HashMap<>();
-        resourceMap.put("id", resourceId);
-        createResourceResult.setData(resourceMap);
 
-        Mockito.when(resourcesService.onlineCreateOrUpdateResourceWithDir(user, resourceFullName, desc, content))
-                .thenReturn(createResourceResult);
+        Mockito.when(resourcesService.createOrUpdateResource(user.getUserName(), resourceFullName, desc, content))
+                .thenReturn(resourceId);
 
         int id = pythonGateway.createOrUpdateResource(
                 user.getUserName(), resourceFullName, desc, content);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -98,32 +98,6 @@ public class PythonGatewayTest {
     }
 
     @Test
-    public void testUpdateResource() {
-        User user = getTestUser();
-        Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
-
-        String resourceDir = "/dev/";
-        String resourceName = "test";
-        String resourceSuffix = "py";
-        String resourceFullName = resourceDir + resourceName + "." + resourceSuffix;
-
-        Result<Object> queryMockResult = new Result<>();
-        queryMockResult.setCode(Status.SUCCESS.getCode());
-        Resource resource = getTestResource();
-        queryMockResult.setData(resource);
-        Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE)).thenReturn(queryMockResult);
-
-        Result<Object> updateMockResult = new Result<>();
-        updateMockResult.setCode(Status.SUCCESS.getCode());
-
-        Mockito.when(resourcesService.updateResourceContent(user, resource.getId(), "")).thenReturn(updateMockResult);
-
-        int id = pythonGateway.createOrUpdateResource(
-                user.getUserName(), resourceFullName, "", "");
-        Assert.assertEquals(id, resource.getId());
-    }
-
-    @Test
     public void testCreateResource() {
         User user = getTestUser();
         Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
@@ -135,11 +109,6 @@ public class PythonGatewayTest {
         String content = "content";
         String resourceFullName = resourceDir + resourceName + "." + resourceSuffix;
 
-        Result<Object> queryMockResult = new Result<>();
-        queryMockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
-        Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE))
-                .thenReturn(queryMockResult);
-
         int resourceId = 3;
         Result<Object> createResourceResult = new Result<>();
         createResourceResult.setCode(Status.SUCCESS.getCode());
@@ -147,7 +116,7 @@ public class PythonGatewayTest {
         resourceMap.put("id", resourceId);
         createResourceResult.setData(resourceMap);
 
-        Mockito.when(resourcesService.onlineCreateResourceWithDir(user, resourceName, resourceSuffix, desc, content, resourceDir))
+        Mockito.when(resourcesService.onlineCreateOrUpdateResourceWithDir(user, resourceFullName, desc, content))
                 .thenReturn(createResourceResult);
 
         int id = pythonGateway.createOrUpdateResource(

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -139,27 +139,6 @@ public class PythonGatewayTest {
         queryMockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
         Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE)).thenReturn(queryMockResult);
 
-        Result<Object> dir1MockResult = new Result<>();
-        dir1MockResult.setCode(Status.SUCCESS.getCode());
-        Resource dir1 = new Resource();
-        dir1.setFullName("/dir1");
-        dir1.setId(1);
-        dir1MockResult.setData(dir1);
-        Mockito.when(resourcesService.queryResource(user, dir1.getFullName(), null, ResourceType.FILE)).thenReturn(dir1MockResult);
-
-        Result<Object> dir2MockResult = new Result<>();
-        dir2MockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
-        Mockito.when(resourcesService.queryResource(user, resourceDir, null, ResourceType.FILE)).thenReturn(dir2MockResult);
-
-        Result<Object> createDir2MockResult = new Result<>();
-        int dir2Id = 2;
-        createDir2MockResult.setCode(Status.SUCCESS.getCode());
-        Map<String, Object> dir2Map = new HashMap<>();
-        dir2Map.put("id", dir2Id);
-        createDir2MockResult.setData(dir2Map);
-        Mockito.when(resourcesService.createDirectory(user, "dir2", "", ResourceType.FILE, dir1.getId(), dir1.getFullName()))
-                .thenReturn(createDir2MockResult);
-
         int resourceId = 3;
         Result<Object> createResourceResult = new Result<>();
         createResourceResult.setCode(Status.SUCCESS.getCode());
@@ -167,7 +146,7 @@ public class PythonGatewayTest {
         resourceMap.put("id", resourceId);
         createResourceResult.setData(resourceMap);
 
-        Mockito.when(resourcesService.onlineCreateResource(user, ResourceType.FILE, resourceName, resourceSuffix, desc, content, dir2Id, resourceDir))
+        Mockito.when(resourcesService.onlineCreateResourceWithDir(user, resourceName, resourceSuffix, desc, content, resourceDir))
                 .thenReturn(createResourceResult);
 
         int id = pythonGateway.createOrUpdateResource(

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -137,7 +137,8 @@ public class PythonGatewayTest {
 
         Result<Object> queryMockResult = new Result<>();
         queryMockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
-        Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE)).thenReturn(queryMockResult);
+        Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE))
+                .thenReturn(queryMockResult);
 
         int resourceId = 3;
         Result<Object> createResourceResult = new Result<>();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -102,10 +102,10 @@ public class PythonGatewayTest {
         User user = getTestUser();
         Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
 
-        String resourceDir = "/dev";
+        String resourceDir = "/dev/";
         String resourceName = "test";
         String resourceSuffix = "py";
-        String resourceFullName = resourceDir + "/" + resourceName + "." + resourceSuffix;
+        String resourceFullName = resourceDir + resourceName + "." + resourceSuffix;
 
         Result<Object> queryMockResult = new Result<>();
         queryMockResult.setCode(Status.SUCCESS.getCode());
@@ -119,7 +119,7 @@ public class PythonGatewayTest {
         Mockito.when(resourcesService.updateResourceContent(user, resource.getId(), "")).thenReturn(updateMockResult);
 
         int id = pythonGateway.createOrUpdateResource(
-                user.getUserName(), resourceDir, resourceName, resourceSuffix, "", "");
+                user.getUserName(), resourceFullName, "", "");
         Assert.assertEquals(id, resource.getId());
     }
 
@@ -128,12 +128,12 @@ public class PythonGatewayTest {
         User user = getTestUser();
         Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
 
-        String resourceDir = "/dir1/dir2";
+        String resourceDir = "/dir1/dir2/";
         String resourceName = "test";
         String resourceSuffix = "py";
         String desc = "desc";
         String content = "content";
-        String resourceFullName = resourceDir + "/" + resourceName + "." + resourceSuffix;
+        String resourceFullName = resourceDir + resourceName + "." + resourceSuffix;
 
         Result<Object> queryMockResult = new Result<>();
         queryMockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
@@ -151,7 +151,7 @@ public class PythonGatewayTest {
                 .thenReturn(createResourceResult);
 
         int id = pythonGateway.createOrUpdateResource(
-                user.getUserName(), resourceDir, resourceName, resourceSuffix, desc, content);
+                user.getUserName(), resourceFullName, desc, content);
         Assert.assertEquals(id, resourceId);
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -40,7 +40,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -94,6 +95,84 @@ public class PythonGatewayTest {
 
         Map<String, Object> result = pythonGateway.getDependentInfo(project.getName(), processDefinition.getName(), taskDefinition.getName());
         Assert.assertEquals((long) result.get("taskDefinitionCode"), taskDefinition.getCode());
+    }
+
+    @Test
+    public void testUpdateResource() {
+        User user = getTestUser();
+        Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
+
+        String resourceDir = "/dev";
+        String resourceName = "test";
+        String resourceSuffix = "py";
+        String resourceFullName = resourceDir + "/" + resourceName + "." + resourceSuffix;
+
+        Result<Object> queryMockResult = new Result<>();
+        queryMockResult.setCode(Status.SUCCESS.getCode());
+        Resource resource = getTestResource();
+        queryMockResult.setData(resource);
+        Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE)).thenReturn(queryMockResult);
+
+        Result<Object> updateMockResult = new Result<>();
+        updateMockResult.setCode(Status.SUCCESS.getCode());
+
+        Mockito.when(resourcesService.updateResourceContent(user, resource.getId(), "")).thenReturn(updateMockResult);
+
+        int id = pythonGateway.createOrUpdateResource(
+                user.getUserName(), resourceDir, resourceName, resourceSuffix, "", "");
+        Assert.assertEquals(id, resource.getId());
+    }
+
+    @Test
+    public void testCreateResource() {
+        User user = getTestUser();
+        Mockito.when(usersService.queryUser(user.getUserName())).thenReturn(user);
+
+        String resourceDir = "/dir1/dir2";
+        String resourceName = "test";
+        String resourceSuffix = "py";
+        String desc = "desc";
+        String content = "content";
+        String resourceFullName = resourceDir + "/" + resourceName + "." + resourceSuffix;
+
+        Result<Object> queryMockResult = new Result<>();
+        queryMockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
+        Mockito.when(resourcesService.queryResource(user, resourceFullName, null, ResourceType.FILE)).thenReturn(queryMockResult);
+
+        Result<Object> dir1MockResult = new Result<>();
+        dir1MockResult.setCode(Status.SUCCESS.getCode());
+        Resource dir1 = new Resource();
+        dir1.setFullName("/dir1");
+        dir1.setId(1);
+        dir1MockResult.setData(dir1);
+        Mockito.when(resourcesService.queryResource(user, dir1.getFullName(), null, ResourceType.FILE)).thenReturn(dir1MockResult);
+
+        Result<Object> dir2MockResult = new Result<>();
+        dir2MockResult.setCode(Status.RESOURCE_NOT_EXIST.getCode());
+        Mockito.when(resourcesService.queryResource(user, resourceDir, null, ResourceType.FILE)).thenReturn(dir2MockResult);
+
+        Result<Object> createDir2MockResult = new Result<>();
+        int dir2Id = 2;
+        createDir2MockResult.setCode(Status.SUCCESS.getCode());
+        Map<String, Object> dir2Map = new HashMap<>();
+        dir2Map.put("id", dir2Id);
+        createDir2MockResult.setData(dir2Map);
+        Mockito.when(resourcesService.createDirectory(user, "dir2", "", ResourceType.FILE, dir1.getId(), dir1.getFullName()))
+                .thenReturn(createDir2MockResult);
+
+        int resourceId = 3;
+        Result<Object> createResourceResult = new Result<>();
+        createResourceResult.setCode(Status.SUCCESS.getCode());
+        Map<String, Object> resourceMap = new HashMap<>();
+        resourceMap.put("id", resourceId);
+        createResourceResult.setData(resourceMap);
+
+        Mockito.when(resourcesService.onlineCreateResource(user, ResourceType.FILE, resourceName, resourceSuffix, desc, content, dir2Id, resourceDir))
+                .thenReturn(createResourceResult);
+
+        int id = pythonGateway.createOrUpdateResource(
+                user.getUserName(), resourceDir, resourceName, resourceSuffix, desc, content);
+        Assert.assertEquals(id, resourceId);
     }
 
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -617,6 +617,7 @@ public class ResourcesServiceTest {
         String resourceSuffix = "py";
         String desc = "desc";
         String content = "content";
+        String fullName = resourceDir + "/" + resourceName + "." + resourceSuffix;
 
         Resource dir1 = new Resource();
         dir1.setFullName(dir1Path);
@@ -658,7 +659,7 @@ public class ResourcesServiceTest {
         Mockito.when(FileUtils.getUploadFilename(Mockito.anyString(), Mockito.anyString())).thenReturn("test");
         PowerMockito.when(FileUtils.writeContent2File(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
 
-        Result<Object> result = resourcesService.onlineCreateResourceWithDir(user, resourceName, resourceSuffix, desc, content, resourceDir);
+        Result<Object> result = resourcesService.onlineCreateOrUpdateResourceWithDir(user, fullName, desc, content);
         Assert.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -627,23 +627,31 @@ public class ResourcesServiceTest {
         dir2.setUserId(user.getId());
         Mockito.when(resourcesMapper.queryResource(dir1.getFullName(), ResourceType.FILE.ordinal())).thenReturn(Collections.singletonList(dir1));
         Mockito.when(resourcesMapper.queryResource(resourceDir, ResourceType.FILE.ordinal())).thenReturn(null);
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_VIEW, serviceLogger)).thenReturn(true);
-        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, new Object[]{dir1.getId()}, 1, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_VIEW, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, new Object[]{dir1.getId()}, 1, serviceLogger)).thenReturn(true);
 
         Tenant tenant = getTenant();
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FOLDER_ONLINE_CREATE, serviceLogger)).thenReturn(true);
-        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FOLDER_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
         try {
             PowerMockito.when(storageOperate.mkdir(tenant.getTenantCode(), null)).thenReturn(true);
         } catch (IOException e) {
             logger.error("storage error", e);
         }
 
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_ONLINE_CREATE, serviceLogger)).thenReturn(true);
-        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
-        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_RENAME, serviceLogger)).thenReturn(true);
-        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_RENAME, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(
+                AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
         Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
         Mockito.when(resourcesMapper.selectById(dir1.getId())).thenReturn(dir1);
         Mockito.when(resourcesMapper.selectById(dir2.getId())).thenReturn(dir2);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -606,6 +606,55 @@ public class ResourcesServiceTest {
     }
 
     @Test
+    public void testOnlineCreateResourceWithDir() {
+        User user = getUser();
+        user.setId(1);
+
+        String dir1Path = "/dir1";
+        String dir2Path = "/dir2";
+        String resourceDir = dir1Path + dir2Path;
+        String resourceName = "test";
+        String resourceSuffix = "py";
+        String desc = "desc";
+        String content = "content";
+
+        Resource dir1 = new Resource();
+        dir1.setFullName(dir1Path);
+        dir1.setId(1);
+        dir1.setUserId(user.getId());
+        Resource dir2 = new Resource();
+        dir2.setFullName(resourceDir);
+        dir2.setUserId(user.getId());
+        Mockito.when(resourcesMapper.queryResource(dir1.getFullName(), ResourceType.FILE.ordinal())).thenReturn(Collections.singletonList(dir1));
+        Mockito.when(resourcesMapper.queryResource(resourceDir, ResourceType.FILE.ordinal())).thenReturn(null);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_VIEW, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, new Object[]{dir1.getId()}, 1, serviceLogger)).thenReturn(true);
+
+        Tenant tenant = getTenant();
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FOLDER_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
+        try {
+            PowerMockito.when(storageOperate.mkdir(tenant.getTenantCode(), null)).thenReturn(true);
+        } catch (IOException e) {
+            logger.error("storage error", e);
+        }
+
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_ONLINE_CREATE, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
+        PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.RESOURCE_FILE_ID, 1, ApiFuncIdentificationConstant.FILE_RENAME, serviceLogger)).thenReturn(true);
+        PowerMockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.RESOURCE_FILE_ID, null, 1, serviceLogger)).thenReturn(true);
+        Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
+        Mockito.when(resourcesMapper.selectById(dir1.getId())).thenReturn(dir1);
+        Mockito.when(resourcesMapper.selectById(dir2.getId())).thenReturn(dir2);
+        Mockito.when(FileUtils.getUploadFilename(Mockito.anyString(), Mockito.anyString())).thenReturn("test");
+        PowerMockito.when(FileUtils.writeContent2File(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
+
+        Result<Object> result = resourcesService.onlineCreateResourceWithDir(user, resourceName, resourceSuffix, desc, content, resourceDir);
+        Assert.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
+    }
+
+    @Test
     public void testUpdateResourceContent() {
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(false);
 
@@ -896,7 +945,7 @@ public class ResourcesServiceTest {
         return resource;
     }
 
-    private Resource getResource(int resourceId,ResourceType type) {
+    private Resource getResource(int resourceId, ResourceType type) {
 
         Resource resource = new Resource();
         resource.setId(resourceId);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -160,6 +160,11 @@ public final class Constants {
     public static final String COLON = ":";
 
     /**
+     * period .
+     */
+    public static final String PERIOD = ".";
+
+    /**
      * QUESTION ?
      */
     public static final String QUESTION = "?";

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/process_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/process_definition.py
@@ -416,7 +416,7 @@ class ProcessDefinition(Base):
         if len(self.resource_list) > 0:
             for res in self.resource_list:
                 gateway.entry_point.createOrUpdateResource(
-                    self.user,
+                    self._user,
                     res.name,
                     res.description,
                     res.content,

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/process_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/process_definition.py
@@ -63,6 +63,9 @@ class ProcessDefinition(Base):
         thought Web UI after it :func:`submit` or :func:`run`. It will create a new project belongs to
         ``user`` if it does not exists. And when ``project`` exists but project's create do not belongs
         to ``user``, will grant `project` to ``user`` automatically.
+    :param resource_list: Resource files required by the current process definition.You can create and modify
+        resource files from this field. When the process definition is submitted, these resource files are also
+        submitted along with it.
     """
 
     # key attribute for identify ProcessDefinition object
@@ -88,6 +91,7 @@ class ProcessDefinition(Base):
         "tasks",
         "task_definition_json",
         "task_relation_json",
+        "resource_list",
     }
 
     def __init__(
@@ -107,6 +111,7 @@ class ProcessDefinition(Base):
         timeout: Optional[int] = 0,
         release_state: Optional[str] = configuration.WORKFLOW_RELEASE_STATE,
         param: Optional[Dict] = None,
+        resource_list: Optional[List] = None,
     ):
         super().__init__(name, description)
         self.schedule = schedule
@@ -132,6 +137,7 @@ class ProcessDefinition(Base):
         # TODO how to fix circle import
         self._task_relations: set["TaskRelation"] = set()  # noqa: F821
         self._process_definition_code = None
+        self.resource_list = resource_list or []
 
     def __enter__(self) -> "ProcessDefinition":
         ProcessDefinitionContext.set(self)
@@ -407,6 +413,14 @@ class ProcessDefinition(Base):
             None,
             None,
         )
+        if len(self.resource_list) > 0:
+            for res in self.resource_list:
+                gateway.entry_point.createOrUpdateResource(
+                    self.user,
+                    res.name,
+                    res.description,
+                    res.content,
+                )
         return self._process_definition_code
 
     def start(self) -> None:

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/resource.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/resource.py
@@ -20,47 +20,24 @@
 from typing import Optional
 
 from pydolphinscheduler.core.base import Base
-from pydolphinscheduler.java_gateway import launch_gateway
 
 
-class ResourceDefinition(Base):
+class Resource(Base):
     """resource object, will define the resources that you want to create or update.
 
-    :param user: The user who create or update resource.
-    :param name: The name of resource.Do not include file suffixes.
-    :param suffix: The suffix of resource.
-    :param current_dir: The folder where the resource resides.
+    :param name: The fullname of resource.Includes path and suffix.
     :param content: The description of resource.
     :param description: The description of resource.
     """
 
-    _DEFINE_ATTR = {"user", "name", "suffix", "current_dir", "content", "description"}
+    _DEFINE_ATTR = {"name", "content", "description"}
 
     def __init__(
         self,
-        user: str,
         name: str,
-        suffix: str,
-        current_dir: str,
         content: str,
         description: Optional[str] = None,
     ):
         super().__init__(name, description)
-        self.user = user
-        self.suffix = suffix
-        self.current_dir = current_dir
         self.content = content
         self._resource_code = None
-
-    def submit(self) -> int:
-        """Submit resource to java gateway."""
-        gateway = launch_gateway()
-        self._resource_code = gateway.entry_point.createOrUpdateResource(
-            self.user,
-            self.current_dir,
-            self.name,
-            self.suffix,
-            self.description,
-            self.content,
-        )
-        return self._resource_code

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/resource_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/resource_definition.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Module resource."""
+
+from typing import Optional
+
+from pydolphinscheduler.core.base import Base
+from pydolphinscheduler.java_gateway import launch_gateway
+
+
+class ResourceDefinition(Base):
+    """resource object, will define the resources that you want to create or update.
+
+    :param user: The user who create or update resource.
+    :param name: The name of resource.Do not include file suffixes.
+    :param suffix: The suffix of resource.
+    :param current_dir: The folder where the resource resides.
+    :param content: The description of resource.
+    :param description: The description of resource.
+    """
+
+    _DEFINE_ATTR = {"user", "name", "suffix", "current_dir", "content", "description"}
+
+    def __init__(
+        self,
+        user: str,
+        name: str,
+        suffix: str,
+        current_dir: str,
+        content: str,
+        description: Optional[str] = None,
+    ):
+        super().__init__(name, description)
+        self.user = user
+        self.suffix = suffix
+        self.current_dir = current_dir
+        self.content = content
+        self._resource_code = None
+
+    def submit(self) -> int:
+        """Submit resource to java gateway."""
+        gateway = launch_gateway()
+        self._resource_code = gateway.entry_point.createOrUpdateResource(
+            self.user,
+            self.current_dir,
+            self.name,
+            self.suffix,
+            self.description,
+            self.content,
+        )
+        return self._resource_code

--- a/dolphinscheduler-python/pydolphinscheduler/tests/core/test_process_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/core/test_process_definition.py
@@ -18,7 +18,7 @@
 """Test process definition."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, List
 from unittest.mock import patch
 
 import pytest
@@ -26,6 +26,7 @@ from freezegun import freeze_time
 
 from pydolphinscheduler.core import configuration
 from pydolphinscheduler.core.process_definition import ProcessDefinition
+from pydolphinscheduler.core.resource import Resource
 from pydolphinscheduler.exceptions import PyDSParamException
 from pydolphinscheduler.side import Project, Tenant, User
 from pydolphinscheduler.tasks.switch import Branch, Default, Switch, SwitchCondition
@@ -90,6 +91,11 @@ def test_process_definition_default_value(name, value):
         ("warning_group_id", int, 1),
         ("timeout", int, 1),
         ("param", dict, {"key": "value"}),
+        (
+            "resource_list",
+            List,
+            [Resource(name="/dev/test.py", content="hello world", description="desc")],
+        ),
     ],
 )
 def test_set_attr(name, cls, expect):
@@ -321,6 +327,7 @@ def test_process_definition_get_define_without_task():
         "tasks": {},
         "taskDefinitionJson": [{}],
         "taskRelationJson": [{}],
+        "resourceList": [],
     }
     with ProcessDefinition(TEST_PROCESS_DEFINITION_NAME) as pd:
         assert pd.get_define() == expect

--- a/dolphinscheduler-python/pydolphinscheduler/tests/core/test_resource_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/core/test_resource_definition.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Test resource definition."""
+
+from pydolphinscheduler.core.resource_definition import ResourceDefinition
+
+
+def test_sql_get_define():
+    """Test resource set attributes which get with same type."""
+    user = "admin"
+    name = "test"
+    suffix = "py"
+    current_dir = "/dev"
+    content = """print("hello world")"""
+    description = "hello world"
+    expect = {
+        "user": user,
+        "name": name,
+        "suffix": suffix,
+        "currentDir": current_dir,
+        "content": content,
+        "description": description,
+    }
+    resourceDefinition = ResourceDefinition(
+        user=user,
+        name=name,
+        suffix=suffix,
+        current_dir=current_dir,
+        content=content,
+        description=description,
+    )
+    assert resourceDefinition.get_define() == expect

--- a/dolphinscheduler-python/pydolphinscheduler/tests/core/test_resource_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/core/test_resource_definition.py
@@ -20,7 +20,7 @@
 from pydolphinscheduler.core.resource import Resource
 
 
-def test_sql_get_define():
+def test_resource():
     """Test resource set attributes which get with same type."""
     name = "/dev/test.py"
     content = """print("hello world")"""

--- a/dolphinscheduler-python/pydolphinscheduler/tests/core/test_resource_definition.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/core/test_resource_definition.py
@@ -17,30 +17,21 @@
 
 """Test resource definition."""
 
-from pydolphinscheduler.core.resource_definition import ResourceDefinition
+from pydolphinscheduler.core.resource import Resource
 
 
 def test_sql_get_define():
     """Test resource set attributes which get with same type."""
-    user = "admin"
-    name = "test"
-    suffix = "py"
-    current_dir = "/dev"
+    name = "/dev/test.py"
     content = """print("hello world")"""
     description = "hello world"
     expect = {
-        "user": user,
         "name": name,
-        "suffix": suffix,
-        "currentDir": current_dir,
         "content": content,
         "description": description,
     }
-    resourceDefinition = ResourceDefinition(
-        user=user,
+    resourceDefinition = Resource(
         name=name,
-        suffix=suffix,
-        current_dir=current_dir,
         content=content,
         description=description,
     )


### PR DESCRIPTION
Our company now deploy and manage scripts automatically through Python-gate, but resource files need to be maintained manually.We find it inconvenient.So, I think Python-gate should supports creating or editing resources.

close: #10822 