### PR TITLE
[3.0.1-prepare]cherry-pick If the task processor is not found need to throw error rather than exception (#11461)

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
@@ -81,8 +81,8 @@ public class TaskStateEventHandler implements StateEventHandler {
             }
             return true;
         }
-        throw new StateEventHandleException(
-            "Task state event handle error, due to the task is not in activeTaskProcessorMaps");
+        throw new StateEventHandleError(
+                "Task state event handle error, due to the task is not in activeTaskProcessorMaps");
     }
 
     @Override


### PR DESCRIPTION
(cherry picked from commit 4362fb8448fecdd1073ced8e268b629de269a649)

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
