### PR TITLE
[fix-10938]: use dot to replace source and make the default env work in shell

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -108,7 +108,7 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
                     sb.append(taskRequest.getEnvironmentConfig()).append("\n");
                 } else {
                     if (taskRequest.getEnvFile() != null) {
-                        sb.append("source ").append(taskRequest.getEnvFile()).append("\n");
+                        sb.append(". ").append(taskRequest.getEnvFile()).append("\n");
                     }
                 }
             }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -101,14 +101,14 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
                     }
                 }
             } else {
-                sb.append("#!/bin/sh\n");
+                sb.append("#!/bin/bash\n");
                 sb.append("BASEDIR=$(cd `dirname $0`; pwd)\n");
                 sb.append("cd $BASEDIR\n");
                 if (!Strings.isNullOrEmpty(taskRequest.getEnvironmentConfig())) {
                     sb.append(taskRequest.getEnvironmentConfig()).append("\n");
                 } else {
                     if (taskRequest.getEnvFile() != null) {
-                        sb.append(". ").append(taskRequest.getEnvFile()).append("\n");
+                        sb.append("source ").append(taskRequest.getEnvFile()).append("\n");
                     }
                 }
             }


### PR DESCRIPTION
## Purpose of the pull request

fix #10938

## Brief change log

use the .  to replace the source command. this two command not have any different. and the . is  Shell Builtins.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.
