### PR TITLE
[Fix-#11669][Workflow Instance Page] Fix the duration and EndTime in Workflow Instance page.

### DIFF
--- a/docs/configs/site.js
+++ b/docs/configs/site.js
@@ -51,7 +51,7 @@ export default {
           {
             key: 'docs1',
             text: '3.0.1',
-            link: '/en-us/docs/3.0.1/user_doc/guide/quick-start.html',
+            link: '/en-us/docs/3.0.1/user_doc/about/introduction.html',
           },
           {
             key: 'docs2',

--- a/docs/configs/site.js
+++ b/docs/configs/site.js
@@ -30,7 +30,7 @@ export default {
   'en-us': {
     banner: {
       text: '🤔 Have queries regarding Apache DolphinScheduler, Join Slack channel to disscuss them ',
-      link: 'https://join.slack.com/t/asf-dolphinscheduler/shared_invite/zt-1e36toy4n-5n9U2R__FDM05R~MJFFVBg'
+      link: 'https://s.apache.org/dolphinscheduler-slack'
     },
     pageMenu: [
       {
@@ -137,7 +137,7 @@ export default {
           name: 'Slack',
           img1: '/img/slack.png',
           img2: '/img/slack-selected.png',
-          link: 'https://join.slack.com/t/asf-dolphinscheduler/shared_invite/zt-1e36toy4n-5n9U2R__FDM05R~MJFFVBg',
+          link: 'https://s.apache.org/dolphinscheduler-slack',
         },
         {
           name: 'Email List',
@@ -158,7 +158,7 @@ export default {
   'zh-cn': {
     banner: {
       text: '🤔 有关于 Apache DolphinScheduler 的疑问，加入 Slack 频道来讨论他们 ',
-      link: 'https://join.slack.com/t/asf-dolphinscheduler/shared_invite/zt-1e36toy4n-5n9U2R__FDM05R~MJFFVBg'
+      link: 'https://s.apache.org/dolphinscheduler-slack'
     },
     pageMenu: [
       {
@@ -267,7 +267,7 @@ export default {
           name: 'Slack',
           img1: '/img/slack.png',
           img2: '/img/slack-selected.png',
-          link: 'https://join.slack.com/t/asf-dolphinscheduler/shared_invite/zt-1e36toy4n-5n9U2R__FDM05R~MJFFVBg',
+          link: 'https://s.apache.org/dolphinscheduler-slack',
         },
         {
           name: '邮件列表',

--- a/docs/docs/en/guide/installation/pseudo-cluster.md
+++ b/docs/docs/en/guide/installation/pseudo-cluster.md
@@ -37,6 +37,7 @@ sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
 
 # Modify directory permissions and grant permissions for user you created above
 chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
+chmod -R 755 apache-dolphinscheduler-*-bin
 ```
 
 > **_NOTICE:_**

--- a/docs/docs/en/guide/installation/standalone.md
+++ b/docs/docs/en/guide/installation/standalone.md
@@ -23,6 +23,7 @@ There is a standalone startup script in the binary compressed package, which can
 ```shell
 # Extract and start Standalone Server
 tar -xvzf apache-dolphinscheduler-*-bin.tar.gz
+chmod -R 755 apache-dolphinscheduler-*-bin
 cd apache-dolphinscheduler-*-bin
 bash ./bin/dolphinscheduler-daemon.sh start standalone-server
 ```

--- a/docs/docs/zh/guide/installation/pseudo-cluster.md
+++ b/docs/docs/zh/guide/installation/pseudo-cluster.md
@@ -37,6 +37,7 @@ sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
 
 # 修改目录权限，使得部署用户对二进制包解压后的 apache-dolphinscheduler-*-bin 目录有操作权限
 chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
+chmod -R 755 apache-dolphinscheduler-*-bin
 ```
 
 > **_注意:_**

--- a/docs/docs/zh/guide/installation/standalone.md
+++ b/docs/docs/zh/guide/installation/standalone.md
@@ -21,6 +21,7 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 ```shell
 # 解压并运行 Standalone Server
 tar -xvzf apache-dolphinscheduler-*-bin.tar.gz
+chmod -R 755 apache-dolphinscheduler-*-bin
 cd apache-dolphinscheduler-*-bin
 bash ./bin/dolphinscheduler-daemon.sh start standalone-server
 ```

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -320,8 +320,10 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
         }
 
         for (ProcessInstance processInstance : processInstances) {
-            processInstance.setDuration(
-                    DateUtils.format2Duration(processInstance.getStartTime(), processInstance.getEndTime()));
+            // if processInstance is running or serial wait, the val of duration should be null
+            String duration = isFinish(processInstance) ?
+                    DateUtils.format2Duration(processInstance.getStartTime(), processInstance.getEndTime()) : null;
+            processInstance.setDuration(duration);
             User executor = idToUserMap.get(processInstance.getExecutorId());
             if (null != executor) {
                 processInstance.setExecutorName(executor.getUserName());
@@ -333,6 +335,16 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
         result.setData(pageInfo);
         putMsg(result, Status.SUCCESS);
         return result;
+    }
+
+    /**
+     * check if the processInstance is finish
+     * @param processInstance processInstance
+     * @return result
+     */
+    private boolean isFinish(ProcessInstance processInstance){
+        return !processInstance.getState().equals(WorkflowExecutionStatus.RUNNING_EXECUTION)
+                && !processInstance.getState().equals(WorkflowExecutionStatus.SERIAL_WAIT);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -347,6 +347,9 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
      * @return result
      */
     private boolean isFinish(ProcessInstance processInstance){
+        if (processInstance.getState() == null) {
+            return false;
+        }
         return !processInstance.getState().equals(WorkflowExecutionStatus.RUNNING_EXECUTION)
                 && !processInstance.getState().equals(WorkflowExecutionStatus.SERIAL_WAIT);
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -320,9 +320,13 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
         }
 
         for (ProcessInstance processInstance : processInstances) {
-            // if processInstance is running or serial wait, the val of duration should be null
+            // if processInstance is running, the val of duration should be current time - last start time
+            // if finished, the val of duration should be end time - start time
             String duration = isFinish(processInstance) ?
-                    DateUtils.format2Duration(processInstance.getStartTime(), processInstance.getEndTime()) : null;
+                DateUtils
+                    .format2Duration(processInstance.getStartTime(), processInstance.getEndTime())
+                : DateUtils.format2Duration(processInstance.getStartTime(), new Date());
+
             processInstance.setDuration(duration);
             User executor = idToUserMap.get(processInstance.getExecutorId());
             if (null != executor) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
@@ -353,6 +353,9 @@ public final class DateUtils {
         if (end == null) {
             end = new Date();
         }
+        if (start.after(end)) {
+            return null;
+        }
         return format2Duration(differMs(start, end));
     }
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/DateUtilsTest.java
@@ -176,6 +176,9 @@ public class DateUtilsTest {
         String duration = DateUtils.format2Duration(start, end);
         Assert.assertEquals("1d 1h 10m 10s", duration);
 
+        duration = DateUtils.format2Duration(end, start);
+        Assert.assertNull(duration);
+
         // hours minutes seconds
         start = DateUtils.stringToDate("2020-01-20 11:00:00");
         end = DateUtils.stringToDate("2020-01-20 12:10:10");

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkerGroupMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkerGroupMapper.java
@@ -55,7 +55,7 @@ public interface WorkerGroupMapper extends BaseMapper<WorkerGroup> {
     int updateById(@Param("et") WorkerGroup entity);
 
     /**
-     * query worer grouop by name
+     * query worker group by name
      *
      * @param name name
      * @return worker group list

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/WorkerGroupMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/WorkerGroupMapperTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.mapper;
+
+import java.util.Date;
+import java.util.List;
+import javax.annotation.Resource;
+import org.apache.dolphinscheduler.dao.BaseDaoTest;
+import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorkerGroupMapperTest extends BaseDaoTest {
+
+    @Resource
+    private WorkerGroupMapper workerGroupMapper;
+
+    @Before
+    public void setUp() {
+        clearTestData();
+    }
+
+    @After
+    public void after() {
+        clearTestData();
+    }
+
+    /**
+     * clear all test data
+     */
+    public void clearTestData() {
+        workerGroupMapper.queryAllWorkerGroup()
+            .forEach(workerGroup -> workerGroupMapper.deleteById(workerGroup.getId()));
+    }
+
+    /**
+     * insert a worker group into DB
+     *
+     * @return worker group
+     */
+    private WorkerGroup insertOneWorkerGroup() {
+        WorkerGroup workerGroup = new WorkerGroup();
+        workerGroup.setName("Server1");
+        workerGroup.setDescription("Server1");
+        workerGroup.setCreateTime(new Date());
+        workerGroup.setUpdateTime(new Date());
+        workerGroup.setSystemDefault(true);
+        workerGroup.setOtherParamsJson("");
+        workerGroup.setAddrList("localhost");
+        workerGroupMapper.insert(workerGroup);
+        return workerGroup;
+    }
+
+    /**
+     * test query all worker groups
+     */
+    @Test
+    public void testQueryAllWorkerGroups() {
+        insertOneWorkerGroup();
+        List<WorkerGroup> workerGroups = workerGroupMapper.queryAllWorkerGroup();
+        Assert.assertEquals(1, workerGroups.size());
+    }
+
+    /**
+     * test query worker group by name
+     */
+    @Test
+    public void testQueryWorkerGroupByName() {
+        WorkerGroup workerGroup = insertOneWorkerGroup();
+        List<WorkerGroup> workerGroups = workerGroupMapper.queryWorkerGroupByName(workerGroup.getName());
+        Assert.assertEquals(1, workerGroups.size());
+
+        workerGroups = workerGroupMapper.queryWorkerGroupByName("server2");
+        Assert.assertEquals(0, workerGroups.size());
+    }
+
+    /**
+     * test update workerGroup
+     */
+    @Test
+    public void testUpdate() {
+        WorkerGroup workerGroup = insertOneWorkerGroup();
+        workerGroup.setDescription("Server Update");
+        int update = workerGroupMapper.updateById(workerGroup);
+        Assert.assertEquals(1, update);
+    }
+
+    /**
+     * test delete workerGroup
+     */
+    @Test
+    public void delete() {
+        WorkerGroup workerGroup = insertOneWorkerGroup();
+        int delete = workerGroupMapper.deleteById(workerGroup.getId());
+        Assert.assertEquals(1, delete);
+    }
+}

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
@@ -22,7 +22,7 @@ CREATE TABLE `t_ds_mysql_registry_data`
 (
     `id`               bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
     `key`              varchar(200) NOT NULL COMMENT 'key, like zookeeper node path',
-    `data`             varchar(200) NOT NULL COMMENT 'data, like zookeeper node value',
+    `data`             text         NOT NULL COMMENT 'data, like zookeeper node value',
     `type`             tinyint(4)   NOT NULL COMMENT '1: ephemeral node, 2: persistent node',
     `last_update_time` timestamp    NULL COMMENT 'last update time',
     `create_time`      timestamp    NULL COMMENT 'create time',

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-chunjun/src/main/java/org/apache/dolphinscheduler/plugin/task/chunjun/ChunJunParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-chunjun/src/main/java/org/apache/dolphinscheduler/plugin/task/chunjun/ChunJunParameters.java
@@ -55,7 +55,7 @@ public class ChunJunParameters extends AbstractParameters {
     private String others;
 
     /**
-     * deploy mode local standlone yarn-session yarn-per-job
+     * deploy mode: [local, standalone, yarn-session, yarn-per-job]
      */
     private String deployMode;
 

--- a/dolphinscheduler-ui/pnpm-lock.yaml
+++ b/dolphinscheduler-ui/pnpm-lock.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@antv/layout': 0.1.31

--- a/dolphinscheduler-ui/src/layouts/content/components/timezone/index.tsx
+++ b/dolphinscheduler-ui/src/layouts/content/components/timezone/index.tsx
@@ -33,6 +33,7 @@ const Timezone = defineComponent({
     }
   },
   setup(props) {
+    // console.log(prosp.timezoneOptions);
     const { t } = useI18n()
     const reload: any = inject('reload')
     const timezoneStore = useTimezoneStore()

--- a/dolphinscheduler-ui/src/layouts/content/use-dataList.ts
+++ b/dolphinscheduler-ui/src/layouts/content/use-dataList.ts
@@ -314,7 +314,15 @@ export function useDataList() {
                   icon: renderIcon(SafetyOutlined)
                 }
               ]
-      }
+      },
+      // add UI setting to the banner
+      {
+        label: () =>
+          h(NEllipsis, null, { default: () => t('menu.ui_setting') }),
+        key: 'ui-setting',
+        icon: renderIcon(SettingOutlined),
+        children: []
+      },
     ]
   }
 

--- a/dolphinscheduler-ui/src/locales/en_US/index.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/index.ts
@@ -30,6 +30,7 @@ import resource from '@/locales/en_US/resource'
 import security from '@/locales/en_US/security'
 import theme from '@/locales/en_US/theme'
 import user_dropdown from '@/locales/en_US/user-dropdown'
+import ui_setting from '@/locales/en_US/ui_setting'
 
 export default {
   login,
@@ -46,5 +47,6 @@ export default {
   security,
   datasource,
   data_quality,
-  crontab
+  crontab,
+  ui_setting
 }

--- a/dolphinscheduler-ui/src/locales/en_US/menu.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/menu.ts
@@ -56,5 +56,6 @@ export default {
   task_group_queue: 'Task Group Queue',
   data_quality: 'Data Quality',
   task_result: 'Task Result',
-  rule: 'Rule management'
+  rule: 'Rule management',
+  ui_setting: 'Setting',
 }

--- a/dolphinscheduler-ui/src/locales/en_US/ui_setting.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/ui_setting.ts
@@ -15,28 +15,9 @@
  * limitations under the License.
  */
 
-import { defineComponent } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { NTabPane, NTabs } from 'naive-ui'
-import BatchTaskInstance from './batch-task'
-import StreamTaskInstance from './stream-task'
-
-
-const TaskDefinition = defineComponent({
-  name: 'task-instance',
-  setup() {
-    const { t } = useI18n()
-    return () => (
-      <NTabs type='line' animated>
-        <NTabPane name='Batch' tab={t('project.task.batch_task')}>
-          <BatchTaskInstance />
-        </NTabPane>
-        <NTabPane name='Stream' tab={t('project.task.stream_task')}>
-          <StreamTaskInstance />
-        </NTabPane>
-      </NTabs>
-    )
+export default {
+    log: {
+      refresh_time: 'Log Auto Refresh Time',
+    }
   }
-})
-
-export default TaskDefinition
+  

--- a/dolphinscheduler-ui/src/locales/zh_CN/index.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/index.ts
@@ -30,6 +30,7 @@ import resource from '@/locales/zh_CN/resource'
 import security from '@/locales/zh_CN/security'
 import theme from '@/locales/zh_CN/theme'
 import user_dropdown from '@/locales/zh_CN/user-dropdown'
+import ui_setting from '@/locales/zh_CN/ui_setting'
 
 export default {
   login,
@@ -46,5 +47,6 @@ export default {
   security,
   datasource,
   data_quality,
-  crontab
+  crontab,
+  ui_setting
 }

--- a/dolphinscheduler-ui/src/locales/zh_CN/menu.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/menu.ts
@@ -22,6 +22,7 @@ export default {
   datasource: '数据源中心',
   monitor: '监控中心',
   security: '安全中心',
+  ui_setting: '界面设置',
   project_overview: '项目概览',
   workflow_relation: '工作流关系',
   workflow: '工作流',

--- a/dolphinscheduler-ui/src/locales/zh_CN/ui_setting.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/ui_setting.ts
@@ -15,28 +15,9 @@
  * limitations under the License.
  */
 
-import { defineComponent } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { NTabPane, NTabs } from 'naive-ui'
-import BatchTaskInstance from './batch-task'
-import StreamTaskInstance from './stream-task'
-
-
-const TaskDefinition = defineComponent({
-  name: 'task-instance',
-  setup() {
-    const { t } = useI18n()
-    return () => (
-      <NTabs type='line' animated>
-        <NTabPane name='Batch' tab={t('project.task.batch_task')}>
-          <BatchTaskInstance />
-        </NTabPane>
-        <NTabPane name='Stream' tab={t('project.task.stream_task')}>
-          <StreamTaskInstance />
-        </NTabPane>
-      </NTabs>
-    )
+export default {
+    log: {
+      refresh_time: '自动刷新时间',
+    }
   }
-})
-
-export default TaskDefinition
+  

--- a/dolphinscheduler-ui/src/router/modules/ui-setting.ts
+++ b/dolphinscheduler-ui/src/router/modules/ui-setting.ts
@@ -15,28 +15,29 @@
  * limitations under the License.
  */
 
-import { defineComponent } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { NTabPane, NTabs } from 'naive-ui'
-import BatchTaskInstance from './batch-task'
-import StreamTaskInstance from './stream-task'
+import type { Component } from 'vue'
+import utils from '@/utils'
 
+// All TSX files under the views folder automatically generate mapping relationship
+const modules = import.meta.glob('/src/views/**/**.tsx')
+const components: { [key: string]: Component } = utils.mapping(modules)
 
-const TaskDefinition = defineComponent({
-  name: 'task-instance',
-  setup() {
-    const { t } = useI18n()
-    return () => (
-      <NTabs type='line' animated>
-        <NTabPane name='Batch' tab={t('project.task.batch_task')}>
-          <BatchTaskInstance />
-        </NTabPane>
-        <NTabPane name='Stream' tab={t('project.task.stream_task')}>
-          <StreamTaskInstance />
-        </NTabPane>
-      </NTabs>
-    )
-  }
-})
-
-export default TaskDefinition
+export default {
+  path: '/ui-setting',
+  name: 'ui-setting',
+  meta: { title: '设置' },
+  component: () => import('@/layouts/content'),
+  children: [
+    {
+      path: '',
+      name: 'ui-setting',
+      component: components['ui-setting'],
+      meta: {
+        title: '设置',
+        activeMenu: 'ui-setting',
+        showSide: false,
+        auth: []
+      }
+    }
+  ]
+}

--- a/dolphinscheduler-ui/src/router/routes.ts
+++ b/dolphinscheduler-ui/src/router/routes.ts
@@ -24,6 +24,8 @@ import datasourcePage from './modules/datasource'
 import monitorPage from './modules/monitor'
 import securityPage from './modules/security'
 import dataQualityPage from './modules/data-quality'
+// todo: why is it throwing cannot find module and its corresponding type, but the render is working?
+import uiSettingPage from './modules/ui-setting'
 
 // All TSX files under the views folder automatically generate mapping relationship
 const modules = import.meta.glob('/src/views/**/**.tsx')
@@ -74,7 +76,8 @@ const basePage: RouteRecordRaw[] = [
   datasourcePage,
   monitorPage,
   securityPage,
-  dataQualityPage
+  dataQualityPage,
+  uiSettingPage
 ]
 
 /**

--- a/dolphinscheduler-ui/src/store/logTimer/logTimer.ts
+++ b/dolphinscheduler-ui/src/store/logTimer/logTimer.ts
@@ -15,28 +15,24 @@
  * limitations under the License.
  */
 
-import { defineComponent } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { NTabPane, NTabs } from 'naive-ui'
-import BatchTaskInstance from './batch-task'
-import StreamTaskInstance from './stream-task'
+import { defineStore } from 'pinia'
+import { LogTimerStore } from './types'
 
-
-const TaskDefinition = defineComponent({
-  name: 'task-instance',
-  setup() {
-    const { t } = useI18n()
-    return () => (
-      <NTabs type='line' animated>
-        <NTabPane name='Batch' tab={t('project.task.batch_task')}>
-          <BatchTaskInstance />
-        </NTabPane>
-        <NTabPane name='Stream' tab={t('project.task.stream_task')}>
-          <StreamTaskInstance />
-        </NTabPane>
-      </NTabs>
-    )
+export const useLogTimerStore = defineStore({
+  id: 'logTimer',
+  state: (): LogTimerStore => ({
+    logTimer: 0,
+  }),
+  persist: true,
+  getters: {
+    getLogTimer(): number {
+      return this.logTimer
+    }
+  },
+  actions: {
+    setLogTimer(timer: number): void {
+      this.logTimer = timer
+    }
   }
 })
 
-export default TaskDefinition

--- a/dolphinscheduler-ui/src/store/logTimer/types.ts
+++ b/dolphinscheduler-ui/src/store/logTimer/types.ts
@@ -14,29 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+interface LogTimerStore {
+  logTimer: number
+}
 
-import { defineComponent } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { NTabPane, NTabs } from 'naive-ui'
-import BatchTaskInstance from './batch-task'
-import StreamTaskInstance from './stream-task'
-
-
-const TaskDefinition = defineComponent({
-  name: 'task-instance',
-  setup() {
-    const { t } = useI18n()
-    return () => (
-      <NTabs type='line' animated>
-        <NTabPane name='Batch' tab={t('project.task.batch_task')}>
-          <BatchTaskInstance />
-        </NTabPane>
-        <NTabPane name='Stream' tab={t('project.task.stream_task')}>
-          <StreamTaskInstance />
-        </NTabPane>
-      </NTabs>
-    )
-  }
-})
-
-export default TaskDefinition
+export { LogTimerStore }

--- a/dolphinscheduler-ui/src/views/profile/use-form.ts
+++ b/dolphinscheduler-ui/src/views/profile/use-form.ts
@@ -23,6 +23,7 @@ import type { FormRules } from 'naive-ui'
 import type { UserInfoRes } from '@/service/modules/users/types'
 
 export function useForm() {
+  // todo: is "t": some kind of function to internationalize text?
   const { t, locale } = useI18n()
   const userInfo = useUserStore().userInfo as UserInfoRes
 
@@ -31,7 +32,7 @@ export function useForm() {
     profileForm: {
       username: userInfo.userName,
       email: userInfo.email,
-      phone: userInfo.phone
+      phone: userInfo.phone,
     },
     saving: false,
     rules: {
@@ -62,7 +63,7 @@ export function useForm() {
     state.profileForm = {
       username: userInfo.userName,
       email: userInfo.email,
-      phone: userInfo.phone
+      phone: userInfo.phone,
     }
   })
 

--- a/dolphinscheduler-ui/src/views/projects/task/instance/stream-task.tsx
+++ b/dolphinscheduler-ui/src/views/projects/task/instance/stream-task.tsx
@@ -39,6 +39,7 @@ import { useI18n } from 'vue-i18n'
 import { useAsyncState } from '@vueuse/core'
 import { queryLog } from '@/service/modules/log'
 import { streamStateType } from '@/common/common'
+import { useLogTimerStore } from '@/store/logTimer/logTimer'
 import Card from '@/components/card'
 import LogModal from '@/components/log-modal'
 
@@ -46,6 +47,8 @@ const BatchTaskInstance = defineComponent({
   name: 'task-instance',
   setup() {
     let setIntervalP: number
+    const logTimerStore = useLogTimerStore()
+    const logTimer = logTimerStore.getLogTimer
     const { t, variables, getTableData, createColumns } = useTable()
 
     const onUpdatePageSize = () => {
@@ -62,20 +65,27 @@ const BatchTaskInstance = defineComponent({
       variables.showModalRef = false
     }
 
-    const getLogs = (row: any) => {
+    const getLogs = (row: any, logTimer: number) => {
       const { state } = useAsyncState(
         queryLog({
           taskInstanceId: Number(row.id),
           limit: variables.limit,
           skipLineNum: variables.skipLineNum
         }).then((res: any) => {
-          if (res?.message) {
-            variables.logRef += res.message
+          variables.logRef += res.message || ''
+          if (res && res.message !== '') {
             variables.limit += 1000
             variables.skipLineNum += res.lineNum
-            getLogs(row)
+            getLogs(row, logTimer)
           } else {
             variables.logLoadingRef = false
+            setTimeout(() => {
+              variables.logRef = ''
+              variables.limit = 1000
+              variables.skipLineNum = 0
+              variables.logLoadingRef = true
+              getLogs(row, logTimer)
+            }, logTimer * 1000)
           }
         }),
         {}
@@ -88,7 +98,7 @@ const BatchTaskInstance = defineComponent({
       variables.logRef = ''
       variables.limit = 1000
       variables.skipLineNum = 0
-      getLogs(row)
+      getLogs(row, logTimer)
     }
 
     const trim = getCurrentInstance()?.appContext.config.globalProperties.trim
@@ -113,7 +123,7 @@ const BatchTaskInstance = defineComponent({
       () => variables.showModalRef,
       () => {
         if (variables.showModalRef) {
-          getLogs(variables.row)
+          getLogs(variables.row, logTimer)
         } else {
           variables.row = {}
           variables.logRef = ''

--- a/dolphinscheduler-ui/src/views/ui-setting/index.tsx
+++ b/dolphinscheduler-ui/src/views/ui-setting/index.tsx
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useI18n } from 'vue-i18n'
+import { NForm, NFormItem, NSelect } from "naive-ui";
+import { defineComponent } from "vue";
+import { useLogTimerStore } from '@/store/logTimer/logTimer'
+ 
+// Update LogTimer store when select value is updated
+const handleUpdateValue = (logTimer: number) => {
+    const logTimerStore = useLogTimerStore()
+    logTimerStore.setLogTimer(logTimer)
+}
+
+const setting = defineComponent({
+    name: 'ui-setting',
+    setup() {
+        const logTimerStore = useLogTimerStore()
+        const defaultLogTimer = logTimerStore.getLogTimer;
+
+        const logTimerMap = {
+            0: "Off",
+            10: '10 Seconds',
+            30: '30 Seconds',
+            60: '1 Minute',
+            300: '5 Minutes',
+            1800: '30 Minutes'
+        } as any
+
+        const logTimerOptions = [
+            {
+                label: "Off",
+                value: 0,
+            },
+            {
+                label: "10 Seconds",
+                value: 10,
+            },
+            {
+                label: "30 Seconds",
+                value: 30,
+            },
+            {
+                label: "1 Minute",
+                value: 60,
+            },
+            {
+                label: "5 Minutes",
+                value: 300,
+            },
+            {
+                label: "30 Minutes",
+                value: 1800,
+            },
+            ]
+        return {defaultLogTimer, logTimerMap, logTimerOptions}
+    },
+    render() {
+        const { t } = useI18n()
+
+        return ( 
+            <>
+            <NForm>
+                <NFormItem label={t('ui_setting.log.refresh_time')}>
+                <NSelect
+                    default-value={this.logTimerMap[this.defaultLogTimer]}
+                    options={this.logTimerOptions} 
+                    onUpdateValue={handleUpdateValue}
+                    />
+                </NFormItem>
+            </NForm>
+            </>
+        )
+    }
+})
+
+export default setting


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix #11669 

## Brief change log

1. Set the update strategy of field ProcessInstance#endTime to @TableField(updateStrategy = FieldStrategy.IGNORED). Because now setEndTime(null) cannot take affect.
2. When processInstance is running or serial wait, the val of workflow instance duration should be null. 
3.  Add a condition in DateUtils.format2Duration, make sure that startTime must before endTime.

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

re-run a workflow instance, then check the endTime and duration.

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
