### PR TITLE
[community] Remove stackoverflow ref link in website

### DIFF
--- a/docs/configs/site.js
+++ b/docs/configs/site.js
@@ -129,6 +129,12 @@ export default {
       content: 'Do you need feedback? Please contact us through the following ways.',
       list: [
         {
+          name: 'Slack',
+          img1: '/img/slack.png',
+          img2: '/img/slack-selected.png',
+          link: 'https://s.apache.org/dolphinscheduler-slack',
+        },
+        {
           name: 'Email List',
           img1: '/img/emailgray.png',
           img2: '/img/emailblue.png',
@@ -140,21 +146,9 @@ export default {
           img2: '/img/twitterblue.png',
           link: 'https://twitter.com/dolphinschedule',
         },
-        {
-          name: 'Stack Overflow',
-          img1: '/img/stackoverflow.png',
-          img2: '/img/stackoverflow-selected.png',
-          link: 'https://stackoverflow.com/questions/tagged/apache-dolphinscheduler',
-        },
-        {
-          name: 'Slack',
-          img1: '/img/slack.png',
-          img2: '/img/slack-selected.png',
-          link: 'https://s.apache.org/dolphinscheduler-slack',
-        },
       ],
     },
-    copyright: 'Copyright © 2019-2021 The Apache Software Foundation. Apache DolphinScheduler, DolphinScheduler, and its feather logo are trademarks of The Apache Software Foundation.',
+    copyright: 'Copyright © 2019-2022 The Apache Software Foundation. Apache DolphinScheduler, DolphinScheduler, and its feather logo are trademarks of The Apache Software Foundation.',
   },
   'zh-cn': {
     banner: {
@@ -260,6 +254,12 @@ export default {
       content: '有问题需要反馈？请通过以下方式联系我们。',
       list: [
         {
+          name: 'Slack',
+          img1: '/img/slack.png',
+          img2: '/img/slack-selected.png',
+          link: 'https://s.apache.org/dolphinscheduler-slack',
+        },
+        {
           name: '邮件列表',
           img1: '/img/emailgray.png',
           img2: '/img/emailblue.png',
@@ -271,20 +271,8 @@ export default {
           img2: '/img/twitterblue.png',
           link: 'https://twitter.com/dolphinschedule',
         },
-        {
-          name: 'Stack Overflow',
-          img1: '/img/stackoverflow.png',
-          img2: '/img/stackoverflow-selected.png',
-          link: 'https://stackoverflow.com/questions/tagged/apache-dolphinscheduler',
-        },
-        {
-          name: 'Slack',
-          img1: '/img/slack.png',
-          img2: '/img/slack-selected.png',
-          link: 'https://s.apache.org/dolphinscheduler-slack',
-        },
       ],
     },
-    copyright: 'Copyright © 2019-2021 The Apache Software Foundation. Apache DolphinScheduler, DolphinScheduler, and its feather logo are trademarks of The Apache Software Foundation.',
+    copyright: 'Copyright © 2019-2022 The Apache Software Foundation. Apache DolphinScheduler, DolphinScheduler, and its feather logo are trademarks of The Apache Software Foundation.',
   },
 };

--- a/docs/docs/en/contribute/have-questions.md
+++ b/docs/docs/en/contribute/have-questions.md
@@ -1,45 +1,22 @@
 # Have Questions?
 
-## StackOverflow
+## Slack
 
-For usage questions, it is recommended you use the StackOverflow tag [apache-dolphinscheduler](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) as it is an active forum for DolphinScheduler users’ questions and answers.
+Chat rooms are great for quick questions or discussions on specialized topics.
 
-Some quick tips when using StackOverflow:
+The following chat rooms are officially part of Apache DolphinScheduler:
 
-- Prior to asking submitting questions, please:
-  - Search StackOverflow’s [apache-dolphinscheduler](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) tag to see if your question has already been answered
-- Please follow the StackOverflow [code of conduct](https://stackoverflow.com/help/how-to-ask)
-- Always use the apache-dolphinscheduler tag when asking questions
-- Please do not cross-post between [StackOverflow](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) and [GitHub issues](https://github.com/apache/dolphinscheduler/issues/new/choose)
+​	The Slack workspace URL: http://asf-dolphinscheduler.slack.com/.
 
-Question template:
+​	You can join through invitation url: https://s.apache.org/dolphinscheduler-slack.
 
-> **Describe the question**
->
-> A clear and concise description of what the question is.
->
-> **Which version of DolphinScheduler:**
->
->  -[1.3.0-preview]
->
-> **Additional context**
->
-> Add any other context about the problem here.
->
-> **Requirement or improvement**
->
-> \- Please describe about your requirements or improvement suggestions.
-
-For broad, opinion based, ask for external resources, debug issues, bugs, contributing to the project, and scenarios, it is recommended you use the[ GitHub issues ](https://github.com/apache/dolphinscheduler/issues/new/choose)or dev@dolphinscheduler.apache.org mailing list.
+This chat room is used for questions and discussions related to using DolphinScheduler.
 
 ## Mailing Lists
 
 - [dev@dolphinscheduler.apache.org](https://lists.apache.org/list.html?dev@dolphinscheduler.apache.org) is for people who want to contribute code to DolphinScheduler. [(subscribe)](mailto:dev-subscribe@dolphinscheduler.apache.org?subject=(send%20this%20email%20to%20subscribe)) [(unsubscribe)](mailto:dev-unsubscribe@dolphinscheduler.apache.org?subject=(send%20this%20email%20to%20unsubscribe)) [(archives)](http://lists.apache.org/list.html?dev@dolphinscheduler.apache.org)
 
 Some quick tips when using email:
-
-- Prior to asking submitting questions, please:
-  - Search StackOverflow at [apache-dolphinscheduler](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) to see if your question has already been answered
 
 - Tagging the subject line of your email will help you get a faster response, e.g. [api-server]: How to get open api interface?
 
@@ -49,17 +26,3 @@ Some quick tips when using email:
   - Scenario: Debug, How-to
 
 - For error logs or long code examples, please use [GitHub gist](https://gist.github.com/) and include only a few lines of the pertinent code / log within the email.
-
-## Chat Rooms
-
-Chat rooms are great for quick questions or discussions on specialized topics. 
-
-The following chat rooms are officially part of Apache DolphinScheduler:
-
-​	The Slack workspace URL: http://asf-dolphinscheduler.slack.com/.
-
-​	You can join through invitation url: https://s.apache.org/dolphinscheduler-slack. 
-
-This chat room is used for questions and discussions related to using DolphinScheduler.
-
- 

--- a/docs/docs/zh/contribute/have-questions.md
+++ b/docs/docs/zh/contribute/have-questions.md
@@ -1,56 +1,6 @@
 # 当你遇到问题时
 
-## StackOverflow
-
-如果在使用上有疑问，建议你使用StackOverflow标签 [apache-dolphinscheduler](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler)，这是一个DolphinScheduler用户问答的活跃论坛。
-
-使用StackOverflow时的快速提示：
-
-- 在提交问题之前：
-  - 在StackOverflow的 [apache-dolphinscheduler](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) 标签下进行搜索，看看你的问题是否已经被回答。
-
-- 请遵守StackOverflow的[行为准则](https://stackoverflow.com/help/how-to-ask)
-
-- 提出问题时，请务必使用apache-dolphinscheduler标签。
-
-- 请不要在 [StackOverflow](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) 和 [GitHub issues](https://github.com/apache/dolphinscheduler/issues/new/choose)之间交叉发帖。
-
-提问模板:
-
-> **Describe the question**
->
-> 对问题的内容进行清晰、简明的描述。
->
-> **Which version of DolphinScheduler:**
->
->  -[1.3.0-preview]
->
-> **Additional context**
->
-> 在此添加关于该问题的其他背景。
->
-> **Requirement or improvement**
->
-> 在此描述您的要求或改进建议。
-
-如果你的问题较为宽泛、有意见或建议、期望请求外部资源，或是有项目调试、bug提交等相关问题，或者想要对项目做出贡献、对场景进行讨论，建议你提交[ GitHub issues ](https://github.com/apache/dolphinscheduler/issues/new/choose)或使用dev@dolphinscheduler.apache.org 邮件列表进行讨论。
-
-## 邮件列表
-
-- [dev@dolphinscheduler.apache.org](https://lists.apache.org/list.html?dev@dolphinscheduler.apache.org) 是为那些想为DolphinScheduler贡献代码的人准备的。 [(订阅)](mailto:dev-subscribe@dolphinscheduler.apache.org?subject=(send%20this%20email%20to%20subscribe)) [(退订)](mailto:dev-unsubscribe@dolphinscheduler.apache.org?subject=(send%20this%20email%20to%20unsubscribe)) [(存档)](http://lists.apache.org/list.html?dev@dolphinscheduler.apache.org)
-
-使用电子邮件时的一些快速提示：
-
-- 在提出问题之前：
-  - 请在StackOverflow的 [apache-dolphinscheduler](https://stackoverflow.com/questions/tagged/apache-dolphinscheduler) 标签下进行搜索，看看你的问题是否已经被回答。
-- 在你的邮件的主题栏里加上标签会帮助你得到更快的回应，例如：[ApiServer]：如何获得开放的api接口？
-- 可以通过以下标签定义你的主题。
-  - 组件相关：MasterServer、ApiServer、WorkerServer、AlertServer等等。
-  - 级别：Beginner、Intermediate、Advanced
-  - 场景相关：Debug,、How-to
-- 如果内容包括错误日志或长代码，请使用 [GitHub gist](https://gist.github.com/)，并在邮件中只附加相关代码/日志的几行。
-
-## Chat Rooms
+## Slack
 
 聊天室是快速提问或讨论具体话题的好地方。
 
@@ -58,8 +8,19 @@
 
 ​	Slack工作区的网址：http://asf-dolphinscheduler.slack.com/
 
-​	你可以通过该邀请链接加入：https://s.apache.org/dolphinscheduler-slack 
+​	你可以通过该邀请链接加入：https://s.apache.org/dolphinscheduler-slack
 
 此聊天室用于与DolphinScheduler使用相关的问题讨论。
 
- 
+## 邮件列表
+
+- [dev@dolphinscheduler.apache.org](https://lists.apache.org/list.html?dev@dolphinscheduler.apache.org) 是为那些想为DolphinScheduler贡献代码的人准备的。 [(订阅)](mailto:dev-subscribe@dolphinscheduler.apache.org?subject=(send%20this%20email%20to%20subscribe)) [(退订)](mailto:dev-unsubscribe@dolphinscheduler.apache.org?subject=(send%20this%20email%20to%20unsubscribe)) [(存档)](http://lists.apache.org/list.html?dev@dolphinscheduler.apache.org)
+
+使用电子邮件时的一些快速提示：
+
+- 在你的邮件的主题栏里加上标签会帮助你得到更快的回应，例如：[ApiServer]：如何获得开放的api接口？
+- 可以通过以下标签定义你的主题。
+  - 组件相关：MasterServer、ApiServer、WorkerServer、AlertServer等等。
+  - 级别：Beginner、Intermediate、Advanced
+  - 场景相关：Debug,、How-to
+- 如果内容包括错误日志或长代码，请使用 [GitHub gist](https://gist.github.com/)，并在邮件中只附加相关代码/日志的几行。


### PR DESCRIPTION
* Our community do not have official support for stack overflow any more
* Change the order side for Slack and mailing list, to avoid some users
  just want to ask question but join mailing list, and then unsubscribe
  found there are too many emails in mailing list
