### PR TITLE
correct post body for http alert plugin

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -143,7 +143,7 @@ public final class HttpSender {
         //set msg content field
         objectNode.put(contentField, msg);
         try {
-            StringEntity entity = new StringEntity(bodyParams, DEFAULT_CHARSET);
+            StringEntity entity = new StringEntity(JSONUtils.toJsonString(objectNode), DEFAULT_CHARSET);
             ((HttpPost) httpRequest).setEntity(entity);
         } catch (Exception e) {
             log.error("send http alert msg  exception : {}", e.getMessage());

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/test/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSenderTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/test/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSenderTest.java
@@ -29,13 +29,14 @@ public class HttpSenderTest {
     @Test
     public void sendTest() {
         Map<String, String> paramsMap = new HashMap<>();
-        paramsMap.put(HttpAlertConstants.URL, "http://www.baidu.com");
+        paramsMap.put(HttpAlertConstants.URL, "https://httpbin.org/post");
         paramsMap.put(HttpAlertConstants.REQUEST_TYPE, "POST");
         paramsMap.put(HttpAlertConstants.HEADER_PARAMS, "{\"Content-Type\":\"application/json\"}");
         paramsMap.put(HttpAlertConstants.BODY_PARAMS, "{\"number\":\"13457654323\"}");
         paramsMap.put(HttpAlertConstants.CONTENT_FIELD, "content");
         HttpSender httpSender = new HttpSender(paramsMap);
         AlertResult alertResult = httpSender.send("Fault tolerance warning");
+        Assert.assertTrue(alertResult.getMessage().contains("\"content\": \"Fault tolerance warning\""));
         Assert.assertEquals("true", alertResult.getStatus());
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

This pull request fixes the issue with http alert plugin for posting correct contentField data

close #11945 

## Brief change log

fix in HttpSender.java and update HttpSenderTest.java

## Verify this pull request

This pull request is already covered by existing tests: HttpSenderTest