### PR TITLE
[fix-11321][ui] fix create workflow contains chunjun node failed

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-chunjun.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-chunjun.ts
@@ -45,7 +45,7 @@ export function useChunjun({
     workerGroup: 'default',
     delayTime: 0,
     timeout: 30,
-    customConfig: false,
+    customConfig: true,
     preStatements: [],
     postStatements: [],
     timeoutNotifyStrategy: ['WARN']


### PR DESCRIPTION
- set customConfig default value as true

This closes apache#11321

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

Purpose of the pull request
fix create workflow contains chunjun node failed bug, and set customConfig default value as true.

Verify this pull request
This pull request is code cleanup without any test coverage.