### PR TITLE
[Improvement-12372][k8s] Update the deprecated k8s api

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/K8sUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/K8sUtils.java
@@ -44,6 +44,7 @@ public class K8sUtils {
     public void createJob(String namespace, Job job) {
         try {
             client.batch()
+                    .v1()
                     .jobs()
                     .inNamespace(namespace)
                     .create(job);
@@ -55,6 +56,7 @@ public class K8sUtils {
     public void deleteJob(String jobName, String namespace) {
         try {
             client.batch()
+                    .v1()
                     .jobs()
                     .inNamespace(namespace)
                     .withName(jobName)
@@ -81,7 +83,10 @@ public class K8sUtils {
     public Watch createBatchJobWatcher(String jobName, Watcher<Job> watcher) {
         try {
             return client.batch()
-                    .jobs().withName(jobName).watch(watcher);
+                    .v1()
+                    .jobs()
+                    .withName(jobName)
+                    .watch(watcher);
         } catch (Exception e) {
             throw new TaskException("fail to register batch job watcher", e);
         }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12372 

## Brief change log

update the `client.batch().jobs()` to `client.batch().v1().jobs()`

<img width="526" alt="image" src="https://user-images.githubusercontent.com/38122586/195756353-b08746f9-b612-42cc-bd1a-cc2542934ca2.png">


<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

