### PR TITLE
[Improvement-12296][Test] Close static mock

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/test/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtilsTest.java
@@ -41,13 +41,15 @@ public class CommonUtilsTest {
         try (
                 MockedStatic<CommonUtils> mockedCommonUtils = Mockito.mockStatic(CommonUtils.class);
                 MockedStatic<PropertyUtils> mockedPropertyUtils = Mockito.mockStatic(PropertyUtils.class)) {
-            Mockito.when(CommonUtils.getKerberosStartupState()).thenAnswer((Answer<Boolean>) invocation -> false);
+            mockedCommonUtils.when(CommonUtils::getKerberosStartupState)
+                    .thenAnswer((Answer<Boolean>) invocation -> false);
             boolean kerberosStartupState = CommonUtils.getKerberosStartupState();
             Assert.assertFalse(kerberosStartupState);
 
-            Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE))
+            mockedPropertyUtils.when(() -> PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE))
                     .thenAnswer((Answer<String>) invocation -> "HDFS");
-            Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, true))
+            mockedPropertyUtils
+                    .when(() -> PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, true))
                     .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
             kerberosStartupState = CommonUtils.getKerberosStartupState();
             Assert.assertFalse(kerberosStartupState);
@@ -61,15 +63,16 @@ public class CommonUtilsTest {
                 MockedStatic<UserGroupInformation> mockedUserGroupInformation =
                         Mockito.mockStatic(UserGroupInformation.class)) {
             try {
-                Mockito.when(PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE))
+                mockedPropertyUtils.when(() -> PropertyUtils.getUpperCaseString(Constants.RESOURCE_STORAGE_TYPE))
                         .thenAnswer((Answer<String>) invocation -> "HDFS");
-                Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+                mockedPropertyUtils.when(
+                        () -> PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
                         .thenAnswer((Answer<Boolean>) invocation -> Boolean.TRUE);
-                Mockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
+                mockedPropertyUtils.when(() -> PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
                         .thenAnswer((Answer<String>) invocation -> "/opt/krb5.conf");
-                Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
+                mockedPropertyUtils.when(() -> PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
                         .thenAnswer((Answer<String>) invocation -> "hdfs-mycluster@ESZ.COM");
-                Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
+                mockedPropertyUtils.when(() -> PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
                         .thenAnswer((Answer<String>) invocation -> "/opt/hdfs.headless.keytab");
                 Configuration configuration = Mockito.mock(Configuration.class);
                 boolean result = CommonUtils.loadKerberosConf(configuration);
@@ -94,7 +97,7 @@ public class CommonUtilsTest {
             Assert.assertEquals("bnVsbElWRkJXbGhUVjBBPQ==", PasswordUtils.encodePassword("!QAZXSW@"));
             Assert.assertEquals("bnVsbE5XUm1aMlZ5S0VBPQ==", PasswordUtils.encodePassword("5dfger(@"));
 
-            Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
+            mockedPropertyUtils.when(() -> PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
                     .thenReturn(Boolean.FALSE);
 
             Assert.assertEquals("", PasswordUtils.encodePassword(""));
@@ -114,9 +117,11 @@ public class CommonUtilsTest {
 
             PropertyUtils.setValue(DATASOURCE_ENCRYPTION_ENABLE, "true");
 
-            Mockito.when(PasswordUtils.decodePassword("bnVsbE1USXpORFUy")).thenReturn("123456");
-            Mockito.when(PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ==")).thenReturn("!QAZXSW@");
-            Mockito.when(PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ==")).thenReturn("5dfger(@");
+            mockedPasswordUtils.when(() -> PasswordUtils.decodePassword("bnVsbE1USXpORFUy")).thenReturn("123456");
+            mockedPasswordUtils.when(() -> PasswordUtils.decodePassword("bnVsbElWRkJXbGhUVjBBPQ=="))
+                    .thenReturn("!QAZXSW@");
+            mockedPasswordUtils.when(() -> PasswordUtils.decodePassword("bnVsbE5XUm1aMlZ5S0VBPQ=="))
+                    .thenReturn("5dfger(@");
 
             Assert.assertEquals(null, PasswordUtils.decodePassword(""));
             Assert.assertEquals("123456", PasswordUtils.decodePassword("bnVsbE1USXpORFUy"));
@@ -126,9 +131,9 @@ public class CommonUtilsTest {
             Mockito.when(PropertyUtils.getBoolean(DATASOURCE_ENCRYPTION_ENABLE, false))
                     .thenAnswer((Answer<Boolean>) invocation -> Boolean.FALSE);
 
-            Mockito.when(PasswordUtils.decodePassword("123456")).thenReturn("123456");
-            Mockito.when(PasswordUtils.decodePassword("!QAZXSW@")).thenReturn("!QAZXSW@");
-            Mockito.when(PasswordUtils.decodePassword("5dfger(@")).thenReturn("5dfger(@");
+            mockedPasswordUtils.when(() -> PasswordUtils.decodePassword("123456")).thenReturn("123456");
+            mockedPasswordUtils.when(() -> PasswordUtils.decodePassword("!QAZXSW@")).thenReturn("!QAZXSW@");
+            mockedPasswordUtils.when(() -> PasswordUtils.decodePassword("5dfger(@")).thenReturn("5dfger(@");
 
             Assert.assertEquals(null, PasswordUtils.decodePassword(""));
             Assert.assertEquals("123456", PasswordUtils.decodePassword("123456"));

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-athena/src/test/java/org/apache/dolphinscheduler/plugin/datasource/athena/param/AthenaDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-athena/src/test/java/org/apache/dolphinscheduler/plugin/datasource/athena/param/AthenaDataSourceProcessorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -45,12 +46,13 @@ public class AthenaDataSourceProcessorTest {
         athenaDataSourceParamDTO.setPassword("123456");
         athenaDataSourceParamDTO.setAwsRegion("cn-north-1");
         athenaDataSourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        AthenaConnectionParam connectionParams = (AthenaConnectionParam) this.athenaDataSourceProcessor
-                .createConnectionParams(athenaDataSourceParamDTO);
-        Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;", connectionParams.getJdbcUrl());
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            AthenaConnectionParam connectionParams = (AthenaConnectionParam) this.athenaDataSourceProcessor
+                    .createConnectionParams(athenaDataSourceParamDTO);
+            Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:awsathena://AwsRegion=cn-north-1;", connectionParams.getJdbcUrl());
+        }
     }
 
     @Test

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-db2/src/test/java/org/apache/dolphinscheduler/plugin/datasource/db2/param/Db2DataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-db2/src/test/java/org/apache/dolphinscheduler/plugin/datasource/db2/param/Db2DataSourceProcessorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -46,14 +47,15 @@ public class Db2DataSourceProcessorTest {
         db2DatasourceParamDTO.setPort(5142);
         db2DatasourceParamDTO.setDatabase("default");
         db2DatasourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
 
-        Db2ConnectionParam connectionParams = (Db2ConnectionParam) db2DatasourceProcessor
-                .createConnectionParams(db2DatasourceParamDTO);
-        Assert.assertNotNull(connectionParams);
-        Assert.assertEquals("jdbc:db2://localhost:5142", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:db2://localhost:5142/default", connectionParams.getJdbcUrl());
+            Db2ConnectionParam connectionParams = (Db2ConnectionParam) db2DatasourceProcessor
+                    .createConnectionParams(db2DatasourceParamDTO);
+            Assert.assertNotNull(connectionParams);
+            Assert.assertEquals("jdbc:db2://localhost:5142", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:db2://localhost:5142/default", connectionParams.getJdbcUrl());
+        }
     }
 
     @Test

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/provider/JDBCDataSourceProviderTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/provider/JDBCDataSourceProviderTest.java
@@ -39,7 +39,8 @@ public class JDBCDataSourceProviderTest {
                 MockedStatic<JDBCDataSourceProvider> mockedJDBCDataSourceProvider =
                         Mockito.mockStatic(JDBCDataSourceProvider.class)) {
             HikariDataSource dataSource = Mockito.mock(HikariDataSource.class);
-            Mockito.when(JDBCDataSourceProvider.createJdbcDataSource(Mockito.any(), Mockito.any()))
+            mockedJDBCDataSourceProvider
+                    .when(() -> JDBCDataSourceProvider.createJdbcDataSource(Mockito.any(), Mockito.any()))
                     .thenReturn(dataSource);
             Assert.assertNotNull(JDBCDataSourceProvider.createJdbcDataSource(new MySQLConnectionParam(), DbType.MYSQL));
         }
@@ -51,7 +52,8 @@ public class JDBCDataSourceProviderTest {
                 MockedStatic<JDBCDataSourceProvider> mockedJDBCDataSourceProvider =
                         Mockito.mockStatic(JDBCDataSourceProvider.class)) {
             HikariDataSource dataSource = Mockito.mock(HikariDataSource.class);
-            Mockito.when(JDBCDataSourceProvider.createOneSessionJdbcDataSource(Mockito.any(), Mockito.any()))
+            mockedJDBCDataSourceProvider
+                    .when(() -> JDBCDataSourceProvider.createOneSessionJdbcDataSource(Mockito.any(), Mockito.any()))
                     .thenReturn(dataSource);
             Assert.assertNotNull(
                     JDBCDataSourceProvider.createOneSessionJdbcDataSource(new MySQLConnectionParam(), DbType.MYSQL));

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/test/java/org/apache/dolphinscheduler/plugin/datasource/oracle/param/OracleDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/test/java/org/apache/dolphinscheduler/plugin/datasource/oracle/param/OracleDataSourceProcessorTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -48,13 +49,15 @@ public class OracleDataSourceProcessorTest {
         oracleDatasourceParamDTO.setPassword("123456");
         oracleDatasourceParamDTO.setDatabase("default");
         oracleDatasourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        OracleConnectionParam connectionParams = (OracleConnectionParam) oracleDatasourceProcessor
-                .createConnectionParams(oracleDatasourceParamDTO);
-        Assert.assertNotNull(connectionParams);
-        Assert.assertEquals("jdbc:oracle:thin:@localhost:3308", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:oracle:thin:@localhost:3308:default", connectionParams.getJdbcUrl());
+
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            OracleConnectionParam connectionParams = (OracleConnectionParam) oracleDatasourceProcessor
+                    .createConnectionParams(oracleDatasourceParamDTO);
+            Assert.assertNotNull(connectionParams);
+            Assert.assertEquals("jdbc:oracle:thin:@localhost:3308", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:oracle:thin:@localhost:3308:default", connectionParams.getJdbcUrl());
+        }
     }
 
     @Test

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-postgresql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/postgresql/param/PostgreSQLDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-postgresql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/postgresql/param/PostgreSQLDataSourceProcessorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -46,13 +47,14 @@ public class PostgreSQLDataSourceProcessorTest {
         postgreSqlDatasourceParamDTO.setPort(3308);
         postgreSqlDatasourceParamDTO.setDatabase("default");
         postgreSqlDatasourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        PostgreSQLConnectionParam connectionParams = (PostgreSQLConnectionParam) postgreSqlDatasourceProcessor
-                .createConnectionParams(postgreSqlDatasourceParamDTO);
-        Assert.assertEquals("jdbc:postgresql://localhost:3308", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:postgresql://localhost:3308/default", connectionParams.getJdbcUrl());
-        Assert.assertEquals("root", connectionParams.getUser());
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            PostgreSQLConnectionParam connectionParams = (PostgreSQLConnectionParam) postgreSqlDatasourceProcessor
+                    .createConnectionParams(postgreSqlDatasourceParamDTO);
+            Assert.assertEquals("jdbc:postgresql://localhost:3308", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:postgresql://localhost:3308/default", connectionParams.getJdbcUrl());
+            Assert.assertEquals("root", connectionParams.getUser());
+        }
     }
 
     @Test

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-presto/src/test/java/org/apache/dolphinscheduler/plugin/datasource/presto/param/PrestoDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-presto/src/test/java/org/apache/dolphinscheduler/plugin/datasource/presto/param/PrestoDataSourceProcessorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -46,12 +47,13 @@ public class PrestoDataSourceProcessorTest {
         prestoDatasourceParamDTO.setUserName("root");
         prestoDatasourceParamDTO.setPassword("123456");
         prestoDatasourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        PrestoConnectionParam connectionParams = (PrestoConnectionParam) prestoDatasourceProcessor
-                .createConnectionParams(prestoDatasourceParamDTO);
-        Assert.assertEquals("jdbc:presto://localhost:1234", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:presto://localhost:1234/default", connectionParams.getJdbcUrl());
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            PrestoConnectionParam connectionParams = (PrestoConnectionParam) prestoDatasourceProcessor
+                    .createConnectionParams(prestoDatasourceParamDTO);
+            Assert.assertEquals("jdbc:presto://localhost:1234", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:presto://localhost:1234/default", connectionParams.getJdbcUrl());
+        }
     }
 
     @Test

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-redshift/src/test/java/org/apache/dolphinscheduler/plugin/datasource/redshift/param/RedshiftDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-redshift/src/test/java/org/apache/dolphinscheduler/plugin/datasource/redshift/param/RedshiftDataSourceProcessorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -46,12 +47,14 @@ public class RedshiftDataSourceProcessorTest {
         redshiftDatasourceParamDTO.setUserName("awsuser");
         redshiftDatasourceParamDTO.setPassword("123456");
         redshiftDatasourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        RedshiftConnectionParam connectionParams = (RedshiftConnectionParam) redshiftDatasourceProcessor
-                .createConnectionParams(redshiftDatasourceParamDTO);
-        Assert.assertEquals("jdbc:redshift://localhost:5439", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:redshift://localhost:5439/dev", connectionParams.getJdbcUrl());
+
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            RedshiftConnectionParam connectionParams = (RedshiftConnectionParam) redshiftDatasourceProcessor
+                    .createConnectionParams(redshiftDatasourceParamDTO);
+            Assert.assertEquals("jdbc:redshift://localhost:5439", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:redshift://localhost:5439/dev", connectionParams.getJdbcUrl());
+        }
     }
 
     @Test

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessorTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -47,13 +48,15 @@ public class SQLServerDataSourceProcessorTest {
         sqlServerDatasourceParamDTO.setHost("localhost");
         sqlServerDatasourceParamDTO.setPort(1234);
         sqlServerDatasourceParamDTO.setOther(props);
-        Mockito.mockStatic(PasswordUtils.class);
-        Mockito.when(PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
-        SQLServerConnectionParam connectionParams = (SQLServerConnectionParam) sqlServerDatasourceProcessor
-                .createConnectionParams(sqlServerDatasourceParamDTO);
-        Assert.assertEquals("jdbc:sqlserver://localhost:1234", connectionParams.getAddress());
-        Assert.assertEquals("jdbc:sqlserver://localhost:1234;databaseName=default", connectionParams.getJdbcUrl());
-        Assert.assertEquals("root", connectionParams.getUser());
+
+        try (MockedStatic<PasswordUtils> mockedStaticPasswordUtils = Mockito.mockStatic(PasswordUtils.class)) {
+            mockedStaticPasswordUtils.when(() -> PasswordUtils.encodePassword(Mockito.anyString())).thenReturn("test");
+            SQLServerConnectionParam connectionParams = (SQLServerConnectionParam) sqlServerDatasourceProcessor
+                    .createConnectionParams(sqlServerDatasourceParamDTO);
+            Assert.assertEquals("jdbc:sqlserver://localhost:1234", connectionParams.getAddress());
+            Assert.assertEquals("jdbc:sqlserver://localhost:1234;databaseName=default", connectionParams.getJdbcUrl());
+            Assert.assertEquals("root", connectionParams.getUser());
+        }
     }
 
     @Test

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskAckProcessorTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskAckProcessorTest.java
@@ -24,11 +24,11 @@ import org.apache.dolphinscheduler.server.master.processor.queue.TaskEventServic
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
-import java.util.Date;
-
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -47,15 +47,19 @@ public class TaskAckProcessorTest {
     private TaskEvent taskResponseEvent;
     private Channel channel;
 
+    private MockedStatic<SpringApplicationContext> mockedStaticSpringApplicationContext;
+
     @Before
     public void before() {
-        Mockito.mockStatic(SpringApplicationContext.class);
+        mockedStaticSpringApplicationContext = Mockito.mockStatic(SpringApplicationContext.class);
 
         taskEventService = Mockito.mock(TaskEventService.class);
-        Mockito.when(SpringApplicationContext.getBean(TaskEventService.class)).thenReturn(taskEventService);
+        mockedStaticSpringApplicationContext.when(() -> SpringApplicationContext.getBean(TaskEventService.class))
+                .thenReturn(taskEventService);
 
         processService = Mockito.mock(ProcessService.class);
-        Mockito.when(SpringApplicationContext.getBean(ProcessService.class)).thenReturn(processService);
+        mockedStaticSpringApplicationContext.when(() -> SpringApplicationContext.getBean(ProcessService.class))
+                .thenReturn(processService);
 
         taskExecuteRunningProcessor = new TaskExecuteRunningProcessor();
 
@@ -72,6 +76,11 @@ public class TaskAckProcessorTest {
         taskExecuteRunningMessage.setStartTime(System.currentTimeMillis());
         taskExecuteRunningMessage.setTaskInstanceId(1);
         taskExecuteRunningMessage.setProcessInstanceId(1);
+    }
+
+    @After
+    public void after() {
+        mockedStaticSpringApplicationContext.close();
     }
 
     @Test

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/utils/ProcessUtilsTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -51,24 +52,32 @@ public class ProcessUtilsTest {
     @Test
     public void getPidsStr() throws Exception {
         int processId = 1;
-        Mockito.mockStatic(OSUtils.class);
-        Mockito.when(OSUtils.exeCmd(anyString())).thenReturn(null);
-        String pidList = ProcessUtils.getPidsStr(processId);
-        Assert.assertEquals("", pidList);
+
+        try (MockedStatic<OSUtils> mockedStaticOSUtils = Mockito.mockStatic(OSUtils.class)) {
+            mockedStaticOSUtils.when(() -> OSUtils.exeCmd(anyString())).thenReturn(null);
+            String pidList = ProcessUtils.getPidsStr(processId);
+            Assert.assertEquals("", pidList);
+        }
     }
 
     @Test
     public void testGetKerberosInitCommand() {
-        Mockito.mockStatic(PropertyUtils.class);
-        Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
-                .thenReturn(true);
-        Mockito.when(PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH)).thenReturn("/etc/krb5.conf");
-        Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH)).thenReturn("/etc/krb5.keytab");
-        Mockito.when(PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME)).thenReturn("test@DS.COM");
-        Assert.assertNotEquals("", ProcessUtils.getKerberosInitCommand());
-        Mockito.when(PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
-                .thenReturn(false);
-        Assert.assertEquals("", ProcessUtils.getKerberosInitCommand());
+        try (MockedStatic<PropertyUtils> mockedStaticPropertyUtils = Mockito.mockStatic(PropertyUtils.class)) {
+            mockedStaticPropertyUtils
+                    .when(() -> PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+                    .thenReturn(true);
+            mockedStaticPropertyUtils.when(() -> PropertyUtils.getString(Constants.JAVA_SECURITY_KRB5_CONF_PATH))
+                    .thenReturn("/etc/krb5.conf");
+            mockedStaticPropertyUtils.when(() -> PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_PATH))
+                    .thenReturn("/etc/krb5.keytab");
+            mockedStaticPropertyUtils.when(() -> PropertyUtils.getString(Constants.LOGIN_USER_KEY_TAB_USERNAME))
+                    .thenReturn("test@DS.COM");
+            Assert.assertNotEquals("", ProcessUtils.getKerberosInitCommand());
+            mockedStaticPropertyUtils
+                    .when(() -> PropertyUtils.getBoolean(Constants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE, false))
+                    .thenReturn(false);
+            Assert.assertEquals("", ProcessUtils.getKerberosInitCommand());
+        }
     }
 
     @Test
@@ -80,17 +89,18 @@ public class ProcessUtilsTest {
         String executePath = "/ds-exec/1/1/1";
         TaskExecutionStatus running = TaskExecutionStatus.RUNNING_EXECUTION;
 
-        Mockito.mockStatic(HadoopUtils.class);
-        HadoopUtils hadoop = HadoopUtils.getInstance();
+        try (MockedStatic<HadoopUtils> mockedStaticHadoopUtils = Mockito.mockStatic(HadoopUtils.class)) {
+            HadoopUtils hadoop = HadoopUtils.getInstance();
 
-        try {
-            Mockito.when(hadoop.getApplicationStatus("application_1585532379175_228491")).thenReturn(running);
-            Mockito.when(hadoop.getApplicationStatus("application_1598885606600_3677")).thenReturn(running);
-        } catch (Exception e) {
-            e.printStackTrace();
-            ProcessUtils.cancelApplication(appIds, logger, tenantCode, executePath);
+            try {
+                Mockito.when(hadoop.getApplicationStatus("application_1585532379175_228491")).thenReturn(running);
+                Mockito.when(hadoop.getApplicationStatus("application_1598885606600_3677")).thenReturn(running);
+            } catch (Exception e) {
+                e.printStackTrace();
+                ProcessUtils.cancelApplication(appIds, logger, tenantCode, executePath);
+            }
+
+            Assert.assertNotNull(appIds);
         }
-
-        Assert.assertNotNull(appIds);
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-jupyter/src/test/java/org/apache/dolphinscheduler/plugin/task/jupyter/JupyterTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-jupyter/src/test/java/org/apache/dolphinscheduler/plugin/task/jupyter/JupyterTaskTest.java
@@ -28,6 +28,7 @@ import org.apache.dolphinscheduler.spi.utils.JSONUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -108,10 +109,12 @@ public class JupyterTaskTest {
     public void jupyterTaskUsePipRequirements() throws Exception {
         String jupyterTaskParameters = buildJupyterTaskUsePipRequirementsCommand();
         JupyterTask jupyterTask = prepareJupyterTaskForTest(jupyterTaskParameters);
-        Mockito.mockStatic(DateUtils.class);
-        when(DateUtils.getTimestampString()).thenReturn("123456789");
-        jupyterTask.init();
-        Assertions.assertEquals(jupyterTask.buildCommand(), EXPECTED_JUPYTER_TASK_COMMAND_USE_PIP_REQUIREMENTS);
+
+        try (MockedStatic<DateUtils> mockedStaticDateUtils = Mockito.mockStatic(DateUtils.class)) {
+            mockedStaticDateUtils.when(DateUtils::getTimestampString).thenReturn("123456789");
+            jupyterTask.init();
+            Assertions.assertEquals(jupyterTask.buildCommand(), EXPECTED_JUPYTER_TASK_COMMAND_USE_PIP_REQUIREMENTS);
+        }
     }
 
     private JupyterTask prepareJupyterTaskForTest(final String jupyterTaskParameters) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12296 
* related: #11405 

## Brief change log

In some UT cases, static mocks are not closed after used. This may cause unexpected UT failure. The best practice is to handle it with try-with-resource, see the code below for an example:

https://github.com/apache/dolphinscheduler/blob/a973054950b3964d439597023e7f9471bbbf95fe/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java#L39-L43


## Verify this pull request

manually tested
