### PR TITLE
Set master's task running status in `runTask` to avoid the task group acquire failed, but the task status is in running

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/BlockingTaskProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/BlockingTaskProcessor.java
@@ -114,19 +114,21 @@ public class BlockingTaskProcessor extends BaseTaskProcessor {
             return false;
         }
         this.setTaskExecutionLogger();
-        initTaskParameters();
-        logger.info("blocking task start");
+        logger.info("blocking task submit success");
         return true;
     }
 
     @Override
     protected boolean runTask() {
+        logger.info("blocking task starting");
+        initTaskParameters();
         if (conditionResult.equals(DependResult.WAITING)) {
             setConditionResult();
             endTask();
         } else {
             endTask();
         }
+        logger.info("blocking task finished");
         return true;
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/ConditionTaskProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/ConditionTaskProcessor.java
@@ -67,19 +67,21 @@ public class ConditionTaskProcessor extends BaseTaskProcessor {
             return false;
         }
         this.setTaskExecutionLogger();
-        initTaskParameters();
-        logger.info("condition task start");
+        logger.info("condition task submit success");
         return true;
     }
 
     @Override
     public boolean runTask() {
+        initTaskParameters();
+        logger.info("condition task start");
         if (conditionResult.equals(DependResult.WAITING)) {
             setConditionResult();
             endTask();
         } else {
             endTask();
         }
+        logger.info("condition task finished");
         return true;
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/SwitchTaskProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/SwitchTaskProcessor.java
@@ -17,8 +17,9 @@
 
 package org.apache.dolphinscheduler.server.master.runner.task;
 
-import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SWITCH;
-
+import com.google.auto.service.AutoService;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
@@ -30,9 +31,6 @@ import org.apache.dolphinscheduler.plugin.task.api.parameters.SwitchParameters;
 import org.apache.dolphinscheduler.server.master.utils.SwitchTaskUtils;
 import org.apache.dolphinscheduler.server.utils.LogUtils;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -41,7 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.google.auto.service.AutoService;
+import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SWITCH;
 
 /**
  * switch task processor
@@ -65,6 +63,13 @@ public class SwitchTaskProcessor extends BaseTaskProcessor {
             return false;
         }
         this.setTaskExecutionLogger();
+        logger.info("switch task submit success");
+        return true;
+    }
+
+    @Override
+    public boolean runTask() {
+        logger.info("switch task starting");
         taskInstance.setLogPath(
                 LogUtils.getTaskLogPath(taskInstance.getFirstSubmitTime(), processInstance.getProcessDefinitionCode(),
                         processInstance.getProcessDefinitionVersion(),
@@ -74,21 +79,12 @@ public class SwitchTaskProcessor extends BaseTaskProcessor {
         taskInstance.setState(TaskExecutionStatus.RUNNING_EXECUTION);
         taskInstance.setStartTime(new Date());
         processService.updateTaskInstance(taskInstance);
-        return true;
-    }
 
-    @Override
-    public boolean runTask() {
-        try {
-            if (!this.taskInstance().getState().isFinished() && setSwitchResult()) {
-                endTaskState();
-            }
-        } catch (Exception e) {
-            logger.error("update work flow {} switch task {} state error:",
-                    this.processInstance.getId(),
-                    this.taskInstance.getId(),
-                    e);
+        if (!this.taskInstance().getState().isFinished()) {
+            setSwitchResult();
         }
+        endTaskState();
+        logger.info("switch task finished");
         return true;
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
