### PR TITLE
[fix#12114] [API] Add TaskInstance validator when deleting the worker group records.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -247,6 +247,7 @@ public enum Status {
     TASK_WITH_DEPENDENT_ERROR(10195, "task used in other tasks", "删除被其他任务引用"),
     TASK_SAVEPOINT_ERROR(10196, "task savepoint error", "任务实例savepoint错误"),
     TASK_STOP_ERROR(10197, "task stop error", "任务实例停止错误"),
+    DELETE_WORKER_GROUP_FAILED_TASK_INSTANCE_EXIST(10198, "delete worker group failed, because there are {0} task instances in executing using it", "删除Wroker工作组失败，因为存在[{0}]个执行的任务实例正在使用它"),
     LIST_TASK_TYPE_ERROR(10200, "list task type error", "查询任务类型列表错误"),
     DELETE_TASK_TYPE_ERROR(10200, "delete task type error", "删除任务类型错误"),
     ADD_TASK_TYPE_ERROR(10200, "add task type error", "添加任务类型错误"),

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -24,9 +24,11 @@ import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ProfileType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
+import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
 import org.apache.dolphinscheduler.service.registry.RegistryClient;
 
@@ -61,6 +63,9 @@ public class WorkerGroupServiceTest {
 
     @MockBean(name = "processInstanceMapper")
     private ProcessInstanceMapper processInstanceMapper;
+
+    @MockBean(name = "taskInstanceMapper")
+    private TaskInstanceMapper taskInstanceMapper;
 
     private String groupName = "groupName000001";
 
@@ -98,8 +103,16 @@ public class WorkerGroupServiceTest {
         WorkerGroup wg3 = getWorkerGroup(3);
         Mockito.when(workerGroupMapper.selectById(3)).thenReturn(wg3);
         Mockito.when(processInstanceMapper.queryByWorkerGroupNameAndStatus(wg3.getName(), Constants.NOT_TERMINATED_STATES)).thenReturn(new ArrayList<>());
+        Mockito.when(taskInstanceMapper.queryByWorkerGroupNameAndStatus(wg3.getName(), Constants.NOT_TERMINATED_STATES)).thenReturn(new ArrayList<>());
         result = workerGroupService.deleteWorkerGroupById(user, 3);
         Assert.assertEquals(Status.SUCCESS.getMsg(), result.get(Constants.MSG));
+
+        WorkerGroup wg4 = getWorkerGroup(4);
+        Mockito.when(workerGroupMapper.selectById(4)).thenReturn(wg4);
+        Mockito.when(processInstanceMapper.queryByWorkerGroupNameAndStatus(wg4.getName(), Constants.NOT_TERMINATED_STATES)).thenReturn(new ArrayList<>());
+        Mockito.when(taskInstanceMapper.queryByWorkerGroupNameAndStatus(wg4.getName(), Constants.NOT_TERMINATED_STATES)).thenReturn(getTaskInstanceList());
+        result = workerGroupService.deleteWorkerGroupById(user, 4);
+        Assert.assertEquals(Status.DELETE_WORKER_GROUP_FAILED_TASK_INSTANCE_EXIST.getCode(), ((Status) result.get(Constants.STATUS)).getCode());
     }
 
     /**
@@ -109,6 +122,15 @@ public class WorkerGroupServiceTest {
         List<ProcessInstance> processInstances = new ArrayList<>();
         processInstances.add(new ProcessInstance());
         return processInstances;
+    }
+
+    /**
+     * get task instances
+     */
+    private List<TaskInstance> getTaskInstanceList() {
+        List<TaskInstance> taskInstances = new ArrayList<>();
+        taskInstances.add(new TaskInstance());
+        return taskInstances;
     }
 
     @Test

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.java
@@ -117,4 +117,14 @@ public interface TaskInstanceMapper extends BaseMapper<TaskInstance> {
 
     List<TaskInstance> loadAllInfosNoRelease(@Param("processInstanceId") int processInstanceId,
                                              @Param("status") int status);
+
+    /**
+     * query task instance list by worker group and status
+     *
+     * @param workerGroupName worker group name
+     * @param states task instance states
+     * @return task instance list
+     */
+    List<TaskInstance> queryByWorkerGroupNameAndStatus(@Param("workerGroupName") String workerGroupName,
+        @Param("states") int[] states);
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -273,4 +273,20 @@
         where instance.process_instance_id = #{processInstanceId}
         and que.status = #{status}
     </select>
+    <select id="queryByWorkerGroupNameAndStatus" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
+        select
+        <include refid="baseSql"/>
+        from t_ds_task_instance
+        where 1=1
+        <if test="workerGroupName != ''">
+        and worker_group =#{workerGroupName}
+        </if>
+        <if test="states != null and states.length != 0">
+        and state in
+        <foreach collection="states" item="i" open="(" close=")" separator=",">
+            #{i}
+        </foreach>
+        </if>
+        order by id asc
+    </select>
 </mapper>

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapperTest.java
@@ -386,4 +386,33 @@ public class TaskInstanceMapperTest extends BaseDaoTest {
         Assert.assertEquals(taskInstanceIPage.getTotal(), 0);
 
     }
+
+    /**
+     * test query task instance list by worker group and status
+     */
+    @Test
+    public void testQueryByWorkerGroupNameAndStatus() {
+        // insert ProcessInstance
+        ProcessInstance processInstance = insertProcessInstance();
+
+        // insert taskInstance
+        TaskInstance task = insertTaskInstance(processInstance.getId());
+        task.setHost("111.111.11.11");
+        task.setWorkerGroup("app01");
+        taskInstanceMapper.updateById(task);
+
+        int[] states = {task.getState().getCode()};
+        List<TaskInstance> tasks = taskInstanceMapper.queryByWorkerGroupNameAndStatus(
+            "app01",
+            states
+        );
+        List<TaskInstance> tasks2 = taskInstanceMapper.queryByWorkerGroupNameAndStatus(
+            "app02",
+            states
+        );
+        taskInstanceMapper.deleteById(task.getId());
+        Assert.assertNotEquals(states, null);
+        Assert.assertEquals(tasks.size(), 1);
+        Assert.assertEquals(tasks2.size(), 0);
+    }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

fix #12114 

## Brief change log

1. Add `queryByWorkerGroupNameAndStatus` function in `TaskInstanceMapper` and relate SQL in mapper.xml
2. Add a validator in `WorkerGroupServiceImpl.deleteWorkerGroupById`, if there are some task instance executing, user cannot delete this worker group record.
3. Add some UT

## Verify this pull request
This change added tests.

