### PR TITLE
[Fix-11465] Serial first, the last executing instance will be stopped

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -341,16 +341,7 @@ public class ProcessServiceImpl implements ProcessService {
                             processInstance.getProcessDefinitionCode(),
                             processInstance.getProcessDefinitionVersion(), Constants.RUNNING_PROCESS_STATE,
                             processInstance.getId());
-            if (CollectionUtils.isEmpty(runningProcessInstances)) {
-                processInstance.setState(WorkflowExecutionStatus.SUBMITTED_SUCCESS);
-                saveProcessInstance(processInstance);
-                return;
-            }
             for (ProcessInstance info : runningProcessInstances) {
-                if (Objects.nonNull(info.getState()) && (WorkflowExecutionStatus.READY_STOP.equals(info.getState())
-                        || info.getState().isFinished())) {
-                    continue;
-                }
                 info.setCommandType(CommandType.STOP);
                 info.addHistoryCmd(CommandType.STOP);
                 info.setState(WorkflowExecutionStatus.READY_STOP);
@@ -368,6 +359,8 @@ public class ProcessServiceImpl implements ProcessService {
                     }
                 }
             }
+            processInstance.setState(WorkflowExecutionStatus.SUBMITTED_SUCCESS);
+            saveProcessInstance(processInstance);
         }
     }
 

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -471,7 +471,7 @@ public class ProcessServiceTest {
         Mockito.when(processInstanceMapper.updateById(processInstance)).thenReturn(1);
         Mockito.when(commandMapper.deleteById(9)).thenReturn(1);
         ProcessInstance processInstance10 = processService.handleCommand(host, command9);
-        Assert.assertTrue(processInstance10 == null);
+        Assert.assertTrue(processInstance10 != null);
     }
 
     @Test(expected = ServiceException.class)


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Serial first, the last executing instance will be stopped

## Brief change log

#11465 

## Verify this pull request

Manually verified the change by testing locally.

