### PR TITLE
[improvement] improve relation between notification strategy and alarm group on ui

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -323,7 +323,7 @@ export default defineComponent({
               clearable
             />
           </NFormItem>
-          {this.startForm.warningType !== 'NONE'? ( <NFormItem
+          {this.startForm.warningType !== 'NONE' && (<NFormItem
             label={t('project.workflow.alarm_group')}
             path='warningGroupId'
           >
@@ -333,7 +333,7 @@ export default defineComponent({
               v-model:value={this.startForm.warningGroupId}
               clearable
             />
-          </NFormItem>) : null}
+          </NFormItem>)}
           <NFormItem
             label={t('project.workflow.complement_data')}
             path='complement_data'

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -323,7 +323,7 @@ export default defineComponent({
               clearable
             />
           </NFormItem>
-          <NFormItem
+          {this.startForm.warningType !== 'NONE'? ( <NFormItem
             label={t('project.workflow.alarm_group')}
             path='warningGroupId'
           >
@@ -333,7 +333,7 @@ export default defineComponent({
               v-model:value={this.startForm.warningGroupId}
               clearable
             />
-          </NFormItem>
+          </NFormItem>) : null}
           <NFormItem
             label={t('project.workflow.complement_data')}
             path='complement_data'

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
@@ -378,7 +378,7 @@ export default defineComponent({
               clearable
             />
           </NFormItem>
-          <NFormItem
+          {this.timingForm.warningType !== 'NONE' ? ( <NFormItem
             label={t('project.workflow.alarm_group')}
             path='warningGroupId'
           >
@@ -388,7 +388,7 @@ export default defineComponent({
               v-model:value={this.timingForm.warningGroupId}
               clearable
             />
-          </NFormItem>
+          </NFormItem> ) : null }
         </NForm>
       </Modal>
     )

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
@@ -378,7 +378,7 @@ export default defineComponent({
               clearable
             />
           </NFormItem>
-          {this.timingForm.warningType !== 'NONE' ? ( <NFormItem
+          {this.timingForm.warningType !== 'NONE' && ( <NFormItem
             label={t('project.workflow.alarm_group')}
             path='warningGroupId'
           >
@@ -388,7 +388,7 @@ export default defineComponent({
               v-model:value={this.timingForm.warningGroupId}
               clearable
             />
-          </NFormItem> ) : null }
+          </NFormItem> )}
         </NForm>
       </Modal>
     )


### PR DESCRIPTION
## Purpose of the pull request

improve relation between notification strategy and alarm group on ui


## Brief change log

improve relation between notification strategy and alarm group on ui
- when notification strategy equal NONE

<img width="590" alt="image" src="https://user-images.githubusercontent.com/33984497/192919644-ed11975b-c4ad-49d7-bddb-8444f6620a34.png">

- when notification strategy not  equal NONE

<img width="587" alt="image" src="https://user-images.githubusercontent.com/33984497/192919768-68f3ffec-d0ad-4ad5-8ba0-80551f054f81.png">

```The difference between them is whether to display the alarm group```


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

this close #11771 