### PR TITLE
[Improvement-#9680][task-plugin] add hive sql log listener, print MapReduce progress log and obtain application_id allows developers to better track tasks

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/pom.xml
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/pom.xml
@@ -55,6 +55,14 @@
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.sql;
+
+import org.apache.dolphinscheduler.common.utils.LoggerUtils;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+
+import org.apache.hive.jdbc.HiveStatement;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.slf4j.Logger;
+
+/**
+ * hive log listener thread
+ */
+public class HiveSqlLogThread extends Thread {
+    /**
+     * hive statement
+     */
+    private final HiveStatement statement;
+    /**
+     * logger
+     */
+    private final Logger threadLogger;
+
+    private final TaskExecutionContext taskExecutionContext;
+
+    public HiveSqlLogThread(Statement statement, Logger logger, TaskExecutionContext taskExecutionContext) {
+        this.statement = (HiveStatement) statement;
+        this.threadLogger = logger;
+        this.taskExecutionContext = taskExecutionContext;
+    }
+
+    @Override
+    public void run() {
+        if (statement == null) {
+            threadLogger.info("hive statement is null,end this log query!");
+            return;
+        }
+        try {
+            while (!statement.isClosed() && statement.hasMoreLogs()) {
+                for (String log : statement.getQueryLog(true, 500)) {
+                    //hive mapreduce log
+                    threadLogger.info(log);
+
+                    List<String> appIds = LoggerUtils.getAppIds(log, threadLogger);
+
+                    //get sql task yarn's application_id
+                    if (!appIds.isEmpty()) {
+                        taskExecutionContext.setAppIds(String.join(",", appIds));
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            threadLogger.error("Failed to view hive log,exception:[{}]", e.getMessage());
+        }
+
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThread.java
@@ -62,7 +62,6 @@ public class HiveSqlLogThread extends Thread {
                     threadLogger.info(log);
 
                     List<String> appIds = LoggerUtils.getAppIds(log, threadLogger);
-
                     //get sql task yarn's application_id
                     if (!appIds.isEmpty()) {
                         taskExecutionContext.setAppIds(String.join(",", appIds));

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -304,6 +304,7 @@ public class SqlTask extends AbstractTaskExecutor {
                         List<SqlBinds> preStatementsBinds) throws Exception {
         for (SqlBinds sqlBind : preStatementsBinds) {
             try (PreparedStatement pstmt = prepareStatementAndBind(connection, sqlBind)) {
+
                 //hive log listener
                 if (DbType.HIVE == DbType.valueOf(sqlParameters.getType())) {
                     logger.info("execute sql type is [{}]",DbType.HIVE.getDescp());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -191,6 +191,12 @@ public class SqlTask extends AbstractTaskExecutor {
             stmt = prepareStatementAndBind(connection, mainSqlBinds);
 
             String result = null;
+            //hive log listener
+            if (DbType.HIVE == DbType.valueOf(sqlParameters.getType())) {
+                logger.info("execute sql type is [{}]",DbType.HIVE.getDescp());
+                HiveSqlLogThread queryThread = new HiveSqlLogThread(stmt, logger,taskExecutionContext);
+                queryThread.start();
+            }
             // decide whether to executeQuery or executeUpdate based on sqlType
             if (sqlParameters.getSqlType() == SqlType.QUERY.ordinal()) {
                 // query statements need to be convert to JsonArray and inserted into Alert to send
@@ -298,6 +304,13 @@ public class SqlTask extends AbstractTaskExecutor {
                         List<SqlBinds> preStatementsBinds) throws Exception {
         for (SqlBinds sqlBind : preStatementsBinds) {
             try (PreparedStatement pstmt = prepareStatementAndBind(connection, sqlBind)) {
+                //hive log listener
+                if (DbType.HIVE == DbType.valueOf(sqlParameters.getType())) {
+                    logger.info("execute sql type is [{}]",DbType.HIVE.getDescp());
+
+                    HiveSqlLogThread queryThread = new HiveSqlLogThread(pstmt, logger,taskExecutionContext);
+                    queryThread.start();
+                }
                 int result = pstmt.executeUpdate();
                 logger.info("pre statement execute result: {}, for sql: {}", result, sqlBind.getSql());
 
@@ -315,6 +328,13 @@ public class SqlTask extends AbstractTaskExecutor {
                          List<SqlBinds> postStatementsBinds) throws Exception {
         for (SqlBinds sqlBind : postStatementsBinds) {
             try (PreparedStatement pstmt = prepareStatementAndBind(connection, sqlBind)) {
+                //hive log listener
+                if (DbType.HIVE == DbType.valueOf(sqlParameters.getType())) {
+                    logger.info("execute sql type is [{}]",DbType.HIVE.getDescp());
+
+                    HiveSqlLogThread queryThread = new HiveSqlLogThread(pstmt, logger,taskExecutionContext);
+                    queryThread.start();
+                }
                 int result = pstmt.executeUpdate();
                 logger.info("post statement execute result: {},for sql: {}", result, sqlBind.getSql());
             }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThreadTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThreadTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.sql;
+
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
+import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
+import org.apache.dolphinscheduler.plugin.datasource.hive.param.HiveConnectionParam;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
+import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
+import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
+import org.apache.dolphinscheduler.spi.enums.DbType;
+
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * hive sql listener test
+ */
+public class HiveSqlLogThreadTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveSqlLogThreadTest.class);
+    @Test
+    public void testHiveSql() throws IOException, ClassNotFoundException, ExecutionException {
+        String taskJson="{\"type\":\"HIVE\",\"datasource\":1,\"sql\":\"select count(*) from tmp.test_doris\",\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\",\"groupId\":null,\"localParams\":[],\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"dependence\":{},\"conditionResult\":{\"successNode\":[],\"failedNode\":[]},\"waitStartTimeout\":{},\"switchResult\":{}}";
+        TaskExecutionContext taskExecutionContext = new TaskExecutionContext();
+        taskExecutionContext.setTaskType("hive");
+        taskExecutionContext.setTaskParams(taskJson);
+        SqlParameters sqlParameters = JSONUtils.parseObject(taskExecutionContext.getTaskParams(), SqlParameters.class);
+        assert sqlParameters != null;
+        String sql = sqlParameters.getSql();
+
+        String krb5FilePath ="/etc/krb5.conf";
+        String krb5KeyTabPath ="/etc/vulcan.keytab";
+        System.setProperty("java.security.krb5.conf", krb5FilePath);
+        System.setProperty("sun.security.krb5.debug", "true");
+        org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
+        configuration.set("hadoop.security.authentication", "Kerberos");
+        configuration.set("keytab.file", krb5KeyTabPath);
+        configuration.set("kerberos.principal", "vulcan@BJ.BAIDU.COM");
+
+        UserGroupInformation.setConfiguration(configuration);
+        UserGroupInformation.loginUserFromKeytab("vulcan", krb5KeyTabPath);
+
+        // 创建hive连接
+        HiveConnectionParam connectionParam = new HiveConnectionParam();
+        connectionParam.setUser("hive");
+        connectionParam.setDriverClassName("org.apache.hive.jdbc.HiveDriver");
+        connectionParam.setAddress("jdbc:hive2://bjbd-test-bigdata-hive-001:10000");
+        connectionParam.setJdbcUrl("jdbc:hive2://bjbd-test-bigdata-hive-001:10000/default;principal=hive/_HOST@BJ.BAIDU.COM");
+        connectionParam.setPrincipal("hive/_HOST@BJ.BAIDU.COM");
+        connectionParam.setDatabase("default");
+        BaseConnectionParam baseConnectionParam = (BaseConnectionParam) DataSourceUtils.buildConnectionParams(
+            DbType.valueOf(sqlParameters.getType()),JSONUtils.toJsonString(connectionParam)
+            );
+
+
+
+        ResultSet res = null;
+        Connection con = null;
+        Statement stmt = null;
+        try{
+            con = DataSourceClientProvider.getInstance().getConnection(DbType.valueOf(sqlParameters.getType()), baseConnectionParam);
+
+            stmt = con.createStatement();
+            //日志进度打印
+            HiveSqlLogThread queryThread = new HiveSqlLogThread(stmt,LOGGER,taskExecutionContext);
+            queryThread.setName("sql log print");
+            queryThread.start();
+            res = stmt.executeQuery(sql);
+            while (res.next()) {
+                System.out.println("---------" + res.getInt(1) + "--------");
+            }
+
+        }catch (Exception e){
+            LOGGER.error(sql+" query failed" , e);
+        }
+
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThreadTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThreadTest.java
@@ -17,24 +17,21 @@
 
 package org.apache.dolphinscheduler.plugin.task.sql;
 
-import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.plugin.datasource.api.datasource.hive.HiveConnectionParam;
 import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
-import org.apache.dolphinscheduler.plugin.datasource.hive.param.HiveConnectionParam;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
 import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
-import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
+import org.apache.dolphinscheduler.spi.utils.JSONUtils;
 
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -46,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class HiveSqlLogThreadTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(HiveSqlLogThreadTest.class);
     @Test
-    public void testHiveSql() throws IOException, ClassNotFoundException, ExecutionException {
+    public void testHiveSql() throws IOException {
         String taskJson="{\"type\":\"HIVE\",\"datasource\":1,\"sql\":\"select count(*) from tmp.test_doris\",\"udfs\":\"\",\"sqlType\":\"0\",\"sendEmail\":false,\"displayRows\":10,\"title\":\"\",\"groupId\":null,\"localParams\":[],\"connParams\":\"\",\"preStatements\":[],\"postStatements\":[],\"dependence\":{},\"conditionResult\":{\"successNode\":[],\"failedNode\":[]},\"waitStartTimeout\":{},\"switchResult\":{}}";
         TaskExecutionContext taskExecutionContext = new TaskExecutionContext();
         taskExecutionContext.setTaskType("hive");
@@ -67,7 +64,7 @@ public class HiveSqlLogThreadTest {
         UserGroupInformation.setConfiguration(configuration);
         UserGroupInformation.loginUserFromKeytab("vulcan", krb5KeyTabPath);
 
-        // 创建hive连接
+        // create hive connection
         HiveConnectionParam connectionParam = new HiveConnectionParam();
         connectionParam.setUser("hive");
         connectionParam.setDriverClassName("org.apache.hive.jdbc.HiveDriver");
@@ -88,13 +85,13 @@ public class HiveSqlLogThreadTest {
             con = DataSourceClientProvider.getInstance().getConnection(DbType.valueOf(sqlParameters.getType()), baseConnectionParam);
 
             stmt = con.createStatement();
-            //日志进度打印
+            //print process log
             HiveSqlLogThread queryThread = new HiveSqlLogThread(stmt,LOGGER,taskExecutionContext);
             queryThread.setName("sql log print");
             queryThread.start();
             res = stmt.executeQuery(sql);
             while (res.next()) {
-                System.out.println("---------" + res.getInt(1) + "--------");
+                LOGGER.info("---------{}--------",res.getInt(1));
             }
 
         }catch (Exception e){

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThreadTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/HiveSqlLogThreadTest.java
@@ -94,7 +94,7 @@ public class HiveSqlLogThreadTest {
                 LOGGER.info("---------{}--------",res.getInt(1));
             }
 
-        }catch (Exception e){
+        } catch (Exception e) {
             LOGGER.error(sql+" query failed" , e);
         }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
