### PR TITLE
[Improvement][API] When the workflow definition is copied, the operation user of the timed instance is changed to the current user

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -2197,6 +2197,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 Schedule scheduleObj = scheduleMapper.queryByProcessDefinitionCode(oldProcessDefinitionCode);
                 if (scheduleObj != null) {
                     scheduleObj.setId(null);
+                    scheduleObj.setUserId(loginUser.getId());
                     scheduleObj.setProcessDefinitionCode(processDefinition.getCode());
                     scheduleObj.setReleaseState(ReleaseState.OFFLINE);
                     scheduleObj.setCreateTime(date);


### PR DESCRIPTION
…ed instance is changed to the current user.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
When the workflow definition is copied, the operation user of the timed instance is changed to the current user

<!--(For example: This pull request adds checkstyle plugin).-->

When the workflow definition is copied, the operation user of the timed instance is changed to the current user.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
