### PR TITLE
[Improvement-11074]Add generated annotation to Lombok generated codes to make the code coverage results of Sonar more meaningful

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

To exclude the `Lombok` generated code during the coverage tests and make the code coverage results of `Sonar` more meaningful.
#11074 

## Brief change log

add a `lombok.config` file in the root of the project and add the config below:
```
lombok.addLombokGeneratedAnnotation = true
```
which makes Lombok to add @lombok.Generated annotation to all generated methods so that Jacoco will automatically ignore the lombok auto generated code.

Ref:
https://community.sonarsource.com/t/getting-meaningful-coverage-results-in-sonarqube-when-using-jacoco-and-lombok/13821

https://projectlombok.org/features/configuration

And here is an example provided by @kezhenxu94 :
https://github.com/apache/skywalking/blob/master/lombok.config

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.