### PR TITLE
[python] Support SageMaker task type

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/docs/source/tasks/sagemaker.rst
+++ b/dolphinscheduler-python/pydolphinscheduler/docs/source/tasks/sagemaker.rst
@@ -15,30 +15,20 @@
    specific language governing permissions and limitations
    under the License.
 
-Tasks
-=====
+SageMaker
+=========
 
-In this section 
 
-.. toctree::
-   :maxdepth: 1
-   
-   func_wrap
-   shell
-   sql
-   python
-   http
+A shell task type's example and dive into information of **PyDolphinScheduler**.
 
-   switch
-   condition
-   dependent
+Example
+-------
 
-   spark
-   flink
-   map_reduce
-   procedure
+.. literalinclude:: ../../../src/pydolphinscheduler/examples/task_sagemaker_example.py
+   :start-after: [start workflow_declare]
+   :end-before: [end workflow_declare]
 
-   datax
-   sub_process
+Dive Into
+---------
 
-   sagemaker
+.. automodule:: pydolphinscheduler.tasks.sagemaker

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/constants.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/constants.py
@@ -57,6 +57,7 @@ class TaskType(str):
     FLINK = "FLINK"
     SPARK = "SPARK"
     MR = "MR"
+    SAGEMAKER = "SAGEMAKER"
 
 
 class DefaultTaskCodeNum(str):

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/examples/task_sagemaker_example.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/examples/task_sagemaker_example.py
@@ -16,6 +16,7 @@
 # under the License.
 
 # [start workflow_declare]
+"""A example workflow for task sagemaker."""
 import json
 
 from pydolphinscheduler.core.process_definition import ProcessDefinition
@@ -32,7 +33,10 @@ sagemaker_request_data = {
     ],
 }
 
-with ProcessDefinition(name="task_sagemaker_example", tenant="tenant_exists",) as pd:
+with ProcessDefinition(
+    name="task_sagemaker_example",
+    tenant="tenant_exists",
+) as pd:
     task_sagemaker = SageMaker(
         name="task_sagemaker",
         sagemaker_request_json=json.dumps(sagemaker_request_data, indent=2),

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/examples/task_sagemaker_example.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/examples/task_sagemaker_example.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# [start workflow_declare]
+import json
+
+from pydolphinscheduler.core.process_definition import ProcessDefinition
+from pydolphinscheduler.tasks.sagemaker import SageMaker
+
+sagemaker_request_data = {
+    "ParallelismConfiguration": {"MaxParallelExecutionSteps": 1},
+    "PipelineExecutionDescription": "test Pipeline",
+    "PipelineExecutionDisplayName": "AbalonePipeline",
+    "PipelineName": "AbalonePipeline",
+    "PipelineParameters": [
+        {"Name": "ProcessingInstanceType", "Value": "ml.m4.xlarge"},
+        {"Name": "ProcessingInstanceCount", "Value": "2"},
+    ],
+}
+
+with ProcessDefinition(name="task_sagemaker_example", tenant="tenant_exists",) as pd:
+    task_sagemaker = SageMaker(
+        name="task_sagemaker",
+        sagemaker_request_json=json.dumps(sagemaker_request_data, indent=2),
+    )
+
+    pd.run()
+# [end workflow_declare]

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/sagemaker.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/sagemaker.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Task SageMaker."""
+
+from pydolphinscheduler.constants import TaskType
+from pydolphinscheduler.core.task import Task
+
+
+class SageMaker(Task):
+    """Task SageMaker object, declare behavior for SageMaker task to dolphinscheduler.
+
+    :param name: A unique, meaningful string for the SageMaker task.
+    :param sagemaker_request_json: Request parameters of StartPipelineExecution，
+        see also `AWS API
+        <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_StartPipelineExecution.html>`_
+
+    """
+
+    _task_custom_attr = {
+        "sagemaker_request_json",
+    }
+
+    def __init__(self, name: str, sagemaker_request_json: str, *args, **kwargs):
+        super().__init__(name, TaskType.SAGEMAKER, *args, **kwargs)
+        self.sagemaker_request_json = sagemaker_request_json

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sagemaker.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sagemaker.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Test Task SageMaker."""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from pydolphinscheduler.tasks.sagemaker import SageMaker
+
+sagemaker_request_json = json.dumps(
+    {
+        "ParallelismConfiguration": {"MaxParallelExecutionSteps": 1},
+        "PipelineExecutionDescription": "test Pipeline",
+        "PipelineExecutionDisplayName": "AbalonePipeline",
+        "PipelineName": "AbalonePipeline",
+        "PipelineParameters": [
+            {"Name": "ProcessingInstanceType", "Value": "ml.m4.xlarge"},
+            {"Name": "ProcessingInstanceCount", "Value": "2"},
+        ],
+    },
+    indent=2,
+)
+
+
+@pytest.mark.parametrize(
+    "attr, expect",
+    [
+        (
+            {"sagemaker_request_json": sagemaker_request_json},
+            {
+                "sagemakerRequestJson": sagemaker_request_json,
+                "localParams": [],
+                "resourceList": [],
+                "dependence": {},
+                "waitStartTimeout": {},
+                "conditionResult": {"successNode": [""], "failedNode": [""]},
+            },
+        )
+    ],
+)
+@patch(
+    "pydolphinscheduler.core.task.Task.gen_code_and_version",
+    return_value=(123, 1),
+)
+def test_property_task_params(mock_code_version, attr, expect):
+    """Test task sagemaker task property."""
+    task = SageMaker("test-sagemaker-task-params", **attr)
+    assert expect == task.task_params
+
+
+def test_sagemaker_get_define():
+    """Test task sagemaker function get_define."""
+    code = 123
+    version = 1
+    name = "test_sagemaker_get_define"
+    expect = {
+        "code": code,
+        "name": name,
+        "version": 1,
+        "description": None,
+        "delayTime": 0,
+        "taskType": "SAGEMAKER",
+        "taskParams": {
+            "resourceList": [],
+            "localParams": [],
+            "sagemakerRequestJson": sagemaker_request_json,
+            "dependence": {},
+            "conditionResult": {"successNode": [""], "failedNode": [""]},
+            "waitStartTimeout": {},
+        },
+        "flag": "YES",
+        "taskPriority": "MEDIUM",
+        "workerGroup": "default",
+        "failRetryTimes": 0,
+        "failRetryInterval": 1,
+        "timeoutFlag": "CLOSE",
+        "timeoutNotifyStrategy": None,
+        "timeout": 0,
+    }
+    with patch(
+        "pydolphinscheduler.core.task.Task.gen_code_and_version",
+        return_value=(code, version),
+    ):
+        sagemaker = SageMaker(name, sagemaker_request_json)
+        assert sagemaker.get_define() == expect


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

- Add SageMaker task type to pydolphinscheduler api

Relate to: #10826

Do not merge until #10935 merged


```python
import json

from pydolphinscheduler.core.process_definition import ProcessDefinition
from pydolphinscheduler.tasks.sagemaker import SageMaker

sagemaker_request_data = {
    "ParallelismConfiguration": {"MaxParallelExecutionSteps": 1},
    "PipelineExecutionDescription": "test Pipeline",
    "PipelineExecutionDisplayName": "AbalonePipeline",
    "PipelineName": "AbalonePipeline",
    "PipelineParameters": [
        {"Name": "ProcessingInstanceType", "Value": "ml.m4.xlarge"},
        {"Name": "ProcessingInstanceCount", "Value": "2"},
    ],
}

with ProcessDefinition(name="task_sagemaker_example", tenant="tenant_exists",) as pd:
    task_sagemaker = SageMaker(
        name="task_sagemaker",
        sagemaker_request_json=json.dumps(sagemaker_request_data, indent=2),
    )

    pd.run()
```

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
