### PR TITLE
Fix #11236, source is not available in sh

### DIFF
--- a/docs/docs/en/guide/upgrade/incompatible.md
+++ b/docs/docs/en/guide/upgrade/incompatible.md
@@ -5,6 +5,7 @@ This document records the incompatible updates between each version. You need to
 ## dev
 
 * Remove the spark version of spark task ([#11860](https://github.com/apache/dolphinscheduler/pull/11860)).
+* Change the default unix shell executor from sh to bash ([#12180](https://github.com/apache/dolphinscheduler/pull/12180)).
 
 ## 3.0.0
 

--- a/docs/docs/zh/guide/upgrade/incompatible.md
+++ b/docs/docs/zh/guide/upgrade/incompatible.md
@@ -5,6 +5,7 @@
 ## dev
 
 * Remove the spark version of spark task ([#11860](https://github.com/apache/dolphinscheduler/pull/11860)).
+* Change the default unix shell executor from sh to bash ([#12180](https://github.com/apache/dolphinscheduler/pull/12180)).
 
 ## 3.0.0
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -127,6 +127,7 @@ public abstract class AbstractCommandExecutor {
                 command.add("sudo");
                 command.add("-u");
                 command.add(taskRequest.getTenantCode());
+                command.add("-E");
             }
         }
         command.add(commandInterpreter());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -38,9 +38,9 @@ import com.google.common.base.Strings;
 public class ShellCommandExecutor extends AbstractCommandExecutor {
 
     /**
-     * For Unix-like, using sh
+     * For Unix-like, using bash
      */
-    private static final String SH = "sh";
+    private static final String SH = "bash";
 
     /**
      * For Windows, using cmd.exe


### PR DESCRIPTION
## Purpose of the pull request

To fix #11236

## Brief change log

Change the default unix shell executor from `sh`  to `bash`

10d2786c fixed the default `/etc/sudoers` in docker image will reset env by setting `Defaults env_reset`, `sudo -E` is required.

## Verify this pull request

This pull request is code cleanup without any test coverage.

`source` is not available in `/bin/sh`, it's replacement in `/bin/sh` is `.`, I think you can either use `/bin/bash` instead of `/bin/sh` or use `.`

Since we use `#!/bin/bash` as command file header, I think change to bash is more reasonable.
