### PR TITLE
[Fix-11031] AccessToken can only be used by the creator.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AccessTokenServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AccessTokenServiceImpl.java
@@ -113,7 +113,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
     /**
      * create token
      *
-     * @param loginUser
+     * @param loginUser loginUser
      * @param userId token for user
      * @param expireTime token expire time
      * @param token token string (if it is absent, it will be automatically generated)

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AccessTokenServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AccessTokenServiceImpl.java
@@ -27,6 +27,7 @@ import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.EncryptionUtils;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
@@ -35,13 +36,10 @@ import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,13 +73,14 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
     public Result queryAccessTokenList(User loginUser, String searchVal, Integer pageNo, Integer pageSize) {
         Result result = new Result();
         PageInfo<AccessToken> pageInfo = new PageInfo<>(pageNo, pageSize);
-        Set<Integer> ids = resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.ACCESS_TOKEN, loginUser.getId(), logger);
-        if (!ids.isEmpty()) {
-            Page<AccessToken> page = new Page<>(pageNo, pageSize);
-            IPage<AccessToken> accessTokenList = accessTokenMapper.selectAccessTokenPage(page, new ArrayList<>(ids), searchVal);
-            pageInfo.setTotal((int) accessTokenList.getTotal());
-            pageInfo.setTotalList(accessTokenList.getRecords());
+        Page<AccessToken> page = new Page<>(pageNo, pageSize);
+        int userId = loginUser.getId();
+        if (loginUser.getUserType() == UserType.ADMIN_USER) {
+            userId = 0;
         }
+        IPage<AccessToken> accessTokenList = accessTokenMapper.selectAccessTokenPage(page, searchVal, userId);
+        pageInfo.setTotal((int) accessTokenList.getTotal());
+        pageInfo.setTotalList(accessTokenList.getRecords());
         result.setData(pageInfo);
         putMsg(result, Status.SUCCESS);
         return result;
@@ -98,11 +97,14 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
     public Map<String, Object> queryAccessTokenByUser(User loginUser, Integer userId) {
         Map<String, Object> result = new HashMap<>();
         result.put(Constants.STATUS, false);
-        List<AccessToken> accessTokenList = Collections.EMPTY_LIST;
-        Set<Integer> ids = resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.ACCESS_TOKEN, loginUser.getId(), logger);
-        if (!ids.isEmpty()) {
-            accessTokenList = this.accessTokenMapper.selectBatchIds(ids);
+        // no permission
+        if (loginUser.getUserType().equals(UserType.GENERAL_USER) && loginUser.getId() != userId) {
+            putMsg(result, Status.USER_NO_OPERATION_PERM);
+            return result;
         }
+        userId = loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : userId;
+        // query access token for specified user
+        List<AccessToken> accessTokenList = this.accessTokenMapper.queryAccessTokenByUser(userId);
         result.put(Constants.DATA_LIST, accessTokenList);
         this.putMsg(result, Status.SUCCESS);
         return result;
@@ -154,7 +156,6 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         if (insert > 0) {
             result.setData(accessToken);
             putMsg(result, Status.SUCCESS);
-            resourcePermissionCheckService.postHandle(AuthorizationType.ACCESS_TOKEN, loginUser.getId(), new ArrayList<>(accessToken.getId()), logger);
         } else {
             putMsg(result, Status.CREATE_ACCESS_TOKEN_ERROR);
         }
@@ -189,19 +190,23 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
     @Override
     public Map<String, Object> delAccessTokenById(User loginUser, int id) {
         Map<String, Object> result = new HashMap<>();
-        if (!canOperatorPermissions(loginUser,new Object[]{id},AuthorizationType.ACCESS_TOKEN,ACCESS_TOKEN_DELETE)) {
+        if (!canOperatorPermissions(loginUser, null, AuthorizationType.ACCESS_TOKEN,ACCESS_TOKEN_DELETE)) {
             putMsg(result, Status.USER_NO_OPERATION_PERM);
             return result;
         }
 
         AccessToken accessToken = accessTokenMapper.selectById(id);
-
         if (accessToken == null) {
             logger.error("access token not exist,  access token id {}", id);
             putMsg(result, Status.ACCESS_TOKEN_NOT_EXIST);
             return result;
         }
 
+        // admin can operate all, non-admin can operate their own
+        if (accessToken.getUserId() != loginUser.getId() && !loginUser.getUserType().equals(UserType.ADMIN_USER)) {
+            putMsg(result, Status.USER_NO_OPERATION_PERM);
+            return result;
+        }
         accessTokenMapper.deleteById(id);
         putMsg(result, Status.SUCCESS);
         return result;
@@ -221,7 +226,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         Map<String, Object> result = new HashMap<>();
 
         // 1. check permission
-        if (!canOperatorPermissions(loginUser,new Object[]{id},AuthorizationType.ACCESS_TOKEN,ACCESS_TOKEN_UPDATE)) {
+        if (!canOperatorPermissions(loginUser, null,AuthorizationType.ACCESS_TOKEN,ACCESS_TOKEN_UPDATE)) {
             putMsg(result, Status.USER_NO_OPERATION_PERM);
             return result;
         }
@@ -231,6 +236,11 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         if (accessToken == null) {
             logger.error("access token not exist,  access token id {}", id);
             putMsg(result, Status.ACCESS_TOKEN_NOT_EXIST);
+            return result;
+        }
+        // admin can operate all, non-admin can operate their own
+        if (accessToken.getUserId() != loginUser.getId() && !loginUser.getUserType().equals(UserType.ADMIN_USER)) {
+            putMsg(result, Status.USER_NO_OPERATION_PERM);
             return result;
         }
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.java
@@ -37,13 +37,13 @@ public interface AccessTokenMapper extends BaseMapper<AccessToken> {
      * access token page
      *
      * @param page page
-     * @param tokenIds tokenIds
+     * @param userId userId
      * @param userName userName
      * @return access token Ipage
      */
     IPage<AccessToken> selectAccessTokenPage(Page page,
-                                             @Param("ids") List<Integer> tokenIds,
-                                             @Param("userName") String userName
+                                             @Param("userName") String userName,
+                                             @Param("userId") int userId
     );
 
     /**

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
@@ -26,11 +26,8 @@
         <if test="userName != null and userName != ''">
             and u.user_name like concat ('%', #{userName}, '%')
         </if>
-        <if test="ids != null and ids.size() > 0">
-            and t.id  in
-            <foreach item="id" index="index" collection="ids" open="(" separator="," close=")">
-                #{id}
-            </foreach>
+        <if test="userId != 0">
+            and t.user_id = #{userId}
         </if>
         order by t.update_time desc
     </select>

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
@@ -26,15 +26,12 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
-import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.BaseDaoTest;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
@@ -87,7 +87,6 @@ public class AccessTokenMapperTest extends BaseDaoTest {
         Assert.assertEquals(insertCount, deleteCount);
     }
 
-
     /**
      * test select by id
      *

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
@@ -141,8 +141,7 @@ public class AccessTokenMapperTest extends BaseDaoTest {
         Map<Integer, AccessToken> accessTokenMap = createAccessTokens(count, userName);
 
         Page page = new Page(offset, size);
-        List<Integer> tokenIds = accessTokenMap.values().stream().map(AccessToken::getId).collect(Collectors.toList());
-        IPage<AccessToken> accessTokenPage = accessTokenMapper.selectAccessTokenPage(page, tokenIds, userName);
+        IPage<AccessToken> accessTokenPage = accessTokenMapper.selectAccessTokenPage(page, userName, 0);
 
         assertEquals(Integer.valueOf(accessTokenPage.getRecords().size()), size);
 

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapperTest.java
@@ -26,13 +26,17 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.BaseDaoTest;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -139,16 +143,26 @@ public class AccessTokenMapperTest extends BaseDaoTest {
         Integer size = 2;
 
         Map<Integer, AccessToken> accessTokenMap = createAccessTokens(count, userName);
+        Set<Integer> userIds = accessTokenMap.values().stream().map(AccessToken::getUserId).collect(Collectors.toSet());
+        Integer createTokenUserId = new ArrayList<>(userIds).get(0);
 
+        // general user and create token user
         Page page = new Page(offset, size);
-        IPage<AccessToken> accessTokenPage = accessTokenMapper.selectAccessTokenPage(page, userName, 0);
-
+        IPage<AccessToken> accessTokenPage = accessTokenMapper.selectAccessTokenPage(page, userName, createTokenUserId);
         assertEquals(Integer.valueOf(accessTokenPage.getRecords().size()), size);
 
-        for (AccessToken accessToken : accessTokenPage.getRecords()) {
+        // admin user
+        IPage<AccessToken> adminAccessTokenPage = accessTokenMapper.selectAccessTokenPage(page, userName, 0);
+        assertEquals(Integer.valueOf(adminAccessTokenPage.getRecords().size()), size);
+        for (AccessToken accessToken : adminAccessTokenPage.getRecords()) {
             AccessToken resultAccessToken = accessTokenMap.get(accessToken.getId());
             assertEquals(accessToken, resultAccessToken);
         }
+
+        // general user
+        Integer emptySize = 0;
+        IPage<AccessToken> generalAccessTokenPage = accessTokenMapper.selectAccessTokenPage(page, userName, 1);
+        assertEquals(Integer.valueOf(generalAccessTokenPage.getRecords().size()), emptySize);
     }
 
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

AccessToken can only be used by the creator.

## Brief change log

close #11031 

## Verify this pull request

Manually verified the change by testing locally.
