### PR TITLE
[Fix-11592] change jre to jdk in worker image to run sqoop task

### DIFF
--- a/dolphinscheduler-worker/src/main/docker/Dockerfile
+++ b/dolphinscheduler-worker/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jdk-slim-buster
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

close: #11592 

To run `sqoop` task, the `dolphinscheduler-worker` needs jdk.

See log below:
```
2022-08-18 11:46:53,095 ERROR orm.CompilationManager: It seems as though you are running sqoop with a JRE.
	2022-08-18 11:46:53,095 ERROR orm.CompilationManager: Sqoop requires a JDK that can compile Java code.
	2022-08-18 11:46:53,095 ERROR orm.CompilationManager: Please install a JDK and set $JAVA_HOME to use it.
	2022-08-18 11:46:53,096 ERROR tool.ImportTool: Import failed: java.io.IOException: Could not start Java compiler.
```

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

manually tested
