### PR TITLE
New version release 2.0.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -102,8 +102,6 @@ body:
         - 3.0.0-beta-2
         - 2.0.6
         - 2.0.5
-        - 1.3.9
-        - 1.3.8
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -100,8 +100,8 @@ body:
       options:
         - dev
         - 3.0.0-beta-2
+        - 2.0.6
         - 2.0.5
-        - 2.0.3
         - 1.3.9
         - 1.3.8
     validations:

--- a/docs/configs/index.md.jsx
+++ b/docs/configs/index.md.jsx
@@ -42,6 +42,7 @@ import docs201Config from '../../../site_config/docs2-0-1';
 import docs202Config from '../../../site_config/docs2-0-2';
 import docs203Config from '../../../site_config/docs2-0-3';
 import docs205Config from '../../../site_config/docs2-0-5';
+import docs206Config from '../../../site_config/docs2-0-6';
 import docs300Config from '../../../site_config/docs3-0-0';
 import docsDevConfig from '../../../site_config/docsdev';
 
@@ -61,6 +62,7 @@ const docsSource = {
   '2.0.2': docs202Config,
   '2.0.3': docs203Config,
   '2.0.5': docs205Config,
+  '2.0.6': docs206Config,
   '3.0.0': docs300Config,
   dev: docsDevConfig,
 };

--- a/docs/configs/site.js
+++ b/docs/configs/site.js
@@ -50,8 +50,8 @@ export default {
           },
           {
             key: 'docs1',
-            text: '1.3.9',
-            link: '/en-us/docs/1.3.9/user_doc/quick-start.html',
+            text: '2.0.6',
+            link: '/en-us/docs/2.0.6/user_doc/quick-start.html',
           },
           {
             key: 'docsHistory',
@@ -226,8 +226,8 @@ export default {
           },
           {
             key: 'docs1',
-            text: '1.3.9',
-            link: '/zh-cn/docs/1.3.9/user_doc/quick-start.html',
+            text: '2.0.6',
+            link: '/zh-cn/docs/2.0.6/user_doc/quick-start.html',
           },
           {
             key: 'docsHistory',

--- a/docs/docs/en/history-versions.md
+++ b/docs/docs/en/history-versions.md
@@ -8,6 +8,10 @@
 
 #### Links： [3.0.0-beta-2 Document](../3.0.0/user_doc/about/introduction.md)
 
+### Versions: 2.0.6
+
+#### Links： [2.0.6 Document](../2.0.6/user_doc/guide/quick-start.md)
+
 ### Versions: 2.0.5
 
 #### Links： [2.0.5 Document](../2.0.5/user_doc/guide/quick-start.md)

--- a/docs/docs/zh/history-versions.md
+++ b/docs/docs/zh/history-versions.md
@@ -7,6 +7,10 @@
 
 #### Links： [3.0.0-beta-2 文档](../3.0.0/user_doc/about/introduction.md)
 
+### 版本：2.0.6
+
+#### 地址：[2.0.6 文档](../2.0.6/user_doc/guide/quick-start.md)
+
 ### 版本：2.0.5
 
 #### 地址：[2.0.5 文档](../2.0.5/user_doc/guide/quick-start.md)


### PR DESCRIPTION
do not merge until https://github.com/apache/dolphinscheduler-website/pull/808 and https://github.com/apache/dolphinscheduler-website/pull/809 merged