### PR TITLE
[fixed-11437]: date parse pattern match error

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
@@ -46,7 +46,7 @@ public class ParameterUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ParameterUtils.class);
 
-    private static final String DATE_PARSE_PATTERN = "\\$\\[([^\\$\\]]+)]";
+    private static final String DATE_PARSE_PATTERN = "\\$\\[(\\w+[^\\$\\]]+)]";
 
     private static final String DATE_START_PATTERN = "^[0-9]";
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
@@ -46,7 +46,7 @@ public class ParameterUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ParameterUtils.class);
 
-    private static final String DATE_PARSE_PATTERN = "\\$\\[(\\w++[^\\$\\]]+)]";
+    private static final String DATE_PARSE_PATTERN = "\\$\\[(\\w[^\\$\\]]+)]";
 
     private static final String DATE_START_PATTERN = "^[0-9]";
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
@@ -46,7 +46,7 @@ public class ParameterUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ParameterUtils.class);
 
-    private static final String DATE_PARSE_PATTERN = "\\$\\[(\\w+[^\\$\\]]+)]";
+    private static final String DATE_PARSE_PATTERN = "\\$\\[(\\w++[^\\$\\]]+)]";
 
     private static final String DATE_START_PATTERN = "^[0-9]";
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
@@ -125,9 +125,9 @@ public class ParameterUtilsTest {
         Assert.assertEquals("065901",
                 ParameterUtils.convertParameterPlaceholders("$[HHmmss-2/24/60]", params));
 
-        String sql = "select JSON_EXTRACT(json_val, CONCAT('$[', id - 1, '].input1') from test";
+        String sql = "select JSON_EXTRACT(json_val, CONCAT('$[', id - 1, '].input1')) from test";
         String sqlScript = ParameterUtils.convertParameterPlaceholders(sql, params);
-        Assert.assertEquals("select JSON_EXTRACT(json_val, CONCAT('$[', id - 1, '].input1') from test",
+        Assert.assertEquals("select JSON_EXTRACT(json_val, CONCAT('$[', id - 1, '].input1')) from test",
                 sqlScript);
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
@@ -49,4 +49,86 @@ public class ParameterUtilsTest {
         Assert.assertEquals(2, params2.size());
 
     }
+
+    @Test
+    public void testBasicBuiltInParameterPlaceholders() {
+        Map<String, String> params = new HashMap<>();
+        params.put("system.datetime", "20220812000000");
+        params.put("system.biz.curdate", "20220812");
+        params.put("system.biz.date", "20220811");
+        String content = "echo ${system.datetime}, ${system.biz.curdate}, ${system.biz.date}";
+        String script = ParameterUtils.convertParameterPlaceholders(content, params);
+        Assert.assertEquals("echo 20220812000000, 20220812, 20220811", script);
+    }
+
+    @Test
+    public void testExtendedBuiltInParameterPlaceholders() {
+        Map<String, String> params = new HashMap<>();
+        params.put("ds.params.1", "ds.params.value.1");
+        params.put("ds.params.2", "ds.params.value.2");
+        String content = "echo ds.params.1=${ds.params.1}, ds.params.2=${ds.params.2}";
+        String script = ParameterUtils.convertParameterPlaceholders(content, params);
+        Assert.assertEquals("echo ds.params.1=ds.params.value.1, ds.params.2=ds.params.value.2", script);
+    }
+
+    @Test
+    public void testExtendedBuiltInParameterPlaceholdersToBenchmarkVariable() {
+        Map<String, String> params = new HashMap<>();
+        params.put("system.datetime", "20220811070101");
+        String content = "$[yyyyMMddHHmmss] $[yyyyMMdd] $[HHmmss]";
+        String script = ParameterUtils.convertParameterPlaceholders(content, params);
+        Assert.assertEquals("20220811070101 20220811 070101", script);
+
+        Map<String, String> params2 = new HashMap<>();
+        params2.put("system.datetime", "20220811070101");
+        String content2 = "$[yyyy-MM-dd HH:mm:ss] $[yyyy-MM-dd] $[HH:mm:ss]";
+        String script2 = ParameterUtils.convertParameterPlaceholders(content2, params2);
+        Assert.assertEquals("2022-08-11 07:01:01 2022-08-11 07:01:01", script2);
+    }
+
+    @Test
+    public void testExtendedBuiltInParameterPlaceholders4() {
+        Map<String, String> params = new HashMap<>();
+        params.put("system.datetime", "20220811070101");
+        Assert.assertEquals("20230811",
+                ParameterUtils.convertParameterPlaceholders("$[add_months(yyyyMMdd,12*1)]", params));
+        Assert.assertEquals("2023-08-11",
+                ParameterUtils.convertParameterPlaceholders("$[add_months(yyyy-MM-dd,12*1)]", params));
+        Assert.assertEquals("20210811",
+                ParameterUtils.convertParameterPlaceholders("$[add_months(yyyyMMdd,-12*1)]", params));
+        Assert.assertEquals("20220911",
+                ParameterUtils.convertParameterPlaceholders("$[add_months(yyyyMMdd,1)]", params));
+        Assert.assertEquals("20220711",
+                ParameterUtils.convertParameterPlaceholders("$[add_months(yyyyMMdd,-1)]", params));
+
+        Assert.assertEquals("20220818",
+                ParameterUtils.convertParameterPlaceholders("$[yyyyMMdd+7*1]", params));
+        Assert.assertEquals("2022-08-18",
+                ParameterUtils.convertParameterPlaceholders("$[yyyy-MM-dd+7*1]", params));
+        Assert.assertEquals("20220804",
+                ParameterUtils.convertParameterPlaceholders("$[yyyyMMdd-7*1]", params));
+        Assert.assertEquals("20220812",
+                ParameterUtils.convertParameterPlaceholders("$[yyyyMMdd+1]", params));
+        Assert.assertEquals("20220810",
+                ParameterUtils.convertParameterPlaceholders("$[yyyyMMdd-1]", params));
+
+        Assert.assertEquals("090101",
+                ParameterUtils.convertParameterPlaceholders("$[HHmmss+2/24]", params));
+        Assert.assertEquals("09:01:01",
+                ParameterUtils.convertParameterPlaceholders("$[HH:mm:ss+2/24]", params));
+        Assert.assertEquals("09 01 01",
+                ParameterUtils.convertParameterPlaceholders("$[HH mm ss+2/24]", params));
+        Assert.assertEquals("050101",
+                ParameterUtils.convertParameterPlaceholders("$[HHmmss-2/24]", params));
+        Assert.assertEquals("070301",
+                ParameterUtils.convertParameterPlaceholders("$[HHmmss+2/24/60]", params));
+        Assert.assertEquals("065901",
+                ParameterUtils.convertParameterPlaceholders("$[HHmmss-2/24/60]", params));
+
+        String sql = "select JSON_EXTRACT(json_val, CONCAT('$[', id - 1, '].input1') from test";
+        String sqlScript = ParameterUtils.convertParameterPlaceholders(sql, params);
+        Assert.assertEquals("select JSON_EXTRACT(json_val, CONCAT('$[', id - 1, '].input1') from test",
+                sqlScript);
+    }
+
 }


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
closed #11437 

## Brief change log
- modify *dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java#DATE_PARSE_PATTERN*

## Verify this pull request

This change added tests and can be verified as follows:

*dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java*
- *Added testBasicBuiltInParameterPlaceholders to verify the change.*
- *Added testExtendedBuiltInParameterPlaceholders to verify the change.*
- *Added testExtendedBuiltInParameterPlaceholdersToBenchmarkVariable to verify the change.*
- *Added testExtendedBuiltInParameterPlaceholders4 to verify the change.*
