### PR TITLE
[Fix-12214] Fix oracle can't choose schema

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -650,7 +650,9 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
                 schemaPattern = connectionParam.getDatabase();
                 break;
             case ORACLE:
-                schemaPattern = connectionParam.getUser();
+                Map<String, String> props = connectionParam.getProps();
+                String tempSchema = props.get(Constants.SCHEMA);
+                schemaPattern = StringUtils.isEmpty(tempSchema) ? connectionParam.getUser() : tempSchema;
                 if (null != schemaPattern) {
                     schemaPattern = schemaPattern.toUpperCase();
                 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -727,6 +727,7 @@ public final class Constants {
     public static final String OTHER = "other";
     public static final String USER = "user";
     public static final String JDBC_URL = "jdbcUrl";
+    public static final String SCHEMA = "schema";
 
     /**
      * session timeout


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
fix bug #12214 
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
oracle can only use the default database, we can't choose databases
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
