### PR TITLE
[fix][doc] Correct release export key step

### DIFF
--- a/docs/docs/en/contribute/release/release.md
+++ b/docs/docs/en/contribute/release/release.md
@@ -245,14 +245,21 @@ svn --username="${A_USERNAME}" co https://dist.apache.org/repos/dist/dev/dolphin
 cd ~/ds_svn/dev/dolphinscheduler
 ```
 
-### Add gpg Public Key
+### Export your new gpg KEYS to release(optional)
 
-Only the account in its first deployment needs to add that.
-It is alright for `KEYS` to only include the public key of the deployed account.
+Only if the first time you release with this gpg KEY, including it is you first release, or you change your KEY. You should
+change working directory to another one because this step need checkout and change KEYS in release directory.
 
 ```shell
+mkdir -p ~/ds_svn/release/
+cd ~/ds_svn/release/
+svn --username="${A_USERNAME}" co https://dist.apache.org/repos/dist/release/dolphinscheduler
 gpg -a --export <YOUR-GPG-KEY-ID> >> KEYS
+svn add *
+svn --username="${A_USERNAME}" commit -m "new key <YOUR-GPG-KEY-ID> add"
 ```
+
+> NOTE: it may take a few minutes to sync to the mirror in your first time checkout, because it will download all the files
 
 ### Add the Release Content to SVN Directory
 
@@ -313,7 +320,7 @@ First, import releaser's public key.
 Import KEYS from SVN repository to local. (The releaser does not need to import again; the checking assistant needs to import it, with the user name filled as the releaser's. )
 
 ```shell
-curl https://dist.apache.org/repos/dist/dev/dolphinscheduler/KEYS >> KEYS
+curl https://dist.apache.org/repos/dist/release/dolphinscheduler/KEYS >> KEYS
 gpg --import KEYS
 gpg --edit-key "${A_USERNAME}"
   > trust
@@ -420,7 +427,7 @@ Git tag for the release: https://github.com/apache/dolphinscheduler/tree/<VERSIO
 
 Release Commit ID: https://github.com/apache/dolphinscheduler/commit/<SHA-VALUE>
 
-Keys to verify the Release Candidate: https://dist.apache.org/repos/dist/dev/dolphinscheduler/KEYS
+Keys to verify the Release Candidate: https://downloads.apache.org/dolphinscheduler/KEYS
 
 Look at here for how to verify this release candidate: https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/contribute/release/release.html
 
@@ -468,19 +475,6 @@ Thanks everyone for taking time to check this release and help us.
 
 ```shell
 svn mv https://dist.apache.org/repos/dist/dev/dolphinscheduler/"${VERSION}" https://dist.apache.org/repos/dist/release/dolphinscheduler/
-```
-
-### Export you new gpg KEYS from dev to release(optional)
-
-Only if the first time you release with this gpg KEY, including it is you first release or you change your KEY
-
-```shell
-mkdir -p ~/ds_svn/release/
-cd ~/ds_svn/release/
-svn --username="${A_USERNAME}" co https://dist.apache.org/repos/dist/release/dolphinscheduler
-gpg -a --export <YOUR-GPG-KEY-ID> >> KEYS
-svn add *
-svn --username="${A_USERNAME}" commit -m "new key <YOUR-GPG-KEY-ID> add"
 ```
 
 ### Update Document

--- a/docs/docs/zh/contribute/release/release.md
+++ b/docs/docs/zh/contribute/release/release.md
@@ -248,13 +248,21 @@ svn --username="${A_USERNAME}" co https://dist.apache.org/repos/dist/dev/dolphin
 cd ~/ds_svn/dev/dolphinscheduler
 ```
 
-### 添加gpg公钥
+### 将 gpg KEYS 文件拷贝至发布目录（可选）
 
-仅第一次部署的账号需要添加，只要`KEYS`中包含已经部署过的账户的公钥即可。
+只有你第一次使用该 KEY 发版时才需要，如果之前已经发过版且 KEY 没有变化则不需要。你需要切换到一个新的目录，因为这步骤需要 checkout 并修改 release
+库中的 KEYS 文件
 
 ```shell
+mkdir -p ~/ds_svn/release/
+cd ~/ds_svn/release/
+svn --username="${A_USERNAME}" co https://dist.apache.org/repos/dist/release/dolphinscheduler
 gpg -a --export <YOUR-GPG-KEY-ID> >> KEYS
+svn add *
+svn --username="${A_USERNAME}" commit -m "new key <YOUR-GPG-KEY-ID> add"
 ```
+
+> 注意：这个步骤需要一定的时间去 checkout 特别是在你第一次 checkout 的时候，因为这个库比较大，且这个操作需要 checkout 出全部文件
 
 ### 将待发布的内容添加至SVN目录
 
@@ -314,7 +322,7 @@ cd ../
 首先导入发布人公钥。从svn仓库导入KEYS到本地环境。（发布版本的人不需要再导入，帮助做验证的人需要导入，用户名填发版人的即可）
 
 ```shell
-curl https://dist.apache.org/repos/dist/dev/dolphinscheduler/KEYS >> KEYS
+curl https://dist.apache.org/repos/dist/release/dolphinscheduler/KEYS >> KEYS
 gpg --import KEYS
 gpg --edit-key "${A_USERNAME}"
   > trust
@@ -418,7 +426,7 @@ Git tag for the release: https://github.com/apache/dolphinscheduler/tree/<VERSIO
 
 Release Commit ID: https://github.com/apache/dolphinscheduler/commit/<SHA-VALUE>
 
-Keys to verify the Release Candidate: https://dist.apache.org/repos/dist/dev/dolphinscheduler/KEYS
+Keys to verify the Release Candidate: https://downloads.apache.org/dolphinscheduler/KEYS
 
 Look at here for how to verify this release candidate: https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/contribute/release/release.html
 
@@ -466,19 +474,6 @@ Thanks everyone for taking time to check this release and help us.
 
 ```shell
 svn mv https://dist.apache.org/repos/dist/dev/dolphinscheduler/"${VERSION}" https://dist.apache.org/repos/dist/release/dolphinscheduler/
-```
-
-### 将 gpg KEYS svn的dev目录移动到release目录
-
-只有你第一次使用该 KEY 发版时才需要，如果之前已经发过版且 KEY 没有变化则不需要
-
-```shell
-mkdir -p ~/ds_svn/release/
-cd ~/ds_svn/release/
-svn --username="${A_USERNAME}" co https://dist.apache.org/repos/dist/release/dolphinscheduler
-gpg -a --export <YOUR-GPG-KEY-ID> >> KEYS
-svn add *
-svn --username="${A_USERNAME}" commit -m "new key <YOUR-GPG-KEY-ID> add"
 ```
 
 ### 更新文档


### PR DESCRIPTION
We should only add KEY to release/KEYS instead of
dev/KEYS, according to
https://lists.apache.org/thread/2gppxc04n0r87vq4qy4j3n52zwhqd442
