### PR TITLE
[Bug] [Service] Use MapUtils to judge globalParamsMap is empty

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
@@ -157,7 +157,7 @@ public class CuringGlobalParams implements CuringParamsService {
         String timeZone = cmdParam.get(Constants.SCHEDULE_TIMEZONE);
         Map<String, String> params = BusinessTimeUtils.getBusinessTime(commandType, scheduleTime, timeZone);
 
-        if (globalParamsMap != null) {
+        if (!globalParamsMap.isEmpty()) {
             params.putAll(globalParamsMap);
         }
 

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
@@ -157,7 +157,7 @@ public class CuringGlobalParams implements CuringParamsService {
         String timeZone = cmdParam.get(Constants.SCHEDULE_TIMEZONE);
         Map<String, String> params = BusinessTimeUtils.getBusinessTime(commandType, scheduleTime, timeZone);
 
-        if (!globalParamsMap.isEmpty()) {
+        if (MapUtils.isNotEmpty(globalParamsMap)) {
             params.putAll(globalParamsMap);
         }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
close #12383 
fix condition 'globalParamsMap != null' is always 'true' .

## Brief change log

Condition 'globalParamsMap != null' is always 'true' .

## Verify this pull request
 if (!globalParamsMap.isEmpty()) {
            params.putAll(globalParamsMap);
        }
