### PR TITLE
[ci] Make cluster test work on release branch

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -93,7 +93,7 @@ jobs:
         name: Upload Binary Package
         with:
           name: binary-package-${{ matrix.java }}
-          path: ./dolphinscheduler-dist/target/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz
+          path: ./dolphinscheduler-dist/target/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz
           retention-days: 1
   cluster-test:
     name: ${{ matrix.case.name }}

--- a/.github/workflows/cluster-test/mysql/Dockerfile
+++ b/.github/workflows/cluster-test/mysql/Dockerfile
@@ -20,11 +20,11 @@ FROM openjdk:8-jre-slim-buster
 RUN apt update ; \
     apt install -y curl wget default-mysql-client sudo openssh-server netcat-traditional ;
 
-#COPY ./dolphinscheduler-dist/target/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz /root/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz
-COPY ./apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz /root/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz
-RUN tar -zxvf /root/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz -C ~
+#COPY ./dolphinscheduler-dist/target/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz /root
+COPY ./apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz /root
+RUN tar -zxvf /root/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz -C ~
 
-ENV DOLPHINSCHEDULER_HOME /root/apache-dolphinscheduler-dev-SNAPSHOT-bin
+ENV DOLPHINSCHEDULER_HOME /root/apache-dolphinscheduler-*-SNAPSHOT-bin
 
 #Setting install.sh
 COPY .github/workflows/cluster-test/mysql/install_env.sh $DOLPHINSCHEDULER_HOME/bin/env/install_env.sh

--- a/.github/workflows/cluster-test/mysql/deploy.sh
+++ b/.github/workflows/cluster-test/mysql/deploy.sh
@@ -19,7 +19,7 @@ set -euox pipefail
 
 
 USER=root
-DOLPHINSCHEDULER_HOME=/root/apache-dolphinscheduler-dev-SNAPSHOT-bin
+DOLPHINSCHEDULER_HOME=/root/apache-dolphinscheduler-*-SNAPSHOT-bin
 
 #Create database
 mysql -hmysql -P3306 -uroot -p123456 -e "CREATE DATABASE IF NOT EXISTS dolphinscheduler DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"

--- a/.github/workflows/cluster-test/mysql/install_env.sh
+++ b/.github/workflows/cluster-test/mysql/install_env.sh
@@ -50,7 +50,7 @@ apiServers=${apiServers:-"localhost"}
 
 # The directory to install DolphinScheduler for all machine we config above. It will automatically be created by `install.sh` script if not exists.
 # Do not set this configuration same as the current path (pwd)
-installPath=${installPath:-"/root/apache-dolphinscheduler-dev-SNAPSHOT-bin"}
+installPath=${installPath:-"/root/apache-dolphinscheduler-*-SNAPSHOT-bin"}
 
 # The user to deploy DolphinScheduler for all machine we config above. For now user must create by yourself before running `install.sh`
 # script. The user needs to have sudo privileges and permissions to operate hdfs. If hdfs is enabled than the root directory needs

--- a/.github/workflows/cluster-test/mysql/running_test.sh
+++ b/.github/workflows/cluster-test/mysql/running_test.sh
@@ -45,7 +45,7 @@ do
   fi
 
   if [[ $i -eq $TIMEOUT ]];then
-    docker exec -u root ds bash -c "cat /root/apache-dolphinscheduler-dev-SNAPSHOT-bin/master-server/logs/dolphinscheduler-master.log"
+    docker exec -u root ds bash -c "cat /root/apache-dolphinscheduler-*-SNAPSHOT-bin/master-server/logs/dolphinscheduler-master.log"
     echo "cluster start health check failed"
     exit $START_HEALTHCHECK_EXITCODE
   fi
@@ -54,7 +54,7 @@ do
 done
 
 #Stop Cluster
-docker exec -u root ds bash -c "/root/apache-dolphinscheduler-dev-SNAPSHOT-bin/bin/stop-all.sh"
+docker exec -u root ds bash -c "/root/apache-dolphinscheduler-*-SNAPSHOT-bin/bin/stop-all.sh"
 
 #Cluster stop health check
 sleep 5

--- a/.github/workflows/cluster-test/postgresql/Dockerfile
+++ b/.github/workflows/cluster-test/postgresql/Dockerfile
@@ -20,11 +20,11 @@ FROM openjdk:8-jre-slim-buster
 RUN apt update ; \
     apt install -y curl wget sudo openssh-server netcat-traditional ;
 
-#COPY ./dolphinscheduler-dist/target/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz /root/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz
-COPY ./apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz /root/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz
-RUN tar -zxvf /root/apache-dolphinscheduler-dev-SNAPSHOT-bin.tar.gz -C ~
+#COPY ./dolphinscheduler-dist/target/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz /root
+COPY ./apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz /root
+RUN tar -zxvf /root/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz -C ~
 
-ENV DOLPHINSCHEDULER_HOME /root/apache-dolphinscheduler-dev-SNAPSHOT-bin
+ENV DOLPHINSCHEDULER_HOME /root/apache-dolphinscheduler-*-SNAPSHOT-bin
 
 #Setting install.sh
 COPY .github/workflows/cluster-test/postgresql/install_env.sh $DOLPHINSCHEDULER_HOME/bin/env/install_env.sh

--- a/.github/workflows/cluster-test/postgresql/deploy.sh
+++ b/.github/workflows/cluster-test/postgresql/deploy.sh
@@ -19,7 +19,7 @@ set -euox pipefail
 
 
 USER=root
-DOLPHINSCHEDULER_HOME=/root/apache-dolphinscheduler-dev-SNAPSHOT-bin
+DOLPHINSCHEDULER_HOME=/root/apache-dolphinscheduler-*-SNAPSHOT-bin
 
 #Sudo
 sed -i '$a'$USER'  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers

--- a/.github/workflows/cluster-test/postgresql/install_env.sh
+++ b/.github/workflows/cluster-test/postgresql/install_env.sh
@@ -50,7 +50,7 @@ apiServers=${apiServers:-"localhost"}
 
 # The directory to install DolphinScheduler for all machine we config above. It will automatically be created by `install.sh` script if not exists.
 # Do not set this configuration same as the current path (pwd)
-installPath=${installPath:-"/root/apache-dolphinscheduler-dev-SNAPSHOT-bin"}
+installPath=${installPath:-"/root/apache-dolphinscheduler-*-SNAPSHOT-bin"}
 
 # The user to deploy DolphinScheduler for all machine we config above. For now user must create by yourself before running `install.sh`
 # script. The user needs to have sudo privileges and permissions to operate hdfs. If hdfs is enabled than the root directory needs

--- a/.github/workflows/cluster-test/postgresql/running_test.sh
+++ b/.github/workflows/cluster-test/postgresql/running_test.sh
@@ -45,7 +45,7 @@ do
   fi
 
   if [[ $i -eq $TIMEOUT ]];then
-    docker exec -u root ds bash -c "cat /root/apache-dolphinscheduler-dev-SNAPSHOT-bin/master-server/logs/dolphinscheduler-master.log"
+    docker exec -u root ds bash -c "cat /root/apache-dolphinscheduler-*-SNAPSHOT-bin/master-server/logs/dolphinscheduler-master.log"
     echo "cluster start health check failed"
     exit $START_HEALTHCHECK_EXITCODE
   fi
@@ -54,7 +54,7 @@ do
 done
 
 #Stop Cluster
-docker exec -u root ds bash -c "/root/apache-dolphinscheduler-dev-SNAPSHOT-bin/bin/stop-all.sh"
+docker exec -u root ds bash -c "/root/apache-dolphinscheduler-*-SNAPSHOT-bin/bin/stop-all.sh"
 
 #Cluster stop health check
 sleep 5


### PR DESCRIPTION
When I try to release the 3.0.0 on branch `3.0.0-prepare`,
I find out cluster-test error due to version change of
tarball, I think we should make cluster test work on both
dev and prepare release branch, so I add this patch
