### PR TITLE
[Bug] [Master] WorkflowExecuteRunnable will face a infinite loop #11838

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskTimeoutStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskTimeoutStateEventHandler.java
@@ -34,29 +34,34 @@ public class TaskTimeoutStateEventHandler implements StateEventHandler {
 
     @Override
     public boolean handleStateEvent(WorkflowExecuteRunnable workflowExecuteRunnable,
-                                    StateEvent stateEvent) throws StateEventHandleError {
+        StateEvent stateEvent) throws StateEventHandleError {
         TaskStateEvent taskStateEvent = (TaskStateEvent) stateEvent;
 
         TaskMetrics.incTaskInstanceByState("timeout");
         workflowExecuteRunnable.checkTaskInstanceByStateEvent(taskStateEvent);
 
         TaskInstance taskInstance =
-                workflowExecuteRunnable.getTaskInstance(taskStateEvent.getTaskInstanceId()).orElseThrow(
-                        () -> new StateEventHandleError(String.format(
-                                "Cannot find the task instance from workflow execute runnable, taskInstanceId: %s",
-                                taskStateEvent.getTaskInstanceId())));
+            workflowExecuteRunnable.getTaskInstance(taskStateEvent.getTaskInstanceId()).orElseThrow(
+                () -> new StateEventHandleError(String.format(
+                    "Cannot find the task instance from workflow execute runnable, taskInstanceId: %s",
+                    taskStateEvent.getTaskInstanceId())));
 
         if (TimeoutFlag.CLOSE == taskInstance.getTaskDefine().getTimeoutFlag()) {
             return true;
         }
-        TaskTimeoutStrategy taskTimeoutStrategy = taskInstance.getTaskDefine().getTimeoutNotifyStrategy();
-        Map<Long, ITaskProcessor> activeTaskProcessMap = workflowExecuteRunnable.getActiveTaskProcessMap();
-        if (TaskTimeoutStrategy.FAILED == taskTimeoutStrategy
-                || TaskTimeoutStrategy.WARNFAILED == taskTimeoutStrategy) {
-            ITaskProcessor taskProcessor = activeTaskProcessMap.get(taskInstance.getTaskCode());
-            taskProcessor.action(TaskAction.TIMEOUT);
+        TaskTimeoutStrategy taskTimeoutStrategy = taskInstance.getTaskDefine()
+            .getTimeoutNotifyStrategy();
+        Map<Long, ITaskProcessor> activeTaskProcessMap = workflowExecuteRunnable
+            .getActiveTaskProcessMap();
+        if ((TaskTimeoutStrategy.FAILED == taskTimeoutStrategy
+            || TaskTimeoutStrategy.WARNFAILED == taskTimeoutStrategy)) {
+            if (activeTaskProcessMap.containsKey(taskInstance.getTaskCode())) {
+                ITaskProcessor taskProcessor = activeTaskProcessMap.get(taskInstance.getTaskCode());
+                taskProcessor.action(TaskAction.TIMEOUT);
+            }
         }
-        if (TaskTimeoutStrategy.WARN == taskTimeoutStrategy || TaskTimeoutStrategy.WARNFAILED == taskTimeoutStrategy) {
+        if (TaskTimeoutStrategy.WARN == taskTimeoutStrategy
+            || TaskTimeoutStrategy.WARNFAILED == taskTimeoutStrategy) {
             workflowExecuteRunnable.processTimeout();
             workflowExecuteRunnable.taskTimeout(taskInstance);
         }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskTimeoutStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskTimeoutStateEventHandler.java
@@ -28,9 +28,13 @@ import org.apache.dolphinscheduler.server.master.runner.task.ITaskProcessor;
 import org.apache.dolphinscheduler.server.master.runner.task.TaskAction;
 
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AutoService(StateEventHandler.class)
 public class TaskTimeoutStateEventHandler implements StateEventHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(TaskTimeoutStateEventHandler.class);
 
     @Override
     public boolean handleStateEvent(WorkflowExecuteRunnable workflowExecuteRunnable,
@@ -58,6 +62,10 @@ public class TaskTimeoutStateEventHandler implements StateEventHandler {
             if (activeTaskProcessMap.containsKey(taskInstance.getTaskCode())) {
                 ITaskProcessor taskProcessor = activeTaskProcessMap.get(taskInstance.getTaskCode());
                 taskProcessor.action(TaskAction.TIMEOUT);
+            } else {
+                logger.warn(
+                    "cannot find the task processor for task {}, so skip task processor action.",
+                    taskInstance.getTaskCode());
             }
         }
         if (TaskTimeoutStrategy.WARN == taskTimeoutStrategy

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -145,6 +145,11 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
     private boolean taskFailedSubmit = false;
 
     /**
+     * handing event flag
+     */
+    private boolean isHandingEvent = false;
+
+    /**
      * task instance hash map, taskId as key
      */
     private final Map<Integer, TaskInstance> taskInstanceMap = new ConcurrentHashMap<>();
@@ -249,6 +254,14 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
     }
 
     /**
+     * the thread is handing event
+     * @return result
+     */
+    public boolean isHandingEvent() {
+        return isHandingEvent;
+    }
+
+    /**
      * handle event
      */
     public void handleEvents() {
@@ -261,6 +274,7 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
         StateEvent stateEvent = null;
         while (!this.stateEvents.isEmpty()) {
             try {
+                isHandingEvent = true;
                 stateEvent = this.stateEvents.peek();
                 LoggerUtils.setWorkflowAndTaskInstanceIDMDC(stateEvent.getProcessInstanceId(),
                         stateEvent.getTaskInstanceId());
@@ -295,8 +309,8 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
             } finally {
                 LoggerUtils.removeWorkflowAndTaskInstanceIdMDC();
             }
-
         }
+        isHandingEvent = false;
     }
 
     public String getKey() {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -145,11 +145,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
     private boolean taskFailedSubmit = false;
 
     /**
-     * handing event flag
-     */
-    private boolean isHandingEvent = false;
-
-    /**
      * task instance hash map, taskId as key
      */
     private final Map<Integer, TaskInstance> taskInstanceMap = new ConcurrentHashMap<>();
@@ -254,14 +249,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
     }
 
     /**
-     * the thread is handing event
-     * @return result
-     */
-    public boolean isHandingEvent() {
-        return isHandingEvent;
-    }
-
-    /**
      * handle event
      */
     public void handleEvents() {
@@ -274,7 +261,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
         StateEvent stateEvent = null;
         while (!this.stateEvents.isEmpty()) {
             try {
-                isHandingEvent = true;
                 stateEvent = this.stateEvents.peek();
                 LoggerUtils.setWorkflowAndTaskInstanceIDMDC(stateEvent.getProcessInstanceId(),
                         stateEvent.getTaskInstanceId());
@@ -310,7 +296,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
                 LoggerUtils.removeWorkflowAndTaskInstanceIdMDC();
             }
         }
-        isHandingEvent = false;
     }
 
     public String getKey() {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
@@ -101,7 +101,8 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
      * Handle the events belong to the given workflow.
      */
     public void executeEvent(final WorkflowExecuteRunnable workflowExecuteThread) {
-        if (!workflowExecuteThread.isStart() || workflowExecuteThread.eventSize() == 0) {
+        if (!workflowExecuteThread.isStart() || workflowExecuteThread.isHandingEvent()
+            || workflowExecuteThread.eventSize() == 0) {
             return;
         }
         if (multiThreadFilterMap.containsKey(workflowExecuteThread.getKey())) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
@@ -101,8 +101,7 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
      * Handle the events belong to the given workflow.
      */
     public void executeEvent(final WorkflowExecuteRunnable workflowExecuteThread) {
-        if (!workflowExecuteThread.isStart() || workflowExecuteThread.isHandingEvent()
-            || workflowExecuteThread.eventSize() == 0) {
+        if (!workflowExecuteThread.isStart() || workflowExecuteThread.eventSize() == 0) {
             return;
         }
         if (multiThreadFilterMap.containsKey(workflowExecuteThread.getKey())) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

fix #11838 and #11796 

## Brief change log

1. Before invoke the TaskProssor.action(TIME_OUT), checked the taskProssor is not null, avoid NPE.
2. Add a `isHandingEvent` flag in `WorkflowExecuteRunnable`, becasue it can avoid many `The workflow has been executed by another thread` print when  `WorkflowExecuteRunnable` is handing StateEvent
3. Why did not restore the ITaskProcessor when handle the `StateEventType.TASK_TIMEOUT`? 1) we should keep the current logic; 2) i think timeout should depend on the task on worker services.
4. Update some code style by Coogle format plugin.

## Verify this pull request

Create a Shell Task, configre the retry time and timeout at the same time.

