### PR TITLE
[Bug] Improve the scenario of continuing to submit subsequent tasks after failure

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -35,7 +35,6 @@ import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.enums.Priority;
-import org.apache.dolphinscheduler.common.enums.ProcessExecutionTypeEnum;
 import org.apache.dolphinscheduler.common.enums.StateEventType;
 import org.apache.dolphinscheduler.common.enums.TaskDependType;
 import org.apache.dolphinscheduler.common.enums.TaskGroupQueueStatus;
@@ -421,15 +420,12 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
      * continue to submit subsequent tasks after failure
      *
      * if there are subsequent tasks:
-     *      1. the execution type is parallel;
-     *      2. the execution type is serial and failed task type is condition;
-     *      3. the execution type is serial and next task type is condition;
+     *      1. nodes are parallel;
+     *      2. nodes are serial and failed task type is condition;
+     *      3. nodes are serial and next task type is condition;
      */
     private void failureContinueSubmitPostNodes(TaskInstance taskInstance) throws StateEventHandleException {
         if (!DagHelper.haveAnyNodeAfterNode(Long.toString(taskInstance.getTaskCode()), dag)) {
-            return;
-        }
-        if (ProcessExecutionTypeEnum.PARALLEL.equals(processDefinition.getExecutionType())) {
             submitPostNode(Long.toString(taskInstance.getTaskCode()));
         } else {
             if (taskInstance.isConditionsTask()

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -425,8 +425,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
      *      3. nodes are serial and next task type is condition;
      */
     private void failureContinueSubmitPostNodes(TaskInstance taskInstance) throws StateEventHandleException {
-        boolean haveAnyNodeAfterNode = DagHelper.haveAnyNodeAfterNode(Long.toString(taskInstance.getTaskCode()), dag);
-        System.out.println("===haveAnyNodeAfterNode===" + haveAnyNodeAfterNode);
         if (!DagHelper.haveAnyNodeAfterNode(Long.toString(taskInstance.getTaskCode()), dag)) {
             submitPostNode(Long.toString(taskInstance.getTaskCode()));
         } else {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -425,6 +425,8 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
      *      3. nodes are serial and next task type is condition;
      */
     private void failureContinueSubmitPostNodes(TaskInstance taskInstance) throws StateEventHandleException {
+        boolean haveAnyNodeAfterNode = DagHelper.haveAnyNodeAfterNode(Long.toString(taskInstance.getTaskCode()), dag);
+        System.out.println("===haveAnyNodeAfterNode===" + haveAnyNodeAfterNode);
         if (!DagHelper.haveAnyNodeAfterNode(Long.toString(taskInstance.getTaskCode()), dag)) {
             submitPostNode(Long.toString(taskInstance.getTaskCode()));
         } else {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -110,14 +110,14 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import lombok.NonNull;
 
 /**
  * Workflow execute task, used to execute a workflow instance.

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/DagHelper.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/DagHelper.java
@@ -574,9 +574,9 @@ public class DagHelper {
     }
 
     /**
-     * is there have all node after the parent node
+     * is there any sub nodes
      */
-    public static boolean haveAllNodeAfterNode(String parentNodeCode,
+    public static boolean haveAnyNodeAfterNode(String parentNodeCode,
                                                DAG<String, TaskNode, TaskNodeRelation> dag) {
         return haveSubAfterNode(parentNodeCode, dag, null);
     }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/utils/DagHelperTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/utils/DagHelperTest.java
@@ -86,7 +86,7 @@ public class DagHelperTest {
         processDag.setEdges(taskNodeRelations);
         processDag.setNodes(taskNodes);
         DAG<String, TaskNode, TaskNodeRelation> dag = DagHelper.buildDagGraph(processDag);
-        boolean canSubmit = DagHelper.haveAllNodeAfterNode(parentNodeCode, dag);
+        boolean canSubmit = DagHelper.haveAnyNodeAfterNode(parentNodeCode, dag);
         Assertions.assertTrue(canSubmit);
 
         boolean haveBlocking = DagHelper.haveBlockingAfterNode(parentNodeCode, dag);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Improve the scenario of continuing to submit subsequent tasks after failure.

## Brief change log

1.  Improve the scenario of continuing to submit subsequent tasks after failure, if there are subsequent tasks:
           a. nodes are parallel;
           b. nodes are serial and failed task type is condition;
           c. nodes are serial and next task type is condition;
2. `haveAllNodeAfterNode` change to `haveAnyNodeAfterNode`;
3. relate https://github.com/apache/dolphinscheduler/pull/9718;

## Verify this pull request

Manually verified the change by testing locally.
