### PR TITLE
[Improvement][Master]add worker group checking steps before workflow executor

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -357,6 +357,8 @@ public enum Status {
     BATCH_EXECUTE_PROCESS_INSTANCE_ERROR(50058, "change process instance status error: {0}", "修改工作实例状态错误: {0}"),
     START_TASK_INSTANCE_ERROR(50059, "start task instance error", "运行任务流实例错误"),
     DELETE_PROCESS_DEFINE_ERROR(50060, "delete process definition [{0}] error: {1}", "删除工作流定义[{0}]错误: {1}"),
+    WORKER_GROUP_NOT_EXISTS(50061, "exist task's worker group not exists", "存在任务的Wroker工作组不存在"),
+    WORKER_GROUP_NOT_EXISTS_PROCESSING(50062, "process instance [{0}] Worker group [{1}] not exists", "工作流实例[{0}]中Worker工作组[{1}]不存在"),
 
     HDFS_NOT_STARTUP(60001, "hdfs not startup", "hdfs未启用"),
     STORAGE_NOT_STARTUP(60002, "storage not startup", "存储未启用"),

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkerGroupService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkerGroupService.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import java.util.List;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.User;
 
@@ -72,5 +73,11 @@ public interface WorkerGroupService {
      * @return all worker address list
      */
     Map<String, Object> getWorkerAddressList();
+
+    /**
+     * get all worker group names
+     * @return worker group name list
+     */
+    List<String> getAllWorkerGroupNames();
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -360,7 +360,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
      */
     @Override
     public List<String> getAllWorkerGroupNames() {
-        List<WorkerGroup> workerGroups = getWorkerGroups(false, null);
+        List<WorkerGroup> workerGroups = getWorkerGroups( null);
         List<String> availableWorkerGroupList = workerGroups.stream()
             .map(WorkerGroup::getName)
             .collect(Collectors.toList());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -353,4 +353,22 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         return result;
     }
 
+    /**
+     * get all worker group names
+     *
+     * @return worker group name list
+     */
+    @Override
+    public List<String> getAllWorkerGroupNames() {
+        List<WorkerGroup> workerGroups = getWorkerGroups(false, null);
+        List<String> availableWorkerGroupList = workerGroups.stream()
+            .map(WorkerGroup::getName)
+            .collect(Collectors.toList());
+        if (!availableWorkerGroupList.contains(Constants.DEFAULT_WORKER_GROUP)) {
+            availableWorkerGroupList.add(Constants.DEFAULT_WORKER_GROUP);
+        }
+        return availableWorkerGroupList;
+    }
+
+
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorServiceTest.java
@@ -123,6 +123,9 @@ public class ExecutorServiceTest {
     @Mock
     private ProcessInstanceMapper processInstanceMapper;
 
+    @Mock
+    private WorkerGroupService workerGroupService;
+
     private int processDefinitionId = 1;
 
     private long processDefinitionCode = 1L;
@@ -172,6 +175,7 @@ public class ExecutorServiceTest {
         processInstance.setTenantId(tenantId);
         processInstance.setProcessDefinitionVersion(1);
         processInstance.setProcessDefinitionCode(1L);
+        processInstance.setWorkerGroup(Constants.DEFAULT_WORKER_GROUP);
 
         // project
         project.setCode(projectCode);
@@ -403,9 +407,18 @@ public class ExecutorServiceTest {
         Mockito.when(processService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
         Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectCode, RERUN))
                 .thenReturn(checkProjectAndAuth());
+        List<String> workerGroups = new ArrayList<>();
+        workerGroups.add(Constants.DEFAULT_WORKER_GROUP);
+        Mockito.when(workerGroupService.getAllWorkerGroupNames()).thenReturn(workerGroups);
         Map<String, Object> result =
                 executorService.execute(loginUser, projectCode, processInstanceId, ExecuteType.REPEAT_RUNNING);
         Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+
+        workerGroups.clear();
+        Mockito.when(workerGroupService.getAllWorkerGroupNames()).thenReturn(workerGroups);
+        result =
+            executorService.execute(loginUser, projectCode, processInstanceId, ExecuteType.REPEAT_RUNNING);
+        Assert.assertEquals(Status.WORKER_GROUP_NOT_EXISTS_PROCESSING, result.get(Constants.STATUS));
     }
 
     @Test
@@ -413,6 +426,9 @@ public class ExecutorServiceTest {
         Mockito.when(processService.verifyIsNeedCreateCommand(any(Command.class))).thenReturn(true);
         Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectCode, RERUN))
                 .thenReturn(checkProjectAndAuth());
+        List<String> workerGroups = new ArrayList<>();
+        workerGroups.add(Constants.DEFAULT_WORKER_GROUP);
+        Mockito.when(workerGroupService.getAllWorkerGroupNames()).thenReturn(workerGroups);
         Map<String, Object> result = executorService.execProcessInstance(loginUser, projectCode,
                 processDefinitionCode,
                 "{\"complementStartDate\":\"2020-01-01 00:00:00\",\"complementEndDate\":\"2020-01-31 23:00:00\"}",


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

fix #12001 

## Brief change log

Just add a validator before task instance was put to dispatch queue.
1. When use start a ProcessInstance or re-run this processInstance, this PR will check if the worker group exists.
## Verify this pull request

