### PR TITLE
[Fix-11249] No-admin user query alert group fix.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -433,7 +433,8 @@ public class ResourcePermissionCheckServiceImpl implements ResourcePermissionChe
 
         @Override
         public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
-            return alertGroupMapper.listAuthorizedAlertGroupList(userId, null).stream().map(AlertGroup::getId).collect(toSet());
+            List<AlertGroup> alertGroupList = alertGroupMapper.queryAllGroupList();
+            return alertGroupList.stream().map(AlertGroup::getId).collect(toSet());
         }
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

1. Non-admin users can also query the alarm group info.
2. Checked other data resource modules.

Currently there are several issues:

1. Non-admin users have no right to access other pages in the Security Center except AccessToken.
2. Some data resource modules cannot be used by non-admin users. For example, WorkerGroup has only one default
3. It is recommended to establish a unified resource authorization mechanism in DS, increase authorization for unauthorized resources, and unified management after the transformation of authorization before projects and data sources.


## Brief change log

related #11249 

## Verify this pull request

Manually verified the change by testing locally.
