### PR TITLE
If the task processor is not found need to throw error rather than exception

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
@@ -82,7 +82,7 @@ public class TaskStateEventHandler implements StateEventHandler {
             }
             return true;
         }
-        throw new StateEventHandleException(
+        throw new StateEventHandleError(
                 "Task state event handle error, due to the task is not in activeTaskProcessorMaps");
     }
 


### PR DESCRIPTION
## Purpose of the pull request

If active task processor has been removed, we need to throw error, and drop the event, rather than retry

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
