### PR TITLE
[Feature-11488][Datax]Datax can submit to YARN

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
@@ -21,7 +21,6 @@ import static org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUt
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EXIT_CODE_FAILURE;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.RWXR_XR_X;
 
-import org.apache.commons.collections4.MapUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTaskExecutor;
@@ -33,6 +32,7 @@ import org.apache.dolphinscheduler.plugin.task.api.model.TaskResponse;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parser.ParamUtils;
 import org.apache.dolphinscheduler.plugin.task.api.parser.ParameterUtils;
+import org.apache.dolphinscheduler.plugin.task.api.utils.MapUtils;
 import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.enums.Flag;
@@ -44,7 +44,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,7 +77,6 @@ import com.alibaba.druid.sql.ast.statement.SQLUnionQuery;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import sun.tools.jar.resources.jar;
 
 public class DataxTask extends AbstractTaskExecutor {
     /**
@@ -96,17 +94,6 @@ public class DataxTask extends AbstractTaskExecutor {
      * datax path
      */
     private static final String DATAX_PATH = "${DATAX_HOME}/bin/datax.py";
-
-    /**
-     * datax hdfs path
-     */
-    private static final String DATAX_HDFS_PATH = "DATAX_HDFS_PATH";
-
-    /**
-     * datax hdfs path
-     */
-    private static final String DATAX_ON_YARN_DEPEND_JAR = "DATAX_ON_YARN_DEPEND_JAR";
-
     /**
      * datax channel count
      */
@@ -168,18 +155,9 @@ public class DataxTask extends AbstractTaskExecutor {
             // replace placeholder,and combine local and global parameters
             Map<String, Property> paramsMap = taskExecutionContext.getPrepareParamsMap();
 
+            // run datax procesDataSourceService.s
             String jsonFilePath = buildDataxJsonFile(paramsMap);
-
-            String dataxHdfsPath = System.getenv(DATAX_HDFS_PATH);
-            String dataxOnYarnDependJar = System.getenv(DATAX_ON_YARN_DEPEND_JAR);
-
-            String shellCommandFilePath = null;
-            if (StringUtils.isNotBlank(dataxHdfsPath) && StringUtils.isNotBlank(dataxOnYarnDependJar)){
-                shellCommandFilePath = buildYarnShellCommandFile(jsonFilePath, paramsMap, dataxHdfsPath, dataxOnYarnDependJar);
-            }else {
-                shellCommandFilePath = buildShellCommandFile(jsonFilePath, paramsMap);
-            }
-
+            String shellCommandFilePath = buildShellCommandFile(jsonFilePath, paramsMap);
             TaskResponse commandExecuteResult = shellCommandExecutor.run(shellCommandFilePath);
 
             setExitStatusCode(commandExecuteResult.getExitStatusCode());
@@ -390,56 +368,6 @@ public class DataxTask extends AbstractTaskExecutor {
         return core;
     }
 
-    private String buildYarnShellCommandFile(String jobConfigFilePath, Map<String, Property> paramsMap, String dataxHdfsPath, String dataxOnYarnDependJar)
-            throws Exception {
-        // generate scripts
-        String fileName = String.format("%s/%s_node.%s",
-                taskExecutionContext.getTaskAppId(),
-                SystemUtils.IS_OS_WINDOWS ? "bat" : "sh");
-
-        Path path = new File(fileName).toPath();
-
-        if (Files.exists(path)) {
-            return fileName;
-        }
-
-        int xms = Math.max(dataXParameters.getXms(), 1);
-        int xmx = Math.max(dataXParameters.getXmx(), 1);
-        int jvm = Math.max(xms, xmx);
-
-        StringBuilder sbr = new StringBuilder("yarn jar " + dataxOnYarnDependJar);;
-        sbr.append(" -jar_path " + dataxOnYarnDependJar);
-        sbr.append(" -appname datax-job");
-        sbr.append(" -master_memory " + (jvm * 1024));
-        sbr.append(" -datax_job " + jobConfigFilePath);
-        sbr.append(" -datax_home_hdfs " + dataxHdfsPath);
-
-        if (paramsMap.size() != 0){
-            StringBuilder customParameters = new StringBuilder();
-            for (Map.Entry<String, Property> entry : paramsMap.entrySet()) {
-                customParameters.append(entry.getKey()).append("=").append(entry.getValue().getValue()).append(",");
-            }
-            sbr.append(" -p " + customParameters);
-        }
-
-        // replace placeholder
-        String dataxCommand = ParameterUtils.convertParameterPlaceholders(sbr.toString(), ParamUtils.convert(paramsMap));
-        logger.debug("raw script : {}", dataxCommand);
-
-        // create shell command file
-        Set<PosixFilePermission> perms = PosixFilePermissions.fromString(RWXR_XR_X);
-        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
-
-        if (SystemUtils.IS_OS_WINDOWS) {
-            Files.createFile(path);
-        } else {
-            Files.createFile(path, attr);
-        }
-
-        Files.write(path, dataxCommand.getBytes(), StandardOpenOption.APPEND);
-
-        return fileName;
-    }
     /**
      * create command
      *
@@ -450,6 +378,7 @@ public class DataxTask extends AbstractTaskExecutor {
             throws Exception {
         // generate scripts
         String fileName = String.format("%s/%s_node.%s",
+                taskExecutionContext.getExecutePath(),
                 taskExecutionContext.getTaskAppId(),
                 SystemUtils.IS_OS_WINDOWS ? "bat" : "sh");
 

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -45,9 +45,5 @@ export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
 export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
 export SEATUNNEL_HOME=${SEATUNNEL_HOME:-/opt/soft/seatunnel}
 export CHUNJUN_HOME=${CHUNJUN_HOME:-/opt/soft/chunjun}
-#export DATAX_ON_YARN_DEPEND_JAR=${DATAX_ON_YARN_DEPEND_JAR:-/opt/soft/datax/datax-on-yarn-1.0.0.jar}
-#DATAX_HDFS_HOME is HDFS path
-#export DATAX_HDFS_PATH=${DATAX_HDFS_HOME:-/hdfs/opt/hadoop/datax.tar.gz}
-
 
 export PATH=$HADOOP_HOME/bin:$SPARK_HOME1/bin:$SPARK_HOME2/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$SEATUNNEL_HOME/bin:$CHUNJUN_HOME/bin:$PATH

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -45,5 +45,8 @@ export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
 export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
 export SEATUNNEL_HOME=${SEATUNNEL_HOME:-/opt/soft/seatunnel}
 export CHUNJUN_HOME=${CHUNJUN_HOME:-/opt/soft/chunjun}
+#export DATAX_ON_YARN_DEPEND_JAR=${DATAX_ON_YARN_DEPEND_JAR:-/opt/soft/datax/datax-on-yarn-1.0.0.jar}
+#DATAX_HDFS_HOME is HDFS path
+#export DATAX_HDFS_PATH=${DATAX_HDFS_HOME:-/hdfs/opt/hadoop/datax.tar.gz}
 
 export PATH=$HADOOP_HOME/bin:$SPARK_HOME1/bin:$SPARK_HOME2/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$SEATUNNEL_HOME/bin:$CHUNJUN_HOME/bin:$PATH

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -45,5 +45,9 @@ export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
 export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
 export SEATUNNEL_HOME=${SEATUNNEL_HOME:-/opt/soft/seatunnel}
 export CHUNJUN_HOME=${CHUNJUN_HOME:-/opt/soft/chunjun}
+#export DATAX_ON_YARN_DEPEND_JAR=${DATAX_ON_YARN_DEPEND_JAR:-/opt/soft/datax/datax-on-yarn-1.0.0.jar}
+#DATAX_HDFS_HOME is HDFS path
+#export DATAX_HDFS_PATH=${DATAX_HDFS_HOME:-/hdfs/opt/hadoop/datax.tar.gz}
+
 
 export PATH=$HADOOP_HOME/bin:$SPARK_HOME1/bin:$SPARK_HOME2/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$SEATUNNEL_HOME/bin:$CHUNJUN_HOME/bin:$PATH


### PR DESCRIPTION
close https://github.com/apache/dolphinscheduler/issues/11488

Instructions:

Configure the environment variables DATAX_ON_YARN_DEPEND_JAR and DATAX_HDFS_PATH to run DATAX ON YARN

Parameter explanation:
DATAX_ON_YARN_DEPEND_JAR:
https://github.com/duhanmin/datax-on-yarn Compile and package

DATAX_HDFS_PATH:
You need to upload the datax installation package to yarn


example:
````
#export DATAX_ON_YARN_DEPEND_JAR=${DATAX_ON_YARN_DEPEND_JAR:-/opt/soft/datax/datax-on-yarn-1.0.0.jar}
#DATAX_HDFS_HOME is HDFS path
#export DATAX_HDFS_PATH=${DATAX_HDFS_HOME:-/hdfs/opt/hadoop/datax.tar.gz}
````