### PR TITLE
[Fix-12109] Fix the errors when starting 2 times with dolphinscheduler-daemon.sh

### DIFF
--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -28,8 +28,6 @@ startStop=$1
 shift
 command=$1
 shift
-CLASS=$1
-shift
 
 echo "Begin $startStop $command......"
 
@@ -81,8 +79,25 @@ else
   exit 1
 fi
 
+state=""
+function get_server_running_status() {
+  state="STOP"
+  if [ -f $pid ]; then
+    TARGET_PID=`cat $pid`
+    if [[ $(ps -p "$TARGET_PID" -o comm=) =~ "bash" ]]; then
+      state="RUNNING"
+    fi
+  fi
+}
+
 case $startStop in
   (start)
+    # if server is already started, cancel this launch
+    get_server_running_status
+    if [[ $state == "RUNNING" ]]; then
+      echo "$command running as process $TARGET_PID.  Stop it first."
+      exit 1
+    fi
     echo starting $command, logging to $DOLPHINSCHEDULER_LOG_DIR
     overwrite_server_env "${command}"
     nohup /bin/bash "$DOLPHINSCHEDULER_HOME/$command/bin/start.sh" > $log 2>&1 &
@@ -110,13 +125,11 @@ case $startStop in
       ;;
 
   (status)
-    # more details about the status can be added later
-    serverCount=`ps -ef | grep "java" | grep "$DOLPHINSCHEDULER_HOME" | grep "$CLASS" | grep -v "grep" | wc -l`
-    state="STOP"
-    #  font color - red
-    state="[ \033[1;31m $state \033[0m ]"
-    if [[ $serverCount -gt 0 ]];then
-      state="RUNNING"
+    get_server_running_status
+    if [[ $state == "STOP" ]]; then
+      #  font color - red
+      state="[ \033[1;31m $state \033[0m ]"
+    else
       # font color - green
       state="[ \033[1;32m $state \033[0m ]"
     fi

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -49,25 +49,25 @@ StateRunning="Running"
 mastersHost=(${masters//,/ })
 for master in ${mastersHost[@]}
 do
-  masterState=`ssh -o StrictHostKeyChecking=no -p $sshPort $master  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status master-server org.apache.dolphinscheduler.server.master.MasterServer;"`
+  masterState=`ssh -o StrictHostKeyChecking=no -p $sshPort $master  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status master-server;"`
   echo "$master  $masterState"
 done
 
 # 2.worker server check state
 for worker in ${workerNames[@]}
 do
-  workerState=`ssh -o StrictHostKeyChecking=no -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server org.apache.dolphinscheduler.server.worker.WorkerServer;"`
+  workerState=`ssh -o StrictHostKeyChecking=no -p $sshPort $worker  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status worker-server;"`
   echo "$worker  $workerState"
 done
 
 # 3.alter server check state
-alertState=`ssh -o StrictHostKeyChecking=no -p $sshPort $alertServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status alert-server org.apache.dolphinscheduler.alert.AlertServer;"`
+alertState=`ssh -o StrictHostKeyChecking=no -p $sshPort $alertServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status alert-server;"`
 echo "$alertServer  $alertState"
 
 # 4.api server check state
 apiServersHost=(${apiServers//,/ })
 for apiServer in ${apiServersHost[@]}
 do
-  apiState=`ssh -o StrictHostKeyChecking=no -p $sshPort $apiServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status api-server org.apache.dolphinscheduler.api.ApiApplicationServer;"`
+  apiState=`ssh -o StrictHostKeyChecking=no -p $sshPort $apiServer  "cd $installPath/; bash bin/dolphinscheduler-daemon.sh status api-server;"`
   echo "$apiServer  $apiState"
 done


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

close: #12109 

If the user starts DS twice (or more) using `dolphinscheduler-daemon.sh`, the `pid` file will be overwritten, making it impossible to stop the initially started DS cluster.

## Brief change log

* Use `pid` to check the status of the server
* If the server is already started, cancel this launch

## Verify this pull request

manually tested

1. Start all the server and `ps -ef`as below
<img width="896" alt="image" src="https://user-images.githubusercontent.com/38122586/191886250-332762be-0201-445f-a0cd-64d6176bad81.png">

2. Start all the server again

<img width="896" alt="截屏2022-09-23 11 21 00" src="https://user-images.githubusercontent.com/38122586/191886323-5d037d5e-47a4-40cb-8477-8170f23aeb47.png">

3. the result of `ps -ef` is unchanged

<img width="894" alt="image" src="https://user-images.githubusercontent.com/38122586/191886400-cd994978-a38b-464e-bb19-df9a74417c6e.png">




