### PR TITLE
[Fix-10830][Doc] Change the start or install script command sh in the document to bash

### DIFF
--- a/docs/docs/en/guide/expansion-reduction.md
+++ b/docs/docs/en/guide/expansion-reduction.md
@@ -137,19 +137,19 @@ sudo chown -R dolphinscheduler:dolphinscheduler dolphinscheduler
 
 bin/stop-all.sh # stop all services
 
-sh bin/dolphinscheduler-daemon.sh stop master-server  # stop master service
-sh bin/dolphinscheduler-daemon.sh stop worker-server  # stop worker service
-sh bin/dolphinscheduler-daemon.sh stop api-server     # stop api    service
-sh bin/dolphinscheduler-daemon.sh stop alert-server   # stop alert  service
+bash bin/dolphinscheduler-daemon.sh stop master-server  # stop master service
+bash bin/dolphinscheduler-daemon.sh stop worker-server  # stop worker service
+bash bin/dolphinscheduler-daemon.sh stop api-server     # stop api    service
+bash bin/dolphinscheduler-daemon.sh stop alert-server   # stop alert  service
 
 
 # start command::
 bin/start-all.sh # start all services
 
-sh bin/dolphinscheduler-daemon.sh start master-server  # start master service
-sh bin/dolphinscheduler-daemon.sh start worker-server  # start worker service
-sh bin/dolphinscheduler-daemon.sh start api-server     # start api    service
-sh bin/dolphinscheduler-daemon.sh start alert-server   # start alert  service
+bash bin/dolphinscheduler-daemon.sh start master-server  # start master service
+bash bin/dolphinscheduler-daemon.sh start worker-server  # start worker service
+bash bin/dolphinscheduler-daemon.sh start api-server     # start api    service
+bash bin/dolphinscheduler-daemon.sh start alert-server   # start alert  service
 
 ```
 
@@ -194,19 +194,19 @@ There are two steps for shrinking. After performing the following two steps, the
 # stop command:
 bin/stop-all.sh # stop all services
 
-sh bin/dolphinscheduler-daemon.sh stop master-server  # stop master service
-sh bin/dolphinscheduler-daemon.sh stop worker-server  # stop worker service
-sh bin/dolphinscheduler-daemon.sh stop api-server     # stop api    service
-sh bin/dolphinscheduler-daemon.sh stop alert-server   # stop alert  service
+bash bin/dolphinscheduler-daemon.sh stop master-server  # stop master service
+bash bin/dolphinscheduler-daemon.sh stop worker-server  # stop worker service
+bash bin/dolphinscheduler-daemon.sh stop api-server     # stop api    service
+bash bin/dolphinscheduler-daemon.sh stop alert-server   # stop alert  service
 
 
 # start command:
 bin/start-all.sh # start all services
 
-sh bin/dolphinscheduler-daemon.sh start master-server # start master service
-sh bin/dolphinscheduler-daemon.sh start worker-server # start worker service
-sh bin/dolphinscheduler-daemon.sh start api-server    # start api    service
-sh bin/dolphinscheduler-daemon.sh start alert-server  # start alert  service
+bash bin/dolphinscheduler-daemon.sh start master-server # start master service
+bash bin/dolphinscheduler-daemon.sh start worker-server # start worker service
+bash bin/dolphinscheduler-daemon.sh start api-server    # start api    service
+bash bin/dolphinscheduler-daemon.sh start alert-server  # start alert  service
 
 ```
 

--- a/docs/docs/en/guide/howto/datasource-setting.md
+++ b/docs/docs/en/guide/howto/datasource-setting.md
@@ -64,7 +64,7 @@ export SPRING_DATASOURCE_PASSWORD={password}
 After the above steps done you would create a new database for DolphinScheduler, then run the Shell script to init database:
 
 ```shell
-sh tools/bin/upgrade-schema.sh
+bash tools/bin/upgrade-schema.sh
 ```
 
 ## DataSource Center

--- a/docs/docs/en/guide/installation/pseudo-cluster.md
+++ b/docs/docs/en/guide/installation/pseudo-cluster.md
@@ -149,7 +149,7 @@ Follow the instructions in [datasource-setting](../howto/datasource-setting.md) 
 Use **deployment user** you created above, running the following command to complete the deployment, and the server log will be stored in the logs folder.
 
 ```shell
-sh ./bin/install.sh
+bash ./bin/install.sh
 ```
 
 > **_Note:_** For the first time deployment, there maybe occur five times of `sh: bin/dolphinscheduler-daemon.sh: No such file or directory` in the terminal,
@@ -163,26 +163,26 @@ Access address `http://localhost:12345/dolphinscheduler/ui` and login DolphinSch
 
 ```shell
 # Stop all DolphinScheduler server
-sh ./bin/stop-all.sh
+bash ./bin/stop-all.sh
 
 # Start all DolphinScheduler server
-sh ./bin/start-all.sh
+bash ./bin/start-all.sh
 
 # Start or stop DolphinScheduler Master
-sh ./bin/dolphinscheduler-daemon.sh stop master-server
-sh ./bin/dolphinscheduler-daemon.sh start master-server
+bash ./bin/dolphinscheduler-daemon.sh stop master-server
+bash ./bin/dolphinscheduler-daemon.sh start master-server
 
 # Start or stop DolphinScheduler Worker
-sh ./bin/dolphinscheduler-daemon.sh start worker-server
-sh ./bin/dolphinscheduler-daemon.sh stop worker-server
+bash ./bin/dolphinscheduler-daemon.sh start worker-server
+bash ./bin/dolphinscheduler-daemon.sh stop worker-server
 
 # Start or stop DolphinScheduler Api
-sh ./bin/dolphinscheduler-daemon.sh start api-server
-sh ./bin/dolphinscheduler-daemon.sh stop api-server
+bash ./bin/dolphinscheduler-daemon.sh start api-server
+bash ./bin/dolphinscheduler-daemon.sh stop api-server
 
 # Start or stop Alert
-sh ./bin/dolphinscheduler-daemon.sh start alert-server
-sh ./bin/dolphinscheduler-daemon.sh stop alert-server
+bash ./bin/dolphinscheduler-daemon.sh start alert-server
+bash ./bin/dolphinscheduler-daemon.sh stop alert-server
 ```
 
 > **_Note1:_**: Each server have `dolphinscheduler_env.sh` file in path `<server-name>/conf/dolphinscheduler_env.sh` which

--- a/docs/docs/en/guide/installation/standalone.md
+++ b/docs/docs/en/guide/installation/standalone.md
@@ -22,7 +22,7 @@ There is a standalone startup script in the binary compressed package, which can
 # Extract and start Standalone Server
 tar -xvzf apache-dolphinscheduler-*-bin.tar.gz
 cd apache-dolphinscheduler-*-bin
-sh ./bin/dolphinscheduler-daemon.sh start standalone-server
+bash ./bin/dolphinscheduler-daemon.sh start standalone-server
 ```
 
 ### Login DolphinScheduler
@@ -35,9 +35,9 @@ The script `./bin/dolphinscheduler-daemon.sh`can be used not only quickly start 
 
 ```shell
 # Start Standalone Server
-sh ./bin/dolphinscheduler-daemon.sh start standalone-server
+bash ./bin/dolphinscheduler-daemon.sh start standalone-server
 # Stop Standalone Server
-sh ./bin/dolphinscheduler-daemon.sh stop standalone-server
+bash ./bin/dolphinscheduler-daemon.sh stop standalone-server
 ```
 
 > Note: Python gateway service is started along with the api-server, and if you do not want to start Python gateway

--- a/docs/docs/zh/guide/expansion-reduction.md
+++ b/docs/docs/zh/guide/expansion-reduction.md
@@ -136,19 +136,19 @@ sudo chown -R dolphinscheduler:dolphinscheduler dolphinscheduler
 停止命令:
 bin/stop-all.sh 停止所有服务
 
-sh bin/dolphinscheduler-daemon.sh stop master-server  停止 master 服务
-sh bin/dolphinscheduler-daemon.sh stop worker-server  停止 worker 服务
-sh bin/dolphinscheduler-daemon.sh stop api-server     停止 api    服务
-sh bin/dolphinscheduler-daemon.sh stop alert-server   停止 alert  服务
+bash bin/dolphinscheduler-daemon.sh stop master-server  停止 master 服务
+bash bin/dolphinscheduler-daemon.sh stop worker-server  停止 worker 服务
+bash bin/dolphinscheduler-daemon.sh stop api-server     停止 api    服务
+bash bin/dolphinscheduler-daemon.sh stop alert-server   停止 alert  服务
 
 
 启动命令:
 bin/start-all.sh 启动所有服务
 
-sh bin/dolphinscheduler-daemon.sh start master-server  启动 master 服务
-sh bin/dolphinscheduler-daemon.sh start worker-server  启动 worker 服务
-sh bin/dolphinscheduler-daemon.sh start api-server     启动 api    服务
-sh bin/dolphinscheduler-daemon.sh start alert-server   启动 alert  服务
+bash bin/dolphinscheduler-daemon.sh start master-server  启动 master 服务
+bash bin/dolphinscheduler-daemon.sh start worker-server  启动 worker 服务
+bash bin/dolphinscheduler-daemon.sh start api-server     启动 api    服务
+bash bin/dolphinscheduler-daemon.sh start alert-server   启动 alert  服务
 
 ```
 
@@ -191,19 +191,19 @@ sh bin/dolphinscheduler-daemon.sh start alert-server   启动 alert  服务
 停止命令:
 bin/stop-all.sh 停止所有服务
 
-sh bin/dolphinscheduler-daemon.sh stop master-server  停止 master 服务
-sh bin/dolphinscheduler-daemon.sh stop worker-server  停止 worker 服务
-sh bin/dolphinscheduler-daemon.sh stop api-server     停止 api    服务
-sh bin/dolphinscheduler-daemon.sh stop alert-server   停止 alert  服务
+bash bin/dolphinscheduler-daemon.sh stop master-server  停止 master 服务
+bash bin/dolphinscheduler-daemon.sh stop worker-server  停止 worker 服务
+bash bin/dolphinscheduler-daemon.sh stop api-server     停止 api    服务
+bash bin/dolphinscheduler-daemon.sh stop alert-server   停止 alert  服务
 
 
 启动命令:
 bin/start-all.sh 启动所有服务
 
-sh bin/dolphinscheduler-daemon.sh start master-server  启动 master 服务
-sh bin/dolphinscheduler-daemon.sh start worker-server  启动 worker 服务
-sh bin/dolphinscheduler-daemon.sh start api-server     启动 api    服务
-sh bin/dolphinscheduler-daemon.sh start alert-server   启动 alert  服务
+bash bin/dolphinscheduler-daemon.sh start master-server  启动 master 服务
+bash bin/dolphinscheduler-daemon.sh start worker-server  启动 worker 服务
+bash bin/dolphinscheduler-daemon.sh start api-server     启动 api    服务
+bash bin/dolphinscheduler-daemon.sh start alert-server   启动 alert  服务
 
 ```
 

--- a/docs/docs/zh/guide/howto/datasource-setting.md
+++ b/docs/docs/zh/guide/howto/datasource-setting.md
@@ -64,7 +64,7 @@ export SPRING_DATASOURCE_PASSWORD={password}
 完成上述步骤后，您已经为 DolphinScheduler 创建一个新数据库，现在你可以通过快速的 Shell 脚本来初始化数据库
 
 ```shell
-sh tools/bin/upgrade-schema.sh
+bash tools/bin/upgrade-schema.sh
 ```
 
 ## 数据源中心

--- a/docs/docs/zh/guide/installation/pseudo-cluster.md
+++ b/docs/docs/zh/guide/installation/pseudo-cluster.md
@@ -146,7 +146,7 @@ export PATH=$HADOOP_HOME/bin:$SPARK_HOME1/bin:$SPARK_HOME2/bin:$PYTHON_HOME/bin:
 使用上面创建的**部署用户**运行以下命令完成部署，部署后的运行日志将存放在 logs 文件夹内
 
 ```shell
-sh ./bin/install.sh
+bash ./bin/install.sh
 ```
 
 > **_注意:_** 第一次部署的话，可能出现 5 次`sh: bin/dolphinscheduler-daemon.sh: No such file or directory`相关信息，次为非重要信息直接忽略即可
@@ -159,26 +159,26 @@ sh ./bin/install.sh
 
 ```shell
 # 一键停止集群所有服务
-sh ./bin/stop-all.sh
+bash ./bin/stop-all.sh
 
 # 一键开启集群所有服务
-sh ./bin/start-all.sh
+bash ./bin/start-all.sh
 
 # 启停 Master
-sh ./bin/dolphinscheduler-daemon.sh stop master-server
-sh ./bin/dolphinscheduler-daemon.sh start master-server
+bash ./bin/dolphinscheduler-daemon.sh stop master-server
+bash ./bin/dolphinscheduler-daemon.sh start master-server
 
 # 启停 Worker
-sh ./bin/dolphinscheduler-daemon.sh start worker-server
-sh ./bin/dolphinscheduler-daemon.sh stop worker-server
+bash ./bin/dolphinscheduler-daemon.sh start worker-server
+bash ./bin/dolphinscheduler-daemon.sh stop worker-server
 
 # 启停 Api
-sh ./bin/dolphinscheduler-daemon.sh start api-server
-sh ./bin/dolphinscheduler-daemon.sh stop api-server
+bash ./bin/dolphinscheduler-daemon.sh start api-server
+bash ./bin/dolphinscheduler-daemon.sh stop api-server
 
 # 启停 Alert
-sh ./bin/dolphinscheduler-daemon.sh start alert-server
-sh ./bin/dolphinscheduler-daemon.sh stop alert-server
+bash ./bin/dolphinscheduler-daemon.sh start alert-server
+bash ./bin/dolphinscheduler-daemon.sh stop alert-server
 ```
 
 > **_注意1:_**: 每个服务在路径 `<server-name>/conf/dolphinscheduler_env.sh` 中都有 `dolphinscheduler_env.sh` 文件，这是可以为微

--- a/docs/docs/zh/guide/installation/standalone.md
+++ b/docs/docs/zh/guide/installation/standalone.md
@@ -22,7 +22,7 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 # 解压并运行 Standalone Server
 tar -xvzf apache-dolphinscheduler-*-bin.tar.gz
 cd apache-dolphinscheduler-*-bin
-sh ./bin/dolphinscheduler-daemon.sh start standalone-server
+bash ./bin/dolphinscheduler-daemon.sh start standalone-server
 ```
 
 ### 登录 DolphinScheduler
@@ -35,9 +35,9 @@ sh ./bin/dolphinscheduler-daemon.sh start standalone-server
 
 ```shell
 # 启动 Standalone Server 服务
-sh ./bin/dolphinscheduler-daemon.sh start standalone-server
+bash ./bin/dolphinscheduler-daemon.sh start standalone-server
 # 停止 Standalone Server 服务
-sh ./bin/dolphinscheduler-daemon.sh stop standalone-server
+bash ./bin/dolphinscheduler-daemon.sh stop standalone-server
 ```
 
 [jdk]: https://www.oracle.com/technetwork/java/javase/downloads/index.html


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

Fix-10830: Change the start or install script command sh in the document to bash

* Change the script execution command sh in the `docs/docs/en/guide/installation/pseudo-cluster.md` to bash
* Change the script execution command sh in the `docs/docs/en/guide/installation/standalone.md` to bash
* Change the script execution command sh in the `docs/docs/zh/guide/installation/pseudo-cluster.md` to bash
* Change the script execution command sh in the `docs/docs/zh/guide/installation/standalone.md` to bash
* Change the script execution command sh in the `docs/docs/en/guide/expansion-reduction.md` to bash
* Change the script execution command sh in the `docs/docs/en/guide/howto/datasource-setting.md` to bash
* Change the script execution command sh in the `docs/docs/zh/guide/expansion-reduction.md` to bash
* Change the script execution command sh in the `docs/docs/zh/guide/howto/datasource-setting.md` to bash

This closes #10830
