### PR TITLE
[Improvement]Add a stop function when you are ready to do pause operation

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -478,6 +478,10 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
         boolean checkResult = false;
         switch (executeType) {
             case PAUSE:
+                if (executionStatus.isRunning()) {
+                    checkResult = true;
+                }
+                break;
             case STOP:
                 if (executionStatus.canStop()) {
                     checkResult = true;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -479,7 +479,7 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
         switch (executeType) {
             case PAUSE:
             case STOP:
-                if (executionStatus.isRunning()) {
+                if (executionStatus.canStop()) {
                     checkResult = true;
                 }
                 break;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
@@ -71,6 +71,10 @@ public enum WorkflowExecutionStatus {
         return this == RUNNING_EXECUTION;
     }
 
+    public boolean canStop() {
+        return this == RUNNING_EXECUTION || this == READY_PAUSE;
+    }
+
     public boolean isFinished() {
         // todo: do we need to remove pause/block in finished judge?
         return isSuccess() || isFailure() || isStop() || isPause() || isBlock();


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request
this pr will close #11547 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
When a workflow is running or blocking for a long time, the user may do pause opteration, and the pause operation may be blocked while waiting for the task to execute, so I think there should be an option to stop it when it is ready pause status




## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
