### PR TITLE
Fix TaskExecuteContext may cause memory leak due to doesn't clear

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/WorkflowStartEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/WorkflowStartEventHandler.java
@@ -53,27 +53,27 @@ public class WorkflowStartEventHandler implements WorkflowEventHandler {
     public void handleWorkflowEvent(final WorkflowEvent workflowEvent) throws WorkflowEventHandleError {
         logger.info("Handle workflow start event, begin to start a workflow, event: {}", workflowEvent);
         WorkflowExecuteRunnable workflowExecuteRunnable = processInstanceExecCacheManager.getByProcessInstanceId(
-            workflowEvent.getWorkflowInstanceId());
+                workflowEvent.getWorkflowInstanceId());
         if (workflowExecuteRunnable == null) {
             throw new WorkflowEventHandleError(
-                "The workflow start event is invalid, cannot find the workflow instance from cache");
+                    "The workflow start event is invalid, cannot find the workflow instance from cache");
         }
         ProcessInstanceMetrics.incProcessInstanceByState("submit");
         ProcessInstance processInstance = workflowExecuteRunnable.getProcessInstance();
         CompletableFuture.supplyAsync(workflowExecuteRunnable::call, workflowExecuteThreadPool)
-            .thenAccept(workflowSubmitStatue -> {
-                if (WorkflowSubmitStatue.SUCCESS == workflowSubmitStatue) {
-                    // submit failed will resend the event to workflow event queue
-                    logger.info("Success submit the workflow instance");
-                    if (processInstance.getTimeout() > 0) {
-                        stateWheelExecuteThread.addProcess4TimeoutCheck(processInstance);
+                .thenAccept(workflowSubmitStatue -> {
+                    if (WorkflowSubmitStatue.SUCCESS == workflowSubmitStatue) {
+                        // submit failed will resend the event to workflow event queue
+                        logger.info("Success submit the workflow instance: {}", processInstance.getId());
+                        if (processInstance.getTimeout() > 0) {
+                            stateWheelExecuteThread.addProcess4TimeoutCheck(processInstance);
+                        }
+                    } else {
+                        logger.error("Failed to submit the workflow instance, will resend the workflow start event: {}",
+                                workflowEvent);
+                        workflowEventQueue.addEvent(workflowEvent);
                     }
-                } else {
-                    logger.error("Failed to submit the workflow instance, will resend the workflow start event: {}",
-                                 workflowEvent);
-                    workflowEventQueue.addEvent(workflowEvent);
-                }
-            });
+                });
     }
 
     @Override

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerManagerThread.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerManagerThread.java
@@ -86,9 +86,9 @@ public class WorkerManagerThread implements Runnable {
      */
     public void killTaskBeforeExecuteByInstanceId(Integer taskInstanceId) {
         waitSubmitQueue.stream()
-                .filter(taskExecuteThread -> taskExecuteThread.getTaskExecutionContext()
-                        .getTaskInstanceId() == taskInstanceId)
+                .filter(taskExecuteThread -> taskExecuteThread.getTaskExecutionContext().getTaskInstanceId() == taskInstanceId)
                 .forEach(waitSubmitQueue::remove);
+        taskExecuteThreadMap.remove(taskInstanceId);
     }
 
     public boolean offer(WorkerDelayTaskExecuteRunnable workerDelayTaskExecuteRunnable) {
@@ -118,6 +118,7 @@ public class WorkerManagerThread implements Runnable {
             try {
                 if (!ServerLifeCycleManager.isRunning()) {
                     Thread.sleep(Constants.SLEEP_TIME_MILLIS);
+                    continue;
                 }
                 if (this.getThreadPoolQueueSize() <= workerExecThreads) {
                     final WorkerDelayTaskExecuteRunnable workerDelayTaskExecuteRunnable = waitSubmitQueue.take();


### PR DESCRIPTION
## Purpose of the pull request

- Add finished/failover field in TaskExecuteStatus/WorkflowExecuteStatus
- Clear TaskExecuteContext in worker cache to avoid the memory leak

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
