### PR TITLE
impv: not mark issue stale with security label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,7 +33,7 @@ jobs:
           days-before-issue-stale: 30
           days-before-issue-close: 7
           # We do not stale Issues with label `Waiting for reply`, `new feature` and `DSIP`
-          exempt-issue-labels: 'Waiting for reply,new feature,DSIP'
+          exempt-issue-labels: 'Waiting for reply,new feature,DSIP,security'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had recent activity
             for 30 days. It will be closed in next 7 days if no further activity occurs.


### PR DESCRIPTION
it comes from #10427, currently issue with the security label will still be
close by stale label bot, we should ignore issue with security because
it is import issue same as `DSIP` or `new feature`