### PR TITLE
[Fix-12254] [Registry] Modify the type of field named data into text

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-mysql/src/main/resources/mysql_registry_init.sql
@@ -22,7 +22,7 @@ CREATE TABLE `t_ds_mysql_registry_data`
 (
     `id`               bigint(11)   NOT NULL AUTO_INCREMENT COMMENT 'primary key',
     `key`              varchar(200) NOT NULL COMMENT 'key, like zookeeper node path',
-    `data`             varchar(200) NOT NULL COMMENT 'data, like zookeeper node value',
+    `data`             text         NOT NULL COMMENT 'data, like zookeeper node value',
     `type`             tinyint(4)   NOT NULL COMMENT '1: ephemeral node, 2: persistent node',
     `last_update_time` timestamp    NULL COMMENT 'last update time',
     `create_time`      timestamp    NULL COMMENT 'create time',


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
Fix field named data length is too short in the table named t_ds_mysql_registry_data.

Modify the type of field named data into text.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`

close #12254 