### PR TITLE
[Feature-10498] Mask the password in the log of sqoop task

### DIFF
--- a/docs/docs/en/architecture/design.md
+++ b/docs/docs/en/architecture/design.md
@@ -197,7 +197,7 @@ In the early schedule design, if there is no priority design and use the fair sc
 - For details, please refer to the logback configuration of Master and Worker, as shown in the following example:
 
 ```xml
-<conversionRule conversionWord="message" converterClass="org.apache.dolphinscheduler.service.log.SensitiveDataConverter"/>
+<conversionRule conversionWord="message" converterClass="org.apache.dolphinscheduler.common.log.SensitiveDataConverter"/>
 <appender name="TASKLOGFILE" class="ch.qos.logback.classic.sift.SiftingAppender">
     <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
     <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">

--- a/docs/docs/zh/architecture/design.md
+++ b/docs/docs/zh/architecture/design.md
@@ -195,7 +195,7 @@
 - 详情可参考Master和Worker的logback配置，如下示例：
 
 ```xml
-<conversionRule conversionWord="message" converterClass="org.apache.dolphinscheduler.service.log.SensitiveDataConverter"/>
+<conversionRule conversionWord="message" converterClass="org.apache.dolphinscheduler.common.log.SensitiveDataConverter"/>
 <appender name="TASKLOGFILE" class="ch.qos.logback.classic.sift.SiftingAppender">
     <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
     <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/log/SensitiveDataConverterTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/log/SensitiveDataConverterTest.java
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.service.log;
-
-import static org.apache.dolphinscheduler.service.log.SensitiveDataConverter.passwordHandler;
-
-import org.apache.dolphinscheduler.common.constants.DataSourceConstants;
-
-import java.util.regex.Pattern;
+package org.apache.dolphinscheduler.common.log;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,11 +25,6 @@ import org.slf4j.LoggerFactory;
 public class SensitiveDataConverterTest {
 
     private final Logger logger = LoggerFactory.getLogger(SensitiveDataConverterTest.class);
-
-    /**
-     * password pattern
-     */
-    private final Pattern pwdPattern = Pattern.compile(DataSourceConstants.DATASOURCE_PASSWORD_REGEX);
 
     private final String logMsg = "{\"address\":\"jdbc:mysql://192.168.xx.xx:3306\","
             + "\"database\":\"carbond\","
@@ -49,21 +38,17 @@ public class SensitiveDataConverterTest {
             + "\"user\":\"view\","
             + "\"password\":\"*****\"}";
 
-    @Test
-    public void convert() {
-        Assertions.assertEquals(maskLogMsg, passwordHandler(pwdPattern, logMsg));
-    }
-
     /**
      * mask sensitive logMsg - sql task datasource password
      */
     @Test
     public void testPwdLogMsgConverter() {
-        logger.info("parameter : {}", logMsg);
-        logger.info("parameter : {}", passwordHandler(pwdPattern, logMsg));
+        final String maskedLog = SensitiveDataConverter.maskSensitiveData(logMsg);
 
-        Assertions.assertNotEquals(logMsg, passwordHandler(pwdPattern, logMsg));
-        Assertions.assertEquals(maskLogMsg, passwordHandler(pwdPattern, logMsg));
+        logger.info("original parameter : {}", logMsg);
+        logger.info("masked parameter : {}", maskedLog);
+
+        Assertions.assertEquals(maskLogMsg, maskedLog);
 
     }
 

--- a/dolphinscheduler-master/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-master/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
     </appender>
 
     <conversionRule conversionWord="message"
-                    converterClass="org.apache.dolphinscheduler.service.log.SensitiveDataConverter"/>
+                    converterClass="org.apache.dolphinscheduler.common.log.SensitiveDataConverter"/>
     <appender name="TASKLOGFILE" class="ch.qos.logback.classic.sift.SiftingAppender">
         <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">

--- a/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml
@@ -48,7 +48,7 @@
     <logger name="org.apache.hadoop" level="WARN"/>
 
     <conversionRule conversionWord="message"
-                    converterClass="org.apache.dolphinscheduler.service.log.SensitiveDataConverter"/>
+                    converterClass="org.apache.dolphinscheduler.common.log.SensitiveDataConverter"/>
     <appender name="TASKLOGFILE" class="ch.qos.logback.classic.sift.SiftingAppender">
         <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopConstants.java
@@ -72,4 +72,5 @@ public final class SqoopConstants {
     public static final String UPDATE_KEY = "--update-key";
     public static final String UPDATE_MODE = "--update-mode";
 
+    public static final String SQOOP_PASSWORD_REGEX = "(?<=(--password \")).+?(?=\")";
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTask.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.task.sqoop;
 
+import org.apache.dolphinscheduler.common.log.SensitiveDataConverter;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractYarnTask;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
@@ -67,6 +68,8 @@ public class SqoopTask extends AbstractYarnTask {
 
         sqoopTaskExecutionContext =
                 sqoopParameters.generateExtendedContext(taskExecutionContext.getResourceParametersHelper());
+
+        SensitiveDataConverter.addMaskPattern(SqoopConstants.SQOOP_PASSWORD_REGEX);
     }
 
     @Override

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/test/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/test/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTaskTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.sqoop;
+
+import org.apache.dolphinscheduler.common.log.SensitiveDataConverter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SqoopTaskTest {
+
+    @Test
+    public void testSqoopPasswordMask() {
+        final String originalScript =
+                "sqoop import -D mapred.job.name=sqoop_task -m 1 --connect \"jdbc:mysql://localhost:3306/defuault\" --username root --password \"mypassword\" --table student --target-dir /sqoop_test --as-textfile";
+
+        final String maskScript =
+                "sqoop import -D mapred.job.name=sqoop_task -m 1 --connect \"jdbc:mysql://localhost:3306/defuault\" --username root --password \"**********\" --table student --target-dir /sqoop_test --as-textfile";
+
+        SensitiveDataConverter.addMaskPattern(SqoopConstants.SQOOP_PASSWORD_REGEX);
+        Assertions.assertEquals(maskScript, SensitiveDataConverter.maskSensitiveData(originalScript));
+    }
+}

--- a/dolphinscheduler-worker/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-worker/src/main/resources/logback-spring.xml
@@ -29,7 +29,7 @@
     </appender>
 
     <conversionRule conversionWord="message"
-                    converterClass="org.apache.dolphinscheduler.service.log.SensitiveDataConverter"/>
+                    converterClass="org.apache.dolphinscheduler.common.log.SensitiveDataConverter"/>
     <appender name="TASKLOGFILE" class="ch.qos.logback.classic.sift.SiftingAppender">
         <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

Mask the password in the log of `sqoop` task.

Currently, there are 2 positions that the log of `sqoop` task will output the password of mysql:
https://github.com/apache/dolphinscheduler/blob/17a9dd25fa0e80b048394f79db130f56eb8ef72f/dolphinscheduler-task-plugin/dolphinscheduler-task-sqoop/src/main/java/org/apache/dolphinscheduler/plugin/task/sqoop/SqoopTask.java#L83

https://github.com/apache/dolphinscheduler/blob/17a9dd25fa0e80b048394f79db130f56eb8ef72f/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java#L116


## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

Manually tested.

<img width="1122" alt="截屏2022-08-22 15 30 38" src="https://user-images.githubusercontent.com/38122586/185864886-c8e827dd-d7e0-461b-9565-59c7bcbc8dcf.png">
