### PR TITLE
[Bug]Set the id to null when copying t_ds_schedules

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -2205,6 +2205,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 // copy timing configuration
                 Schedule scheduleObj = scheduleMapper.queryByProcessDefinitionCode(oldProcessDefinitionCode);
                 if (scheduleObj != null) {
+                    scheduleObj.setId(null);
                     scheduleObj.setProcessDefinitionCode(processDefinition.getCode());
                     scheduleObj.setReleaseState(ReleaseState.OFFLINE);
                     scheduleObj.setCreateTime(date);


### PR DESCRIPTION
Set the id to null when copying t_ds_schedules


close:#12274 