### PR TITLE
 [Improvement-11834] Upgrade docker base image to support python3.9

### DIFF
--- a/.github/workflows/cluster-test/mysql/Dockerfile
+++ b/.github/workflows/cluster-test/mysql/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 RUN apt update ; \
     apt install -y curl wget default-mysql-client sudo openssh-server netcat-traditional ;

--- a/.github/workflows/cluster-test/postgresql/Dockerfile
+++ b/.github/workflows/cluster-test/postgresql/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 RUN apt update ; \
     apt install -y curl wget sudo openssh-server netcat-traditional ;

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/docker/Dockerfile
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai

--- a/dolphinscheduler-api/src/main/docker/Dockerfile
+++ b/dolphinscheduler-api/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai

--- a/dolphinscheduler-master/src/main/docker/Dockerfile
+++ b/dolphinscheduler-master/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai

--- a/dolphinscheduler-standalone-server/src/main/docker/Dockerfile
+++ b/dolphinscheduler-standalone-server/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai

--- a/dolphinscheduler-tools/src/main/docker/Dockerfile
+++ b/dolphinscheduler-tools/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai

--- a/dolphinscheduler-worker/src/main/docker/Dockerfile
+++ b/dolphinscheduler-worker/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

Upgrade the docker base image to debian 11 bullseye, so when users want to install python3 via `apt udpate && apt install python3`, the installed version will be python3.9 instead of python3.7 as in debian 10 buster.

## Brief change log

change  `openjdk:8-jre-slim-buster` to `openjdk:8-jre-slim-bullseye`

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

