### PR TITLE
[3.0.1-prepare][cherry-pick][doc] Add how obtain IP address from network card in FAQ (#11311)

### DIFF
--- a/docs/docs/en/faq.md
+++ b/docs/docs/en/faq.md
@@ -575,6 +575,12 @@ Modify the configuration in `common.properties`:
 # dolphin.scheduler.network.priority.strategy=default
 ```
 
+In addition, if you would like to obtain the ip address from the specified network card, modify the configuration `dolphin.scheduler.network.interface.preferred` in `common.properties`. For example, you could modify the configuration in `common.properties` as follows to obtain the ip address from the network card `eth1`:
+
+```shell
+dolphin.scheduler.network.interface.preferred=eth1
+```
+
 After configuration is modified, restart the service to activation
 
 If the ip address is still wrong, please download [dolphinscheduler-netutils.jar](/asset/dolphinscheduler-netutils.jar) to the machine, execute the following commands and feedback the output to the community developers:

--- a/docs/docs/zh/faq.md
+++ b/docs/docs/zh/faq.md
@@ -555,6 +555,12 @@ master 服务、worker 服务在 zookeeper 注册时，会以 ip:port 的形式�
 # dolphin.scheduler.network.priority.strategy=default
 ```
 
+另外，如果希望从指定的网卡获取 ip 地址，配置方式是在 `common.properties` 中设置配置项 `dolphin.scheduler.network.interface.preferred`。例如，如果希望从网卡 `eth1` 获取 ip 地址，配置方式是：
+
+```shell
+dolphin.scheduler.network.interface.preferred=eth1
+```
+
 以上配置修改后重启服务生效
 
 如果 ip 地址获取依然错误，请下载 [dolphinscheduler-netutils.jar](/asset/dolphinscheduler-netutils.jar) 到相应机器，执行以下命令以进一步排障，并反馈给社区开发人员：


### PR DESCRIPTION
This pull request update the FAQ doc (faq.md) by adding how to obtain the IP address from the specified network card, which is part of relevant information created when  the master service and worker service are registered with zookeeper.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->


## Purpose of the pull request

this pr: #11311 
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
