### PR TITLE
Use temurin Java docker images instead of deprecated ones

### DIFF
--- a/.github/workflows/cluster-test/mysql/Dockerfile
+++ b/.github/workflows/cluster-test/mysql/Dockerfile
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 RUN apt update ; \
-    apt install -y curl wget default-mysql-client sudo openssh-server netcat-traditional ;
+    apt install -y wget default-mysql-client sudo openssh-server netcat-traditional ;
 
 COPY ./apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz /root
 RUN tar -zxvf /root/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz -C ~

--- a/.github/workflows/cluster-test/mysql/dolphinscheduler_env.sh
+++ b/.github/workflows/cluster-test/mysql/dolphinscheduler_env.sh
@@ -16,7 +16,7 @@
 #
 
 # JAVA_HOME, will use it to start DolphinScheduler server
-export JAVA_HOME=${JAVA_HOME:-/usr/local/openjdk-8}
+export JAVA_HOME=${JAVA_HOME:-/opt/java/openjdk}
 
 # Database related configuration, set database type, username and password
 export DATABASE=${DATABASE:-mysql}

--- a/.github/workflows/cluster-test/postgresql/Dockerfile
+++ b/.github/workflows/cluster-test/postgresql/Dockerfile
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 RUN apt update ; \
-    apt install -y curl wget sudo openssh-server netcat-traditional ;
+    apt install -y wget sudo openssh-server netcat-traditional ;
 
 COPY ./apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz /root
 RUN tar -zxvf /root/apache-dolphinscheduler-*-SNAPSHOT-bin.tar.gz -C ~

--- a/.github/workflows/cluster-test/postgresql/dolphinscheduler_env.sh
+++ b/.github/workflows/cluster-test/postgresql/dolphinscheduler_env.sh
@@ -16,7 +16,7 @@
 #
 
 # JAVA_HOME, will use it to start DolphinScheduler server
-export JAVA_HOME=${JAVA_HOME:-/usr/local/openjdk-8}
+export JAVA_HOME=${JAVA_HOME:-/opt/java/openjdk}
 
 # Database related configuration, set database type, username and password
 export DATABASE=${DATABASE:-postgresql}

--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/docker/Dockerfile
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/docker/Dockerfile
@@ -15,15 +15,11 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
-
-RUN apt update ; \
-    apt install -y curl ; \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR $DOLPHINSCHEDULER_HOME
 

--- a/dolphinscheduler-api/src/main/bin/start.sh
+++ b/dolphinscheduler-api/src/main/bin/start.sh
@@ -27,6 +27,6 @@ if [[ "$DOCKER" == "true" ]]; then
   JAVA_OPTS="${JAVA_OPTS} -XX:-UseContainerSupport"
 fi
 
-java $JAVA_OPTS \
+$JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$DOLPHINSCHEDULER_HOME/conf":"$DOLPHINSCHEDULER_HOME/libs/*" \
   org.apache.dolphinscheduler.api.ApiApplicationServer

--- a/dolphinscheduler-api/src/main/docker/Dockerfile
+++ b/dolphinscheduler-api/src/main/docker/Dockerfile
@@ -15,15 +15,11 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
-
-RUN apt update ; \
-    apt install -y curl ; \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR $DOLPHINSCHEDULER_HOME
 

--- a/dolphinscheduler-master/src/main/bin/start.sh
+++ b/dolphinscheduler-master/src/main/bin/start.sh
@@ -27,6 +27,6 @@ if [[ "$DOCKER" == "true" ]]; then
   JAVA_OPTS="${JAVA_OPTS} -XX:-UseContainerSupport"
 fi
 
-java $JAVA_OPTS \
+$JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$DOLPHINSCHEDULER_HOME/conf":"$DOLPHINSCHEDULER_HOME/libs/*" \
   org.apache.dolphinscheduler.server.master.MasterServer

--- a/dolphinscheduler-master/src/main/docker/Dockerfile
+++ b/dolphinscheduler-master/src/main/docker/Dockerfile
@@ -15,15 +15,11 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
-
-RUN apt update ; \
-    apt install -y curl ; \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR $DOLPHINSCHEDULER_HOME
 

--- a/dolphinscheduler-standalone-server/src/main/bin/start.sh
+++ b/dolphinscheduler-standalone-server/src/main/bin/start.sh
@@ -35,6 +35,6 @@ for d in $DOLPHINSCHEDULER_HOME/libs/*; do
   done
 done
 
-java $JAVA_OPTS \
+$JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$DOLPHINSCHEDULER_HOME/conf":"$CP" \
   org.apache.dolphinscheduler.StandaloneServer

--- a/dolphinscheduler-standalone-server/src/main/dist-bin/start.sh
+++ b/dolphinscheduler-standalone-server/src/main/dist-bin/start.sh
@@ -38,6 +38,6 @@ for d in alert-server api-server master-server worker-server; do
   done
 done
 
-java $JAVA_OPTS \
+$JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$DOLPHINSCHEDULER_HOME/conf":"$CP" \
   org.apache.dolphinscheduler.StandaloneServer

--- a/dolphinscheduler-standalone-server/src/main/docker/Dockerfile
+++ b/dolphinscheduler-standalone-server/src/main/docker/Dockerfile
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
 
 RUN apt update ; \
-    apt install -y curl sudo ; \
+    apt install -y sudo ; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR $DOLPHINSCHEDULER_HOME

--- a/dolphinscheduler-tools/src/main/bin/upgrade-schema.sh
+++ b/dolphinscheduler-tools/src/main/bin/upgrade-schema.sh
@@ -25,7 +25,7 @@ fi
 
 JAVA_OPTS=${JAVA_OPTS:-"-server -Duser.timezone=${SPRING_JACKSON_TIME_ZONE} -Xms1g -Xmx1g -Xmn512m -XX:+PrintGCDetails -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof"}
 
-java $JAVA_OPTS \
+$JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$DOLPHINSCHEDULER_HOME/tools/conf":"$DOLPHINSCHEDULER_HOME/tools/libs/*":"$DOLPHINSCHEDULER_HOME/tools/sql" \
   -Dspring.profiles.active=upgrade,${DATABASE} \
   org.apache.dolphinscheduler.tools.datasource.UpgradeDolphinScheduler

--- a/dolphinscheduler-tools/src/main/docker/Dockerfile
+++ b/dolphinscheduler-tools/src/main/docker/Dockerfile
@@ -15,15 +15,11 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
-
-RUN apt update ; \
-    apt install -y curl ; \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR $DOLPHINSCHEDULER_HOME
 

--- a/dolphinscheduler-worker/src/main/bin/start.sh
+++ b/dolphinscheduler-worker/src/main/bin/start.sh
@@ -30,6 +30,6 @@ if [[ "$DOCKER" == "true" ]]; then
   JAVA_OPTS="${JAVA_OPTS} -XX:-UseContainerSupport"
 fi
 
-java $JAVA_OPTS \
+$JAVA_HOME/bin/java $JAVA_OPTS \
   -cp "$DOLPHINSCHEDULER_HOME/conf":"$DOLPHINSCHEDULER_HOME/libs/*" \
   org.apache.dolphinscheduler.server.worker.WorkerServer

--- a/dolphinscheduler-worker/src/main/docker/Dockerfile
+++ b/dolphinscheduler-worker/src/main/docker/Dockerfile
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre
 
 ENV DOCKER true
 ENV TZ Asia/Shanghai
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
 
 RUN apt update ; \
-    apt install -y curl sudo ; \
+    apt install -y sudo ; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR $DOLPHINSCHEDULER_HOME

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -16,7 +16,7 @@
 #
 
 # JAVA_HOME, will use it to start DolphinScheduler server
-export JAVA_HOME=${JAVA_HOME:-/opt/soft/java}
+export JAVA_HOME=${JAVA_HOME:-/opt/java/openjdk}
 
 # Never put sensitive config such as database password here in your production environment,
 # this file will be sourced everytime a new task is executed.


### PR DESCRIPTION
openjdk is deprecated and moved to eclipse-temurin, also openjdk has many CVEs in system level, this patch migrates the base Docker image to eclipse-temurin.