### PR TITLE
[fix] Also auto formatter workflow instance if location is null

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/instance/detail/index.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/instance/detail/index.tsx
@@ -33,6 +33,7 @@ import {
   Location
 } from '../../components/dag/types'
 import Styles from './index.module.scss'
+import { useGraphAutoLayout } from '../../components/dag/use-graph-auto-layout'
 
 interface SaveData {
   saveForm: SaveForm
@@ -53,10 +54,19 @@ export default defineComponent({
 
     const definition = ref<WorkflowDefinition>()
     const instance = ref<WorkflowInstance>()
+    const dagInstanceRef = ref()
 
     const refresh = () => {
       queryProcessInstanceById(id, projectCode).then((res: any) => {
         instance.value = res
+        console.log(res)
+        if (!res.dagData.processDefinition.locations) {
+          setTimeout(() => {
+            const graph = dagInstanceRef.value
+            const { submit } = useGraphAutoLayout({ graph })
+            submit()
+          }, 1000)
+        }
         if (res.dagData) {
           definition.value = res.dagData
         }
@@ -109,6 +119,7 @@ export default defineComponent({
         ]}
       >
         <Dag
+          ref={dagInstanceRef}
           instance={instance.value}
           definition={definition.value}
           onRefresh={refresh}

--- a/dolphinscheduler-ui/src/views/projects/workflow/instance/detail/index.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/instance/detail/index.tsx
@@ -59,7 +59,6 @@ export default defineComponent({
     const refresh = () => {
       queryProcessInstanceById(id, projectCode).then((res: any) => {
         instance.value = res
-        console.log(res)
         if (!res.dagData.processDefinition.locations) {
           setTimeout(() => {
             const graph = dagInstanceRef.value


### PR DESCRIPTION
In #11535(096fae77) and #11681(4dca488c), we already formatted the workflow definition, but I found out we forgot formatted the workflow instance with the definition's location is null, this patch also formatted the workflow instance.
