### PR TITLE
[Fix-12350] fix source not found error

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -40,7 +40,7 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
     /**
      * For Unix-like, using sh
      */
-    private static final String SH = "sh";
+    private static final String SH = "bash";
 
     /**
      * For Windows, using cmd.exe


### PR DESCRIPTION
### Search before asking

- [X] I had searched in the [issues](https://github.com/apache/dolphinscheduler/issues?q=is%3Aissue) and found no similar issues.

### What happened

We run worker in k8s, will meet `source not found` error when submit tasks.

![image](https://user-images.githubusercontent.com/95013770/195524917-ef54a7b3-b38e-4c1a-95c5-04b32010084e.png)


And, I found someone meet the same error.

> Unlucky, Version 3.1.0 does not include a fix for this bug.

_Originally posted by @black-06 in https://github.com/apache/dolphinscheduler/issues/10938#issuecomment-1269309737_
      
### Version

3.1.x

### Fix

We should use `bash` as the base command.

https://www.cnblogs.com/qianxiaoPro/p/16218564.html
