### PR TITLE
[fix][python] Sql pattern add truncate.

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/sql.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/sql.py
@@ -98,7 +98,7 @@ class Sql(Task):
             return self.param_sql_type
         pattern_select_str = (
             "^(?!(.* |)insert |(.* |)delete |(.* |)drop "
-            "|(.* |)update |(.* |)alter |(.* |)create ).*"
+            "|(.* |)update |(.* |)truncate |(.* |)alter |(.* |)create ).*"
         )
         pattern_select = re.compile(pattern_select_str, re.IGNORECASE)
         if pattern_select.match(self.sql) is None:

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sql.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sql.py
@@ -54,7 +54,7 @@ from pydolphinscheduler.tasks.sql import Sql, SqlType
         ("delete from table_name where id < 10", None, SqlType.NOT_SELECT),
         ("alter table table_name add column col1 int", None, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", None, SqlType.NOT_SELECT),
-        ("truncate table  table_name", None, SqlType.NOT_SELECT),
+        ("truncate table table_name", None, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", SqlType.SELECT, SqlType.SELECT),
         ("select 1", SqlType.NOT_SELECT, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", SqlType.NOT_SELECT, SqlType.NOT_SELECT),

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sql.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sql.py
@@ -54,7 +54,7 @@ from pydolphinscheduler.tasks.sql import Sql, SqlType
         ("delete from table_name where id < 10", None, SqlType.NOT_SELECT),
         ("alter table table_name add column col1 int", None, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", None, SqlType.NOT_SELECT),
-        ("truncate table table_name", None, SqlType.NOT_SELECT),
+        ("truncate table  table_name", None, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", SqlType.SELECT, SqlType.SELECT),
         ("select 1", SqlType.NOT_SELECT, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", SqlType.NOT_SELECT, SqlType.NOT_SELECT),

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sql.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_sql.py
@@ -54,6 +54,7 @@ from pydolphinscheduler.tasks.sql import Sql, SqlType
         ("delete from table_name where id < 10", None, SqlType.NOT_SELECT),
         ("alter table table_name add column col1 int", None, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", None, SqlType.NOT_SELECT),
+        ("truncate table table_name", None, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", SqlType.SELECT, SqlType.SELECT),
         ("select 1", SqlType.NOT_SELECT, SqlType.NOT_SELECT),
         ("create table table_name2 (col1 int)", SqlType.NOT_SELECT, SqlType.NOT_SELECT),


### PR DESCRIPTION
Now if python-gate creates a truncate statement in SQL, it is recognized as a query statement.
Therefore, truncate should be added to the SQL pattern.