### PR TITLE
[Fix][Worker] alert email in sql task in K8S

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
@@ -64,7 +64,7 @@ spec:
               value: {{ .Values.timezone }}
             - name: SPRING_JACKSON_TIME_ZONE
               value: {{ .Values.timezone }}
-            - name: ALERT_LISTEN_HOST
+            - name: WORKER_ALERT_LISTEN_HOST
               value: {{ include "dolphinscheduler.fullname" . }}-alert
             {{- include "dolphinscheduler.database.env_vars" . | nindent 12 }}
             {{- include "dolphinscheduler.registry.env_vars" . | nindent 12 }}

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -69,7 +69,7 @@ worker:
   # worker reserved memory, only lower than system available memory, worker server can be dispatched tasks. default value 0.3, the unit is G
   reserved-memory: 0.3
   # alert server listen host
-  alert-listen-host: localhost
+  alert-listen-host: ${ALERT_LISTEN_HOST:localhost}
   alert-listen-port: 50052
   registry-disconnect-strategy:
     # The disconnect strategy: stop, waiting

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -69,7 +69,7 @@ worker:
   # worker reserved memory, only lower than system available memory, worker server can be dispatched tasks. default value 0.3, the unit is G
   reserved-memory: 0.3
   # alert server listen host
-  alert-listen-host: ${ALERT_LISTEN_HOST:localhost}
+  alert-listen-host: localhost
   alert-listen-port: 50052
   registry-disconnect-strategy:
     # The disconnect strategy: stop, waiting


### PR DESCRIPTION
worker.alert-listen-host has not get ALERT_LISTEN_HOST environment variable in worker containers env

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

This pull request fix #12088 

## Brief change log

This pull request update deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml

```yaml
      containers:
        - name: {{ include "dolphinscheduler.fullname" . }}-worker
          env:
            - name: WORKER_ALERT_LISTEN_HOST
```
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.


