### PR TITLE
[Improvement-11380][scp-host.sh] Set StrictHostKeyChecking=no option to ssh

### DIFF
--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -35,8 +35,8 @@ hostsArr=(${ips//,/ })
 for host in ${hostsArr[@]}
 do
 
-  if ! ssh -p $sshPort $host test -e $installPath; then
-    ssh -p $sshPort $host "sudo mkdir -p $installPath; sudo chown -R $deployUser:$deployUser $installPath"
+  if ! ssh -o StrictHostKeyChecking=no -p $sshPort $host test -e $installPath; then
+    ssh -o StrictHostKeyChecking=no -p $sshPort $host "sudo mkdir -p $installPath; sudo chown -R $deployUser:$deployUser $installPath"
   fi
 
   echo "scp dirs to $host/$installPath starting"

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -49,25 +49,25 @@ StateRunning="Running"
 mastersHost=(${masters//,/ })
 for master in ${mastersHost[@]}
 do
-  masterState=`ssh -p $sshPort $master  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status master-server;"`
+  masterState=`ssh -o StrictHostKeyChecking=no -p $sshPort $master  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status master-server;"`
   echo "$master  $masterState"
 done
 
 # 2.worker server check state
 for worker in ${workerNames[@]}
 do
-  workerState=`ssh -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server;"`
+  workerState=`ssh -o StrictHostKeyChecking=no -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server;"`
   echo "$worker  $workerState"
 done
 
 # 3.alter server check state
-alertState=`ssh -p $sshPort $alertServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status alert-server;"`
+alertState=`ssh -o StrictHostKeyChecking=no -p $sshPort $alertServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status alert-server;"`
 echo "$alertServer  $alertState"
 
 # 4.api server check state
 apiServersHost=(${apiServers//,/ })
 for apiServer in ${apiServersHost[@]}
 do
-  apiState=`ssh -p $sshPort $apiServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status api-server;"`
+  apiState=`ssh -o StrictHostKeyChecking=no -p $sshPort $apiServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status api-server;"`
   echo "$apiServer  $apiState"
 done


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This PR close: #11380 

Even if the password-free account is configured, when the user uses the scp-host.sh script to log in to the machine for the first time, an error (Host key verification failed.) may occur.

So set the ` -o StrictHostKeyChecking=no` option to ssh in `scp-hosts.sh`.

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.



