### PR TITLE
[Improvement][Test] Remove powermock in service and server modules

### DIFF
--- a/dolphinscheduler-server/pom.xml
+++ b/dolphinscheduler-server/pom.xml
@@ -15,7 +15,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,8 +24,20 @@
         <version>dev-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-server</artifactId>
-    <name>dolphinscheduler-server</name>
     <packaging>jar</packaging>
+    <name>dolphinscheduler-server</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.dolphinscheduler</groupId>
+                <artifactId>dolphinscheduler-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- dolphinscheduler -->
@@ -47,7 +58,13 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.12.4</version>
+            <!-- TODO: move this dependency to root pom after removing powermock in the whole project -->
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
@@ -62,8 +79,8 @@
                     <artifactId>jdk.tools</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>servlet-api</artifactId>
                     <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -127,16 +144,16 @@
                     <artifactId>jsp-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-json</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-server</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jersey-core</artifactId>
                     <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -154,8 +171,8 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>servlet-api</artifactId>
                     <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.jackson</groupId>
@@ -179,36 +196,24 @@
                     <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-client</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jaxb-api</artifactId>
                     <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.dolphinscheduler</groupId>
-                <artifactId>dolphinscheduler-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ProcessUtils.java
@@ -17,10 +17,6 @@
 
 package org.apache.dolphinscheduler.server.utils;
 
-import lombok.NonNull;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.CommonUtils;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
@@ -31,10 +27,11 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.remote.utils.Host;
 import org.apache.dolphinscheduler.service.log.LogClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -42,6 +39,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+import lombok.NonNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * mainly used to get the start command line of a process.
@@ -166,7 +170,9 @@ public class ProcessUtils {
             }
         } else {
             String pids = OSUtils.exeCmd(String.format("%s -p %d", Constants.PSTREE, processId));
-            mat = WINDOWSATTERN.matcher(pids);
+            if (null != pids) {
+                mat = WINDOWSATTERN.matcher(pids);
+            }
         }
 
         if (null != mat) {
@@ -206,10 +212,12 @@ public class ProcessUtils {
                                     taskExecutionContext.getTaskInstanceId()));
                 }
                 FileUtils.createWorkDirIfAbsent(taskExecutionContext.getExecutePath());
-                cancelApplication(appIds, logger, taskExecutionContext.getTenantCode(), taskExecutionContext.getExecutePath());
+                cancelApplication(appIds, logger, taskExecutionContext.getTenantCode(),
+                        taskExecutionContext.getExecutePath());
                 return appIds;
             } else {
-                logger.info("The current appId is empty, don't need to kill the yarn job, taskInstanceId: {}", taskExecutionContext.getTaskInstanceId());
+                logger.info("The current appId is empty, don't need to kill the yarn job, taskInstanceId: {}",
+                        taskExecutionContext.getTaskInstanceId());
             }
         } catch (Exception e) {
             logger.error("Kill yarn job failure, taskInstanceId: {}", taskExecutionContext.getTaskInstanceId(), e);

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ProcessUtilsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.server.utils;
 
+import static org.mockito.ArgumentMatchers.anyString;
+
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.HadoopUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
@@ -50,10 +52,9 @@ public class ProcessUtilsTest {
     public void getPidsStr() throws Exception {
         int processId = 1;
         Mockito.mockStatic(OSUtils.class);
-        Mockito.when(OSUtils.exeCmd(String.format("%s -p %d", Constants.PSTREE, processId))).thenReturn(null);
-        Mockito.when(OSUtils.exeCmd(String.format("%s -sp %d", Constants.PSTREE, processId))).thenReturn(null);
-        String pidListMac = ProcessUtils.getPidsStr(processId);
-        Assert.assertEquals("", pidListMac);
+        Mockito.when(OSUtils.exeCmd(anyString())).thenReturn(null);
+        String pidList = ProcessUtils.getPidsStr(processId);
+        Assert.assertEquals("", pidList);
     }
 
     @Test

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ProcessUtilsTest.java
@@ -51,6 +51,7 @@ public class ProcessUtilsTest {
         int processId = 1;
         Mockito.mockStatic(OSUtils.class);
         Mockito.when(OSUtils.exeCmd(String.format("%s -p %d", Constants.PSTREE, processId))).thenReturn(null);
+        Mockito.when(OSUtils.exeCmd(String.format("%s -sp %d", Constants.PSTREE, processId))).thenReturn(null);
         String pidListMac = ProcessUtils.getPidsStr(processId);
         Assert.assertEquals("", pidListMac);
     }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ProcessUtilsTest.java
@@ -17,31 +17,26 @@
 
 package org.apache.dolphinscheduler.server.utils;
 
-import static org.powermock.api.mockito.PowerMockito.when;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.utils.HadoopUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({System.class, OSUtils.class, HadoopUtils.class, PropertyUtils.class, SystemUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class ProcessUtilsTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessUtils.class);
@@ -54,23 +49,22 @@ public class ProcessUtilsTest {
     @Test
     public void getPidsStr() throws Exception {
         int processId = 1;
-        PowerMockito.mockStatic(OSUtils.class);
-        Whitebox.setInternalState(SystemUtils.class, "IS_OS_MAC", true);
-        when(OSUtils.exeCmd(String.format("%s -p %d", Constants.PSTREE, processId))).thenReturn(null);
+        Mockito.mockStatic(OSUtils.class);
+        Mockito.when(OSUtils.exeCmd(String.format("%s -p %d", Constants.PSTREE, processId))).thenReturn(null);
         String pidListMac = ProcessUtils.getPidsStr(processId);
         Assert.assertEquals("", pidListMac);
     }
 
     @Test
     public void testGetKerberosInitCommand() {
-        PowerMockito.mockStatic(PropertyUtils.class);
-        PowerMockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+        Mockito.mockStatic(PropertyUtils.class);
+        Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
                 .thenReturn(true);
-        PowerMockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH)).thenReturn("/etc/krb5.conf");
-        PowerMockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH)).thenReturn("/etc/krb5.keytab");
-        PowerMockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME)).thenReturn("test@DS.COM");
+        Mockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH)).thenReturn("/etc/krb5.conf");
+        Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH)).thenReturn("/etc/krb5.keytab");
+        Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME)).thenReturn("test@DS.COM");
         Assert.assertNotEquals("", ProcessUtils.getKerberosInitCommand());
-        PowerMockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+        Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
                 .thenReturn(false);
         Assert.assertEquals("", ProcessUtils.getKerberosInitCommand());
     }
@@ -84,17 +78,12 @@ public class ProcessUtilsTest {
         String executePath = "/ds-exec/1/1/1";
         TaskExecutionStatus running = TaskExecutionStatus.RUNNING_EXECUTION;
 
-        PowerMockito.mockStatic(HadoopUtils.class);
+        Mockito.mockStatic(HadoopUtils.class);
         HadoopUtils hadoop = HadoopUtils.getInstance();
 
         try {
-            PowerMockito.whenNew(HadoopUtils.class).withAnyArguments().thenReturn(hadoop);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        try {
-            when(hadoop.getApplicationStatus("application_1585532379175_228491")).thenReturn(running);
-            when(hadoop.getApplicationStatus("application_1598885606600_3677")).thenReturn(running);
+            Mockito.when(hadoop.getApplicationStatus("application_1585532379175_228491")).thenReturn(running);
+            Mockito.when(hadoop.getApplicationStatus("application_1598885606600_3677")).thenReturn(running);
         } catch (Exception e) {
             e.printStackTrace();
             ProcessUtils.cancelApplication(appIds, logger, tenantCode, executePath);

--- a/dolphinscheduler-service/pom.xml
+++ b/dolphinscheduler-service/pom.xml
@@ -17,16 +17,28 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>dolphinscheduler</artifactId>
         <groupId>org.apache.dolphinscheduler</groupId>
+        <artifactId>dolphinscheduler</artifactId>
         <version>dev-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dolphinscheduler-service</artifactId>
 
     <name>dolphinscheduler-service</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.dolphinscheduler</groupId>
+                <artifactId>dolphinscheduler-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- dolphinscheduler -->
@@ -52,6 +64,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.12.4</version>
+            <!-- TODO: move this dependency to root pom after removing powermock in the whole project -->
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.cronutils</groupId>
             <artifactId>cron-utils</artifactId>
         </dependency>
@@ -63,16 +83,4 @@
         </dependency>
 
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.dolphinscheduler</groupId>
-                <artifactId>dolphinscheduler-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/alert/AlertClientService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/alert/AlertClientService.java
@@ -21,20 +21,19 @@ import org.apache.dolphinscheduler.remote.NettyRemotingClient;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.alert.AlertSendRequestCommand;
 import org.apache.dolphinscheduler.remote.command.alert.AlertSendResponseCommand;
-import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
 import org.apache.dolphinscheduler.remote.utils.Host;
 import org.apache.dolphinscheduler.remote.utils.JsonSerializer;
+import org.apache.dolphinscheduler.service.factory.NettyRemotingClientFactory;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// TODO: powermock removed, need to fix it
 public class AlertClientService implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(AlertClientService.class);
-
-    private final NettyClientConfig clientConfig;
 
     private final NettyRemotingClient client;
 
@@ -53,8 +52,7 @@ public class AlertClientService implements AutoCloseable {
      * alert client
      */
     public AlertClientService() {
-        this.clientConfig = new NettyClientConfig();
-        this.client = new NettyRemotingClient(clientConfig);
+        this.client = NettyRemotingClientFactory.buildNettyRemotingClient();
         this.isRunning = new AtomicBoolean(true);
     }
 
@@ -89,8 +87,8 @@ public class AlertClientService implements AutoCloseable {
      * @param content
      * @return
      */
-    public AlertSendResponseCommand sendAlert(int groupId, String title,  String content, int strategy) {
-        return this.sendAlert(this.host,this.port,groupId,title,content,strategy);
+    public AlertSendResponseCommand sendAlert(int groupId, String title, String content, int strategy) {
+        return this.sendAlert(this.host, this.port, groupId, title, content, strategy);
     }
 
     /**
@@ -102,8 +100,10 @@ public class AlertClientService implements AutoCloseable {
      * @param content content
      * @return AlertSendResponseCommand
      */
-    public AlertSendResponseCommand sendAlert(String host, int port, int groupId, String title,  String content, int strategy) {
-        logger.info("sync alert send, host : {}, port : {}, groupId : {}, title : {} , strategy : {} ", host, port, groupId, title, strategy);
+    public AlertSendResponseCommand sendAlert(String host, int port, int groupId, String title, String content,
+                                              int strategy) {
+        logger.info("sync alert send, host : {}, port : {}, groupId : {}, title : {} , strategy : {} ", host, port,
+                groupId, title, strategy);
         AlertSendRequestCommand request = new AlertSendRequestCommand(groupId, title, content, strategy);
         final Host address = new Host(host, port);
         try {

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/alert/AlertClientService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/alert/AlertClientService.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO: powermock removed, need to fix it
 public class AlertClientService implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(AlertClientService.class);

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/factory/NettyRemotingClientFactory.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/factory/NettyRemotingClientFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.service.factory;
 
 import org.apache.dolphinscheduler.remote.NettyRemotingClient;

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/factory/NettyRemotingClientFactory.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/factory/NettyRemotingClientFactory.java
@@ -1,0 +1,21 @@
+package org.apache.dolphinscheduler.service.factory;
+
+import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
+
+import lombok.experimental.UtilityClass;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@UtilityClass
+public class NettyRemotingClientFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(NettyRemotingClientFactory.class);
+
+    public NettyRemotingClient buildNettyRemotingClient() {
+        NettyClientConfig nettyClientConfig = new NettyClientConfig();
+        logger.info("NettyRemotingClient initialized with config: {}", nettyClientConfig);
+        return new NettyRemotingClient(nettyClientConfig);
+    }
+}

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/log/LogClient.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/log/LogClient.java
@@ -33,9 +33,9 @@ import org.apache.dolphinscheduler.remote.command.log.RollViewLogRequestCommand;
 import org.apache.dolphinscheduler.remote.command.log.RollViewLogResponseCommand;
 import org.apache.dolphinscheduler.remote.command.log.ViewLogRequestCommand;
 import org.apache.dolphinscheduler.remote.command.log.ViewLogResponseCommand;
-import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
 import org.apache.dolphinscheduler.remote.exceptions.RemotingException;
 import org.apache.dolphinscheduler.remote.utils.Host;
+import org.apache.dolphinscheduler.service.factory.NettyRemotingClientFactory;
 
 import java.util.List;
 
@@ -59,9 +59,7 @@ public class LogClient implements AutoCloseable {
     private static final long LOG_REQUEST_TIMEOUT = 10 * 1000L;
 
     public LogClient() {
-        NettyClientConfig nettyClientConfig = new NettyClientConfig();
-        this.client = new NettyRemotingClient(nettyClientConfig);
-        logger.info("Initialized LogClientService with config: {}", nettyClientConfig);
+        client = NettyRemotingClientFactory.buildNettyRemotingClient();
     }
 
     /**

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -169,7 +169,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-
 import io.micrometer.core.annotation.Counted;
 
 /**
@@ -939,7 +938,7 @@ public class ProcessServiceImpl implements ProcessService {
             throw new IllegalArgumentException("Cannot find the process definition for this workflowInstance");
         }
         Map<String, String> cmdParam = JSONUtils.toMap(command.getCommandParam());
-        if(cmdParam == null){
+        if (cmdParam == null) {
             cmdParam = new HashMap<>();
         }
         int processInstanceId = command.getProcessInstanceId();
@@ -963,10 +962,10 @@ public class ProcessServiceImpl implements ProcessService {
 
         // Recalculate global parameters after rerun.
         String globalParams = curingGlobalParamsService.curingGlobalParams(processInstance.getId(),
-            processDefinition.getGlobalParamMap(),
-            processDefinition.getGlobalParamList(),
-            commandTypeIfComplement,
-            processInstance.getScheduleTime(), timezoneId);
+                processDefinition.getGlobalParamMap(),
+                processDefinition.getGlobalParamList(),
+                commandTypeIfComplement,
+                processInstance.getScheduleTime(), timezoneId);
         processInstance.setGlobalParams(globalParams);
         processInstance.setProcessDefinition(processDefinition);
 
@@ -1014,7 +1013,7 @@ public class ProcessServiceImpl implements ProcessService {
                     initTaskInstance(this.findTaskInstanceById(taskId));
                 }
                 cmdParam.put(Constants.CMD_PARAM_RECOVERY_START_NODE_STRING,
-                    String.join(Constants.COMMA, convertIntListToString(failedList)));
+                        String.join(Constants.COMMA, convertIntListToString(failedList)));
                 processInstance.setCommandParam(JSONUtils.toJsonString(cmdParam));
                 processInstance.setRunTimes(runTime + 1);
                 break;
@@ -1032,7 +1031,7 @@ public class ProcessServiceImpl implements ProcessService {
                     initTaskInstance(this.findTaskInstanceById(taskId));
                 }
                 cmdParam.put(Constants.CMD_PARAM_RECOVERY_START_NODE_STRING,
-                    String.join(Constants.COMMA, convertIntListToString(stopNodeList)));
+                        String.join(Constants.COMMA, convertIntListToString(stopNodeList)));
                 processInstance.setCommandParam(JSONUtils.toJsonString(cmdParam));
                 processInstance.setRunTimes(runTime + 1);
                 break;
@@ -1817,7 +1816,7 @@ public class ProcessServiceImpl implements ProcessService {
      * @param res origin resource info
      * @return {@link ResourceInfo}
      */
-    private ResourceInfo updateResourceInfo(ResourceInfo res) {
+    protected ResourceInfo updateResourceInfo(ResourceInfo res) {
         ResourceInfo resourceInfo = null;
         // only if mainJar is not null and does not contains "resourceName" field
         if (res != null) {

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/alert/AlertClientServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/alert/AlertClientServiceTest.java
@@ -23,27 +23,27 @@ import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.alert.AlertSendRequestCommand;
 import org.apache.dolphinscheduler.remote.command.alert.AlertSendResponseCommand;
 import org.apache.dolphinscheduler.remote.command.alert.AlertSendResponseResult;
+import org.apache.dolphinscheduler.service.factory.NettyRemotingClientFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * alert client service test
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({AlertClientService.class})
+@RunWith(MockitoJUnitRunner.class)
 public class AlertClientServiceTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AlertClientServiceTest.class);
@@ -52,11 +52,20 @@ public class AlertClientServiceTest {
 
     private AlertClientService alertClient;
 
+    private MockedStatic<NettyRemotingClientFactory> mockedNettyRemotingClientFactory;
+
     @Before
     public void before() throws Exception {
-        client = PowerMockito.mock(NettyRemotingClient.class);
-        PowerMockito.whenNew(NettyRemotingClient.class).withAnyArguments().thenReturn(client);
+        client = Mockito.mock(NettyRemotingClient.class);
+        mockedNettyRemotingClientFactory = Mockito.mockStatic(NettyRemotingClientFactory.class);
+        mockedNettyRemotingClientFactory.when(NettyRemotingClientFactory::buildNettyRemotingClient)
+                .thenReturn(client);
         alertClient = new AlertClientService();
+    }
+
+    @After
+    public void after() {
+        mockedNettyRemotingClientFactory.close();
     }
 
     @Test
@@ -89,7 +98,7 @@ public class AlertClientServiceTest {
                 new AlertSendResponseCommand(sendResponseStatus, sendResponseResults);
         Command resCommand = alertSendResponseCommandData.convert2Command(reqCommand.getOpaque());
 
-        PowerMockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
+        Mockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
         alertSendResponseCommand =
                 alertClient.sendAlert(host, port, groupId, title, content, WarningType.FAILURE.getCode());
         Assert.assertFalse(alertSendResponseCommand.isSuccess());
@@ -104,7 +113,7 @@ public class AlertClientServiceTest {
         alertResult.setMessage(message);
         alertSendResponseCommandData = new AlertSendResponseCommand(sendResponseStatus, sendResponseResults);
         resCommand = alertSendResponseCommandData.convert2Command(reqCommand.getOpaque());
-        PowerMockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
+        Mockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
         alertSendResponseCommand =
                 alertClient.sendAlert(host, port, groupId, title, content, WarningType.FAILURE.getCode());
         Assert.assertFalse(alertSendResponseCommand.isSuccess());
@@ -118,7 +127,7 @@ public class AlertClientServiceTest {
         alertResult.setMessage(message);
         alertSendResponseCommandData = new AlertSendResponseCommand(sendResponseStatus, sendResponseResults);
         resCommand = alertSendResponseCommandData.convert2Command(reqCommand.getOpaque());
-        PowerMockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
+        Mockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
         alertSendResponseCommand =
                 alertClient.sendAlert(host, port, groupId, title, content, WarningType.FAILURE.getCode());
         Assert.assertFalse(alertSendResponseCommand.isSuccess());
@@ -131,7 +140,7 @@ public class AlertClientServiceTest {
         alertResult.setMessage("Abnormal information inside the alert plug-in code");
         alertSendResponseCommandData = new AlertSendResponseCommand(sendResponseStatus, sendResponseResults);
         resCommand = alertSendResponseCommandData.convert2Command(reqCommand.getOpaque());
-        PowerMockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
+        Mockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
         alertSendResponseCommand =
                 alertClient.sendAlert(host, port, groupId, title, content, WarningType.FAILURE.getCode());
         Assert.assertFalse(alertSendResponseCommand.isSuccess());
@@ -145,7 +154,7 @@ public class AlertClientServiceTest {
         alertResult.setMessage(message);
         alertSendResponseCommandData = new AlertSendResponseCommand(sendResponseStatus, sendResponseResults);
         resCommand = alertSendResponseCommandData.convert2Command(reqCommand.getOpaque());
-        PowerMockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
+        Mockito.when(client.sendSync(Mockito.any(), Mockito.any(), Mockito.anyLong())).thenReturn(resCommand);
         alertSendResponseCommand =
                 alertClient.sendAlert(host, port, groupId, title, content, WarningType.FAILURE.getCode());
         Assert.assertTrue(alertSendResponseCommand.isSuccess());

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/alert/AlertClientServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/alert/AlertClientServiceTest.java
@@ -40,9 +40,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * alert client service test
- */
 @RunWith(MockitoJUnitRunner.class)
 public class AlertClientServiceTest {
 

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/alert/ProcessAlertManagerTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/alert/ProcessAlertManagerTest.java
@@ -33,14 +33,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * ProcessAlertManager Test
  */
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ProcessAlertManagerTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessAlertManagerTest.class);

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/log/LogClientTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/log/LogClientTest.java
@@ -27,20 +27,18 @@ import org.apache.dolphinscheduler.remote.command.log.RemoveTaskLogResponseComma
 import org.apache.dolphinscheduler.remote.command.log.RollViewLogResponseCommand;
 import org.apache.dolphinscheduler.remote.command.log.ViewLogResponseCommand;
 import org.apache.dolphinscheduler.remote.utils.Host;
+import org.apache.dolphinscheduler.service.factory.NettyRemotingClientFactory;
 
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Test.None;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({LogClient.class, NetUtils.class, LoggerUtils.class, NettyRemotingClient.class})
+@RunWith(MockitoJUnitRunner.class)
 public class LogClientTest {
 
     @Test
@@ -49,14 +47,17 @@ public class LogClientTest {
         int port = 1234;
         String path = "/tmp/log";
 
-        PowerMockito.mockStatic(NetUtils.class);
-        PowerMockito.when(NetUtils.getHost()).thenReturn(localMachine);
-        PowerMockito.mockStatic(LoggerUtils.class);
-        PowerMockito.when(LoggerUtils.readWholeFileContent(Mockito.anyString())).thenReturn("application_xx_11");
-
-        LogClient logClient = new LogClient();
-        String log = logClient.viewLog(localMachine, port, path);
-        Assert.assertNotNull(log);
+        try (
+                MockedStatic<NetUtils> mockedNetUtils = Mockito.mockStatic(NetUtils.class);
+                MockedStatic<LoggerUtils> mockedLoggerUtils = Mockito.mockStatic(LoggerUtils.class)) {
+            mockedNetUtils.when(NetUtils::getHost)
+                    .thenReturn(localMachine);
+            mockedLoggerUtils.when(() -> LoggerUtils.readWholeFileContent(Mockito.anyString()))
+                    .thenReturn("application_xx_11");
+            LogClient logClient = new LogClient();
+            String log = logClient.viewLog(localMachine, port, path);
+            Assert.assertNotNull(log);
+        }
     }
 
     @Test
@@ -65,74 +66,93 @@ public class LogClientTest {
         int port = 1234;
         String path = "/tmp/log";
 
-        PowerMockito.mockStatic(NetUtils.class);
-        PowerMockito.when(NetUtils.getHost()).thenReturn(localMachine + "1");
-
-        NettyRemotingClient remotingClient = PowerMockito.mock(NettyRemotingClient.class);
-        PowerMockito.whenNew(NettyRemotingClient.class).withAnyArguments().thenReturn(remotingClient);
+        try (MockedStatic<NetUtils> mockedNetUtils = Mockito.mockStatic(NetUtils.class)) {
+            mockedNetUtils.when(NetUtils::getHost)
+                    .thenReturn(localMachine + "1");
+            LogClient logClient = new LogClient();
+            String log = logClient.viewLog(localMachine, port, path);
+            Assert.assertNotNull(log);
+        }
 
         Command command = new Command();
         command.setBody(JSONUtils.toJsonString(new ViewLogResponseCommand("")).getBytes(StandardCharsets.UTF_8));
-        PowerMockito.when(remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
-                .thenReturn(command);
         LogClient logClient = new LogClient();
         String log = logClient.viewLog(localMachine, port, path);
         Assert.assertNotNull(log);
     }
 
-    @Test(expected = None.class)
-    public void testClose() throws Exception {
-        NettyRemotingClient remotingClient = PowerMockito.mock(NettyRemotingClient.class);
-        PowerMockito.whenNew(NettyRemotingClient.class).withAnyArguments().thenReturn(remotingClient);
-        PowerMockito.doNothing().when(remotingClient).close();
-
-        LogClient logClient = new LogClient();
-        logClient.close();
+    @Test
+    public void testClose() {
+        try (
+                MockedStatic<NettyRemotingClientFactory> mockedNettyRemotingClientFactory =
+                        Mockito.mockStatic(NettyRemotingClientFactory.class)) {
+            NettyRemotingClient remotingClient = Mockito.mock(NettyRemotingClient.class);
+            mockedNettyRemotingClientFactory.when(NettyRemotingClientFactory::buildNettyRemotingClient)
+                    .thenReturn(remotingClient);
+            LogClient logClient = new LogClient();
+            logClient.close();
+        }
     }
 
     @Test
     public void testRollViewLog() throws Exception {
-        NettyRemotingClient remotingClient = PowerMockito.mock(NettyRemotingClient.class);
-        PowerMockito.whenNew(NettyRemotingClient.class).withAnyArguments().thenReturn(remotingClient);
+        try (
+                MockedStatic<NettyRemotingClientFactory> mockedNettyRemotingClientFactory =
+                        Mockito.mockStatic(NettyRemotingClientFactory.class)) {
+            NettyRemotingClient remotingClient = Mockito.mock(NettyRemotingClient.class);
+            mockedNettyRemotingClientFactory.when(NettyRemotingClientFactory::buildNettyRemotingClient)
+                    .thenReturn(remotingClient);
+            Command command = new Command();
+            command.setBody(JSONUtils.toJsonByteArray(new RollViewLogResponseCommand("success")));
+            Mockito.when(
+                    remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
+                    .thenReturn(command);
 
-        Command command = new Command();
-        command.setBody(JSONUtils.toJsonByteArray(new RollViewLogResponseCommand("success")));
-        PowerMockito.when(remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
-                .thenReturn(command);
-
-        LogClient logClient = new LogClient();
-        String msg = logClient.rollViewLog("localhost", 1234, "/tmp/log", 0, 10);
-        Assert.assertNotNull(msg);
+            LogClient logClient = new LogClient();
+            String msg = logClient.rollViewLog("localhost", 1234, "/tmp/log", 0, 10);
+            Assert.assertNotNull(msg);
+        }
     }
 
     @Test
     public void testGetLogBytes() throws Exception {
-        NettyRemotingClient remotingClient = PowerMockito.mock(NettyRemotingClient.class);
-        PowerMockito.whenNew(NettyRemotingClient.class).withAnyArguments().thenReturn(remotingClient);
+        try (
+                MockedStatic<NettyRemotingClientFactory> mockedNettyRemotingClientFactory =
+                        Mockito.mockStatic(NettyRemotingClientFactory.class)) {
+            NettyRemotingClient remotingClient = Mockito.mock(NettyRemotingClient.class);
+            mockedNettyRemotingClientFactory.when(NettyRemotingClientFactory::buildNettyRemotingClient)
+                    .thenReturn(remotingClient);
+            Command command = new Command();
+            command.setBody(
+                    JSONUtils.toJsonByteArray(new GetLogBytesResponseCommand("log".getBytes(StandardCharsets.UTF_8))));
+            Mockito.when(
+                    remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
+                    .thenReturn(command);
 
-        Command command = new Command();
-        command.setBody(JSONUtils.toJsonByteArray(new GetLogBytesResponseCommand("log".getBytes(StandardCharsets.UTF_8))));
-        PowerMockito.when(remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
-                .thenReturn(command);
-
-        LogClient logClient = new LogClient();
-        byte[] logBytes = logClient.getLogBytes("localhost", 1234, "/tmp/log");
-        Assert.assertNotNull(logBytes);
+            LogClient logClient = new LogClient();
+            byte[] logBytes = logClient.getLogBytes("localhost", 1234, "/tmp/log");
+            Assert.assertNotNull(logBytes);
+        }
     }
 
     @Test
     public void testRemoveTaskLog() throws Exception {
-        NettyRemotingClient remotingClient = PowerMockito.mock(NettyRemotingClient.class);
-        PowerMockito.whenNew(NettyRemotingClient.class).withAnyArguments().thenReturn(remotingClient);
 
-        Command command = new Command();
-        command.setBody(JSONUtils.toJsonByteArray(new RemoveTaskLogResponseCommand(true)));
-        PowerMockito.when(remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
-                .thenReturn(command);
+        try (
+                MockedStatic<NettyRemotingClientFactory> mockedNettyRemotingClientFactory =
+                        Mockito.mockStatic(NettyRemotingClientFactory.class)) {
+            NettyRemotingClient remotingClient = Mockito.mock(NettyRemotingClient.class);
+            mockedNettyRemotingClientFactory.when(NettyRemotingClientFactory::buildNettyRemotingClient)
+                    .thenReturn(remotingClient);
+            Command command = new Command();
+            command.setBody(JSONUtils.toJsonByteArray(new RemoveTaskLogResponseCommand(true)));
+            Mockito.when(
+                    remotingClient.sendSync(Mockito.any(Host.class), Mockito.any(Command.class), Mockito.anyLong()))
+                    .thenReturn(command);
 
-        LogClient logClient = new LogClient();
-        Boolean status = logClient.removeTaskLog("localhost", 1234, "/log/path");
-        Assert.assertTrue(status);
+            LogClient logClient = new LogClient();
+            Boolean status = logClient.removeTaskLog("localhost", 1234, "/log/path");
+            Assert.assertTrue(status);
+        }
     }
-
 }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -102,7 +102,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -823,16 +822,12 @@ public class ProcessServiceTest {
     public void testUpdateResourceInfo() throws Exception {
         // test if input is null
         ResourceInfo resourceInfoNull = null;
-        ResourceInfo updatedResourceInfo1 = Whitebox.invokeMethod(processService,
-                "updateResourceInfo",
-                resourceInfoNull);
+        ResourceInfo updatedResourceInfo1 = processService.updateResourceInfo(resourceInfoNull);
         Assert.assertNull(updatedResourceInfo1);
 
         // test if resource id less than 1
         ResourceInfo resourceInfoVoid = new ResourceInfo();
-        ResourceInfo updatedResourceInfo2 = Whitebox.invokeMethod(processService,
-                "updateResourceInfo",
-                resourceInfoVoid);
+        ResourceInfo updatedResourceInfo2 = processService.updateResourceInfo(resourceInfoVoid);
         Assert.assertNull(updatedResourceInfo2);
 
         // test normal situation
@@ -843,9 +838,8 @@ public class ProcessServiceTest {
         resource.setFileName("test.txt");
         resource.setFullName("/test.txt");
         Mockito.when(resourceMapper.selectById(1)).thenReturn(resource);
-        ResourceInfo updatedResourceInfo3 = Whitebox.invokeMethod(processService,
-                "updateResourceInfo",
-                resourceInfoNormal);
+
+        ResourceInfo updatedResourceInfo3 = processService.updateResourceInfo(resourceInfoNormal);
 
         Assert.assertEquals(1, updatedResourceInfo3.getId().intValue());
         Assert.assertEquals("test.txt", updatedResourceInfo3.getRes());
@@ -911,13 +905,15 @@ public class ProcessServiceTest {
         DateInterval dateInterval = new DateInterval(new Date(), new Date());
         int testFlag = 1;
 
-        //find test lastManualProcessInterval
-        ProcessInstance lastManualProcessInterval = processService.findLastManualProcessInterval(definitionCode, dateInterval, testFlag);
+        // find test lastManualProcessInterval
+        ProcessInstance lastManualProcessInterval =
+                processService.findLastManualProcessInterval(definitionCode, dateInterval, testFlag);
         Assert.assertEquals(null, lastManualProcessInterval);
 
-        //find online lastManualProcessInterval
+        // find online lastManualProcessInterval
         testFlag = 0;
-        lastManualProcessInterval = processService.findLastManualProcessInterval(definitionCode, dateInterval, testFlag);
+        lastManualProcessInterval =
+                processService.findLastManualProcessInterval(definitionCode, dateInterval, testFlag);
         Assert.assertEquals(null, lastManualProcessInterval);
     }
 
@@ -925,12 +921,12 @@ public class ProcessServiceTest {
     public void testQueryTestDataSourceId() {
         Integer onlineDataSourceId = 1;
 
-        //unbound testDataSourceId
+        // unbound testDataSourceId
         Mockito.when(dataSourceMapper.queryTestDataSourceId(any(Integer.class))).thenReturn(null);
         Integer result = processService.queryTestDataSourceId(onlineDataSourceId);
         Assert.assertNull(result);
 
-        //bound testDataSourceId
+        // bound testDataSourceId
         Integer testDataSourceId = 2;
         Mockito.when(dataSourceMapper.queryTestDataSourceId(any(Integer.class))).thenReturn(testDataSourceId);
         result = processService.queryTestDataSourceId(onlineDataSourceId);


### PR DESCRIPTION
## Purpose of the pull request

* This PR closes #12155

## Brief change log

* Remove `Powermock` in `dolphinscheduler-service` and `dolphinscheduler-server` modules.
* Refactor some related code to decouple instantiation from constructor.

## Verify this pull request

* Verified by unit tests.