### PR TITLE
[Fix-11366][UI] Workflow instance should not support right-click running

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/dag-context-menu.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/dag-context-menu.tsx
@@ -26,6 +26,10 @@ import { IWorkflowTaskInstance } from './types'
 import { NButton } from 'naive-ui'
 
 const props = {
+  startButtonDisplay: {
+    type: Boolean as PropType<boolean>,
+    default: true
+  },
   startReadonly: {
     type: Boolean as PropType<boolean>,
     default: false
@@ -127,13 +131,15 @@ export default defineComponent({
           class={styles['dag-context-menu']}
           style={{ left: `${this.left}px`, top: `${this.top}px` }}
         >
-          <NButton
-            class={`${styles['menu-item']}`}
-            disabled={this.startReadonly}
-            onClick={this.startRunning}
-          >
-            {t('project.node.start')}
-          </NButton>
+          {this.startButtonDisplay && (
+            <NButton
+              class={`${styles['menu-item']}`}
+              disabled={this.startReadonly}
+              onClick={this.startRunning}
+            >
+              {t('project.node.start')}
+            </NButton>)
+          }
           <NButton
             class={`${styles['menu-item']}`}
             disabled={this.menuReadonly}

--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx
@@ -362,6 +362,7 @@ export default defineComponent({
           onCancel={taskCancel}
         />
         <ContextMenuItem
+          startButtonDisplay={!props.instance}
           startReadonly={startReadonly.value}
           menuReadonly={menuReadonly.value}
           taskInstance={taskInstance.value}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
Workflow instance should not support right-click running but it support now, the pr will fix this
close #11366 

## Brief change log
Removed start support in the menu of workflow instances

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

