### PR TITLE
[Bug] [spark-sql] In spark-sql, select both SPARK1 and SPARK2 versions and execute ${SPARK_HOME2}/bin/spark-sql

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkCommand.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.spark;
+
+public enum SparkCommand {
+
+    /**
+     * 0 SPARK1SUBMIT
+     * 1 SPARK2SUBMIT
+     * 2 SPARK1SQL
+     * 3 SPARK2SQL
+     */
+    SPARK1SUBMIT(0, "SPARK1SUBMIT", "${SPARK_HOME1}/bin/spark-submit", SparkVersion.SPARK1),
+    SPARK2SUBMIT(1, "SPARK2SUBMIT", "${SPARK_HOME2}/bin/spark-submit", SparkVersion.SPARK2),
+
+    SPARK1SQL(2, "SPARK1SQL", "${SPARK_HOME1}/bin/spark-sql", SparkVersion.SPARK1),
+
+    SPARK2SQL(3, "SPARK2SQL", "${SPARK_HOME2}/bin/spark-sql", SparkVersion.SPARK2);
+
+    private final int code;
+    private final String descp;
+    /**
+     * usage: spark-submit [options] <app jar | python file> [app arguments]
+     */
+    private final String command;
+    private final SparkVersion sparkVersion;
+
+    SparkCommand(int code, String descp, String command, SparkVersion sparkVersion) {
+        this.code = code;
+        this.descp = descp;
+        this.command = command;
+        this.sparkVersion = sparkVersion;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDescp() {
+        return descp;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public SparkVersion getSparkVersion() {
+        return sparkVersion;
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkTask.java
@@ -27,7 +27,6 @@ import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters
 import org.apache.dolphinscheduler.plugin.task.api.parser.ParamUtils;
 import org.apache.dolphinscheduler.plugin.task.api.parser.ParameterUtils;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ArgsUtils;
-import org.apache.dolphinscheduler.plugin.task.api.utils.MapUtils;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
 
@@ -42,7 +41,6 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -103,13 +101,16 @@ public class SparkTask extends AbstractYarnTask {
         String sparkCommand = SparkVersion.SPARK2.getCommand();
 
         // If the programType is non-SQL, execute bin/spark-submit
-        if (SparkVersion.SPARK1.name().equals(sparkParameters.getSparkVersion())) {
+        if (SparkVersion.SPARK1.getSparkVersion().equals(sparkParameters.getSparkVersion())) {
             sparkCommand = SparkVersion.SPARK1.getCommand();
         }
 
         // If the programType is SQL, execute bin/spark-sql
         if (sparkParameters.getProgramType() == ProgramType.SQL) {
-            sparkCommand = SparkVersion.SPARKSQL.getCommand();
+            sparkCommand = SparkVersion.SPARK2SQL.getCommand();
+            if (SparkVersion.SPARK1SQL.getSparkVersion().equals(sparkParameters.getSparkVersion())) {
+                sparkCommand = SparkVersion.SPARK1SQL.getCommand();
+            }
         }
 
         args.add(sparkCommand);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkTask.java
@@ -98,18 +98,18 @@ public class SparkTask extends AbstractYarnTask {
         List<String> args = new ArrayList<>();
 
         // spark version
-        String sparkCommand = SparkVersion.SPARK2.getCommand();
+        String sparkCommand = SparkCommand.SPARK2SUBMIT.getCommand();
 
         // If the programType is non-SQL, execute bin/spark-submit
-        if (SparkVersion.SPARK1.getSparkVersion().equals(sparkParameters.getSparkVersion())) {
-            sparkCommand = SparkVersion.SPARK1.getCommand();
+        if (SparkCommand.SPARK1SUBMIT.getSparkVersion().name().equals(sparkParameters.getSparkVersion())) {
+            sparkCommand = SparkCommand.SPARK1SUBMIT.getCommand();
         }
 
         // If the programType is SQL, execute bin/spark-sql
         if (sparkParameters.getProgramType() == ProgramType.SQL) {
-            sparkCommand = SparkVersion.SPARK2SQL.getCommand();
-            if (SparkVersion.SPARK1SQL.getSparkVersion().equals(sparkParameters.getSparkVersion())) {
-                sparkCommand = SparkVersion.SPARK1SQL.getCommand();
+            sparkCommand = SparkCommand.SPARK2SQL.getCommand();
+            if (SparkCommand.SPARK1SQL.getSparkVersion().name().equals(sparkParameters.getSparkVersion())) {
+                sparkCommand = SparkCommand.SPARK1SQL.getCommand();
             }
         }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkVersion.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkVersion.java
@@ -18,48 +18,5 @@
 package org.apache.dolphinscheduler.plugin.task.spark;
 
 public enum SparkVersion {
-
-    /**
-     * 0 SPARK1
-     * 1 SPARK2
-     * 2 SPARK1SQL
-     * 3 SPARK2SQL
-     */
-    SPARK1(0, "SPARK1", "${SPARK_HOME1}/bin/spark-submit", "SPARK1"),
-    SPARK2(1, "SPARK2", "${SPARK_HOME2}/bin/spark-submit", "SPARK2"),
-
-    SPARK1SQL(2, "SPARK1SQL", "${SPARK_HOME1}/bin/spark-sql", "SPARK1"),
-
-    SPARK2SQL(3, "SPARK2SQL", "${SPARK_HOME2}/bin/spark-sql", "SPARK2");
-
-    private final int code;
-    private final String descp;
-    /**
-     * usage: spark-submit [options] <app jar | python file> [app arguments]
-     */
-    private final String command;
-    private final String sparkVersion;
-
-    SparkVersion(int code, String descp, String command, String sparkVersion) {
-        this.code = code;
-        this.descp = descp;
-        this.command = command;
-        this.sparkVersion = sparkVersion;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public String getDescp() {
-        return descp;
-    }
-
-    public String getCommand() {
-        return command;
-    }
-
-    public String getSparkVersion() {
-        return sparkVersion;
-    }
+    SPARK1, SPARK2
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkVersion.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-spark/src/main/java/org/apache/dolphinscheduler/plugin/task/spark/SparkVersion.java
@@ -22,11 +22,15 @@ public enum SparkVersion {
     /**
      * 0 SPARK1
      * 1 SPARK2
-     * 2 SPARKSQL
+     * 2 SPARK1SQL
+     * 3 SPARK2SQL
      */
-    SPARK1(0, "SPARK1", "${SPARK_HOME1}/bin/spark-submit"),
-    SPARK2(1, "SPARK2", "${SPARK_HOME2}/bin/spark-submit"),
-    SPARKSQL(2, "SPARKSQL", "${SPARK_HOME2}/bin/spark-sql");
+    SPARK1(0, "SPARK1", "${SPARK_HOME1}/bin/spark-submit", "SPARK1"),
+    SPARK2(1, "SPARK2", "${SPARK_HOME2}/bin/spark-submit", "SPARK2"),
+
+    SPARK1SQL(2, "SPARK1SQL", "${SPARK_HOME1}/bin/spark-sql", "SPARK1"),
+
+    SPARK2SQL(3, "SPARK2SQL", "${SPARK_HOME2}/bin/spark-sql", "SPARK2");
 
     private final int code;
     private final String descp;
@@ -34,11 +38,13 @@ public enum SparkVersion {
      * usage: spark-submit [options] <app jar | python file> [app arguments]
      */
     private final String command;
+    private final String sparkVersion;
 
-    SparkVersion(int code, String descp, String command) {
+    SparkVersion(int code, String descp, String command, String sparkVersion) {
         this.code = code;
         this.descp = descp;
         this.command = command;
+        this.sparkVersion = sparkVersion;
     }
 
     public int getCode() {
@@ -51,5 +57,9 @@ public enum SparkVersion {
 
     public String getCommand() {
         return command;
+    }
+
+    public String getSparkVersion() {
+        return sparkVersion;
     }
 }

--- a/dolphinscheduler-worker/src/main/bin/start.sh
+++ b/dolphinscheduler-worker/src/main/bin/start.sh
@@ -21,7 +21,7 @@ DOLPHINSCHEDULER_HOME=${DOLPHINSCHEDULER_HOME:-$(cd $BIN_DIR/..; pwd)}
 
 source "$DOLPHINSCHEDULER_HOME/conf/dolphinscheduler_env.sh"
 
-chmod -R 700 ${DOLPHINSCHEDULER_HOME}/config
+chmod -R 700 ${DOLPHINSCHEDULER_HOME}/conf
 export DOLPHINSCHEDULER_WORK_HOME=${DOLPHINSCHEDULER_HOME}
 
 JAVA_OPTS=${JAVA_OPTS:-"-server -Duser.timezone=${SPRING_JACKSON_TIME_ZONE} -Xms4g -Xmx4g -Xmn2g -XX:+PrintGCDetails -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof"}


### PR DESCRIPTION
close https://github.com/apache/dolphinscheduler/issues/11720

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

In spark-sql, selecting SPARK1 should execute ${SPARK_HOME1}/bin/spark-sql and selecting SPARK2 should execute ${SPARK_HOME1}/bin/spark-sql

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
