### PR TITLE
[Fix][Issue-11579] Cannot check the application status.

### DIFF
--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -28,6 +28,8 @@ startStop=$1
 shift
 command=$1
 shift
+CLASS=$1
+shift
 
 echo "Begin $startStop $command......"
 
@@ -109,7 +111,7 @@ case $startStop in
 
   (status)
     # more details about the status can be added later
-    serverCount=`ps -ef | grep "$DOLPHINSCHEDULER_HOME" | grep "$CLASS" | grep -v "grep" | wc -l`
+    serverCount=`ps -ef | grep "java" | grep "$DOLPHINSCHEDULER_HOME" | grep "$CLASS" | grep -v "grep" | wc -l`
     state="STOP"
     #  font color - red
     state="[ \033[1;31m $state \033[0m ]"

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -49,25 +49,25 @@ StateRunning="Running"
 mastersHost=(${masters//,/ })
 for master in ${mastersHost[@]}
 do
-  masterState=`ssh -o StrictHostKeyChecking=no -p $sshPort $master  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status master-server;"`
+  masterState=`ssh -o StrictHostKeyChecking=no -p $sshPort $master  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status master-server org.apache.dolphinscheduler.server.master.MasterServer;"`
   echo "$master  $masterState"
 done
 
 # 2.worker server check state
 for worker in ${workerNames[@]}
 do
-  workerState=`ssh -o StrictHostKeyChecking=no -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server;"`
+  workerState=`ssh -o StrictHostKeyChecking=no -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server org.apache.dolphinscheduler.server.worker.WorkerServer;"`
   echo "$worker  $workerState"
 done
 
 # 3.alter server check state
-alertState=`ssh -o StrictHostKeyChecking=no -p $sshPort $alertServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status alert-server;"`
+alertState=`ssh -o StrictHostKeyChecking=no -p $sshPort $alertServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status alert-server org.apache.dolphinscheduler.alert.AlertServer;"`
 echo "$alertServer  $alertState"
 
 # 4.api server check state
 apiServersHost=(${apiServers//,/ })
 for apiServer in ${apiServersHost[@]}
 do
-  apiState=`ssh -o StrictHostKeyChecking=no -p $sshPort $apiServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status api-server;"`
+  apiState=`ssh -o StrictHostKeyChecking=no -p $sshPort $apiServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status api-server org.apache.dolphinscheduler.api.ApiApplicationServer;"`
   echo "$apiServer  $apiState"
 done


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

Change status check scripts, fix issue: #11579 

## Brief change log
Modify the status-all.sh and dolphinscheduler-daemon.sh, just add each Main class name to grep command:

Why do not use jps command to check process? Because many product env do not approve to install JDK, just JRE.

Why i add a "java"? This is a double guarantee mechanism 


<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

Just modify the shell script
