### PR TITLE
[ci] Milestone and Label are required before the PR merged

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,6 +45,7 @@ github:
           - Build
           - Unit Test
           - E2E
+          - "Mergeable: milestone-label-check"
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -17,7 +17,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "[Feature][Module Name] Feature title"
-labels: [ "new feature", "Waiting for reply" ]
+labels: [ "feature", "Waiting for reply" ]
 body:
   - type: markdown
     attributes:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -22,7 +22,7 @@ mergeable:
   # GitHub action workflow `pull_requests` https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request like,
   # which only trigger runs when a pull_request event's activity type is opened, synchronize, or reopened
   - when: pull_request.opened, pull_request.reopened, pull_request.synchronize
-    name: synchronize change for sql files
+    name: sync-sql-ddl
     validate:
       # Sql files must change synchronize
       - do: dependent
@@ -44,3 +44,15 @@ mergeable:
     pass:
       - do: labels
         delete: 'sql not sync'
+
+  - when: pull_request.*
+    name: milestone-label-check
+    validate:
+      - do: milestone
+        no_empty:
+          enabled: true # Cannot be empty when true.
+          message: 'Milestone is required and cannot be empty.'
+      - do: label
+        must_include:
+          regex: 'feature|bug|improvement|document|chore'
+          message: 'Label must include one of the following: `feature`, `bug`, `improvement`, `document`, `chore`'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,8 +32,8 @@ jobs:
           # Stale Issues
           days-before-issue-stale: 30
           days-before-issue-close: 7
-          # We do not stale Issues with label `Waiting for reply`, `new feature` and `DSIP`
-          exempt-issue-labels: 'Waiting for reply,new feature,DSIP,security'
+          # We do not stale Issues with label `Waiting for reply`, `feature` and `DSIP`
+          exempt-issue-labels: 'Waiting for reply,feature,DSIP,security'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had recent activity
             for 30 days. It will be closed in next 7 days if no further activity occurs.

--- a/docs/docs/en/contribute/join/commit-message.md
+++ b/docs/docs/en/contribute/join/commit-message.md
@@ -29,7 +29,7 @@ The header part has only one line, including three fields: type (required), scop
 
 (1) Type is used to indicate the category of commit, and only the following 7 types are allowed.
 
-- feat：New features
+- feat：features
 - fix：Bug fixes
 - docs：Documentation
 - style： Format (does not affect changes in code operation)

--- a/docs/docs/en/contribute/join/contribute.md
+++ b/docs/docs/en/contribute/join/contribute.md
@@ -31,7 +31,7 @@ Refer to the [Submit Guide-Issue Notice](./issue.md), [Submit Guide-Pull Request
 
 If you want to implement a Feature or fix a Bug. Please refer to the following:
 
-* All Bugs and the new Features are recommended and managed using the Issues Page.
+* All bugs and the features are recommended and managed using the GitHub issues(https://github.com/apache/dolphinscheduler/issues).
 * If you want to develop a Feature, first reply to the Issue associated with that feature, indicating that you are currently working on it. And set yourself a "deadline" when to Submit the Feature, and add it in the reply comment.
 * It's a good idea to find a mentor (or an instructor) in the core contributors who gives immediate feedback on design and functional implementation.
 * You should create a new branch to start your work, to get the name of the branch refer to the [Submit Guide-Pull Request Notice](./pull-request.md). For example, if you want to complete the feature and submit Issue 111, your branch name should be feature-111. The feature name can be determined after discussion with the instructor.

--- a/docs/docs/en/contribute/join/issue.md
+++ b/docs/docs/en/contribute/join/issue.md
@@ -30,7 +30,7 @@ The `Issue Type` is as follows:
     <tbody>
         <tr>
             <td style="text-align: center;">Feature</td>
-            <td style="text-align: center;">Include expected new features and functions</td>
+            <td style="text-align: center;">Include expected features and functions</td>
             <td style="text-align: center;">[Feature][api] Add xxx api in xxx controller</td>
         </tr>
         <tr>


### PR DESCRIPTION
To make our release process easier, I plan to mark milestones and labels required before the PR merged, they use for

* **label**: In this patch, we required a label with at least one 'feature|bug|improvement|document|chore' to make our changelog more convenient
* **milestone**: For easier to cherry-pick PR, currently some of our milestones only exist in issue and not exists in related PR, it is difficult to find those PR bucause github do not have existing API to get them, we can only use timeline API to find them