### PR TITLE
[Feature-10117][UI] Hide node execution when start from the workflow definition list page

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -23,9 +23,11 @@ import {
   onMounted,
   ref,
   watch,
-  getCurrentInstance
+  getCurrentInstance,
+  computed
 } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from "vue-router"
 import Modal from '@/components/modal'
 import { useForm } from './use-form'
 import { useModal } from './use-modal'
@@ -74,6 +76,7 @@ export default defineComponent({
   setup(props, ctx) {
     const parallelismRef = ref(false)
     const { t } = useI18n()
+    const route = useRoute()
     const { startState } = useForm()
     const {
       variables,
@@ -144,6 +147,8 @@ export default defineComponent({
       }
     ]
 
+    const showTaskDependType = computed(() => route.name === 'workflow-definition-detail')
+
     const renderLabel = (option: any) => {
       return [
         h(
@@ -205,6 +210,7 @@ export default defineComponent({
 
     return {
       t,
+      showTaskDependType,
       parallelismRef,
       hideModal,
       handleStart,
@@ -224,7 +230,6 @@ export default defineComponent({
 
   render() {
     const { t } = this
-
     return (
       <Modal
         show={this.show}
@@ -255,18 +260,20 @@ export default defineComponent({
               </NSpace>
             </NRadioGroup>
           </NFormItem>
-          <NFormItem
-            label={t('project.workflow.node_execution')}
-            path='taskDependType'
-          >
-            <NRadioGroup v-model:value={this.startForm.taskDependType}>
-              <NSpace>
-                <NRadio value='TASK_POST'>{t('project.workflow.backward_execution')}</NRadio>
-                <NRadio value='TASK_PRE'>{t('project.workflow.forward_execution')}</NRadio>
-                <NRadio value='TASK_ONLY'>{t('project.workflow.current_node_execution')}</NRadio>
-              </NSpace>
-            </NRadioGroup>
-          </NFormItem>
+          {this.showTaskDependType && (
+            <NFormItem
+              label={t('project.workflow.node_execution')}
+              path='taskDependType'
+            >
+              <NRadioGroup v-model:value={this.startForm.taskDependType}>
+                <NSpace>
+                  <NRadio value='TASK_POST'>{t('project.workflow.backward_execution')}</NRadio>
+                  <NRadio value='TASK_PRE'>{t('project.workflow.forward_execution')}</NRadio>
+                  <NRadio value='TASK_ONLY'>{t('project.workflow.current_node_execution')}</NRadio>
+                </NSpace>
+              </NRadioGroup>
+            </NFormItem>)
+          }
           <NFormItem
             label={t('project.workflow.notification_strategy')}
             path='warningType'


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
Hide node execution when start from the workflow definition list page
relate #10117 
## Brief change log
* show node execution when start from the workflow definition detail page
* show node execution when start from the workflow instance detail page
* hide node execution when start from other page like the workflow definition list page
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

