### PR TITLE
[ci] Add path filter for CodeQL

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -29,8 +29,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  paths-filter:
+    name: CodeQL-Path-Filter
+    runs-on: ubuntu-latest
+    outputs:
+      not-ignore: ${{ steps.filter.outputs.not-ignore }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        id: filter
+        with:
+          # All `src` directory except `pydolphinscheduler/src`
+          filters: |
+            not-ignore:
+              - 'src/**'
+              - '!(pydolphinscheduler/src/**)'
+
   analyze:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/dolphinscheduler') || (github.event_name != 'schedule')
+    if: ${{ (needs.paths-filter.outputs.not-ignore == 'true') ｜｜ (github.event_name == 'schedule' && github.repository == 'apache/dolphinscheduler') || (github.event_name != 'schedule')
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add new rule for CodeQL, All `src` directory
except `pydolphinscheduler/src`
