### PR TITLE
[Feature] Support run all level dependent when complement

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
@@ -122,7 +122,8 @@ public class ExecutorController extends BaseController {
             @Parameter(name = "expectedParallelismNumber", description = "EXPECTED_PARALLELISM_NUMBER", schema = @Schema(implementation = int.class, example = "8")),
             @Parameter(name = "dryRun", description = "DRY_RUN", schema = @Schema(implementation = int.class, example = "0")),
             @Parameter(name = "testFlag", description = "TEST_FLAG", schema = @Schema(implementation = int.class, example = "0")),
-            @Parameter(name = "complementDependentMode", description = "COMPLEMENT_DEPENDENT_MODE", schema = @Schema(implementation = ComplementDependentMode.class))
+            @Parameter(name = "complementDependentMode", description = "COMPLEMENT_DEPENDENT_MODE", schema = @Schema(implementation = ComplementDependentMode.class)),
+            @Parameter(name = "allLevelDependent", description = "ALL_LEVEL_DEPENDENT", schema = @Schema(implementation = boolean.class, example = "false"))
     })
     @PostMapping(value = "start-process-instance")
     @ResponseStatus(HttpStatus.OK)
@@ -149,7 +150,8 @@ public class ExecutorController extends BaseController {
                                        @RequestParam(value = "dryRun", defaultValue = "0", required = false) int dryRun,
                                        @RequestParam(value = "testFlag", defaultValue = "0") int testFlag,
                                        @RequestParam(value = "complementDependentMode", required = false) ComplementDependentMode complementDependentMode,
-                                       @RequestParam(value = "version", required = false) Integer version) {
+                                       @RequestParam(value = "version", required = false) Integer version,
+                                       @RequestParam(value = "allLevelDependent", required = false, defaultValue = "false") boolean allLevelDependent) {
 
         if (timeout == null) {
             timeout = Constants.MAX_TASK_TIMEOUT;
@@ -168,7 +170,7 @@ public class ExecutorController extends BaseController {
                 startNodeList, taskDependType, warningType, warningGroupId, runMode, processInstancePriority,
                 workerGroup, tenantCode, environmentCode, timeout, startParamMap, expectedParallelismNumber, dryRun,
                 testFlag,
-                complementDependentMode, version);
+                complementDependentMode, version, allLevelDependent);
         return returnDataList(result);
     }
 
@@ -215,7 +217,8 @@ public class ExecutorController extends BaseController {
             @Parameter(name = "expectedParallelismNumber", description = "EXPECTED_PARALLELISM_NUMBER", schema = @Schema(implementation = int.class, example = "8")),
             @Parameter(name = "dryRun", description = "DRY_RUN", schema = @Schema(implementation = int.class, example = "0")),
             @Parameter(name = "testFlag", description = "TEST_FLAG", schema = @Schema(implementation = int.class, example = "0")),
-            @Parameter(name = "complementDependentMode", description = "COMPLEMENT_DEPENDENT_MODE", schema = @Schema(implementation = ComplementDependentMode.class))
+            @Parameter(name = "complementDependentMode", description = "COMPLEMENT_DEPENDENT_MODE", schema = @Schema(implementation = ComplementDependentMode.class)),
+            @Parameter(name = "allLevelDependent", description = "ALL_LEVEL_DEPENDENT", schema = @Schema(implementation = boolean.class, example = "false"))
     })
     @PostMapping(value = "batch-start-process-instance")
     @ResponseStatus(HttpStatus.OK)
@@ -241,7 +244,8 @@ public class ExecutorController extends BaseController {
                                             @RequestParam(value = "expectedParallelismNumber", required = false) Integer expectedParallelismNumber,
                                             @RequestParam(value = "dryRun", defaultValue = "0", required = false) int dryRun,
                                             @RequestParam(value = "testFlag", defaultValue = "0") int testFlag,
-                                            @RequestParam(value = "complementDependentMode", required = false) ComplementDependentMode complementDependentMode) {
+                                            @RequestParam(value = "complementDependentMode", required = false) ComplementDependentMode complementDependentMode,
+                                            @RequestParam(value = "allLevelDependent", required = false, defaultValue = "false") boolean allLevelDependent) {
 
         if (timeout == null) {
             log.debug("Parameter timeout set to {} due to null.", Constants.MAX_TASK_TIMEOUT);
@@ -271,7 +275,7 @@ public class ExecutorController extends BaseController {
                     startNodeList, taskDependType, warningType, warningGroupId, runMode, processInstancePriority,
                     workerGroup, tenantCode, environmentCode, timeout, startParamMap, expectedParallelismNumber, dryRun,
                     testFlag,
-                    complementDependentMode, null);
+                    complementDependentMode, null, allLevelDependent);
 
             if (!Status.SUCCESS.equals(result.get(Constants.STATUS))) {
                 log.error("Process definition start failed, projectCode:{}, processDefinitionCode:{}.", projectCode,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -404,7 +404,8 @@ public class PythonGateway {
                 DEFAULT_DRY_RUN,
                 DEFAULT_TEST_FLAG,
                 COMPLEMENT_DEPENDENT_MODE,
-                processDefinition.getVersion());
+                processDefinition.getVersion(),
+            false);
     }
 
     // side object

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -405,7 +405,7 @@ public class PythonGateway {
                 DEFAULT_TEST_FLAG,
                 COMPLEMENT_DEPENDENT_MODE,
                 processDefinition.getVersion(),
-            false);
+                false);
     }
 
     // side object

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
@@ -71,7 +71,8 @@ public interface ExecutorService {
                                             Integer timeout,
                                             Map<String, String> startParams, Integer expectedParallelismNumber,
                                             int dryRun, int testFlag,
-                                            ComplementDependentMode complementDependentMode, Integer version);
+                                            ComplementDependentMode complementDependentMode, Integer version,
+                                            boolean allLevelDependent);
 
     /**
      * check whether the process definition can be executed

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -428,8 +428,6 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
 
     /**
      * do action to workflow instance：pause, stop, repeat, recover from pause, recover from stop，rerun failed task
-    
-    
      *
      * @param loginUser         login user
      * @param workflowInstanceId workflow instance id
@@ -750,7 +748,8 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
                               Priority processInstancePriority, String workerGroup, String tenantCode,
                               Long environmentCode,
                               Map<String, String> startParams, Integer expectedParallelismNumber, int dryRun,
-                              int testFlag, ComplementDependentMode complementDependentMode, boolean allLevelDependent) {
+                              int testFlag, ComplementDependentMode complementDependentMode,
+                              boolean allLevelDependent) {
 
         /**
          * instantiate command schedule instance
@@ -897,7 +896,8 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
                         log.info(
                                 "Complement dependent mode is all dependent and Scheduler is not empty, need create complement dependent command, processDefinitionCode:{}.",
                                 command.getProcessDefinitionCode());
-                        dependentProcessDefinitionCreateCount += createComplementDependentCommand(schedules, command, allLevelDependent);
+                        dependentProcessDefinitionCreateCount +=
+                                createComplementDependentCommand(schedules, command, allLevelDependent);
                     }
                 }
                 if (createCount > 0) {
@@ -1020,7 +1020,8 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
 
         List<DependentProcessDefinition> dependentProcessDefinitionList =
                 getComplementDependentDefinitionList(dependentCommand.getProcessDefinitionCode(),
-                        CronUtils.getMaxCycle(schedules.get(0).getCrontab()), dependentCommand.getWorkerGroup(), allLevelDependent);
+                        CronUtils.getMaxCycle(schedules.get(0).getCrontab()), dependentCommand.getWorkerGroup(),
+                        allLevelDependent);
         dependentCommand.setTaskDependType(TaskDependType.TASK_POST);
         for (DependentProcessDefinition dependentProcessDefinition : dependentProcessDefinitionList) {
             // If the id is Integer, the auto-increment id will be obtained by mybatis-plus

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -1047,8 +1047,10 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
                                                                                   String workerGroup,
                                                                                   boolean allLevelDependent) {
         List<DependentProcessDefinition> dependentProcessDefinitionList =
-            checkDependentProcessDefinitionValid(processService.queryDependentProcessDefinitionByProcessDefinitionCode(processDefinitionCode), processDefinitionCycle, workerGroup,
-                processDefinitionCode);
+                checkDependentProcessDefinitionValid(
+                        processService.queryDependentProcessDefinitionByProcessDefinitionCode(processDefinitionCode),
+                        processDefinitionCycle, workerGroup,
+                        processDefinitionCode);
 
         if (dependentProcessDefinitionList.isEmpty()) {
             return dependentProcessDefinitionList;
@@ -1058,13 +1060,14 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
             List<DependentProcessDefinition> childList = new ArrayList<>(dependentProcessDefinitionList);
             while (true) {
                 List<DependentProcessDefinition> childDependentList = childList
-                    .stream()
-                    .flatMap(dependentProcessDefinition -> checkDependentProcessDefinitionValid(
-                        processService.queryDependentProcessDefinitionByProcessDefinitionCode(dependentProcessDefinition.getProcessDefinitionCode()),
-                        processDefinitionCycle,
-                        workerGroup,
-                        dependentProcessDefinition.getProcessDefinitionCode()).stream())
-                    .collect(Collectors.toList());
+                        .stream()
+                        .flatMap(dependentProcessDefinition -> checkDependentProcessDefinitionValid(
+                                processService.queryDependentProcessDefinitionByProcessDefinitionCode(
+                                        dependentProcessDefinition.getProcessDefinitionCode()),
+                                processDefinitionCycle,
+                                workerGroup,
+                                dependentProcessDefinition.getProcessDefinitionCode()).stream())
+                        .collect(Collectors.toList());
                 if (childDependentList.isEmpty()) {
                     break;
                 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -1072,7 +1072,6 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
                 childList = new ArrayList<>(childDependentList);
             }
         }
-        log.info("processDefinitionCode={}, size={}, dependentProcessDefinitionList={}", processDefinitionCode, dependentProcessDefinitionList.size(), dependentProcessDefinitionList);
         return dependentProcessDefinitionList;
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecuteFunctionControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecuteFunctionControllerTest.java
@@ -80,12 +80,14 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
     final ComplementDependentMode complementDependentMode = ComplementDependentMode.OFF_MODE;
     final Integer version = null;
 
+    final boolean allLevelDependent = false;
+
     final JsonObject expectResponseContent = gson
-            .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
-                    JsonObject.class);
+        .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
+            JsonObject.class);
 
     final ImmutableMap<String, Object> executeServiceResult =
-            ImmutableMap.of(Constants.STATUS, Status.SUCCESS, Constants.DATA_LIST, "Test Data");
+        ImmutableMap.of(Constants.STATUS, Status.SUCCESS, Constants.DATA_LIST, "Test Data");
 
     @MockBean(name = "executorServiceImpl")
     private ExecutorService executorService;
@@ -114,25 +116,26 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", String.valueOf(testFlag));
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-                eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
-                eq(warningType),
-                eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
-                eq(environmentCode),
-                eq(timeout), eq(startParams), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
-                eq(complementDependentMode), eq(version)))
-                        .thenReturn(executeServiceResult);
+            eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
+            eq(warningType),
+            eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
+            eq(environmentCode),
+            eq(timeout), eq(startParams), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
+            eq(complementDependentMode), eq(version),
+            eq(allLevelDependent)))
+            .thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
-                        .params(paramsMap))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andReturn();
+            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                .header("sessionId", sessionId)
+                .params(paramsMap))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
         // Then
         final JsonObject actualResponseContent =
-                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -159,25 +162,25 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", String.valueOf(testFlag));
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-                eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
-                eq(warningType),
-                eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
-                eq(environmentCode),
-                eq(Constants.MAX_TASK_TIMEOUT), eq(startParams), eq(expectedParallelismNumber), eq(dryRun),
-                eq(testFlag),
-                eq(complementDependentMode), eq(version))).thenReturn(executeServiceResult);
+            eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
+            eq(warningType),
+            eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
+            eq(environmentCode),
+            eq(Constants.MAX_TASK_TIMEOUT), eq(startParams), eq(expectedParallelismNumber), eq(dryRun),
+            eq(testFlag),
+            eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
-                        .params(paramsMap))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andReturn();
+            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                .header("sessionId", sessionId)
+                .params(paramsMap))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
         // Then
         final JsonObject actualResponseContent =
-                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -204,24 +207,24 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", String.valueOf(testFlag));
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-                eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
-                eq(warningType),
-                eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
-                eq(environmentCode),
-                eq(timeout), eq(null), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
-                eq(complementDependentMode), eq(version))).thenReturn(executeServiceResult);
+            eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
+            eq(warningType),
+            eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
+            eq(environmentCode),
+            eq(timeout), eq(null), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
+            eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
-                        .params(paramsMap))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andReturn();
+            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                .header("sessionId", sessionId)
+                .params(paramsMap))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
         // Then
         final JsonObject actualResponseContent =
-                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -235,22 +238,22 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("scheduleTime", scheduleTime);
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-                eq(scheduleTime), eq(null), eq(failureStrategy), eq(null), eq(null), eq(warningType),
-                eq(null), eq(null), eq(null), eq("default"), eq("default"), eq(-1L),
-                eq(Constants.MAX_TASK_TIMEOUT), eq(null), eq(null), eq(0), eq(0),
-                eq(complementDependentMode), eq(version))).thenReturn(executeServiceResult);
+            eq(scheduleTime), eq(null), eq(failureStrategy), eq(null), eq(null), eq(warningType),
+            eq(null), eq(null), eq(null), eq("default"), eq("default"), eq(-1L),
+            eq(Constants.MAX_TASK_TIMEOUT), eq(null), eq(null), eq(0), eq(0),
+            eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
-                        .params(paramsMap))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andReturn();
+            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                .header("sessionId", sessionId)
+                .params(paramsMap))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
         // Then
         final JsonObject actualResponseContent =
-                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -268,22 +271,22 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         executeServiceResult.put(Constants.DATA_LIST, "Test Data");
 
         final JsonObject expectResponseContent = gson
-                .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
-                        JsonObject.class);
+            .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
+                JsonObject.class);
 
         when(executorService.execute(any(User.class), eq(projectCode), eq(processInstanceId), eq(ExecuteType.NONE)))
-                .thenReturn(executeServiceResult);
+            .thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/executors/execute", projectCode)
                 .header("sessionId", sessionId)
                 .params(paramsMap))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andReturn();
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
         // Then
         final JsonObject actualResponseContent =
-                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -291,17 +294,17 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
     public void testStartCheckProcessDefinition() throws Exception {
         // Given
         when(executorService.startCheckByProcessDefinedCode(processDefinitionCode))
-                .thenReturn(executeServiceResult);
+            .thenReturn(executeServiceResult);
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/executors/start-check", projectCode)
                 .header(SESSION_ID, sessionId)
                 .param("processDefinitionCode", String.valueOf(processDefinitionCode)))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andReturn();
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
         // Then
         final JsonObject actualResponseContent =
-                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecuteFunctionControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecuteFunctionControllerTest.java
@@ -81,11 +81,11 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
     final Integer version = null;
     final boolean allLevelDependent = false;
     final JsonObject expectResponseContent = gson
-        .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
-            JsonObject.class);
+            .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
+                    JsonObject.class);
 
     final ImmutableMap<String, Object> executeServiceResult =
-        ImmutableMap.of(Constants.STATUS, Status.SUCCESS, Constants.DATA_LIST, "Test Data");
+            ImmutableMap.of(Constants.STATUS, Status.SUCCESS, Constants.DATA_LIST, "Test Data");
 
     @MockBean(name = "executorServiceImpl")
     private ExecutorService executorService;
@@ -114,26 +114,26 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", String.valueOf(testFlag));
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-            eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
-            eq(warningType),
-            eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
-            eq(environmentCode),
-            eq(timeout), eq(startParams), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
-            eq(complementDependentMode), eq(version),
-            eq(allLevelDependent)))
-            .thenReturn(executeServiceResult);
+                eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
+                eq(warningType),
+                eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
+                eq(environmentCode),
+                eq(timeout), eq(startParams), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
+                eq(complementDependentMode), eq(version),
+                eq(allLevelDependent)))
+                        .thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                .header("sessionId", sessionId)
-                .params(paramsMap))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                        .header("sessionId", sessionId)
+                        .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
         // Then
         final JsonObject actualResponseContent =
-            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -160,25 +160,25 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", String.valueOf(testFlag));
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-            eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
-            eq(warningType),
-            eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
-            eq(environmentCode),
-            eq(Constants.MAX_TASK_TIMEOUT), eq(startParams), eq(expectedParallelismNumber), eq(dryRun),
-            eq(testFlag),
-            eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
+                eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
+                eq(warningType),
+                eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
+                eq(environmentCode),
+                eq(Constants.MAX_TASK_TIMEOUT), eq(startParams), eq(expectedParallelismNumber), eq(dryRun),
+                eq(testFlag),
+                eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                .header("sessionId", sessionId)
-                .params(paramsMap))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                        .header("sessionId", sessionId)
+                        .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
         // Then
         final JsonObject actualResponseContent =
-            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -205,24 +205,24 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", String.valueOf(testFlag));
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-            eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
-            eq(warningType),
-            eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
-            eq(environmentCode),
-            eq(timeout), eq(null), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
-            eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
+                eq(scheduleTime), eq(execType), eq(failureStrategy), eq(startNodeList), eq(taskDependType),
+                eq(warningType),
+                eq(warningGroupId), eq(runMode), eq(processInstancePriority), eq(workerGroup), eq(tenantCode),
+                eq(environmentCode),
+                eq(timeout), eq(null), eq(expectedParallelismNumber), eq(dryRun), eq(testFlag),
+                eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                .header("sessionId", sessionId)
-                .params(paramsMap))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                        .header("sessionId", sessionId)
+                        .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
         // Then
         final JsonObject actualResponseContent =
-            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -236,22 +236,22 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         paramsMap.add("scheduleTime", scheduleTime);
 
         when(executorService.execProcessInstance(any(User.class), eq(projectCode), eq(processDefinitionCode),
-            eq(scheduleTime), eq(null), eq(failureStrategy), eq(null), eq(null), eq(warningType),
-            eq(null), eq(null), eq(null), eq("default"), eq("default"), eq(-1L),
-            eq(Constants.MAX_TASK_TIMEOUT), eq(null), eq(null), eq(0), eq(0),
-            eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
+                eq(scheduleTime), eq(null), eq(failureStrategy), eq(null), eq(null), eq(warningType),
+                eq(null), eq(null), eq(null), eq("default"), eq("default"), eq(-1L),
+                eq(Constants.MAX_TASK_TIMEOUT), eq(null), eq(null), eq(0), eq(0),
+                eq(complementDependentMode), eq(version), eq(allLevelDependent))).thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc
-            .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                .header("sessionId", sessionId)
-                .params(paramsMap))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+                .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
+                        .header("sessionId", sessionId)
+                        .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
         // Then
         final JsonObject actualResponseContent =
-            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -269,22 +269,22 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
         executeServiceResult.put(Constants.DATA_LIST, "Test Data");
 
         final JsonObject expectResponseContent = gson
-            .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
-                JsonObject.class);
+                .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
+                        JsonObject.class);
 
         when(executorService.execute(any(User.class), eq(projectCode), eq(processInstanceId), eq(ExecuteType.NONE)))
-            .thenReturn(executeServiceResult);
+                .thenReturn(executeServiceResult);
 
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/executors/execute", projectCode)
                 .header("sessionId", sessionId)
                 .params(paramsMap))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
         // Then
         final JsonObject actualResponseContent =
-            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 
@@ -292,17 +292,17 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
     public void testStartCheckProcessDefinition() throws Exception {
         // Given
         when(executorService.startCheckByProcessDefinedCode(processDefinitionCode))
-            .thenReturn(executeServiceResult);
+                .thenReturn(executeServiceResult);
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/executors/start-check", projectCode)
                 .header(SESSION_ID, sessionId)
                 .param("processDefinitionCode", String.valueOf(processDefinitionCode)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andReturn();
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
         // Then
         final JsonObject actualResponseContent =
-            gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), JsonObject.class);
         assertThat(actualResponseContent).isEqualTo(expectResponseContent);
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecuteFunctionControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecuteFunctionControllerTest.java
@@ -79,9 +79,7 @@ public class ExecuteFunctionControllerTest extends AbstractControllerTest {
     final int testFlag = 0;
     final ComplementDependentMode complementDependentMode = ComplementDependentMode.OFF_MODE;
     final Integer version = null;
-
     final boolean allLevelDependent = false;
-
     final JsonObject expectResponseContent = gson
         .fromJson("{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}",
             JsonObject.class);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
@@ -389,9 +389,10 @@ public class ExecuteFunctionServiceTest {
         childDependent.setTaskDefinitionCode(4);
         childDependent.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
         childDependent.setTaskParams(
-            "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":3,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
+                "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":3,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
         Mockito.when(processService.queryDependentProcessDefinitionByProcessDefinitionCode(
-            dependentProcessDefinition.getProcessDefinitionCode())).thenReturn(Lists.newArrayList(childDependent)).thenReturn(Lists.newArrayList());
+                dependentProcessDefinition.getProcessDefinitionCode())).thenReturn(Lists.newArrayList(childDependent))
+                .thenReturn(Lists.newArrayList());
         int allLevelDependentCount = executorService.createComplementDependentCommand(schedules, command, true);
         Assertions.assertEquals(2, allLevelDependentCount);
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
@@ -240,21 +240,21 @@ public class ExecuteFunctionServiceTest {
         // mock
         Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_START))
-            .thenReturn(checkProjectAndAuth());
+                .thenReturn(checkProjectAndAuth());
         Mockito.when(processDefinitionMapper.queryByCode(processDefinitionCode)).thenReturn(this.processDefinition);
         Mockito.when(processService.getTenantForProcess(tenantCode, userId)).thenReturn(tenantCode);
         doReturn(1).when(commandService).createCommand(argThat(c -> c.getId() == null));
         doReturn(0).when(commandService).createCommand(argThat(c -> c.getId() != null));
         Mockito.when(monitorService.getServerListFromRegistry(true)).thenReturn(getMasterServersList());
         Mockito.when(processService.findProcessInstanceDetailById(processInstanceId))
-            .thenReturn(Optional.ofNullable(processInstance));
+                .thenReturn(Optional.ofNullable(processInstance));
         Mockito.when(processService.findProcessDefinition(1L, 1)).thenReturn(this.processDefinition);
         Mockito.when(taskGroupQueueMapper.selectById(1)).thenReturn(taskGroupQueue);
         Mockito.when(processInstanceMapper.selectById(1)).thenReturn(processInstance);
         Mockito.when(triggerRelationService.saveProcessInstanceTrigger(Mockito.any(), Mockito.any()))
-            .thenReturn(1);
+                .thenReturn(1);
         Mockito.when(processService.findRelationByCode(processDefinitionCode, processDefinitionVersion))
-            .thenReturn(processTaskRelations);
+                .thenReturn(processTaskRelations);
     }
 
     @Test
@@ -271,19 +271,19 @@ public class ExecuteFunctionServiceTest {
     public void testNoComplement() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(zeroSchedulerList());
+                .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.START_PROCESS,
-            null, null,
-            null, null, null,
-            RunMode.RUN_MODE_SERIAL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 10, null, 0, Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.START_PROCESS,
+                null, null,
+                null, null, null,
+                RunMode.RUN_MODE_SERIAL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 10, null, 0, Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(1)).createCommand(any(Command.class));
 
@@ -296,19 +296,19 @@ public class ExecuteFunctionServiceTest {
     public void testComplementWithStartNodeList() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(zeroSchedulerList());
+                .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.START_PROCESS,
-            null, "123456789,987654321",
-            null, null, null,
-            RunMode.RUN_MODE_SERIAL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.START_PROCESS,
+                null, "123456789,987654321",
+                null, null, null,
+                RunMode.RUN_MODE_SERIAL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(1)).createCommand(any(Command.class));
 
@@ -317,22 +317,22 @@ public class ExecuteFunctionServiceTest {
     @Test
     public void testComplementWithOldStartNodeList() {
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(zeroSchedulerList());
+                .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = new HashMap<>();
         try {
             result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.START_PROCESS,
-                null, "1123456789,987654321",
-                null, null, null,
-                RunMode.RUN_MODE_SERIAL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0,
-                Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null,
-                false);
+                    processDefinitionCode,
+                    "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                    CommandType.START_PROCESS,
+                    null, "1123456789,987654321",
+                    null, null, null,
+                    RunMode.RUN_MODE_SERIAL,
+                    Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0,
+                    Constants.DRY_RUN_FLAG_NO,
+                    Constants.TEST_FLAG_NO,
+                    ComplementDependentMode.OFF_MODE, null,
+                    false);
         } catch (ServiceException e) {
             Assertions.assertEquals(Status.START_NODE_NOT_EXIST_IN_LAST_PROCESS.getCode(), e.getCode());
         }
@@ -352,7 +352,7 @@ public class ExecuteFunctionServiceTest {
         List<Schedule> schedules = Lists.newArrayList(schedule);
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(
                 processDefinitionCode))
-            .thenReturn(schedules);
+                .thenReturn(schedules);
 
         DependentProcessDefinition dependentProcessDefinition = new DependentProcessDefinition();
         dependentProcessDefinition.setProcessDefinitionCode(2);
@@ -360,20 +360,20 @@ public class ExecuteFunctionServiceTest {
         dependentProcessDefinition.setTaskDefinitionCode(1);
         dependentProcessDefinition.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
         dependentProcessDefinition.setTaskParams(
-            "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":2,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
+                "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":2,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
         Mockito.when(processService.queryDependentProcessDefinitionByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(Lists.newArrayList(dependentProcessDefinition));
+                .thenReturn(Lists.newArrayList(dependentProcessDefinition));
 
         Map<Long, String> processDefinitionWorkerGroupMap = new HashMap<>();
         processDefinitionWorkerGroupMap.put(1L, Constants.DEFAULT_WORKER_GROUP);
         Mockito.when(workerGroupService.queryWorkerGroupByProcessDefinitionCodes(Lists.newArrayList(1L)))
-            .thenReturn(processDefinitionWorkerGroupMap);
+                .thenReturn(processDefinitionWorkerGroupMap);
 
         Command command = new Command();
         command.setId(1);
         command.setCommandType(CommandType.COMPLEMENT_DATA);
         command.setCommandParam(
-            "{\"StartNodeList\":\"1\",\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}");
+                "{\"StartNodeList\":\"1\",\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}");
         command.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
         command.setProcessDefinitionCode(processDefinitionCode);
         command.setExecutorId(1);
@@ -404,19 +404,19 @@ public class ExecuteFunctionServiceTest {
     public void testDateError() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(zeroSchedulerList());
+                .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2022-01-07 12:12:12\",\"complementEndDate\":\"2022-01-06 12:12:12\"}",
-            CommandType.COMPLEMENT_DATA,
-            null, null,
-            null, null, null,
-            RunMode.RUN_MODE_SERIAL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2022-01-07 12:12:12\",\"complementEndDate\":\"2022-01-06 12:12:12\"}",
+                CommandType.COMPLEMENT_DATA,
+                null, null,
+                null, null, null,
+                RunMode.RUN_MODE_SERIAL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.START_PROCESS_INSTANCE_ERROR, result.get(Constants.STATUS));
         verify(commandService, times(0)).createCommand(any(Command.class));
     }
@@ -428,19 +428,19 @@ public class ExecuteFunctionServiceTest {
     public void testSerial() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(zeroSchedulerList());
+                .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.COMPLEMENT_DATA,
-            null, null,
-            null, null, null,
-            RunMode.RUN_MODE_SERIAL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.COMPLEMENT_DATA,
+                null, null,
+                null, null, null,
+                RunMode.RUN_MODE_SERIAL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(1)).createCommand(any(Command.class));
     }
@@ -452,19 +452,19 @@ public class ExecuteFunctionServiceTest {
     public void testParallelWithOutSchedule() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(zeroSchedulerList());
+                .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.COMPLEMENT_DATA,
-            null, null,
-            null, null, null,
-            RunMode.RUN_MODE_PARALLEL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.COMPLEMENT_DATA,
+                null, null,
+                null, null, null,
+                RunMode.RUN_MODE_PARALLEL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(31)).createCommand(any(Command.class));
 
@@ -477,20 +477,20 @@ public class ExecuteFunctionServiceTest {
     public void testParallelWithSchedule() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-            .thenReturn(oneSchedulerList());
+                .thenReturn(oneSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.COMPLEMENT_DATA,
-            null, null,
-            null, null, null,
-            RunMode.RUN_MODE_PARALLEL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
-            Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.COMPLEMENT_DATA,
+                null, null,
+                null, null, null,
+                RunMode.RUN_MODE_PARALLEL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
+                Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(15)).createCommand(any(Command.class));
 
@@ -501,40 +501,40 @@ public class ExecuteFunctionServiceTest {
         Mockito.when(monitorService.getServerListFromRegistry(true)).thenReturn(new ArrayList<>());
 
         Assertions.assertThrows(ServiceException.class, () -> executorService.execProcessInstance(
-            loginUser,
-            projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.COMPLEMENT_DATA,
-            null,
-            null,
-            null,
-            null,
-            null,
-            RunMode.RUN_MODE_PARALLEL,
-            Priority.LOW,
-            Constants.DEFAULT_WORKER_GROUP,
-            tenantCode,
-            100L,
-            110,
-            null,
-            0,
-            Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_NO,
-            ComplementDependentMode.OFF_MODE, null,
-            false));
+                loginUser,
+                projectCode,
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.COMPLEMENT_DATA,
+                null,
+                null,
+                null,
+                null,
+                null,
+                RunMode.RUN_MODE_PARALLEL,
+                Priority.LOW,
+                Constants.DEFAULT_WORKER_GROUP,
+                tenantCode,
+                100L,
+                110,
+                null,
+                0,
+                Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false));
     }
 
     @Test
     public void testExecuteRepeatRunning() {
         when(commandService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
         when(projectService.checkProjectAndAuth(loginUser, project, projectCode, RERUN))
-            .thenReturn(checkProjectAndAuth());
+                .thenReturn(checkProjectAndAuth());
         when(processInstanceDao.queryByWorkflowInstanceId(processInstanceId)).thenReturn(processInstance);
         when(processDefinitionService.queryWorkflowDefinitionThrowExceptionIfNotFound(processDefinitionCode,
-            processDefinitionVersion)).thenReturn(processDefinition);
+                processDefinitionVersion)).thenReturn(processDefinition);
         Map<String, Object> result =
-            executorService.execute(loginUser, projectCode, processInstanceId, ExecuteType.REPEAT_RUNNING);
+                executorService.execute(loginUser, projectCode, processInstanceId, ExecuteType.REPEAT_RUNNING);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
     }
 
@@ -542,20 +542,20 @@ public class ExecuteFunctionServiceTest {
     public void testOfTestRun() {
         Mockito.when(commandService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
         Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectCode, RERUN))
-            .thenReturn(checkProjectAndAuth());
+                .thenReturn(checkProjectAndAuth());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-            processDefinitionCode,
-            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-            CommandType.COMPLEMENT_DATA,
-            null, null,
-            null, null, 0,
-            RunMode.RUN_MODE_PARALLEL,
-            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
-            Constants.DRY_RUN_FLAG_NO,
-            Constants.TEST_FLAG_YES,
-            ComplementDependentMode.OFF_MODE, null,
-            false);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.COMPLEMENT_DATA,
+                null, null,
+                null, null, 0,
+                RunMode.RUN_MODE_PARALLEL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
+                Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_YES,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
     }
 
@@ -571,7 +571,7 @@ public class ExecuteFunctionServiceTest {
         processDefinition.setReleaseState(ReleaseState.ONLINE);
         processDefinitionList.add(processDefinition);
         Mockito.when(processDefinitionMapper.queryDefinitionListByIdList(new Integer[ids.size()]))
-            .thenReturn(processDefinitionList);
+                .thenReturn(processDefinitionList);
 
         Map<String, Object> result = executorService.startCheckByProcessDefinedCode(1L);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
@@ -659,35 +659,35 @@ public class ExecuteFunctionServiceTest {
 
         ProcessInstance processInstanceMock = Mockito.mock(ProcessInstance.class, RETURNS_DEEP_STUBS);
         Mockito.when(processService.findProcessInstanceDetailById(processInstanceId))
-            .thenReturn(Optional.ofNullable(processInstanceMock));
+                .thenReturn(Optional.ofNullable(processInstanceMock));
 
         ProcessDefinition processDefinition = new ProcessDefinition();
         processDefinition.setProjectCode(projectCode);
         Mockito.when(processService.findProcessDefinition(Mockito.anyLong(), Mockito.anyInt()))
-            .thenReturn(processDefinition);
+                .thenReturn(processDefinition);
 
         Mockito.when(processService.getTenantForProcess(Mockito.anyString(), Mockito.anyInt())).thenReturn(tenantCode);
 
         when(processInstanceMock.getState().isFinished()).thenReturn(false);
         WorkflowExecuteResponse responseInstanceIsNotFinished =
-            executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
+                executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
         Assertions.assertEquals(Status.WORKFLOW_INSTANCE_IS_NOT_FINISHED.getCode(),
-            responseInstanceIsNotFinished.getCode());
+                responseInstanceIsNotFinished.getCode());
 
         when(processInstanceMock.getState().isFinished()).thenReturn(true);
         WorkflowExecuteResponse responseStartNodeListError =
-            executorService.executeTask(loginUser, projectCode, processInstanceId, "1234567870,", taskDependType);
+                executorService.executeTask(loginUser, projectCode, processInstanceId, "1234567870,", taskDependType);
         Assertions.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), responseStartNodeListError.getCode());
 
         Mockito.when(taskDefinitionLogMapper.queryMaxVersionForDefinition(Mockito.anyLong())).thenReturn(null);
         WorkflowExecuteResponse responseNotDefineTask =
-            executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
+                executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
         Assertions.assertEquals(Status.EXECUTE_NOT_DEFINE_TASK.getCode(), responseNotDefineTask.getCode());
 
         Mockito.when(taskDefinitionLogMapper.queryMaxVersionForDefinition(Mockito.anyLong())).thenReturn(1);
         Mockito.when(commandService.verifyIsNeedCreateCommand(any())).thenReturn(true);
         WorkflowExecuteResponse responseSuccess =
-            executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
+                executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
         Assertions.assertEquals(Status.SUCCESS.getCode(), responseSuccess.getCode());
 
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
@@ -240,21 +240,21 @@ public class ExecuteFunctionServiceTest {
         // mock
         Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_START))
-                .thenReturn(checkProjectAndAuth());
+            .thenReturn(checkProjectAndAuth());
         Mockito.when(processDefinitionMapper.queryByCode(processDefinitionCode)).thenReturn(this.processDefinition);
         Mockito.when(processService.getTenantForProcess(tenantCode, userId)).thenReturn(tenantCode);
         doReturn(1).when(commandService).createCommand(argThat(c -> c.getId() == null));
         doReturn(0).when(commandService).createCommand(argThat(c -> c.getId() != null));
         Mockito.when(monitorService.getServerListFromRegistry(true)).thenReturn(getMasterServersList());
         Mockito.when(processService.findProcessInstanceDetailById(processInstanceId))
-                .thenReturn(Optional.ofNullable(processInstance));
+            .thenReturn(Optional.ofNullable(processInstance));
         Mockito.when(processService.findProcessDefinition(1L, 1)).thenReturn(this.processDefinition);
         Mockito.when(taskGroupQueueMapper.selectById(1)).thenReturn(taskGroupQueue);
         Mockito.when(processInstanceMapper.selectById(1)).thenReturn(processInstance);
         Mockito.when(triggerRelationService.saveProcessInstanceTrigger(Mockito.any(), Mockito.any()))
-                .thenReturn(1);
+            .thenReturn(1);
         Mockito.when(processService.findRelationByCode(processDefinitionCode, processDefinitionVersion))
-                .thenReturn(processTaskRelations);
+            .thenReturn(processTaskRelations);
     }
 
     @Test
@@ -271,18 +271,19 @@ public class ExecuteFunctionServiceTest {
     public void testNoComplement() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(zeroSchedulerList());
+            .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.START_PROCESS,
-                null, null,
-                null, null, null,
-                RunMode.RUN_MODE_SERIAL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 10, null, 0, Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.START_PROCESS,
+            null, null,
+            null, null, null,
+            RunMode.RUN_MODE_SERIAL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 10, null, 0, Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(1)).createCommand(any(Command.class));
 
@@ -295,18 +296,19 @@ public class ExecuteFunctionServiceTest {
     public void testComplementWithStartNodeList() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(zeroSchedulerList());
+            .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.START_PROCESS,
-                null, "123456789,987654321",
-                null, null, null,
-                RunMode.RUN_MODE_SERIAL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.START_PROCESS,
+            null, "123456789,987654321",
+            null, null, null,
+            RunMode.RUN_MODE_SERIAL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(1)).createCommand(any(Command.class));
 
@@ -315,21 +317,22 @@ public class ExecuteFunctionServiceTest {
     @Test
     public void testComplementWithOldStartNodeList() {
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(zeroSchedulerList());
+            .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = new HashMap<>();
         try {
             result = executorService.execProcessInstance(loginUser, projectCode,
-                    processDefinitionCode,
-                    "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                    CommandType.START_PROCESS,
-                    null, "1123456789,987654321",
-                    null, null, null,
-                    RunMode.RUN_MODE_SERIAL,
-                    Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0,
-                    Constants.DRY_RUN_FLAG_NO,
-                    Constants.TEST_FLAG_NO,
-                    ComplementDependentMode.OFF_MODE, null);
+                processDefinitionCode,
+                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+                CommandType.START_PROCESS,
+                null, "1123456789,987654321",
+                null, null, null,
+                RunMode.RUN_MODE_SERIAL,
+                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0,
+                Constants.DRY_RUN_FLAG_NO,
+                Constants.TEST_FLAG_NO,
+                ComplementDependentMode.OFF_MODE, null,
+                false);
         } catch (ServiceException e) {
             Assertions.assertEquals(Status.START_NODE_NOT_EXIST_IN_LAST_PROCESS.getCode(), e.getCode());
         }
@@ -349,7 +352,7 @@ public class ExecuteFunctionServiceTest {
         List<Schedule> schedules = Lists.newArrayList(schedule);
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(
                 processDefinitionCode))
-                .thenReturn(schedules);
+            .thenReturn(schedules);
 
         DependentProcessDefinition dependentProcessDefinition = new DependentProcessDefinition();
         dependentProcessDefinition.setProcessDefinitionCode(2);
@@ -357,25 +360,25 @@ public class ExecuteFunctionServiceTest {
         dependentProcessDefinition.setTaskDefinitionCode(1);
         dependentProcessDefinition.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
         dependentProcessDefinition.setTaskParams(
-                "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":2,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
+            "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":2,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
         Mockito.when(processService.queryDependentProcessDefinitionByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(Lists.newArrayList(dependentProcessDefinition));
+            .thenReturn(Lists.newArrayList(dependentProcessDefinition));
 
         Map<Long, String> processDefinitionWorkerGroupMap = new HashMap<>();
         processDefinitionWorkerGroupMap.put(1L, Constants.DEFAULT_WORKER_GROUP);
         Mockito.when(workerGroupService.queryWorkerGroupByProcessDefinitionCodes(Lists.newArrayList(1L)))
-                .thenReturn(processDefinitionWorkerGroupMap);
+            .thenReturn(processDefinitionWorkerGroupMap);
 
         Command command = new Command();
         command.setId(1);
         command.setCommandType(CommandType.COMPLEMENT_DATA);
         command.setCommandParam(
-                "{\"StartNodeList\":\"1\",\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}");
+            "{\"StartNodeList\":\"1\",\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}");
         command.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
         command.setProcessDefinitionCode(processDefinitionCode);
         command.setExecutorId(1);
 
-        int count = executorService.createComplementDependentCommand(schedules, command);
+        int count = executorService.createComplementDependentCommand(schedules, command, false);
         Assertions.assertEquals(1, count);
     }
 
@@ -386,18 +389,19 @@ public class ExecuteFunctionServiceTest {
     public void testDateError() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(zeroSchedulerList());
+            .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2022-01-07 12:12:12\",\"complementEndDate\":\"2022-01-06 12:12:12\"}",
-                CommandType.COMPLEMENT_DATA,
-                null, null,
-                null, null, null,
-                RunMode.RUN_MODE_SERIAL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2022-01-07 12:12:12\",\"complementEndDate\":\"2022-01-06 12:12:12\"}",
+            CommandType.COMPLEMENT_DATA,
+            null, null,
+            null, null, null,
+            RunMode.RUN_MODE_SERIAL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.START_PROCESS_INSTANCE_ERROR, result.get(Constants.STATUS));
         verify(commandService, times(0)).createCommand(any(Command.class));
     }
@@ -409,18 +413,19 @@ public class ExecuteFunctionServiceTest {
     public void testSerial() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(zeroSchedulerList());
+            .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.COMPLEMENT_DATA,
-                null, null,
-                null, null, null,
-                RunMode.RUN_MODE_SERIAL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.COMPLEMENT_DATA,
+            null, null,
+            null, null, null,
+            RunMode.RUN_MODE_SERIAL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(1)).createCommand(any(Command.class));
     }
@@ -432,18 +437,19 @@ public class ExecuteFunctionServiceTest {
     public void testParallelWithOutSchedule() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(zeroSchedulerList());
+            .thenReturn(zeroSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.COMPLEMENT_DATA,
-                null, null,
-                null, null, null,
-                RunMode.RUN_MODE_PARALLEL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.COMPLEMENT_DATA,
+            null, null,
+            null, null, null,
+            RunMode.RUN_MODE_PARALLEL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 0, Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(31)).createCommand(any(Command.class));
 
@@ -456,19 +462,20 @@ public class ExecuteFunctionServiceTest {
     public void testParallelWithSchedule() {
 
         Mockito.when(processService.queryReleaseSchedulerListByProcessDefinitionCode(processDefinitionCode))
-                .thenReturn(oneSchedulerList());
+            .thenReturn(oneSchedulerList());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.COMPLEMENT_DATA,
-                null, null,
-                null, null, null,
-                RunMode.RUN_MODE_PARALLEL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
-                Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.COMPLEMENT_DATA,
+            null, null,
+            null, null, null,
+            RunMode.RUN_MODE_PARALLEL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
+            Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
         verify(commandService, times(15)).createCommand(any(Command.class));
 
@@ -479,41 +486,40 @@ public class ExecuteFunctionServiceTest {
         Mockito.when(monitorService.getServerListFromRegistry(true)).thenReturn(new ArrayList<>());
 
         Assertions.assertThrows(ServiceException.class, () -> executorService.execProcessInstance(
-                loginUser,
-                projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.COMPLEMENT_DATA,
-                null,
-                null,
-                null,
-                null,
-                null,
-                RunMode.RUN_MODE_PARALLEL,
-                Priority.LOW,
-                Constants.DEFAULT_WORKER_GROUP,
-                tenantCode,
-                100L,
-                110,
-                null,
-                0,
-                Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_NO,
-                ComplementDependentMode.OFF_MODE,
-                null));
-
+            loginUser,
+            projectCode,
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.COMPLEMENT_DATA,
+            null,
+            null,
+            null,
+            null,
+            null,
+            RunMode.RUN_MODE_PARALLEL,
+            Priority.LOW,
+            Constants.DEFAULT_WORKER_GROUP,
+            tenantCode,
+            100L,
+            110,
+            null,
+            0,
+            Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_NO,
+            ComplementDependentMode.OFF_MODE, null,
+            false));
     }
 
     @Test
     public void testExecuteRepeatRunning() {
         when(commandService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
         when(projectService.checkProjectAndAuth(loginUser, project, projectCode, RERUN))
-                .thenReturn(checkProjectAndAuth());
+            .thenReturn(checkProjectAndAuth());
         when(processInstanceDao.queryByWorkflowInstanceId(processInstanceId)).thenReturn(processInstance);
         when(processDefinitionService.queryWorkflowDefinitionThrowExceptionIfNotFound(processDefinitionCode,
-                processDefinitionVersion)).thenReturn(processDefinition);
+            processDefinitionVersion)).thenReturn(processDefinition);
         Map<String, Object> result =
-                executorService.execute(loginUser, projectCode, processInstanceId, ExecuteType.REPEAT_RUNNING);
+            executorService.execute(loginUser, projectCode, processInstanceId, ExecuteType.REPEAT_RUNNING);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
     }
 
@@ -521,19 +527,20 @@ public class ExecuteFunctionServiceTest {
     public void testOfTestRun() {
         Mockito.when(commandService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
         Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectCode, RERUN))
-                .thenReturn(checkProjectAndAuth());
+            .thenReturn(checkProjectAndAuth());
         Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(new Tenant());
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
-                processDefinitionCode,
-                "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
-                CommandType.COMPLEMENT_DATA,
-                null, null,
-                null, null, 0,
-                RunMode.RUN_MODE_PARALLEL,
-                Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
-                Constants.DRY_RUN_FLAG_NO,
-                Constants.TEST_FLAG_YES,
-                ComplementDependentMode.OFF_MODE, null);
+            processDefinitionCode,
+            "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",
+            CommandType.COMPLEMENT_DATA,
+            null, null,
+            null, null, 0,
+            RunMode.RUN_MODE_PARALLEL,
+            Priority.LOW, Constants.DEFAULT_WORKER_GROUP, tenantCode, 100L, 110, null, 15,
+            Constants.DRY_RUN_FLAG_NO,
+            Constants.TEST_FLAG_YES,
+            ComplementDependentMode.OFF_MODE, null,
+            false);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
     }
 
@@ -549,7 +556,7 @@ public class ExecuteFunctionServiceTest {
         processDefinition.setReleaseState(ReleaseState.ONLINE);
         processDefinitionList.add(processDefinition);
         Mockito.when(processDefinitionMapper.queryDefinitionListByIdList(new Integer[ids.size()]))
-                .thenReturn(processDefinitionList);
+            .thenReturn(processDefinitionList);
 
         Map<String, Object> result = executorService.startCheckByProcessDefinedCode(1L);
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
@@ -637,35 +644,35 @@ public class ExecuteFunctionServiceTest {
 
         ProcessInstance processInstanceMock = Mockito.mock(ProcessInstance.class, RETURNS_DEEP_STUBS);
         Mockito.when(processService.findProcessInstanceDetailById(processInstanceId))
-                .thenReturn(Optional.ofNullable(processInstanceMock));
+            .thenReturn(Optional.ofNullable(processInstanceMock));
 
         ProcessDefinition processDefinition = new ProcessDefinition();
         processDefinition.setProjectCode(projectCode);
         Mockito.when(processService.findProcessDefinition(Mockito.anyLong(), Mockito.anyInt()))
-                .thenReturn(processDefinition);
+            .thenReturn(processDefinition);
 
         Mockito.when(processService.getTenantForProcess(Mockito.anyString(), Mockito.anyInt())).thenReturn(tenantCode);
 
         when(processInstanceMock.getState().isFinished()).thenReturn(false);
         WorkflowExecuteResponse responseInstanceIsNotFinished =
-                executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
+            executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
         Assertions.assertEquals(Status.WORKFLOW_INSTANCE_IS_NOT_FINISHED.getCode(),
-                responseInstanceIsNotFinished.getCode());
+            responseInstanceIsNotFinished.getCode());
 
         when(processInstanceMock.getState().isFinished()).thenReturn(true);
         WorkflowExecuteResponse responseStartNodeListError =
-                executorService.executeTask(loginUser, projectCode, processInstanceId, "1234567870,", taskDependType);
+            executorService.executeTask(loginUser, projectCode, processInstanceId, "1234567870,", taskDependType);
         Assertions.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), responseStartNodeListError.getCode());
 
         Mockito.when(taskDefinitionLogMapper.queryMaxVersionForDefinition(Mockito.anyLong())).thenReturn(null);
         WorkflowExecuteResponse responseNotDefineTask =
-                executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
+            executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
         Assertions.assertEquals(Status.EXECUTE_NOT_DEFINE_TASK.getCode(), responseNotDefineTask.getCode());
 
         Mockito.when(taskDefinitionLogMapper.queryMaxVersionForDefinition(Mockito.anyLong())).thenReturn(1);
         Mockito.when(commandService.verifyIsNeedCreateCommand(any())).thenReturn(true);
         WorkflowExecuteResponse responseSuccess =
-                executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
+            executorService.executeTask(loginUser, projectCode, processInstanceId, startNodeList, taskDependType);
         Assertions.assertEquals(Status.SUCCESS.getCode(), responseSuccess.getCode());
 
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
@@ -381,7 +381,6 @@ public class ExecuteFunctionServiceTest {
         // not enable allLevelDependent
         int count = executorService.createComplementDependentCommand(schedules, command, false);
         Assertions.assertEquals(1, count);
-        Assert.assertEquals(1, count);
 
         // enable allLevelDependent
         DependentProcessDefinition childDependent = new DependentProcessDefinition();
@@ -394,7 +393,7 @@ public class ExecuteFunctionServiceTest {
         Mockito.when(processService.queryDependentProcessDefinitionByProcessDefinitionCode(
             dependentProcessDefinition.getProcessDefinitionCode())).thenReturn(Lists.newArrayList(childDependent)).thenReturn(Lists.newArrayList());
         int allLevelDependentCount = executorService.createComplementDependentCommand(schedules, command, true);
-        Assert.assertEquals(2, allLevelDependentCount);
+        Assertions.assertEquals(2, allLevelDependentCount);
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecuteFunctionServiceTest.java
@@ -378,8 +378,23 @@ public class ExecuteFunctionServiceTest {
         command.setProcessDefinitionCode(processDefinitionCode);
         command.setExecutorId(1);
 
+        // not enable allLevelDependent
         int count = executorService.createComplementDependentCommand(schedules, command, false);
         Assertions.assertEquals(1, count);
+        Assert.assertEquals(1, count);
+
+        // enable allLevelDependent
+        DependentProcessDefinition childDependent = new DependentProcessDefinition();
+        childDependent.setProcessDefinitionCode(3);
+        childDependent.setProcessDefinitionVersion(1);
+        childDependent.setTaskDefinitionCode(4);
+        childDependent.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
+        childDependent.setTaskParams(
+            "{\"localParams\":[],\"resourceList\":[],\"dependence\":{\"relation\":\"AND\",\"dependTaskList\":[{\"relation\":\"AND\",\"dependItemList\":[{\"depTaskCode\":3,\"status\":\"SUCCESS\"}]}]},\"conditionResult\":{\"successNode\":[1],\"failedNode\":[1]}}");
+        Mockito.when(processService.queryDependentProcessDefinitionByProcessDefinitionCode(
+            dependentProcessDefinition.getProcessDefinitionCode())).thenReturn(Lists.newArrayList(childDependent)).thenReturn(Lists.newArrayList());
+        int allLevelDependentCount = executorService.createComplementDependentCommand(schedules, command, true);
+        Assert.assertEquals(2, allLevelDependentCount);
     }
 
     /**

--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -206,6 +206,7 @@ export default {
     cancel_full_screen: 'Cancel full screen',
     task_state: 'Task status',
     mode_of_dependent: 'Mode of dependent',
+    all_level_dependent: 'all level dependent',
     open: 'Open',
     project_name_required: 'Project name is required',
     related_items: 'Related items',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -207,6 +207,7 @@ export default {
     cancel_full_screen: '取消全屏',
     task_state: '任务状态',
     mode_of_dependent: '依赖模式',
+    all_level_dependent: '所有层级依赖',
     open: '打开',
     project_name_required: '项目名称必填',
     related_items: '关联项目',

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -389,10 +389,10 @@ export default defineComponent({
                       v-model:value={this.startForm.allLevelDependent}
                     >
                       <NSpace>
-                        <NRadio value={false}>
+                        <NRadio value={'false'}>
                           {t('project.workflow.close')}
                         </NRadio>
-                        <NRadio value={true}>
+                        <NRadio value={'true'}>
                           {t('project.workflow.open')}
                         </NRadio>
                       </NSpace>

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -380,6 +380,25 @@ export default defineComponent({
                     </NSpace>
                   </NRadioGroup>
                 </NFormItem>
+                {this.startForm.complementDependentMode === 'ALL_DEPENDENT' && (
+                  <NFormItem
+                    label={t('project.workflow.all_level_dependent')}
+                    path='allLevelDependent'
+                  >
+                    <NRadioGroup
+                      v-model:value={this.startForm.allLevelDependent}
+                    >
+                      <NSpace>
+                        <NRadio value={false}>
+                          {t('project.workflow.close')}
+                        </NRadio>
+                        <NRadio value={true}>
+                          {t('project.workflow.open')}
+                        </NRadio>
+                      </NSpace>
+                    </NRadioGroup>
+                  </NFormItem>
+                )}
                 <NFormItem
                   label={t('project.workflow.mode_of_execution')}
                   path='runMode'

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/use-form.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/use-form.ts
@@ -69,7 +69,8 @@ export const useForm = () => {
       expectedParallelismNumber: '',
       dryRun: 0,
       testFlag: 0,
-      version: null
+      version: null,
+      allLevelDependent: false
     },
     saving: false,
     rules: {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

Support all level dependent when complement
1. Frontend add switch support user choose whether enable complement all level dependent process.
2. Backends add find all level dependent process logic

child1 dependent parent, child2 and child2_1 dependent child1, the screenshot of the implementation is shown below
![截屏2022-09-14 16 01 35](https://user-images.githubusercontent.com/24592373/190109173-1ed835b6-c09a-4b0c-aa87-7ba5f09df296.png)
![截屏2022-09-14 16 01 47](https://user-images.githubusercontent.com/24592373/190109189-484a070b-3ad5-4aa4-8089-d9468b682832.png)
![截屏2022-09-14 16 04 39](https://user-images.githubusercontent.com/24592373/190109216-522d0c12-df87-46eb-b088-67c65efbffa1.png)
![截屏2022-09-14 16 52 08](https://user-images.githubusercontent.com/24592373/190109228-bee6d018-da5b-49e7-b756-fac9559bf21e.png)


This pr whill close https://github.com/apache/dolphinscheduler/issues/11736

