### PR TITLE
[Improvement-12335][ui] Make the resources to be reactive in hivecli task

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-hive-cli.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-hive-cli.ts
@@ -22,6 +22,8 @@ import type { IJsonItem } from '../types'
 export function useHiveCli(model: { [field: string]: any }): IJsonItem[] {
   const { t } = useI18n()
   const hiveSqlScriptSpan = computed(() => (model.hiveCliTaskExecutionType === 'SCRIPT' ? 24 : 0))
+  const resourcesRequired = computed(() => (model.hiveCliTaskExecutionType === 'SCRIPT' ? false : true))
+  const resourcesLimit = computed(() => (model.hiveCliTaskExecutionType === 'SCRIPT' ? -1 : 1))
 
   return [
     {
@@ -56,7 +58,7 @@ export function useHiveCli(model: { [field: string]: any }): IJsonItem[] {
         placeholder: t('project.node.hive_cli_options_tips')
       }
     },
-    useResources(),
+    useResources(24, resourcesRequired, resourcesLimit),
     ...useCustomParams({ model, field: 'localParams', isSimple: false })
   ]
 }


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* After @Amy0104 has fixed the `required` to be reactive in #12225 
* Make the resources in hivecli task to be reactive.
* close: #12335

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

* choose FROM_SCRIPT
 
<img width="575" alt="截屏2022-10-12 16 01 07" src="https://user-images.githubusercontent.com/38122586/195287836-9f05d8ab-ff29-413c-8642-12e3f463115a.png">

* choose FROM_FILE, resource file is needed

<img width="583" alt="截屏2022-10-12 16 01 16" src="https://user-images.githubusercontent.com/38122586/195287945-79dd7ef5-7140-4827-b8a6-75dc1ce42ce7.png">

