### PR TITLE
[Improvement-11291][sql] Improvement the log output while executing multiple sql statements

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -302,6 +302,7 @@ public class SqlTask extends AbstractTaskExecutor {
     private String executeUpdate(Connection connection, List<SqlBinds> statementsBinds, String handlerType) throws Exception {
         int result = 0;
         for (SqlBinds sqlBind : statementsBinds) {
+            logger.info("{} statement execute update query, for sql: {}", handlerType, sqlBind.getSql());
             try (PreparedStatement statement = prepareStatementAndBind(connection, sqlBind)) {
                 result = statement.executeUpdate();
                 logger.info("{} statement execute update result: {}, for sql: {}", handlerType, result, sqlBind.getSql());
@@ -365,7 +366,6 @@ public class SqlTask extends AbstractTaskExecutor {
                     ParameterUtils.setInParameter(entry.getKey(), stmt, prop.getType(), prop.getValue());
                 }
             }
-            logger.info("prepare statement replace sql : {} ", stmt);
             return stmt;
         } catch (Exception exception) {
             throw new TaskException("SQL task prepareStatementAndBind error", exception);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -293,7 +293,6 @@ public class SqlTask extends AbstractTaskExecutor {
 
     private String executeQuery(Connection connection, SqlBinds sqlBinds, String handlerType) throws Exception {
         try (PreparedStatement statement = prepareStatementAndBind(connection, sqlBinds)) {
-            logger.info("{} statement execute query, for sql: {}", handlerType, sqlBinds.getSql());
             ResultSet resultSet = statement.executeQuery();
             return resultProcess(resultSet);
         }
@@ -302,7 +301,6 @@ public class SqlTask extends AbstractTaskExecutor {
     private String executeUpdate(Connection connection, List<SqlBinds> statementsBinds, String handlerType) throws Exception {
         int result = 0;
         for (SqlBinds sqlBind : statementsBinds) {
-            logger.info("{} statement execute update query, for sql: {}", handlerType, sqlBind.getSql());
             try (PreparedStatement statement = prepareStatementAndBind(connection, sqlBind)) {
                 result = statement.executeUpdate();
                 logger.info("{} statement execute update result: {}, for sql: {}", handlerType, result, sqlBind.getSql());
@@ -366,6 +364,7 @@ public class SqlTask extends AbstractTaskExecutor {
                     ParameterUtils.setInParameter(entry.getKey(), stmt, prop.getType(), prop.getValue());
                 }
             }
+            logger.info("prepare statement replace sql : {}, sql parameters : {}", sqlBinds.getSql(), sqlBinds.getParamsMap());
             return stmt;
         } catch (Exception exception) {
             throw new TaskException("SQL task prepareStatementAndBind error", exception);


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Currently, the log does not output the currently executing sql statement while executing multiple sql statements.

Also, the log output in the `prepareStatementAndBind()` is kind of odd:

For example, as for multiple mysql statements, it outputs
```
[INFO] 2022-08-04 05:56:57.774 +0000 [taskAppId=TASK-20220804-6410011658368_11-73-78] TaskLogLogger-class org.apache.dolphinscheduler.plugin.task.sql.SqlTask:[367] - prepare statement replace sql : HikariProxyPreparedStatement@1694477678 wrapping com.mysql.cj.jdbc.ClientPreparedStatement: 
insert into student values ('Ton', 18); 
```

which can output the sql statement.

However, as for multiple hive statements, it outputs
```
[INFO] 2022-08-04 05:41:58.610 +0000 [taskAppId=TASK-20220804-6418931330048_7-72-77] TaskLogLogger-class org.apache.dolphinscheduler.plugin.task.sql.SqlTask:[367] - prepare statement replace sql : HikariProxyPreparedStatement@894649176 wrapping org.apache.hive.jdbc.HivePreparedStatement@4041a5d6
```

which can not output the current sql statement since `toString()` is not implemented in the class `HivePreparedStatement`.


So why don't we just delete the log output in the `prepareStatementAndBind()` and add the log output in the `executeUpdate()` 

close #11291

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

