### PR TITLE
[fix][python] Task switch branch not show in webui

### DIFF
--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/task.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/task.py
@@ -231,7 +231,7 @@ class Task(Base):
         """Set attribute condition_result."""
         self._condition_result = condition_result
 
-    def _get_attr(self) -> set[str]:
+    def _get_attr(self) -> Set[str]:
         """Get final task task_params attribute.
 
         Base on `_task_default_attr`, append attribute from `_task_custom_attr` and subtract attribute from

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/task.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/core/task.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """DolphinScheduler Task and TaskRelation object."""
-
+import copy
 from logging import getLogger
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
@@ -100,6 +100,17 @@ class Task(Base):
         "timeout",
     }
 
+    # task default attribute will into `task_params` property
+    _task_default_attr = {
+        "local_params",
+        "resource_list",
+        "dependence",
+        "wait_start_timeout",
+        "condition_result",
+    }
+    # task attribute ignore from _task_default_attr and will not into `task_params` property
+    _task_ignore_attr: set = set()
+    # task custom attribute define in sub class and will append to `task_params` property
     _task_custom_attr: set = set()
 
     ext: set = None
@@ -220,20 +231,24 @@ class Task(Base):
         """Set attribute condition_result."""
         self._condition_result = condition_result
 
+    def _get_attr(self) -> set[str]:
+        """Get final task task_params attribute.
+
+        Base on `_task_default_attr`, append attribute from `_task_custom_attr` and subtract attribute from
+        `_task_ignore_attr`.
+        """
+        attr = copy.deepcopy(self._task_default_attr)
+        attr -= self._task_ignore_attr
+        attr |= self._task_custom_attr
+        return attr
+
     @property
     def task_params(self) -> Optional[Dict]:
         """Get task parameter object.
 
         Will get result to combine _task_custom_attr and custom_attr.
         """
-        custom_attr = {
-            "local_params",
-            "resource_list",
-            "dependence",
-            "wait_start_timeout",
-            "condition_result",
-        }
-        custom_attr |= self._task_custom_attr
+        custom_attr = self._get_attr()
         return self.get_define_custom(custom_attr=custom_attr)
 
     def get_plugin(self):

--- a/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/switch.py
+++ b/dolphinscheduler-python/pydolphinscheduler/src/pydolphinscheduler/tasks/switch.py
@@ -134,6 +134,11 @@ class Switch(Task):
     if task `switch` in this workflow.
     """
 
+    _task_ignore_attr = {
+        "condition_result",
+        "dependence",
+    }
+
     def __init__(self, name: str, condition: SwitchCondition, *args, **kwargs):
         super().__init__(name, TaskType.SWITCH, *args, **kwargs)
         self.condition = condition

--- a/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_switch.py
+++ b/dolphinscheduler-python/pydolphinscheduler/tests/tasks/test_switch.py
@@ -236,8 +236,6 @@ def test_switch_get_define(mock_task_code_version):
         "taskParams": {
             "resourceList": [],
             "localParams": [],
-            "dependence": {},
-            "conditionResult": {"successNode": [""], "failedNode": [""]},
             "waitStartTimeout": {},
             "switchResult": {
                 "dependTaskList": [


### PR DESCRIPTION
when create task switch in python api, switch branch not show correctly, due to we add some unnecessary attribute to switch task, this patch we add `_task_ignore_attr` in class `Task` to ignore those unnecessary attribute from `_task_default_attr`
