### PR TITLE
[Improvement-11013][dolphinscheduler-common] YarnHAAdminUtils#getActiveRMName function Add HTTPS Hadoop environment support 

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -130,8 +130,8 @@ public class HadoopUtils implements Closeable, StorageOperate {
 
             String defaultFS = configuration.get(Constants.FS_DEFAULT_FS);
 
-            if (StringUtils.isBlank(defaultFS)){
-                defaultFS= PropertyUtils.getString(Constants.FS_DEFAULT_FS);
+            if (StringUtils.isBlank(defaultFS)) {
+                defaultFS = PropertyUtils.getString(Constants.FS_DEFAULT_FS);
             }
 
             //first get key from core-site.xml hdfs-site.xml ,if null ,then try to get from properties file
@@ -615,12 +615,6 @@ public class HadoopUtils implements Closeable, StorageOperate {
      */
     public static String getAppAddress(String appAddress, String rmHa) {
 
-        //get active ResourceManager
-        String activeRM = YarnHAAdminUtils.getActiveRMName(rmHa);
-
-        if (StringUtils.isEmpty(activeRM)) {
-            return null;
-        }
 
         String[] split1 = appAddress.split(Constants.DOUBLE_SLASH);
 
@@ -636,6 +630,13 @@ public class HadoopUtils implements Closeable, StorageOperate {
         }
 
         String end = Constants.COLON + split2[1];
+
+        //get active ResourceManager
+        String activeRM = YarnHAAdminUtils.getActiveRMName(start, rmHa);
+
+        if (StringUtils.isEmpty(activeRM)) {
+            return null;
+        }
 
         return start + activeRM + end;
     }
@@ -658,13 +659,16 @@ public class HadoopUtils implements Closeable, StorageOperate {
     private static final class YarnHAAdminUtils {
 
         /**
-         * get active resourcemanager
+         *  get active resourcemanager node
+         * @param protocol http protocol
+         * @param rmIds yarn ha ids
+         * @return yarn active node
          */
-        public static String getActiveRMName(String rmIds) {
+        public static String getActiveRMName(String protocol, String rmIds) {
 
             String[] rmIdArr = rmIds.split(Constants.COMMA);
 
-            String yarnUrl = "http://%s:" + HADOOP_RESOURCE_MANAGER_HTTP_ADDRESS_PORT_VALUE + "/ws/v1/cluster/info";
+            String yarnUrl = protocol + "%s:" + HADOOP_RESOURCE_MANAGER_HTTP_ADDRESS_PORT_VALUE + "/ws/v1/cluster/info";
 
             try {
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
@@ -88,4 +88,10 @@ public class CommonUtilsTest {
         Assert.assertTrue(true);
     }
 
+    @Test
+    public void getHdfsTenantDir(){
+        logger.info(HadoopUtils.getHdfsTenantDir("1234"));
+        Assert.assertTrue(true);
+    }
+
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
@@ -36,9 +36,10 @@ import org.slf4j.LoggerFactory;
  * configuration test
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(value = { PropertyUtils.class, UserGroupInformation.class})
+@PrepareForTest(value = {PropertyUtils.class, UserGroupInformation.class})
 public class CommonUtilsTest {
     private static final Logger logger = LoggerFactory.getLogger(CommonUtilsTest.class);
+
     @Test
     public void getSystemEnvPath() {
         String envPath;
@@ -48,7 +49,7 @@ public class CommonUtilsTest {
 
     @Test
     public void isDevelopMode() {
-        logger.info("develop mode: {}",CommonUtils.isDevelopMode());
+        logger.info("develop mode: {}", CommonUtils.isDevelopMode());
         Assert.assertTrue(true);
     }
 
@@ -89,7 +90,7 @@ public class CommonUtilsTest {
     }
 
     @Test
-    public void getHdfsTenantDir(){
+    public void getHdfsTenantDir() {
         logger.info(HadoopUtils.getHdfsTenantDir("1234"));
         Assert.assertTrue(true);
     }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.common.utils;
 
-import org.apache.dolphinscheduler.spi.enums.ResourceType;
 import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 
 import org.apache.hadoop.security.UserGroupInformation;

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.common.utils;
 
+import org.apache.dolphinscheduler.spi.enums.ResourceType;
 import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 
 import org.apache.hadoop.security.UserGroupInformation;
@@ -94,5 +95,24 @@ public class CommonUtilsTest {
         logger.info(HadoopUtils.getHdfsTenantDir("1234"));
         Assert.assertTrue(true);
     }
+
+    @Test
+    public void getHdfsUdfFileName() {
+        logger.info(HadoopUtils.getHdfsUdfFileName("admin", "file_name"));
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void getHdfsResourceFileName() {
+        logger.info(HadoopUtils.getHdfsResourceFileName("admin", "file_name"));
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void getHdfsFileName() {
+        logger.info(HadoopUtils.getHdfsFileName(ResourceType.FILE, "admin", "file_name"));
+        Assert.assertTrue(true);
+    }
+
 
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/CommonUtilsTest.java
@@ -114,5 +114,4 @@ public class CommonUtilsTest {
         Assert.assertTrue(true);
     }
 
-
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
@@ -18,14 +18,13 @@
 package org.apache.dolphinscheduler.common.utils;
 
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
-
-import org.apache.hadoop.security.UserGroupInformation;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +33,8 @@ import org.slf4j.LoggerFactory;
  * hadoop utils test
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(value = {PropertyUtils.class, UserGroupInformation.class})
+@PrepareForTest(value = {HadoopUtils.class})
+@SuppressStaticInitializationFor("org.apache.dolphinscheduler.common.utils.HttpUtils")
 public class HadoopUtilsTest {
     private static final Logger logger = LoggerFactory.getLogger(HadoopUtilsTest.class);
 
@@ -59,6 +59,15 @@ public class HadoopUtilsTest {
     @Test
     public void getHdfsFileName() {
         logger.info(HadoopUtils.getHdfsFileName(ResourceType.FILE, "admin", "file_name"));
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void getAppAddress() {
+        PowerMockito.mockStatic(HttpUtils.class);
+        PowerMockito.when(HttpUtils.get("http://ds1:8088/ws/v1/cluster/info")).thenReturn(
+            "{\"clusterInfo\":{\"id\":1657034250022,\"startedOn\":1657034250022,\"state\":\"STARTED\",\"haState\":\"ACTIVE\",\"rmStateStoreName\":\"org.apache.hadoop.yarn.server.resourcemanager.recovery.NullRMStateStore\",\"resourceManagerVersion\":\"2.8.5\",\"resourceManagerBuildVersion\":\"2.8.5 from 0b8464d75227fcee2c6e7f2410377b3d53d3d5f8 by jdu source checksum ba3b9c96362faf6bc5c4cfc9cb53880\",\"resourceManagerVersionBuiltOn\":\"2018-09-10T03:44Z\",\"hadoopVersion\":\"2.8.5\",\"hadoopBuildVersion\":\"2.8.5 from 0b8464d75227fcee2c6e7f2410377b3d53d3d5f8 by jdu source checksum 9942ca5c745417c14e318835f420733\",\"hadoopVersionBuiltOn\":\"2018-09-10T03:32Z\",\"haZooKeeperConnectionState\":\"CONNECTED\"}}");
+        logger.info(HadoopUtils.getAppAddress("http://ds1:8088/ws/v1/cluster/apps/%s", "ds1,ds2"));
         Assert.assertTrue(true);
     }
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
@@ -66,7 +66,8 @@ public class HadoopUtilsTest {
     public void getAppAddress() {
         PowerMockito.mockStatic(HttpUtils.class);
         PowerMockito.when(HttpUtils.get("http://ds1:8088/ws/v1/cluster/info")).thenReturn(
-            "{\"clusterInfo\":{\"id\":1657034250022,\"startedOn\":1657034250022,\"state\":\"STARTED\",\"haState\":\"ACTIVE\",\"rmStateStoreName\":\"org.apache.hadoop.yarn.server.resourcemanager.recovery.NullRMStateStore\",\"resourceManagerVersion\":\"2.8.5\",\"resourceManagerBuildVersion\":\"2.8.5 from 0b8464d75227fcee2c6e7f2410377b3d53d3d5f8 by jdu source checksum ba3b9c96362faf6bc5c4cfc9cb53880\",\"resourceManagerVersionBuiltOn\":\"2018-09-10T03:44Z\",\"hadoopVersion\":\"2.8.5\",\"hadoopBuildVersion\":\"2.8.5 from 0b8464d75227fcee2c6e7f2410377b3d53d3d5f8 by jdu source checksum 9942ca5c745417c14e318835f420733\",\"hadoopVersionBuiltOn\":\"2018-09-10T03:32Z\",\"haZooKeeperConnectionState\":\"CONNECTED\"}}");
+            "{\"clusterInfo\":{\"id\":1657034250022,\"startedOn\":1657034250022,\"" +
+                "state\":\"STARTED\",\"haState\":\"ACTIVE\",\"haZooKeeperConnectionState\":\"CONNECTED\"}}");
         logger.info(HadoopUtils.getAppAddress("http://ds1:8088/ws/v1/cluster/apps/%s", "ds1,ds2"));
         Assert.assertTrue(true);
     }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
@@ -22,9 +22,6 @@ import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 
 import org.apache.hadoop.security.UserGroupInformation;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,59 +31,34 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * configuration test
+ * hadoop utils test
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(value = {PropertyUtils.class, UserGroupInformation.class})
-public class CommonUtilsTest {
-    private static final Logger logger = LoggerFactory.getLogger(CommonUtilsTest.class);
+public class HadoopUtilsTest {
+    private static final Logger logger = LoggerFactory.getLogger(HadoopUtilsTest.class);
 
     @Test
-    public void getSystemEnvPath() {
-        String envPath;
-        envPath = CommonUtils.getSystemEnvPath();
-        Assert.assertEquals("/etc/profile", envPath);
-    }
-
-    @Test
-    public void isDevelopMode() {
-        logger.info("develop mode: {}", CommonUtils.isDevelopMode());
+    public void getHdfsTenantDir() {
+        logger.info(HadoopUtils.getHdfsTenantDir("1234"));
         Assert.assertTrue(true);
     }
 
     @Test
-    public void getHdfsDataBasePath() {
-        logger.info(HadoopUtils.getHdfsDataBasePath());
+    public void getHdfsUdfFileName() {
+        logger.info(HadoopUtils.getHdfsUdfFileName("admin", "file_name"));
         Assert.assertTrue(true);
     }
 
     @Test
-    public void getDownloadFilename() {
-        logger.info(FileUtils.getDownloadFilename("a.txt"));
+    public void getHdfsResourceFileName() {
+        logger.info(HadoopUtils.getHdfsResourceFileName("admin", "file_name"));
         Assert.assertTrue(true);
     }
 
     @Test
-    public void getUploadFilename() {
-        logger.info(FileUtils.getUploadFilename("1234", "a.txt"));
-        Assert.assertTrue(true);
-    }
-
-    @Test
-    public void getHdfsDir() {
-        logger.info(HadoopUtils.getHdfsResDir("1234"));
-        Assert.assertTrue(true);
-    }
-
-    @Test
-    public void test() {
-        InetAddress ip;
-        try {
-            ip = InetAddress.getLocalHost();
-            logger.info(ip.getHostAddress());
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-        }
+    public void getHdfsFileName() {
+        logger.info(HadoopUtils.getHdfsFileName(ResourceType.FILE, "admin", "file_name"));
         Assert.assertTrue(true);
     }
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
@@ -65,9 +65,7 @@ public class HadoopUtilsTest {
     @Test
     public void getAppAddress() {
         PowerMockito.mockStatic(HttpUtils.class);
-        PowerMockito.when(HttpUtils.get("http://ds1:8088/ws/v1/cluster/info")).thenReturn(
-            "{\"clusterInfo\":{\"id\":1657034250022,\"startedOn\":1657034250022,\"" +
-                "state\":\"STARTED\",\"haState\":\"ACTIVE\",\"haZooKeeperConnectionState\":\"CONNECTED\"}}");
+        PowerMockito.when(HttpUtils.get("http://ds1:8088/ws/v1/cluster/info")).thenReturn("{\"clusterInfo\":{\"state\":\"STARTED\",\"haState\":\"ACTIVE\"}}");
         logger.info(HadoopUtils.getAppAddress("http://ds1:8088/ws/v1/cluster/apps/%s", "ds1,ds2"));
         Assert.assertTrue(true);
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

**YarnHAAdminUtils#getActiveRMName function Add HTTPS Hadoop environment support**

This closes #11013

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
