### PR TITLE
[Feature][Style] Enable spotless to manage imports

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-zeppelin/src/main/java/org/apache/dolphinscheduler/plugin/task/zeppelin/ZeppelinTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-zeppelin/src/main/java/org/apache/dolphinscheduler/plugin/task/zeppelin/ZeppelinTask.java
@@ -17,23 +17,24 @@
 
 package org.apache.dolphinscheduler.plugin.task.zeppelin;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import kong.unirest.Unirest;
-
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTaskExecutor;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
 import org.apache.dolphinscheduler.spi.utils.DateUtils;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
+
 import org.apache.zeppelin.client.ClientConfig;
 import org.apache.zeppelin.client.NoteResult;
 import org.apache.zeppelin.client.ParagraphResult;
 import org.apache.zeppelin.client.Status;
 import org.apache.zeppelin.client.ZeppelinClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import kong.unirest.Unirest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-zeppelin/src/main/java/org/apache/dolphinscheduler/plugin/task/zeppelin/ZeppelinTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-zeppelin/src/main/java/org/apache/dolphinscheduler/plugin/task/zeppelin/ZeppelinTask.java
@@ -17,8 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.task.zeppelin;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import kong.unirest.Unirest;
+
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTaskExecutor;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
@@ -30,10 +34,8 @@ import org.apache.zeppelin.client.NoteResult;
 import org.apache.zeppelin.client.ParagraphResult;
 import org.apache.zeppelin.client.Status;
 import org.apache.zeppelin.client.ZeppelinClient;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ZeppelinTask extends AbstractTaskExecutor {
 
@@ -51,7 +53,6 @@ public class ZeppelinTask extends AbstractTaskExecutor {
      * zeppelin api client
      */
     private ZeppelinClient zClient;
-
 
     /**
      * constructor
@@ -121,7 +122,8 @@ public class ZeppelinTask extends AbstractTaskExecutor {
 
                 resultContent = resultContentBuilder.toString();
             } else {
-                final ParagraphResult paragraphResult = this.zClient.executeParagraph(noteId, paragraphId, zeppelinParamsMap);
+                final ParagraphResult paragraphResult =
+                        this.zClient.executeParagraph(noteId, paragraphId, zeppelinParamsMap);
                 resultContent = paragraphResult.getResultInText();
                 status = paragraphResult.getStatus();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <description>Dolphin Scheduler is a distributed and easy-to-expand visual DAG workflow scheduling system, dedicated
         to solving the complex dependencies in data processing, making the scheduling system out of the box for data
         processing.</description>
-    
+
     <modules>
         <module>dolphinscheduler-bom</module>
         <module>dolphinscheduler-alert</module>
@@ -58,7 +58,7 @@
         <module>dolphinscheduler-ui</module>
         <module>dolphinscheduler-scheduler-plugin</module>
     </modules>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -91,11 +91,11 @@
         <docker.tag>${project.version}</docker.tag>
         <docker.build.skip>true</docker.build.skip>
         <docker.push.skip>true</docker.push.skip>
-        
+
         <python.sign.skip>true</python.sign.skip>
         <skipDepCheck>true</skipDepCheck>
     </properties>
-    
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -173,13 +173,13 @@
                 <artifactId>dolphinscheduler-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-data-quality</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-python</artifactId>
@@ -260,7 +260,7 @@
                 <artifactId>dolphinscheduler-registry-mysql</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-scheduler-api</artifactId>
@@ -271,7 +271,7 @@
                 <artifactId>dolphinscheduler-scheduler-quartz</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-datasource-all</artifactId>
@@ -282,7 +282,7 @@
                 <artifactId>dolphinscheduler-datasource-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-task-api</artifactId>
@@ -298,7 +298,7 @@
                 <artifactId>dolphinscheduler-task-all</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-ui</artifactId>
@@ -310,9 +310,9 @@
                 <version>${project.version}</version>
             </dependency>
         </dependencies>
-        
+
     </dependencyManagement>
-    
+
     <dependencies>
         <!--
           NOTE: only development / test phase dependencies (scope = test / provided)
@@ -370,7 +370,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -380,7 +380,7 @@
                     <version>${rpm-maven-plugion.version}</version>
                     <inherited>false</inherited>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -392,7 +392,7 @@
                         <testTarget>${java.version}</testTarget>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
@@ -401,13 +401,13 @@
                         <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>${maven-assembly-plugin.version}</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -417,7 +417,7 @@
                         <failOnError>false</failOnError>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
@@ -512,7 +512,7 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        
+
         <plugins>
             <plugin>
                 <groupId>org.owasp</groupId>
@@ -554,7 +554,7 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -584,7 +584,7 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            
+
             <!-- jenkins plugin jacoco report-->
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -648,13 +648,22 @@
                         <eclipse>
                             <file>style/spotless_dolphinscheduler_formatter.xml</file>
                         </eclipse>
+                        <removeUnusedImports />
+                        <importOrder>
+                            <file>style/eclipse.importorder</file>
+                        </importOrder>
+                        <replaceRegex>
+                            <name>Remove wildcard imports</name>
+                            <searchRegex>import\s+[^\*\s]+\*;(\r\n|\r|\n)</searchRegex>
+                            <replacement>$1</replacement>
+                        </replaceRegex>
                     </java>
                     <pom>
                         <sortPom>
                             <encoding>UTF-8</encoding>
                             <nrOfIndentSpace>4</nrOfIndentSpace>
                             <keepBlankLines>true</keepBlankLines>
-                            <indentBlankLines>true</indentBlankLines>
+                            <indentBlankLines>false</indentBlankLines>
                             <indentSchemaLocation>true</indentSchemaLocation>
                             <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                             <sortModules>false</sortModules>
@@ -747,7 +756,7 @@
         <url>https://github.com/apache/dolphinscheduler</url>
         <tag>HEAD</tag>
     </scm>
-    
+
     <profiles>
         <profile>
             <id>docker</id>

--- a/style/eclipse.importorder
+++ b/style/eclipse.importorder
@@ -1,0 +1,5 @@
+#Organize Import Order
+0=java
+1=javax
+2=org
+3=com

--- a/style/eclipse.importorder
+++ b/style/eclipse.importorder
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 #Organize Import Order
-0=java
-1=javax
-2=org
-3=com
+0=org.apache.dolphinscheduler
+1=org.apache
+2=java
+3=javax
+4=org
+5=com

--- a/style/eclipse.importorder
+++ b/style/eclipse.importorder
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 #Organize Import Order
 0=java
 1=javax


### PR DESCRIPTION
## Purpose of the pull request

* Enable spotless to manage `imports`.
* This PR closes: #11457 

## Brief change log

1. Configure `Spotless` to remove unused `imports`.
2. Configure `Spotless` to sort `imports` in better order (instead of simply sorting import alphabetically).
3. Configure `Spotless` to remove wildcards imports.
4. Configure `Spotless` to remove empty line indents in `pom.xml`.
5. Reformat `ZeppelinTask.java` as an example.

## Verify this pull request

* Verified by manual tests.