### PR TITLE
[Improvement][Test] Remove the usage of powermock in datasource-plugin module

### DIFF
--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
@@ -42,7 +42,7 @@ import org.apache.dolphinscheduler.plugin.datasource.postgresql.param.PostgreSQL
 import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbConnectType;
 import org.apache.dolphinscheduler.spi.enums.DbType;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 
 import org.apache.commons.collections.CollectionUtils;
 

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
@@ -15,16 +15,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>dolphinscheduler-datasource-plugin</artifactId>
         <groupId>org.apache.dolphinscheduler</groupId>
+        <artifactId>dolphinscheduler-datasource-plugin</artifactId>
         <version>dev-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dolphinscheduler-datasource-api</artifactId>
 
@@ -92,8 +90,8 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>servlet-api</artifactId>
                     <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.jackson</groupId>
@@ -117,20 +115,20 @@
                     <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-client</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jaxb-api</artifactId>
                     <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -144,6 +142,10 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
@@ -35,6 +35,11 @@
 
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-task-api</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -142,10 +147,6 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-common</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/plugin/DataSourceClientProvider.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/plugin/DataSourceClientProvider.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.api.plugin;
 
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
 import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
@@ -24,7 +25,6 @@ import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.spi.datasource.DataSourceChannel;
 import org.apache.dolphinscheduler.spi.datasource.DataSourceClient;
 import org.apache.dolphinscheduler.spi.enums.DbType;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 
 import java.sql.Connection;
 import java.util.Map;
@@ -39,18 +39,19 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 
 public class DataSourceClientProvider {
+
     private static final Logger logger = LoggerFactory.getLogger(DataSourceClientProvider.class);
 
     private static final long duration = PropertyUtils.getLong(TaskConstants.KERBEROS_EXPIRE_TIME, 24);
     private static final Cache<String, DataSourceClient> uniqueId2dataSourceClientCache = CacheBuilder.newBuilder()
-        .expireAfterWrite(duration, TimeUnit.HOURS)
-        .removalListener((RemovalListener<String, DataSourceClient>) notification -> {
-            try (DataSourceClient closedClient = notification.getValue()) {
-                logger.info("Datasource: {} is removed from cache due to expire", notification.getKey());
-            }
-        })
-        .maximumSize(100)
-        .build();
+            .expireAfterWrite(duration, TimeUnit.HOURS)
+            .removalListener((RemovalListener<String, DataSourceClient>) notification -> {
+                try (DataSourceClient closedClient = notification.getValue()) {
+                    logger.info("Datasource: {} is removed from cache due to expire", notification.getKey());
+                }
+            })
+            .maximumSize(100)
+            .build();
     private DataSourcePluginManager dataSourcePluginManager;
 
     private DataSourceClientProvider() {
@@ -58,6 +59,7 @@ public class DataSourceClientProvider {
     }
 
     private static class DataSourceClientProviderHolder {
+
         private static final DataSourceClientProvider INSTANCE = new DataSourceClientProvider();
     }
 

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/provider/JDBCDataSourceProvider.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/provider/JDBCDataSourceProvider.java
@@ -17,12 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.api.provider;
 
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
 
 import java.sql.Driver;
@@ -40,10 +40,11 @@ public class JDBCDataSourceProvider {
     private static final Logger logger = LoggerFactory.getLogger(JDBCDataSourceProvider.class);
 
     public static HikariDataSource createJdbcDataSource(BaseConnectionParam properties, DbType dbType) {
-        logger.info("Creating HikariDataSource pool for maxActive:{}", PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MAX_ACTIVE, 50));
+        logger.info("Creating HikariDataSource pool for maxActive:{}",
+                PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MAX_ACTIVE, 50));
         HikariDataSource dataSource = new HikariDataSource();
 
-        //TODO Support multiple versions of data sources
+        // TODO Support multiple versions of data sources
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         loaderJdbcDriver(classLoader, properties, dbType);
 
@@ -68,7 +69,8 @@ public class JDBCDataSourceProvider {
      * @return One Session Jdbc DataSource
      */
     public static HikariDataSource createOneSessionJdbcDataSource(BaseConnectionParam properties, DbType dbType) {
-        logger.info("Creating OneSession HikariDataSource pool for maxActive:{}", PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MAX_ACTIVE, 50));
+        logger.info("Creating OneSession HikariDataSource pool for maxActive:{}",
+                PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MAX_ACTIVE, 50));
 
         HikariDataSource dataSource = new HikariDataSource();
 
@@ -79,7 +81,8 @@ public class JDBCDataSourceProvider {
 
         Boolean isOneSession = PropertyUtils.getBoolean(Constants.SUPPORT_HIVE_ONE_SESSION, false);
         dataSource.setMinimumIdle(isOneSession ? 1 : PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MIN_IDLE, 5));
-        dataSource.setMaximumPoolSize(isOneSession ? 1 : PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MAX_ACTIVE, 50));
+        dataSource.setMaximumPoolSize(
+                isOneSession ? 1 : PropertyUtils.getInt(Constants.SPRING_DATASOURCE_MAX_ACTIVE, 50));
         dataSource.setConnectionTestQuery(properties.getValidationQuery());
 
         if (properties.getProps() != null) {
@@ -91,7 +94,9 @@ public class JDBCDataSourceProvider {
     }
 
     protected static void loaderJdbcDriver(ClassLoader classLoader, BaseConnectionParam properties, DbType dbType) {
-        String drv = StringUtils.isBlank(properties.getDriverClassName()) ? DataSourceUtils.getDatasourceProcessor(dbType).getDatasourceDriver() : properties.getDriverClassName();
+        String drv = StringUtils.isBlank(properties.getDriverClassName())
+                ? DataSourceUtils.getDatasourceProcessor(dbType).getDatasourceDriver()
+                : properties.getDriverClassName();
         try {
             final Class<?> clazz = Class.forName(drv, true, classLoader);
             final Driver driver = (Driver) clazz.newInstance();

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtils.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtils.java
@@ -20,8 +20,8 @@ package org.apache.dolphinscheduler.plugin.datasource.api.utils;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.*;
 import static org.apache.dolphinscheduler.spi.utils.Constants.RESOURCE_STORAGE_TYPE;
 
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.enums.ResUploadType;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
 
 import org.apache.hadoop.conf.Configuration;

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/PasswordUtils.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/PasswordUtils.java
@@ -21,7 +21,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.DATASOUR
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.DATASOURCE_ENCRYPTION_SALT;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.DATASOURCE_ENCRYPTION_SALT_DEFAULT;
 
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
 
 import org.apache.commons.codec.binary.Base64;
@@ -48,7 +48,7 @@ public class PasswordUtils {
         if (StringUtils.isEmpty(password)) {
             return StringUtils.EMPTY;
         }
-        //if encryption is not turned on, return directly
+        // if encryption is not turned on, return directly
         boolean encryptionEnable = PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false);
         if (!encryptionEnable) {
             return password;
@@ -57,7 +57,7 @@ public class PasswordUtils {
         // Using Base64 + salt to process password
         String salt = PropertyUtils.getString(DATASOURCE_ENCRYPTION_SALT, DATASOURCE_ENCRYPTION_SALT_DEFAULT);
         String passwordWithSalt = salt + new String(BASE64.encode(password.getBytes(
-            StandardCharsets.UTF_8)));
+                StandardCharsets.UTF_8)));
         return new String(BASE64.encode(passwordWithSalt.getBytes(StandardCharsets.UTF_8)));
     }
 
@@ -69,7 +69,7 @@ public class PasswordUtils {
             return StringUtils.EMPTY;
         }
 
-        //if encryption is not turned on, return directly
+        // if encryption is not turned on, return directly
         boolean encryptionEnable = PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false);
         if (!encryptionEnable) {
             return password;

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/client/CommonDataSourceClientTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/client/CommonDataSourceClientTest.java
@@ -18,7 +18,6 @@
 package org.apache.dolphinscheduler.plugin.datasource.api.client;
 
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.MySQLConnectionParam;
-import org.apache.dolphinscheduler.plugin.datasource.api.provider.JDBCDataSourceProvider;
 import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 
@@ -29,17 +28,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import com.zaxxer.hikari.HikariDataSource;
-
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest(value = {HikariDataSource.class, CommonDataSourceClient.class, JDBCDataSourceProvider.class, JdbcTemplate.class, Connection.class})
+@RunWith(MockitoJUnitRunner.class)
 public class CommonDataSourceClientTest {
 
     @Mock
@@ -47,7 +38,7 @@ public class CommonDataSourceClientTest {
 
     @Test
     public void testPreInit() {
-        PowerMockito.doNothing().when(commonDataSourceClient).preInit();
+        Mockito.doNothing().when(commonDataSourceClient).preInit();
         commonDataSourceClient.preInit();
         Mockito.verify(commonDataSourceClient).preInit();
     }
@@ -55,19 +46,19 @@ public class CommonDataSourceClientTest {
     @Test
     public void testCheckEnv() {
         BaseConnectionParam baseConnectionParam = new MySQLConnectionParam();
-        PowerMockito.doNothing().when(commonDataSourceClient).checkEnv(Mockito.any(BaseConnectionParam.class));
+        Mockito.doNothing().when(commonDataSourceClient).checkEnv(Mockito.any(BaseConnectionParam.class));
         commonDataSourceClient.checkEnv(baseConnectionParam);
         Mockito.verify(commonDataSourceClient).checkEnv(Mockito.any(BaseConnectionParam.class));
 
-        PowerMockito.doNothing().when(commonDataSourceClient).checkValidationQuery(Mockito.any(BaseConnectionParam.class));
+        Mockito.doNothing().when(commonDataSourceClient).checkValidationQuery(Mockito.any(BaseConnectionParam.class));
         commonDataSourceClient.checkValidationQuery(baseConnectionParam);
         Mockito.verify(commonDataSourceClient).checkValidationQuery(Mockito.any(BaseConnectionParam.class));
 
-        PowerMockito.doNothing().when(commonDataSourceClient).checkUser(Mockito.any(BaseConnectionParam.class));
+        Mockito.doNothing().when(commonDataSourceClient).checkUser(Mockito.any(BaseConnectionParam.class));
         commonDataSourceClient.checkUser(baseConnectionParam);
         Mockito.verify(commonDataSourceClient).checkUser(Mockito.any(BaseConnectionParam.class));
 
-        PowerMockito.doNothing().when(commonDataSourceClient).setDefaultUsername(Mockito.any(BaseConnectionParam.class));
+        Mockito.doNothing().when(commonDataSourceClient).setDefaultUsername(Mockito.any(BaseConnectionParam.class));
         commonDataSourceClient.setDefaultUsername(baseConnectionParam);
         Mockito.verify(commonDataSourceClient).setDefaultUsername(Mockito.any(BaseConnectionParam.class));
     }
@@ -75,22 +66,23 @@ public class CommonDataSourceClientTest {
     @Test
     public void testInitClient() {
         BaseConnectionParam baseConnectionParam = new MySQLConnectionParam();
-        PowerMockito.doNothing().when(commonDataSourceClient).initClient(Mockito.any(BaseConnectionParam.class), Mockito.any());
+        Mockito.doNothing().when(commonDataSourceClient).initClient(Mockito.any(BaseConnectionParam.class),
+                Mockito.any());
         commonDataSourceClient.initClient(baseConnectionParam, DbType.MYSQL);
         Mockito.verify(commonDataSourceClient).initClient(Mockito.any(BaseConnectionParam.class), Mockito.any());
     }
 
     @Test
     public void testCheckClient() {
-        PowerMockito.doNothing().when(this.commonDataSourceClient).checkClient();
+        Mockito.doNothing().when(this.commonDataSourceClient).checkClient();
         this.commonDataSourceClient.checkClient();
         Mockito.verify(this.commonDataSourceClient).checkClient();
     }
 
     @Test
     public void testGetConnection() {
-        Connection connection = PowerMockito.mock(Connection.class);
-        PowerMockito.when(commonDataSourceClient.getConnection()).thenReturn(connection);
+        Connection connection = Mockito.mock(Connection.class);
+        Mockito.when(commonDataSourceClient.getConnection()).thenReturn(connection);
         Assert.assertNotNull(commonDataSourceClient.getConnection());
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtilsTest.java
@@ -1,135 +1,140 @@
-/// *
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements. See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License. You may obtain a copy of the License at
-// *
-// * http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-// package org.apache.dolphinscheduler.plugin.datasource.api.utils;
-//
-// import static org.apache.dolphinscheduler.spi.utils.Constants.DATASOURCE_ENCRYPTION_ENABLE;
-//
-// import org.apache.dolphinscheduler.spi.utils.Constants;
-// import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
-//
-// import org.apache.hadoop.conf.Configuration;
-// import org.apache.hadoop.security.UserGroupInformation;
-//
-// import org.junit.Assert;
-// import org.junit.Test;
-// import org.junit.runner.RunWith;
-// import org.mockito.junit.MockitoJUnitRunner;
-// import org.mockito.stubbing.Answer;
-//
-// TODO: fix powermock answer in this class
-// @RunWith(MockitoJUnitRunner.class)
-// public class CommonUtilsTest {
-//
-// @Test
-// public void testGetKerberosStartupState() {
-// Mockito.mockStatic(CommonUtils.class);
-// Mockito.when(CommonUtils.getKerberosStartupState()).thenAnswer((Answer<Boolean>) invocation -> false);
-// boolean kerberosStartupState = CommonUtils.getKerberosStartupState();
-// Assert.assertFalse(kerberosStartupState);
-//
-// Mockito.mockStatic(PropertyUtils.class);
-// Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE)).thenAnswer((Answer<String>)
-/// invocation -> "HDFS");
-// Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, true))
-// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-// kerberosStartupState = CommonUtils.getKerberosStartupState();
-// Assert.assertFalse(kerberosStartupState);
-// }
-//
-// @Test
-// public void testLoadKerberosConf() {
-// try {
-// Mockito.mockStatic(PropertyUtils.class);
-// Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE)).thenAnswer((Answer<String>)
-/// invocation -> "HDFS");
-// Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
-// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-// Mockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
-// .thenAnswer((Answer<String>) invocation -> "/opt/krb5.conf");
-// Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
-// .thenAnswer((Answer<String>) invocation -> "hdfs-mycluster@ESZ.COM");
-// Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
-// .thenAnswer((Answer<String>) invocation -> "/opt/hdfs.headless.keytab");
-//
-// Mockito.mockStatic(UserGroupInformation.class);
-// Configuration configuration = Mockito.mock(Configuration.class);
-// Mockito.whenNew(Configuration.class).withNoArguments().thenReturn(configuration);
-//
-// boolean result = CommonUtils.loadKerberosConf(configuration);
-// Assert.assertTrue(result);
-//
-// CommonUtils.loadKerberosConf(null, null, null);
-//
-// } catch (Exception e) {
-// Assert.fail("load Kerberos Conf failed" + e.getMessage());
-// }
-// }
-//
-// @Test
-// public void encodePassword() {
-// Mockito.mockStatic(PropertyUtils.class);
-// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-//
-// Assert.assertEquals("", PasswordUtils.encodePassword(""));
-// Assert.assertEquals("bnVsbE1USXpORFUy", PasswordUtils.encodePassword("123456"));
-// Assert.assertEquals("bnVsbElWRkJXbGhUVjBBPQ==", PasswordUtils.encodePassword("!QAZXSW@"));
-// Assert.assertEquals("bnVsbE5XUm1aMlZ5S0VBPQ==", PasswordUtils.encodePassword("5dfger(@"));
-//
-// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-// .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
-//
-// Assert.assertEquals("", PasswordUtils.encodePassword(""));
-// Assert.assertEquals("123456", PasswordUtils.encodePassword("123456"));
-// Assert.assertEquals("!QAZXSW@", PasswordUtils.encodePassword("!QAZXSW@"));
-// Assert.assertEquals("5dfger(@", PasswordUtils.encodePassword("5dfger(@"));
-//
-// }
-//
-// @Test
-// public void decodePassword() {
-// Mockito.mockStatic(PropertyUtils.class);
-// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-//
-// PropertyUtils.setValue(DATASOURCE_ENCRYPTION_ENABLE, "true");
-//
-// Mockito.mockStatic(PasswordUtils.class);
-// Mockito.when(PasswordUtils.decodePassword("bnVsbE1USXpORFUy")).thenReturn("123456");
-// Mockito.when(PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ==")).thenReturn("!QAZXSW@");
-// Mockito.when(PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ==")).thenReturn("5dfger(@");
-//
-// Assert.assertEquals(null, PasswordUtils.decodePassword(""));
-// Assert.assertEquals("123456", PasswordUtils.decodePassword("bnVsbE1USXpORFUy"));
-// Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ=="));
-// Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ=="));
-//
-// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-// .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
-//
-// Mockito.when(PasswordUtils.decodePassword("123456")).thenReturn("123456");
-// Mockito.when(PasswordUtils.decodePassword("!QAZXSW@")).thenReturn("!QAZXSW@");
-// Mockito.when(PasswordUtils.decodePassword("5dfger(@")).thenReturn("5dfger(@");
-//
-// Assert.assertEquals(null, PasswordUtils.decodePassword(""));
-// Assert.assertEquals("123456", PasswordUtils.decodePassword("123456"));
-// Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("!QAZXSW@"));
-// Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("5dfger(@"));
-// }
-//
-// }
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.datasource.api.utils;
+
+import static org.apache.dolphinscheduler.spi.utils.Constants.DATASOURCE_ENCRYPTION_ENABLE;
+
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+import org.apache.dolphinscheduler.spi.utils.Constants;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommonUtilsTest {
+
+    @Test
+    public void testGetKerberosStartupState() {
+        try (
+                MockedStatic<CommonUtils> mockedCommonUtils = Mockito.mockStatic(CommonUtils.class);
+                MockedStatic<PropertyUtils> mockedPropertyUtils = Mockito.mockStatic(PropertyUtils.class)) {
+            Mockito.when(CommonUtils.getKerberosStartupState()).thenAnswer((Answer<Boolean>) invocation -> false);
+            boolean kerberosStartupState = CommonUtils.getKerberosStartupState();
+            Assert.assertFalse(kerberosStartupState);
+
+            Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE))
+                    .thenAnswer((Answer<String>) invocation -> "HDFS");
+            Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, true))
+                    .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+            kerberosStartupState = CommonUtils.getKerberosStartupState();
+            Assert.assertFalse(kerberosStartupState);
+        }
+    }
+
+    @Test
+    public void testLoadKerberosConf() {
+        try (
+                MockedStatic<PropertyUtils> mockedPropertyUtils = Mockito.mockStatic(PropertyUtils.class);
+                MockedStatic<UserGroupInformation> mockedUserGroupInformation =
+                        Mockito.mockStatic(UserGroupInformation.class)) {
+            try {
+                Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE))
+                        .thenAnswer((Answer<String>) invocation -> "HDFS");
+                Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+                        .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+                Mockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
+                        .thenAnswer((Answer<String>) invocation -> "/opt/krb5.conf");
+                Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
+                        .thenAnswer((Answer<String>) invocation -> "hdfs-mycluster@ESZ.COM");
+                Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
+                        .thenAnswer((Answer<String>) invocation -> "/opt/hdfs.headless.keytab");
+                Configuration configuration = Mockito.mock(Configuration.class);
+                boolean result = CommonUtils.loadKerberosConf(configuration);
+                Assert.assertTrue(result);
+
+                CommonUtils.loadKerberosConf(null, null, null);
+
+            } catch (Exception e) {
+                Assert.fail("load Kerberos Conf failed" + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void encodePassword() {
+        try (MockedStatic<PropertyUtils> mockedPropertyUtils = Mockito.mockStatic(PropertyUtils.class)) {
+            Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+                    .thenReturn(Boolean.TRUE);
+
+            Assert.assertEquals("", PasswordUtils.encodePassword(""));
+            Assert.assertEquals("bnVsbE1USXpORFUy", PasswordUtils.encodePassword("123456"));
+            Assert.assertEquals("bnVsbElWRkJXbGhUVjBBPQ==", PasswordUtils.encodePassword("!QAZXSW@"));
+            Assert.assertEquals("bnVsbE5XUm1aMlZ5S0VBPQ==", PasswordUtils.encodePassword("5dfger(@"));
+
+            Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+                    .thenReturn(Boolean.FALSE);
+
+            Assert.assertEquals("", PasswordUtils.encodePassword(""));
+            Assert.assertEquals("123456", PasswordUtils.encodePassword("123456"));
+            Assert.assertEquals("!QAZXSW@", PasswordUtils.encodePassword("!QAZXSW@"));
+            Assert.assertEquals("5dfger(@", PasswordUtils.encodePassword("5dfger(@"));
+        }
+    }
+
+    @Test
+    public void decodePassword() {
+        try (
+                MockedStatic<CommonUtils> mockedCommonUtils = Mockito.mockStatic(CommonUtils.class);
+                MockedStatic<PasswordUtils> mockedPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+                    .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+
+            PropertyUtils.setValue(DATASOURCE_ENCRYPTION_ENABLE, "true");
+
+            Mockito.when(PasswordUtils.decodePassword("bnVsbE1USXpORFUy")).thenReturn("123456");
+            Mockito.when(PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ==")).thenReturn("!QAZXSW@");
+            Mockito.when(PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ==")).thenReturn("5dfger(@");
+
+            Assert.assertEquals(null, PasswordUtils.decodePassword(""));
+            Assert.assertEquals("123456", PasswordUtils.decodePassword("bnVsbE1USXpORFUy"));
+            Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ=="));
+            Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ=="));
+
+            Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+                    .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
+
+            Mockito.when(PasswordUtils.decodePassword("123456")).thenReturn("123456");
+            Mockito.when(PasswordUtils.decodePassword("!QAZXSW@")).thenReturn("!QAZXSW@");
+            Mockito.when(PasswordUtils.decodePassword("5dfger(@")).thenReturn("5dfger(@");
+
+            Assert.assertEquals(null, PasswordUtils.decodePassword(""));
+            Assert.assertEquals("123456", PasswordUtils.decodePassword("123456"));
+            Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("!QAZXSW@"));
+            Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("5dfger(@"));
+        }
+    }
+
+}

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtilsTest.java
@@ -1,141 +1,135 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.dolphinscheduler.plugin.datasource.api.utils;
-
-import static org.apache.dolphinscheduler.spi.utils.Constants.DATASOURCE_ENCRYPTION_ENABLE;
-
-import org.apache.dolphinscheduler.spi.utils.Constants;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor(
-    value = {"org.apache.dolphinscheduler.spi.utils.PropertyUtils", "org.apache.hadoop.security.UserGroupInformation"}
-)
-@PrepareForTest(value = {PropertyUtils.class, UserGroupInformation.class, CommonUtils.class, PasswordUtils.class})
-@PowerMockIgnore({"jdk.xml.*", "org.apache.hadoop.security.*"})
-public class CommonUtilsTest {
-
-    @Test
-    public void testGetKerberosStartupState() {
-        PowerMockito.mockStatic(CommonUtils.class);
-        PowerMockito.when(CommonUtils.getKerberosStartupState()).thenAnswer((Answer<Boolean>) invocation -> false);
-        boolean kerberosStartupState = CommonUtils.getKerberosStartupState();
-        Assert.assertFalse(kerberosStartupState);
-
-        PowerMockito.mockStatic(PropertyUtils.class);
-        PowerMockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE)).thenAnswer((Answer<String>) invocation -> "HDFS");
-        PowerMockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, true))
-            .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-        kerberosStartupState = CommonUtils.getKerberosStartupState();
-        Assert.assertFalse(kerberosStartupState);
-    }
-
-    @Test
-    public void testLoadKerberosConf() {
-        try {
-            PowerMockito.mockStatic(PropertyUtils.class);
-            PowerMockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE)).thenAnswer((Answer<String>) invocation -> "HDFS");
-            PowerMockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
-                .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-            PowerMockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
-                .thenAnswer((Answer<String>) invocation -> "/opt/krb5.conf");
-            PowerMockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
-                .thenAnswer((Answer<String>) invocation -> "hdfs-mycluster@ESZ.COM");
-            PowerMockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
-                .thenAnswer((Answer<String>) invocation -> "/opt/hdfs.headless.keytab");
-
-            PowerMockito.mockStatic(UserGroupInformation.class);
-            Configuration configuration = PowerMockito.mock(Configuration.class);
-            PowerMockito.whenNew(Configuration.class).withNoArguments().thenReturn(configuration);
-
-            boolean result = CommonUtils.loadKerberosConf(configuration);
-            Assert.assertTrue(result);
-
-            CommonUtils.loadKerberosConf(null, null, null);
-
-        } catch (Exception e) {
-            Assert.fail("load Kerberos Conf failed" + e.getMessage());
-        }
-    }
-
-    @Test
-    public void encodePassword() {
-        PowerMockito.mockStatic(PropertyUtils.class);
-        PowerMockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-            .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-
-        Assert.assertEquals("", PasswordUtils.encodePassword(""));
-        Assert.assertEquals("bnVsbE1USXpORFUy", PasswordUtils.encodePassword("123456"));
-        Assert.assertEquals("bnVsbElWRkJXbGhUVjBBPQ==", PasswordUtils.encodePassword("!QAZXSW@"));
-        Assert.assertEquals("bnVsbE5XUm1aMlZ5S0VBPQ==", PasswordUtils.encodePassword("5dfger(@"));
-
-        PowerMockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-            .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
-
-        Assert.assertEquals("", PasswordUtils.encodePassword(""));
-        Assert.assertEquals("123456", PasswordUtils.encodePassword("123456"));
-        Assert.assertEquals("!QAZXSW@", PasswordUtils.encodePassword("!QAZXSW@"));
-        Assert.assertEquals("5dfger(@", PasswordUtils.encodePassword("5dfger(@"));
-
-    }
-
-    @Test
-    public void decodePassword() {
-        PowerMockito.mockStatic(PropertyUtils.class);
-        PowerMockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-            .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-
-        PropertyUtils.setValue(DATASOURCE_ENCRYPTION_ENABLE, "true");
-
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.decodePassword("bnVsbE1USXpORFUy")).thenReturn("123456");
-        PowerMockito.when(PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ==")).thenReturn("!QAZXSW@");
-        PowerMockito.when(PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ==")).thenReturn("5dfger(@");
-
-        Assert.assertEquals(null, PasswordUtils.decodePassword(""));
-        Assert.assertEquals("123456", PasswordUtils.decodePassword("bnVsbE1USXpORFUy"));
-        Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ=="));
-        Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ=="));
-
-        PowerMockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
-            .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
-
-        PowerMockito.when(PasswordUtils.decodePassword("123456")).thenReturn("123456");
-        PowerMockito.when(PasswordUtils.decodePassword("!QAZXSW@")).thenReturn("!QAZXSW@");
-        PowerMockito.when(PasswordUtils.decodePassword("5dfger(@")).thenReturn("5dfger(@");
-
-        Assert.assertEquals(null, PasswordUtils.decodePassword(""));
-        Assert.assertEquals("123456", PasswordUtils.decodePassword("123456"));
-        Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("!QAZXSW@"));
-        Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("5dfger(@"));
-    }
-
-}
+/// *
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements. See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License. You may obtain a copy of the License at
+// *
+// * http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+// package org.apache.dolphinscheduler.plugin.datasource.api.utils;
+//
+// import static org.apache.dolphinscheduler.spi.utils.Constants.DATASOURCE_ENCRYPTION_ENABLE;
+//
+// import org.apache.dolphinscheduler.spi.utils.Constants;
+// import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
+//
+// import org.apache.hadoop.conf.Configuration;
+// import org.apache.hadoop.security.UserGroupInformation;
+//
+// import org.junit.Assert;
+// import org.junit.Test;
+// import org.junit.runner.RunWith;
+// import org.mockito.junit.MockitoJUnitRunner;
+// import org.mockito.stubbing.Answer;
+//
+// TODO: fix powermock answer in this class
+// @RunWith(MockitoJUnitRunner.class)
+// public class CommonUtilsTest {
+//
+// @Test
+// public void testGetKerberosStartupState() {
+// Mockito.mockStatic(CommonUtils.class);
+// Mockito.when(CommonUtils.getKerberosStartupState()).thenAnswer((Answer<Boolean>) invocation -> false);
+// boolean kerberosStartupState = CommonUtils.getKerberosStartupState();
+// Assert.assertFalse(kerberosStartupState);
+//
+// Mockito.mockStatic(PropertyUtils.class);
+// Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE)).thenAnswer((Answer<String>)
+/// invocation -> "HDFS");
+// Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, true))
+// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+// kerberosStartupState = CommonUtils.getKerberosStartupState();
+// Assert.assertFalse(kerberosStartupState);
+// }
+//
+// @Test
+// public void testLoadKerberosConf() {
+// try {
+// Mockito.mockStatic(PropertyUtils.class);
+// Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE)).thenAnswer((Answer<String>)
+/// invocation -> "HDFS");
+// Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+// Mockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
+// .thenAnswer((Answer<String>) invocation -> "/opt/krb5.conf");
+// Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
+// .thenAnswer((Answer<String>) invocation -> "hdfs-mycluster@ESZ.COM");
+// Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
+// .thenAnswer((Answer<String>) invocation -> "/opt/hdfs.headless.keytab");
+//
+// Mockito.mockStatic(UserGroupInformation.class);
+// Configuration configuration = Mockito.mock(Configuration.class);
+// Mockito.whenNew(Configuration.class).withNoArguments().thenReturn(configuration);
+//
+// boolean result = CommonUtils.loadKerberosConf(configuration);
+// Assert.assertTrue(result);
+//
+// CommonUtils.loadKerberosConf(null, null, null);
+//
+// } catch (Exception e) {
+// Assert.fail("load Kerberos Conf failed" + e.getMessage());
+// }
+// }
+//
+// @Test
+// public void encodePassword() {
+// Mockito.mockStatic(PropertyUtils.class);
+// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+//
+// Assert.assertEquals("", PasswordUtils.encodePassword(""));
+// Assert.assertEquals("bnVsbE1USXpORFUy", PasswordUtils.encodePassword("123456"));
+// Assert.assertEquals("bnVsbElWRkJXbGhUVjBBPQ==", PasswordUtils.encodePassword("!QAZXSW@"));
+// Assert.assertEquals("bnVsbE5XUm1aMlZ5S0VBPQ==", PasswordUtils.encodePassword("5dfger(@"));
+//
+// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+// .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
+//
+// Assert.assertEquals("", PasswordUtils.encodePassword(""));
+// Assert.assertEquals("123456", PasswordUtils.encodePassword("123456"));
+// Assert.assertEquals("!QAZXSW@", PasswordUtils.encodePassword("!QAZXSW@"));
+// Assert.assertEquals("5dfger(@", PasswordUtils.encodePassword("5dfger(@"));
+//
+// }
+//
+// @Test
+// public void decodePassword() {
+// Mockito.mockStatic(PropertyUtils.class);
+// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+// .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
+//
+// PropertyUtils.setValue(DATASOURCE_ENCRYPTION_ENABLE, "true");
+//
+// Mockito.mockStatic(PasswordUtils.class);
+// Mockito.when(PasswordUtils.decodePassword("bnVsbE1USXpORFUy")).thenReturn("123456");
+// Mockito.when(PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ==")).thenReturn("!QAZXSW@");
+// Mockito.when(PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ==")).thenReturn("5dfger(@");
+//
+// Assert.assertEquals(null, PasswordUtils.decodePassword(""));
+// Assert.assertEquals("123456", PasswordUtils.decodePassword("bnVsbE1USXpORFUy"));
+// Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ=="));
+// Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ=="));
+//
+// Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+// .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
+//
+// Mockito.when(PasswordUtils.decodePassword("123456")).thenReturn("123456");
+// Mockito.when(PasswordUtils.decodePassword("!QAZXSW@")).thenReturn("!QAZXSW@");
+// Mockito.when(PasswordUtils.decodePassword("5dfger(@")).thenReturn("5dfger(@");
+//
+// Assert.assertEquals(null, PasswordUtils.decodePassword(""));
+// Assert.assertEquals("123456", PasswordUtils.decodePassword("123456"));
+// Assert.assertEquals("!QAZXSW@", PasswordUtils.decodePassword("!QAZXSW@"));
+// Assert.assertEquals("5dfger(@", PasswordUtils.decodePassword("5dfger(@"));
+// }
+//
+// }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-athena/src/test/java/org/apache/dolphinscheduler/plugin/datasource/athena/param/AthenaDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-athena/src/test/java/org/apache/dolphinscheduler/plugin/datasource/athena/param/AthenaDataSourceProcessorTest.java
@@ -17,14 +17,10 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.athena.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +28,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class AthenaDataSourceProcessorTest {
 
     private final AthenaDataSourceProcessor athenaDataSourceProcessor = new AthenaDataSourceProcessor();
@@ -52,20 +45,21 @@ public class AthenaDataSourceProcessorTest {
         athenaDataSourceParamDTO.setPassword("123456");
         athenaDataSourceParamDTO.setAwsRegion("cn-north-1");
         athenaDataSourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
         AthenaConnectionParam connectionParams = (AthenaConnectionParam) this.athenaDataSourceProcessor
-            .createConnectionParams(athenaDataSourceParamDTO);
+                .createConnectionParams(athenaDataSourceParamDTO);
         Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;", connectionParams.getAddress());
         Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;", connectionParams.getJdbcUrl());
     }
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"awsuser\",\"password\":\"123456\",\"address\":\"jdbc:awsathena://AwsRegion=cn-north-1;\""
-            + ",\"database\":\"\",\"jdbcUrl\":\"jdbc:awsathena://AwsRegion=cn-north-1;\", \"awsRegion\":\"cn-north-1\"}";
+        String connectionJson =
+                "{\"user\":\"awsuser\",\"password\":\"123456\",\"address\":\"jdbc:awsathena://AwsRegion=cn-north-1;\""
+                        + ",\"database\":\"\",\"jdbcUrl\":\"jdbc:awsathena://AwsRegion=cn-north-1;\", \"awsRegion\":\"cn-north-1\"}";
         AthenaConnectionParam connectionParams = (AthenaConnectionParam) this.athenaDataSourceProcessor
-            .createConnectionParams(connectionJson);
+                .createConnectionParams(connectionJson);
         Assert.assertNotNull(connectionParams);
         Assert.assertEquals("awsuser", connectionParams.getUser());
         Assert.assertEquals("cn-north-1", connectionParams.getAwsRegion());
@@ -82,7 +76,7 @@ public class AthenaDataSourceProcessorTest {
         athenaConnectionParam.setJdbcUrl("jdbc:awsathena://AwsRegion=cn-north-1;");
         athenaConnectionParam.setOther("LogLevel=6;LogPath=/tmp;");
         Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;LogLevel=6;LogPath=/tmp;",
-            this.athenaDataSourceProcessor.getJdbcUrl(athenaConnectionParam));
+                this.athenaDataSourceProcessor.getJdbcUrl(athenaConnectionParam));
 
     }
 
@@ -92,7 +86,7 @@ public class AthenaDataSourceProcessorTest {
         athenaConnectionParam.setJdbcUrl("jdbc:awsathena://AwsRegion=cn-north-1;");
         athenaConnectionParam.setOther("");
         Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;",
-            this.athenaDataSourceProcessor.getJdbcUrl(athenaConnectionParam));
+                this.athenaDataSourceProcessor.getJdbcUrl(athenaConnectionParam));
 
     }
 
@@ -109,10 +103,11 @@ public class AthenaDataSourceProcessorTest {
 
     @Test
     public void testCreateDatasourceParamDTO() {
-        String connectionJson = "{\"user\":\"awsuser\",\"password\":\"123456\",\"address\":\"jdbc:awsathena://AwsRegion=cn-north-1;\""
-            + ",\"database\":\"\",\"jdbcUrl\":\"jdbc:awsathena://AwsRegion=cn-north-1;\", \"awsRegion\":\"cn-north-1\"}";
+        String connectionJson =
+                "{\"user\":\"awsuser\",\"password\":\"123456\",\"address\":\"jdbc:awsathena://AwsRegion=cn-north-1;\""
+                        + ",\"database\":\"\",\"jdbcUrl\":\"jdbc:awsathena://AwsRegion=cn-north-1;\", \"awsRegion\":\"cn-north-1\"}";
         AthenaDataSourceParamDTO athenaDataSourceParamDTO = (AthenaDataSourceParamDTO) this.athenaDataSourceProcessor
-            .createDatasourceParamDTO(connectionJson);
+                .createDatasourceParamDTO(connectionJson);
         Assert.assertEquals("awsuser", athenaDataSourceParamDTO.getUserName());
         Assert.assertEquals("cn-north-1", athenaDataSourceParamDTO.getAwsRegion());
         Assert.assertEquals("", athenaDataSourceParamDTO.getDatabase());

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-clickhouse/src/test/java/org/apache/dolphinscheduler/plugin/datasource/clickhouse/ClickHouseDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-clickhouse/src/test/java/org/apache/dolphinscheduler/plugin/datasource/clickhouse/ClickHouseDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({ClickHouseDataSourceClient.class, ClickHouseDataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class ClickHouseDataSourceChannelTest {
-    
+
     @Test
     public void testCreateDataSourceClient() {
-        ClickHouseDataSourceChannel sourceChannel = PowerMockito.mock(ClickHouseDataSourceChannel.class);
-        ClickHouseDataSourceClient dataSourceClient = PowerMockito.mock(ClickHouseDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        ClickHouseDataSourceChannel sourceChannel = Mockito.mock(ClickHouseDataSourceChannel.class);
+        ClickHouseDataSourceClient dataSourceClient = Mockito.mock(ClickHouseDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new ClickHouseConnectionParam(), DbType.CLICKHOUSE));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-db2/src/test/java/org/apache/dolphinscheduler/plugin/datasource/db2/DB2DataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-db2/src/test/java/org/apache/dolphinscheduler/plugin/datasource/db2/DB2DataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({DB2DataSourceClient.class, DB2DataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class DB2DataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        DB2DataSourceChannel sourceChannel = PowerMockito.mock(DB2DataSourceChannel.class);
-        DB2DataSourceClient dataSourceClient = PowerMockito.mock(DB2DataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        DB2DataSourceChannel sourceChannel = Mockito.mock(DB2DataSourceChannel.class);
+        DB2DataSourceClient dataSourceClient = Mockito.mock(DB2DataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new Db2ConnectionParam(), DbType.DB2));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-db2/src/test/java/org/apache/dolphinscheduler/plugin/datasource/db2/param/Db2DataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-db2/src/test/java/org/apache/dolphinscheduler/plugin/datasource/db2/param/Db2DataSourceProcessorTest.java
@@ -17,14 +17,10 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.db2.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +28,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class Db2DataSourceProcessorTest {
 
     private Db2DataSourceProcessor db2DatasourceProcessor = new Db2DataSourceProcessor();
@@ -53,8 +46,8 @@ public class Db2DataSourceProcessorTest {
         db2DatasourceParamDTO.setPort(5142);
         db2DatasourceParamDTO.setDatabase("default");
         db2DatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
 
         Db2ConnectionParam connectionParams = (Db2ConnectionParam) db2DatasourceProcessor
                 .createConnectionParams(db2DatasourceParamDTO);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/pom.xml
@@ -15,19 +15,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>dolphinscheduler-datasource-plugin</artifactId>
         <groupId>org.apache.dolphinscheduler</groupId>
+        <artifactId>dolphinscheduler-datasource-plugin</artifactId>
         <version>dev-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dolphinscheduler-datasource-hive</artifactId>
-    <name>${project.artifactId}</name>
     <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
 
     <dependencies>
 
@@ -36,6 +35,13 @@
             <artifactId>dolphinscheduler-spi</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-datasource-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-task-api</artifactId>
@@ -56,8 +62,8 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>servlet-api</artifactId>
                     <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.jackson</groupId>
@@ -81,38 +87,31 @@
                     <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-client</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jaxb-api</artifactId>
                     <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-datasource-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
 
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
             <exclusions>
                 <exclusion>
-                    <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty.aggregate</groupId>
@@ -194,124 +193,124 @@
                     <artifactId>json</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j-impl</artifactId>
-                    <groupId>org.apache.logging.log4j</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>javax.servlet</artifactId>
                     <groupId>org.eclipse.jetty.orbit</groupId>
+                    <artifactId>javax.servlet</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>servlet-api-2.5</artifactId>
                     <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>tomcat</groupId>
                     <artifactId>jasper-runtime</artifactId>
-                    <groupId>tomcat</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>slider-core</artifactId>
                     <groupId>org.apache.slider</groupId>
+                    <artifactId>slider-core</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-server</artifactId>
-                    <groupId>org.apache.hbase</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-client</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-json</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-server</artifactId>
-                    <groupId>com.sun.jersey</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jersey-guice</artifactId>
                     <groupId>com.sun.jersey.contribs</groupId>
+                    <artifactId>jersey-guice</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-common</artifactId>
-                    <groupId>org.apache.hbase</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-hadoop2-compat</artifactId>
-                    <groupId>org.apache.hbase</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
-                    <groupId>org.apache.hbase</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-hadoop-compat</artifactId>
-                    <groupId>org.apache.hbase</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>co.cask.tephra</groupId>
                     <artifactId>tephra-hbase-compat-1.0</artifactId>
-                    <groupId>co.cask.tephra</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jaxb-api</artifactId>
                     <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hive</groupId>
                     <artifactId>hive-llap-client</artifactId>
-                    <groupId>org.apache.hive</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hive</groupId>
                     <artifactId>hive-llap-common</artifactId>
-                    <groupId>org.apache.hive</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hive</groupId>
                     <artifactId>hive-llap-server</artifactId>
-                    <groupId>org.apache.hive</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>tephra-core</artifactId>
                     <groupId>co.cask.tephra</groupId>
+                    <artifactId>tephra-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>ant</artifactId>
                     <groupId>ant</groupId>
+                    <artifactId>ant</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.antlr</groupId>
                     <artifactId>stringtemplate</artifactId>
-                    <groupId>org.antlr</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.antlr</groupId>
                     <artifactId>antlr-runtime</artifactId>
-                    <groupId>org.antlr</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>hive-shims</artifactId>
                     <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-shims</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jsp-api</artifactId>
                     <groupId>javax.servlet</groupId>
+                    <artifactId>jsp-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
-                    <groupId>org.apache.logging.log4j</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <groupId>org.apache.logging.log4j</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-web</artifactId>
-                    <groupId>org.apache.logging.log4j</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jasper-compiler</artifactId>
                     <groupId>tomcat</groupId>
+                    <artifactId>jasper-compiler</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/main/java/org/apache/dolphinscheduler/plugin/datasource/hive/HiveDataSourceClient.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/main/java/org/apache/dolphinscheduler/plugin/datasource/hive/HiveDataSourceClient.java
@@ -21,14 +21,16 @@ import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.HADOOP_S
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.JAVA_SECURITY_KRB5_CONF;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.JAVA_SECURITY_KRB5_CONF_PATH;
 
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient;
 import org.apache.dolphinscheduler.plugin.datasource.api.provider.JDBCDataSourceProvider;
 import org.apache.dolphinscheduler.plugin.datasource.hive.utils.CommonUtil;
 import org.apache.dolphinscheduler.spi.datasource.BaseConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
+
+import sun.security.krb5.Config;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -45,8 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import sun.security.krb5.Config;
 
 public class HiveDataSourceClient extends CommonDataSourceClient {
 
@@ -150,7 +150,8 @@ public class HiveDataSourceClient extends CommonDataSourceClient {
         try {
             return dataSource.getConnection();
         } catch (SQLException e) {
-            boolean kerberosStartupState = PropertyUtils.getBoolean(HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false);
+            boolean kerberosStartupState =
+                    PropertyUtils.getBoolean(HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false);
             if (retryGetConnection && kerberosStartupState) {
                 retryGetConnection = false;
                 createUserGroupInformation(baseConnectionParam.getUser());

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/main/java/org/apache/dolphinscheduler/plugin/datasource/hive/utils/CommonUtil.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/main/java/org/apache/dolphinscheduler/plugin/datasource/hive/utils/CommonUtil.java
@@ -19,9 +19,9 @@ package org.apache.dolphinscheduler.plugin.datasource.hive.utils;
 
 import static org.apache.dolphinscheduler.spi.utils.Constants.JAVA_SECURITY_KRB5_CONF;
 
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.enums.ResUploadType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
 
 import org.apache.hadoop.conf.Configuration;
@@ -38,12 +38,14 @@ public class CommonUtil {
     public static boolean getKerberosStartupState() {
         String resUploadStartupType = PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE);
         ResUploadType resUploadType = ResUploadType.valueOf(resUploadStartupType);
-        Boolean kerberosStartupState = PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false);
+        Boolean kerberosStartupState =
+                PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false);
         return resUploadType == ResUploadType.HDFS && kerberosStartupState;
     }
 
-    public static synchronized UserGroupInformation createUGI(Configuration configuration, String principal, String keyTab, String krb5File, String username)
-            throws IOException {
+    public static synchronized UserGroupInformation createUGI(Configuration configuration, String principal,
+                                                              String keyTab, String krb5File,
+                                                              String username) throws IOException {
         if (getKerberosStartupState()) {
             Objects.requireNonNull(keyTab);
             if (StringUtils.isNotBlank(krb5File)) {
@@ -54,8 +56,8 @@ public class CommonUtil {
         return UserGroupInformation.createRemoteUser(username);
     }
 
-    public static synchronized UserGroupInformation loginKerberos(final Configuration config, final String principal, final String keyTab)
-            throws IOException {
+    public static synchronized UserGroupInformation loginKerberos(final Configuration config, final String principal,
+                                                                  final String keyTab) throws IOException {
         config.set(Constants.HADOOP_SECURITY_AUTHENTICATION, Constants.KERBEROS);
         UserGroupInformation.setConfiguration(config);
         UserGroupInformation.loginUserFromKeytab(principal.trim(), keyTab.trim());

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/test/java/org/apache/dolphinscheduler/plugin/datasource/hive/HiveDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/test/java/org/apache/dolphinscheduler/plugin/datasource/hive/HiveDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({HiveDataSourceChannel.class, HiveDataSourceClient.class})
+@RunWith(MockitoJUnitRunner.class)
 public class HiveDataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        HiveDataSourceChannel sourceChannel = PowerMockito.mock(HiveDataSourceChannel.class);
-        HiveDataSourceClient dataSourceClient = PowerMockito.mock(HiveDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        HiveDataSourceChannel sourceChannel = Mockito.mock(HiveDataSourceChannel.class);
+        HiveDataSourceClient dataSourceClient = Mockito.mock(HiveDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new HiveConnectionParam(), DbType.HIVE));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/test/java/org/apache/dolphinscheduler/plugin/datasource/hive/param/HiveDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-hive/src/test/java/org/apache/dolphinscheduler/plugin/datasource/hive/param/HiveDataSourceProcessorTest.java
@@ -17,14 +17,11 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.hive.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +29,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class HiveDataSourceProcessorTest {
 
     private HiveDataSourceProcessor hiveDatasourceProcessor = new HiveDataSourceProcessor();
@@ -52,10 +46,10 @@ public class HiveDataSourceProcessorTest {
         hiveDataSourceParamDTO.setUserName("default");
         hiveDataSourceParamDTO.setDatabase("default");
         hiveDataSourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        PowerMockito.mockStatic(CommonUtils.class);
-        PowerMockito.when(CommonUtils.getKerberosStartupState()).thenReturn(false);
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(CommonUtils.class);
+        Mockito.when(CommonUtils.getKerberosStartupState()).thenReturn(false);
         HiveConnectionParam connectionParams = (HiveConnectionParam) hiveDatasourceProcessor
                 .createConnectionParams(hiveDataSourceParamDTO);
         Assert.assertNotNull(connectionParams);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/MySQLDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/MySQLDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({MySQLDataSourceClient.class, MySQLDataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class MySQLDataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        MySQLDataSourceChannel sourceChannel = PowerMockito.mock(MySQLDataSourceChannel.class);
-        MySQLDataSourceClient dataSourceClient = PowerMockito.mock(MySQLDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        MySQLDataSourceChannel sourceChannel = Mockito.mock(MySQLDataSourceChannel.class);
+        MySQLDataSourceClient dataSourceClient = Mockito.mock(MySQLDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new MySQLConnectionParam(), DbType.MYSQL));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/param/MySQLDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/param/MySQLDataSourceProcessorTest.java
@@ -17,27 +17,21 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.mysql.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class MySQLDataSourceProcessorTest {
 
     private MySQLDataSourceProcessor mysqlDatasourceProcessor = new MySQLDataSourceProcessor();
@@ -53,12 +47,13 @@ public class MySQLDataSourceProcessorTest {
         mysqlDatasourceParamDTO.setPort(3306);
         mysqlDatasourceParamDTO.setDatabase("default");
         mysqlDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        MySQLConnectionParam connectionParams = (MySQLConnectionParam) mysqlDatasourceProcessor
-                .createConnectionParams(mysqlDatasourceParamDTO);
-        Assert.assertEquals("jdbc:mysql://localhost:3306", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:mysql://localhost:3306/default", connectionParams.getJdbcUrl());
+        try (MockedStatic<PasswordUtils> mockedPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            MySQLConnectionParam connectionParams = (MySQLConnectionParam) mysqlDatasourceProcessor
+                    .createConnectionParams(mysqlDatasourceParamDTO);
+            Assert.assertEquals("jdbc:mysql://localhost:3306", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:mysql://localhost:3306/default", connectionParams.getJdbcUrl());
+        }
     }
 
     @Test
@@ -80,7 +75,8 @@ public class MySQLDataSourceProcessorTest {
     public void testGetJdbcUrl() {
         MySQLConnectionParam mysqlConnectionParam = new MySQLConnectionParam();
         mysqlConnectionParam.setJdbcUrl("jdbc:mysql://localhost:3306/default");
-        Assert.assertEquals("jdbc:mysql://localhost:3306/default?allowLoadLocalInfile=false&autoDeserialize=false&allowLocalInfile=false&allowUrlInLocalInfile=false",
+        Assert.assertEquals(
+                "jdbc:mysql://localhost:3306/default?allowLoadLocalInfile=false&autoDeserialize=false&allowLocalInfile=false&allowUrlInLocalInfile=false",
                 mysqlDatasourceProcessor.getJdbcUrl(mysqlConnectionParam));
     }
 
@@ -100,8 +96,10 @@ public class MySQLDataSourceProcessorTest {
         mysqlConnectionParam.setJdbcUrl("jdbc:mysql://localhost:3306/default");
         mysqlConnectionParam.setUser("root");
         mysqlConnectionParam.setPassword("123456");
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("123456");
-        Assert.assertEquals("mysql@root@123456@jdbc:mysql://localhost:3306/default", mysqlDatasourceProcessor.getDatasourceUniqueId(mysqlConnectionParam, DbType.MYSQL));
+        try (MockedStatic<PasswordUtils> mockedPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("123456");
+            Assert.assertEquals("mysql@root@123456@jdbc:mysql://localhost:3306/default",
+                    mysqlDatasourceProcessor.getDatasourceUniqueId(mysqlConnectionParam, DbType.MYSQL));
+        }
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/provider/JDBCDataSourceProviderTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/provider/JDBCDataSourceProviderTest.java
@@ -24,31 +24,38 @@ import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.zaxxer.hikari.HikariDataSource;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(value = {HikariDataSource.class, JDBCDataSourceProvider.class})
+@RunWith(MockitoJUnitRunner.class)
 public class JDBCDataSourceProviderTest {
 
     @Test
     public void testCreateJdbcDataSource() {
-        PowerMockito.mockStatic(JDBCDataSourceProvider.class);
-        HikariDataSource dataSource = PowerMockito.mock(HikariDataSource.class);
-        PowerMockito.when(JDBCDataSourceProvider.createJdbcDataSource(Mockito.any(), Mockito.any())).thenReturn(dataSource);
-        Assert.assertNotNull(JDBCDataSourceProvider.createJdbcDataSource(new MySQLConnectionParam(), DbType.MYSQL));
+        try (
+                MockedStatic<JDBCDataSourceProvider> mockedJDBCDataSourceProvider =
+                        Mockito.mockStatic(JDBCDataSourceProvider.class)) {
+            HikariDataSource dataSource = Mockito.mock(HikariDataSource.class);
+            Mockito.when(JDBCDataSourceProvider.createJdbcDataSource(Mockito.any(), Mockito.any()))
+                    .thenReturn(dataSource);
+            Assert.assertNotNull(JDBCDataSourceProvider.createJdbcDataSource(new MySQLConnectionParam(), DbType.MYSQL));
+        }
     }
 
     @Test
     public void testCreateOneSessionJdbcDataSource() {
-        PowerMockito.mockStatic(JDBCDataSourceProvider.class);
-        HikariDataSource dataSource = PowerMockito.mock(HikariDataSource.class);
-        PowerMockito.when(JDBCDataSourceProvider.createOneSessionJdbcDataSource(Mockito.any(), Mockito.any())).thenReturn(dataSource);
-        Assert.assertNotNull(JDBCDataSourceProvider.createOneSessionJdbcDataSource(new MySQLConnectionParam(), DbType.MYSQL));
+        try (
+                MockedStatic<JDBCDataSourceProvider> mockedJDBCDataSourceProvider =
+                        Mockito.mockStatic(JDBCDataSourceProvider.class)) {
+            HikariDataSource dataSource = Mockito.mock(HikariDataSource.class);
+            Mockito.when(JDBCDataSourceProvider.createOneSessionJdbcDataSource(Mockito.any(), Mockito.any()))
+                    .thenReturn(dataSource);
+            Assert.assertNotNull(
+                    JDBCDataSourceProvider.createOneSessionJdbcDataSource(new MySQLConnectionParam(), DbType.MYSQL));
+        }
     }
 
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/utils/DataSourceUtilsTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/utils/DataSourceUtilsTest.java
@@ -23,32 +23,26 @@ import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.plugin.datasource.mysql.param.MySQLConnectionParam;
 import org.apache.dolphinscheduler.plugin.datasource.mysql.param.MySQLDataSourceParamDTO;
-import org.apache.dolphinscheduler.plugin.datasource.mysql.param.MySQLDataSourceProcessor;
 import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
-import org.apache.dolphinscheduler.spi.utils.PropertyUtils;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.spi.utils.PropertyUtils")
-@PrepareForTest({Class.class, DriverManager.class, MySQLDataSourceProcessor.class, DataSourceClientProvider.class, PasswordUtils.class, CommonUtils.class, PropertyUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class DataSourceUtilsTest {
 
+    @Ignore
     @Test
     public void testCheckDatasourceParam() {
         MySQLDataSourceParamDTO mysqlDatasourceParamDTO = new MySQLDataSourceParamDTO();
@@ -63,6 +57,7 @@ public class DataSourceUtilsTest {
         Assert.assertTrue(true);
     }
 
+    @Ignore
     @Test
     public void testBuildConnectionParams() {
         MySQLDataSourceParamDTO mysqlDatasourceParamDTO = new MySQLDataSourceParamDTO();
@@ -71,14 +66,15 @@ public class DataSourceUtilsTest {
         mysqlDatasourceParamDTO.setUserName("root");
         mysqlDatasourceParamDTO.setPort(3306);
         mysqlDatasourceParamDTO.setPassword("123456");
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("123456");
-        PowerMockito.mockStatic(CommonUtils.class);
-        PowerMockito.when(CommonUtils.getKerberosStartupState()).thenReturn(false);
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("123456");
+        Mockito.mockStatic(CommonUtils.class);
+        Mockito.when(CommonUtils.getKerberosStartupState()).thenReturn(false);
         ConnectionParam connectionParam = DataSourceUtils.buildConnectionParams(mysqlDatasourceParamDTO);
         Assert.assertNotNull(connectionParam);
     }
 
+    @Ignore
     @Test
     public void testBuildConnectionParams2() {
         MySQLDataSourceParamDTO mysqlDatasourceParamDTO = new MySQLDataSourceParamDTO();
@@ -87,20 +83,23 @@ public class DataSourceUtilsTest {
         mysqlDatasourceParamDTO.setUserName("root");
         mysqlDatasourceParamDTO.setPort(3306);
         mysqlDatasourceParamDTO.setPassword("123456");
-        ConnectionParam connectionParam = DataSourceUtils.buildConnectionParams(DbType.MYSQL, JSONUtils.toJsonString(mysqlDatasourceParamDTO));
+        ConnectionParam connectionParam =
+                DataSourceUtils.buildConnectionParams(DbType.MYSQL, JSONUtils.toJsonString(mysqlDatasourceParamDTO));
         Assert.assertNotNull(connectionParam);
     }
 
     @Test
     public void testGetConnection() throws ExecutionException {
-        PowerMockito.mockStatic(PropertyUtils.class);
-        PowerMockito.when(PropertyUtils.getLong("kerberos.expire.time", 24L)).thenReturn(24L);
-        PowerMockito.mockStatic(DataSourceClientProvider.class);
-        DataSourceClientProvider clientProvider = PowerMockito.mock(DataSourceClientProvider.class);
-        PowerMockito.when(DataSourceClientProvider.getInstance()).thenReturn(clientProvider);
+        // TODO: refactor and fix this
+        // Mockito.mockStatic(PropertyUtils.class);
+        // Mockito.when(PropertyUtils.getLong("kerberos.expire.time", 24L)).thenReturn(24L);
+        // Mockito.mockStatic(DataSourceClientProvider.class);
+        // DataSourceClientProvider clientProvider = Mockito.mock(DataSourceClientProvider.class);
+        DataSourceClientProvider clientProvider = Mockito.spy(DataSourceClientProvider.getInstance());
+        // Mockito.when(DataSourceClientProvider.getInstance()).thenReturn(clientProvider);
 
-        Connection connection = PowerMockito.mock(Connection.class);
-        PowerMockito.when(clientProvider.getConnection(Mockito.any(), Mockito.any())).thenReturn(connection);
+        Connection connection = Mockito.mock(Connection.class);
+        Mockito.when(clientProvider.getConnection(Mockito.any(), Mockito.any())).thenReturn(connection);
 
         MySQLConnectionParam connectionParam = new MySQLConnectionParam();
         connectionParam.setUser("root");
@@ -111,32 +110,39 @@ public class DataSourceUtilsTest {
 
     }
 
+    @Ignore
     @Test
     public void testGetJdbcUrl() {
         MySQLConnectionParam mysqlConnectionParam = new MySQLConnectionParam();
         mysqlConnectionParam.setJdbcUrl("jdbc:mysql://localhost:3308");
         String jdbcUrl = DataSourceUtils.getJdbcUrl(DbType.MYSQL, mysqlConnectionParam);
-        Assert.assertEquals("jdbc:mysql://localhost:3308?allowLoadLocalInfile=false&autoDeserialize=false&allowLocalInfile=false&allowUrlInLocalInfile=false",
+        Assert.assertEquals(
+                "jdbc:mysql://localhost:3308?allowLoadLocalInfile=false&autoDeserialize=false&allowLocalInfile=false&allowUrlInLocalInfile=false",
                 jdbcUrl);
     }
 
+    @Ignore
     @Test
     public void testBuildDatasourceParamDTO() {
         MySQLConnectionParam connectionParam = new MySQLConnectionParam();
-        connectionParam.setJdbcUrl("jdbc:mysql://localhost:3308?allowLoadLocalInfile=false&autoDeserialize=false&allowLocalInfile=false&allowUrlInLocalInfile=false");
+        connectionParam.setJdbcUrl(
+                "jdbc:mysql://localhost:3308?allowLoadLocalInfile=false&autoDeserialize=false&allowLocalInfile=false&allowUrlInLocalInfile=false");
         connectionParam.setAddress("jdbc:mysql://localhost:3308");
         connectionParam.setUser("root");
         connectionParam.setPassword("123456");
 
-        Assert.assertNotNull(DataSourceUtils.buildDatasourceParamDTO(DbType.MYSQL, JSONUtils.toJsonString(connectionParam)));
+        Assert.assertNotNull(
+                DataSourceUtils.buildDatasourceParamDTO(DbType.MYSQL, JSONUtils.toJsonString(connectionParam)));
 
     }
 
+    @Ignore
     @Test
     public void testGetDatasourceProcessor() {
         Assert.assertNotNull(DataSourceUtils.getDatasourceProcessor(DbType.MYSQL));
     }
 
+    @Ignore
     @Test(expected = Exception.class)
     public void testGetDatasourceProcessorError() {
         DataSourceUtils.getDatasourceProcessor(null);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/utils/DataSourceUtilsTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/utils/DataSourceUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.mysql.utils;
 
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
@@ -33,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -42,7 +42,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DataSourceUtilsTest {
 
-    @Ignore
     @Test
     public void testCheckDatasourceParam() {
         MySQLDataSourceParamDTO mysqlDatasourceParamDTO = new MySQLDataSourceParamDTO();
@@ -57,7 +56,6 @@ public class DataSourceUtilsTest {
         Assert.assertTrue(true);
     }
 
-    @Ignore
     @Test
     public void testBuildConnectionParams() {
         MySQLDataSourceParamDTO mysqlDatasourceParamDTO = new MySQLDataSourceParamDTO();
@@ -74,7 +72,6 @@ public class DataSourceUtilsTest {
         Assert.assertNotNull(connectionParam);
     }
 
-    @Ignore
     @Test
     public void testBuildConnectionParams2() {
         MySQLDataSourceParamDTO mysqlDatasourceParamDTO = new MySQLDataSourceParamDTO();
@@ -90,13 +87,11 @@ public class DataSourceUtilsTest {
 
     @Test
     public void testGetConnection() throws ExecutionException {
-        // TODO: refactor and fix this
-        // Mockito.mockStatic(PropertyUtils.class);
-        // Mockito.when(PropertyUtils.getLong("kerberos.expire.time", 24L)).thenReturn(24L);
-        // Mockito.mockStatic(DataSourceClientProvider.class);
-        // DataSourceClientProvider clientProvider = Mockito.mock(DataSourceClientProvider.class);
-        DataSourceClientProvider clientProvider = Mockito.spy(DataSourceClientProvider.getInstance());
-        // Mockito.when(DataSourceClientProvider.getInstance()).thenReturn(clientProvider);
+        Mockito.mockStatic(PropertyUtils.class);
+        Mockito.when(PropertyUtils.getLong("kerberos.expire.time", 24L)).thenReturn(24L);
+        Mockito.mockStatic(DataSourceClientProvider.class);
+        DataSourceClientProvider clientProvider = Mockito.mock(DataSourceClientProvider.class);
+        Mockito.when(DataSourceClientProvider.getInstance()).thenReturn(clientProvider);
 
         Connection connection = Mockito.mock(Connection.class);
         Mockito.when(clientProvider.getConnection(Mockito.any(), Mockito.any())).thenReturn(connection);
@@ -110,7 +105,6 @@ public class DataSourceUtilsTest {
 
     }
 
-    @Ignore
     @Test
     public void testGetJdbcUrl() {
         MySQLConnectionParam mysqlConnectionParam = new MySQLConnectionParam();
@@ -121,7 +115,6 @@ public class DataSourceUtilsTest {
                 jdbcUrl);
     }
 
-    @Ignore
     @Test
     public void testBuildDatasourceParamDTO() {
         MySQLConnectionParam connectionParam = new MySQLConnectionParam();
@@ -136,13 +129,11 @@ public class DataSourceUtilsTest {
 
     }
 
-    @Ignore
     @Test
     public void testGetDatasourceProcessor() {
         Assert.assertNotNull(DataSourceUtils.getDatasourceProcessor(DbType.MYSQL));
     }
 
-    @Ignore
     @Test(expected = Exception.class)
     public void testGetDatasourceProcessorError() {
         DataSourceUtils.getDatasourceProcessor(null);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/test/java/org/apache/dolphinscheduler/plugin/datasource/oracle/OracleDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/test/java/org/apache/dolphinscheduler/plugin/datasource/oracle/OracleDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({OracleDataSourceClient.class, OracleDataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class OracleDataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        OracleDataSourceChannel sourceChannel = PowerMockito.mock(OracleDataSourceChannel.class);
-        OracleDataSourceClient dataSourceClient = PowerMockito.mock(OracleDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        OracleDataSourceChannel sourceChannel = Mockito.mock(OracleDataSourceChannel.class);
+        OracleDataSourceClient dataSourceClient = Mockito.mock(OracleDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new OracleConnectionParam(), DbType.ORACLE));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/test/java/org/apache/dolphinscheduler/plugin/datasource/oracle/param/OracleDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/test/java/org/apache/dolphinscheduler/plugin/datasource/oracle/param/OracleDataSourceProcessorTest.java
@@ -17,15 +17,11 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.oracle.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbConnectType;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,12 +29,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class OracleDataSourceProcessorTest {
 
     private OracleDataSourceProcessor oracleDatasourceProcessor = new OracleDataSourceProcessor();
@@ -55,8 +48,8 @@ public class OracleDataSourceProcessorTest {
         oracleDatasourceParamDTO.setPassword("123456");
         oracleDatasourceParamDTO.setDatabase("default");
         oracleDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
         OracleConnectionParam connectionParams = (OracleConnectionParam) oracleDatasourceProcessor
                 .createConnectionParams(oracleDatasourceParamDTO);
         Assert.assertNotNull(connectionParams);
@@ -66,8 +59,9 @@ public class OracleDataSourceProcessorTest {
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:oracle:thin:@localhost:3308\""
-                + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:oracle:thin:@localhost:3308:default\",\"connectType\":\"ORACLE_SID\"}";
+        String connectionJson =
+                "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:oracle:thin:@localhost:3308\""
+                        + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:oracle:thin:@localhost:3308:default\",\"connectType\":\"ORACLE_SID\"}";
         OracleConnectionParam connectionParams = (OracleConnectionParam) oracleDatasourceProcessor
                 .createConnectionParams(connectionJson);
         Assert.assertNotNull(connectionParams);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-postgresql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/postgresql/PostgreSQLDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-postgresql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/postgresql/PostgreSQLDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({PostgreSQLDataSourceClient.class, PostgreSQLDataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class PostgreSQLDataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        PostgreSQLDataSourceChannel sourceChannel = PowerMockito.mock(PostgreSQLDataSourceChannel.class);
-        PostgreSQLDataSourceClient dataSourceClient = PowerMockito.mock(PostgreSQLDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        PostgreSQLDataSourceChannel sourceChannel = Mockito.mock(PostgreSQLDataSourceChannel.class);
+        PostgreSQLDataSourceClient dataSourceClient = Mockito.mock(PostgreSQLDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new PostgreSQLConnectionParam(), DbType.POSTGRESQL));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-postgresql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/postgresql/param/PostgreSQLDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-postgresql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/postgresql/param/PostgreSQLDataSourceProcessorTest.java
@@ -17,14 +17,10 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.postgresql.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +28,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class PostgreSQLDataSourceProcessorTest {
 
     private PostgreSQLDataSourceProcessor postgreSqlDatasourceProcessor = new PostgreSQLDataSourceProcessor();
@@ -53,8 +46,8 @@ public class PostgreSQLDataSourceProcessorTest {
         postgreSqlDatasourceParamDTO.setPort(3308);
         postgreSqlDatasourceParamDTO.setDatabase("default");
         postgreSqlDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
         PostgreSQLConnectionParam connectionParams = (PostgreSQLConnectionParam) postgreSqlDatasourceProcessor
                 .createConnectionParams(postgreSqlDatasourceParamDTO);
         Assert.assertEquals("jdbc:postgresql://localhost:3308", connectionParams.getAddress());
@@ -64,8 +57,9 @@ public class PostgreSQLDataSourceProcessorTest {
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:postgresql://localhost:3308\""
-                + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:postgresql://localhost:3308/default\"}";
+        String connectionJson =
+                "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:postgresql://localhost:3308\""
+                        + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:postgresql://localhost:3308/default\"}";
         PostgreSQLConnectionParam connectionParams = (PostgreSQLConnectionParam) postgreSqlDatasourceProcessor
                 .createConnectionParams(connectionJson);
         Assert.assertNotNull(connectionParams);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-presto/src/test/java/org/apache/dolphinscheduler/plugin/datasource/presto/PrestoDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-presto/src/test/java/org/apache/dolphinscheduler/plugin/datasource/presto/PrestoDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({PrestoDataSourceClient.class, PrestoDataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class PrestoDataSourceChannelTest {
-    
+
     @Test
     public void testCreateDataSourceClient() {
-        PrestoDataSourceChannel sourceChannel = PowerMockito.mock(PrestoDataSourceChannel.class);
-        PrestoDataSourceClient dataSourceClient = PowerMockito.mock(PrestoDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        PrestoDataSourceChannel sourceChannel = Mockito.mock(PrestoDataSourceChannel.class);
+        PrestoDataSourceClient dataSourceClient = Mockito.mock(PrestoDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new PrestoConnectionParam(), DbType.PRESTO));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-presto/src/test/java/org/apache/dolphinscheduler/plugin/datasource/presto/param/PrestoDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-presto/src/test/java/org/apache/dolphinscheduler/plugin/datasource/presto/param/PrestoDataSourceProcessorTest.java
@@ -17,14 +17,10 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.presto.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +28,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class PrestoDataSourceProcessorTest {
 
     private PrestoDataSourceProcessor prestoDatasourceProcessor = new PrestoDataSourceProcessor();
@@ -53,8 +46,8 @@ public class PrestoDataSourceProcessorTest {
         prestoDatasourceParamDTO.setUserName("root");
         prestoDatasourceParamDTO.setPassword("123456");
         prestoDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
         PrestoConnectionParam connectionParams = (PrestoConnectionParam) prestoDatasourceProcessor
                 .createConnectionParams(prestoDatasourceParamDTO);
         Assert.assertEquals("jdbc:presto://localhost:1234", connectionParams.getAddress());
@@ -63,8 +56,9 @@ public class PrestoDataSourceProcessorTest {
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:presto://localhost:1234\""
-                + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:presto://localhost:1234/default\"}";
+        String connectionJson =
+                "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:presto://localhost:1234\""
+                        + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:presto://localhost:1234/default\"}";
         PrestoConnectionParam connectionParams = (PrestoConnectionParam) prestoDatasourceProcessor
                 .createConnectionParams(connectionJson);
         Assert.assertNotNull(connectionParams);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-redshift/src/test/java/org/apache/dolphinscheduler/plugin/datasource/redshift/param/RedshiftDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-redshift/src/test/java/org/apache/dolphinscheduler/plugin/datasource/redshift/param/RedshiftDataSourceProcessorTest.java
@@ -17,14 +17,10 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.redshift.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +28,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class RedshiftDataSourceProcessorTest {
 
     private RedshiftDataSourceProcessor redshiftDatasourceProcessor = new RedshiftDataSourceProcessor();
@@ -53,8 +46,8 @@ public class RedshiftDataSourceProcessorTest {
         redshiftDatasourceParamDTO.setUserName("awsuser");
         redshiftDatasourceParamDTO.setPassword("123456");
         redshiftDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
         RedshiftConnectionParam connectionParams = (RedshiftConnectionParam) redshiftDatasourceProcessor
                 .createConnectionParams(redshiftDatasourceParamDTO);
         Assert.assertEquals("jdbc:redshift://localhost:5439", connectionParams.getAddress());
@@ -63,8 +56,9 @@ public class RedshiftDataSourceProcessorTest {
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"awsuser\",\"password\":\"123456\",\"address\":\"jdbc:redshift://localhost:5439\""
-                + ",\"database\":\"dev\",\"jdbcUrl\":\"jdbc:redshift://localhost:5439/dev\"}";
+        String connectionJson =
+                "{\"user\":\"awsuser\",\"password\":\"123456\",\"address\":\"jdbc:redshift://localhost:5439\""
+                        + ",\"database\":\"dev\",\"jdbcUrl\":\"jdbc:redshift://localhost:5439/dev\"}";
         RedshiftConnectionParam connectionParams = (RedshiftConnectionParam) redshiftDatasourceProcessor
                 .createConnectionParams(connectionJson);
         Assert.assertNotNull(connectionParams);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-spark/src/test/java/org/apache/dolphinscheduler/plugin/datasource/spark/SparkDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-spark/src/test/java/org/apache/dolphinscheduler/plugin/datasource/spark/SparkDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({SparkDataSourceChannel.class, SparkDataSourceClient.class})
+@RunWith(MockitoJUnitRunner.class)
 public class SparkDataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        SparkDataSourceChannel sourceChannel = PowerMockito.mock(SparkDataSourceChannel.class);
-        SparkDataSourceClient dataSourceClient = PowerMockito.mock(SparkDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        SparkDataSourceChannel sourceChannel = Mockito.mock(SparkDataSourceChannel.class);
+        SparkDataSourceClient dataSourceClient = Mockito.mock(SparkDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new SparkConnectionParam(), DbType.SPARK));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-spark/src/test/java/org/apache/dolphinscheduler/plugin/datasource/spark/param/SparkDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-spark/src/test/java/org/apache/dolphinscheduler/plugin/datasource/spark/param/SparkDataSourceProcessorTest.java
@@ -17,14 +17,11 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.spark.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,12 +29,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class SparkDataSourceProcessorTest {
 
     private SparkDataSourceProcessor sparkDatasourceProcessor = new SparkDataSourceProcessor();
@@ -53,10 +47,10 @@ public class SparkDataSourceProcessorTest {
         sparkDatasourceParamDTO.setPort(1234);
         sparkDatasourceParamDTO.setDatabase("default");
         sparkDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        PowerMockito.mockStatic(CommonUtils.class);
-        PowerMockito.when(CommonUtils.getKerberosStartupState()).thenReturn(false);
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(CommonUtils.class);
+        Mockito.when(CommonUtils.getKerberosStartupState()).thenReturn(false);
         SparkConnectionParam connectionParams = (SparkConnectionParam) sparkDatasourceProcessor
                 .createConnectionParams(sparkDatasourceParamDTO);
         Assert.assertEquals("jdbc:hive2://localhost1:1234,localhost2:1234", connectionParams.getAddress());
@@ -65,8 +59,9 @@ public class SparkDataSourceProcessorTest {
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"root\",\"password\":\"12345\",\"address\":\"jdbc:hive2://localhost1:1234,localhost2:1234\""
-                + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:hive2://localhost1:1234,localhost2:1234/default\"}";
+        String connectionJson =
+                "{\"user\":\"root\",\"password\":\"12345\",\"address\":\"jdbc:hive2://localhost1:1234,localhost2:1234\""
+                        + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:hive2://localhost1:1234,localhost2:1234/default\"}";
         SparkConnectionParam connectionParams = (SparkConnectionParam) sparkDatasourceProcessor
                 .createConnectionParams(connectionJson);
         Assert.assertNotNull(connectionParams);

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/SQLServerDataSourceChannelTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/SQLServerDataSourceChannelTest.java
@@ -24,21 +24,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("org.apache.dolphinscheduler.plugin.datasource.api.client.CommonDataSourceClient")
-@PrepareForTest({SQLServerDataSourceClient.class, SQLServerDataSourceChannel.class})
+@RunWith(MockitoJUnitRunner.class)
 public class SQLServerDataSourceChannelTest {
 
     @Test
     public void testCreateDataSourceClient() {
-        SQLServerDataSourceChannel sourceChannel = PowerMockito.mock(SQLServerDataSourceChannel.class);
-        SQLServerDataSourceClient dataSourceClient = PowerMockito.mock(SQLServerDataSourceClient.class);
-        PowerMockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
+        SQLServerDataSourceChannel sourceChannel = Mockito.mock(SQLServerDataSourceChannel.class);
+        SQLServerDataSourceClient dataSourceClient = Mockito.mock(SQLServerDataSourceClient.class);
+        Mockito.when(sourceChannel.createDataSourceClient(Mockito.any(), Mockito.any())).thenReturn(dataSourceClient);
         Assert.assertNotNull(sourceChannel.createDataSourceClient(new SQLServerConnectionParam(), DbType.SQLSERVER));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessorTest.java
@@ -17,15 +17,11 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.sqlserver.param;
 
-import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceClientProvider;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
-import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.dolphinscheduler.spi.utils.Constants;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
 
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,12 +29,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class, DriverManager.class, DataSourceUtils.class, CommonUtils.class, DataSourceClientProvider.class, PasswordUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class SQLServerDataSourceProcessorTest {
 
     private SQLServerDataSourceProcessor sqlServerDatasourceProcessor = new SQLServerDataSourceProcessor();
@@ -54,8 +47,8 @@ public class SQLServerDataSourceProcessorTest {
         sqlServerDatasourceParamDTO.setHost("localhost");
         sqlServerDatasourceParamDTO.setPort(1234);
         sqlServerDatasourceParamDTO.setOther(props);
-        PowerMockito.mockStatic(PasswordUtils.class);
-        PowerMockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        Mockito.mockStatic(PasswordUtils.class);
+        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
         SQLServerConnectionParam connectionParams = (SQLServerConnectionParam) sqlServerDatasourceProcessor
                 .createConnectionParams(sqlServerDatasourceParamDTO);
         Assert.assertEquals("jdbc:sqlserver://localhost:1234", connectionParams.getAddress());
@@ -65,9 +58,11 @@ public class SQLServerDataSourceProcessorTest {
 
     @Test
     public void testCreateConnectionParams2() {
-        String connectionJson = "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:sqlserver://localhost:1234\""
-                + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:sqlserver://localhost:1234;databaseName=default\"}";
-        SQLServerConnectionParam sqlServerConnectionParam = JSONUtils.parseObject(connectionJson, SQLServerConnectionParam.class);
+        String connectionJson =
+                "{\"user\":\"root\",\"password\":\"123456\",\"address\":\"jdbc:sqlserver://localhost:1234\""
+                        + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:sqlserver://localhost:1234;databaseName=default\"}";
+        SQLServerConnectionParam sqlServerConnectionParam =
+                JSONUtils.parseObject(connectionJson, SQLServerConnectionParam.class);
         Assert.assertNotNull(sqlServerConnectionParam);
         Assert.assertEquals("root", sqlServerConnectionParam.getUser());
     }

--- a/dolphinscheduler-datasource-plugin/pom.xml
+++ b/dolphinscheduler-datasource-plugin/pom.xml
@@ -15,18 +15,17 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>dolphinscheduler</artifactId>
         <groupId>org.apache.dolphinscheduler</groupId>
+        <artifactId>dolphinscheduler</artifactId>
         <version>dev-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>dolphinscheduler-datasource-plugin</artifactId>
-    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
 
     <modules>
         <module>dolphinscheduler-datasource-sqlserver</module>
@@ -60,4 +59,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.12.4</version>
+            <!-- TODO: move this dependency to root pom after removing powermock in the whole project -->
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/dolphinscheduler-datasource-plugin/pom.xml
+++ b/dolphinscheduler-datasource-plugin/pom.xml
@@ -64,8 +64,8 @@
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-common</artifactId>
-            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>

--- a/dolphinscheduler-datasource-plugin/pom.xml
+++ b/dolphinscheduler-datasource-plugin/pom.xml
@@ -62,6 +62,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>3.12.4</version>


### PR DESCRIPTION
## Purpose of the pull request

* This PR closes: #12179 

## Brief change log

* Remove the usage of powermock in datasource-plugin module
* Switch datasource-plugin module to use PropertyUtils in `common` module instead of that in `spi` module.

## Verify this pull request

* Verified by unit tests.