### PR TITLE
[Doc][Upgrade] Fix tiny error in upgrade docs

### DIFF
--- a/docs/docs/en/guide/upgrade.md
+++ b/docs/docs/en/guide/upgrade.md
@@ -27,13 +27,13 @@ jar package and add it to the `./tools/libs` directory, then change `./bin/ env/
     ```shell
     export DATABASE=${DATABASE:-mysql}
     export SPRING_PROFILES_ACTIVE=${DATABASE}
-    export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8"
+    export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
     export SPRING_DATASOURCE_USERNAME={user}
     export SPRING_DATASOURCE_PASSWORD={password}
     ```
 
 Execute database upgrade script: `sh ./tools/bin/upgrade-schema.sh`
-K
+
 ### Upgrade Service
 
 #### Change Configuration `bin/env/install_config.conf`

--- a/docs/docs/en/guide/upgrade.md
+++ b/docs/docs/en/guide/upgrade.md
@@ -27,7 +27,7 @@ jar package and add it to the `./tools/libs` directory, then change `./bin/ env/
     ```shell
     export DATABASE=${DATABASE:-mysql}
     export SPRING_PROFILES_ACTIVE=${DATABASE}
-    export SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+    export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8"
     export SPRING_DATASOURCE_USERNAME={user}
     export SPRING_DATASOURCE_PASSWORD={password}
     ```

--- a/docs/docs/zh/guide/upgrade.md
+++ b/docs/docs/zh/guide/upgrade.md
@@ -26,7 +26,7 @@ jar 包 并添加到 `./tools/libs` 目录下，修改 `./bin/env/dolphinschedul
     ```shell
     export DATABASE=${DATABASE:-mysql}
     export SPRING_PROFILES_ACTIVE=${DATABASE}
-    export SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8
+    export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8"
     export SPRING_DATASOURCE_USERNAME={user}
     export SPRING_DATASOURCE_PASSWORD={password}
     ```

--- a/docs/docs/zh/guide/upgrade.md
+++ b/docs/docs/zh/guide/upgrade.md
@@ -26,7 +26,7 @@ jar 包 并添加到 `./tools/libs` 目录下，修改 `./bin/env/dolphinschedul
     ```shell
     export DATABASE=${DATABASE:-mysql}
     export SPRING_PROFILES_ACTIVE=${DATABASE}
-    export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8"
+    export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
     export SPRING_DATASOURCE_USERNAME={user}
     export SPRING_DATASOURCE_PASSWORD={password}
     ```


### PR DESCRIPTION
## Purpose of the pull request
*  Fix tiny error in upgrade docs.
* Got some feedback from users in DS Slack Channel, SPRING_DATASOURCE_URL example value in upgrade docs is not quoted, which misleads users.
* This PR closes: #10846 

## Brief change log

* Quote example datasource url value in upgrade docs.

## Verify this pull request

* Verified by manual test.
