### PR TITLE
[Feature][Style] Make sure there is one and only one empty line at the end of each java file 

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertConfig.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/AlertConfig.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("alert")
 public final class AlertConfig {
+
     private int port;
 
     private int waitTimeout;
@@ -42,5 +43,4 @@ public final class AlertConfig {
     public void setWaitTimeout(final int waitTimeout) {
         this.waitTimeout = waitTimeout;
     }
-
 }

--- a/style/spotless_dolphinscheduler_formatter.xml
+++ b/style/spotless_dolphinscheduler_formatter.xml
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 -->
-<profiles version="13">
+<profiles version="22">
     <profile kind="CodeFormatterProfile" name="'DolphinScheduler Apache Current'" version="13">
         <setting id="org.eclipse.jdt.core.compiler.source" value="1.8" />
         <setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8" />
@@ -47,5 +47,6 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="106" />
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="106" />
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80" />
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
     </profile>
 </profiles>


### PR DESCRIPTION
## Purpose of the pull request

* Configure `Spotless` to make sure there is one and only one empty line at the end of each java file, see: https://github.com/apache/dolphinscheduler/pull/11498#discussion_r947371088
* related: #10963 

## Brief change log

* Already described above.

## Verify this pull request

* Verified by manual tests.