### PR TITLE
[improvement-#12416] Use CollectionUtils.isEmpty judge the collection isEmpty to avoid NPE

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-feishu/src/main/java/org/apache/dolphinscheduler/plugin/alert/feishu/FeiShuSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-feishu/src/main/java/org/apache/dolphinscheduler/plugin/alert/feishu/FeiShuSender.java
@@ -17,12 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.alert.feishu;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.alert.api.AlertData;
 import org.apache.dolphinscheduler.alert.api.AlertResult;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
 
 import org.apache.commons.codec.binary.StringUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-feishu/src/main/java/org/apache/dolphinscheduler/plugin/alert/feishu/FeiShuSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-feishu/src/main/java/org/apache/dolphinscheduler/plugin/alert/feishu/FeiShuSender.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.alert.feishu;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.alert.api.AlertData;
 import org.apache.dolphinscheduler.alert.api.AlertResult;
 import org.apache.dolphinscheduler.spi.utils.JSONUtils;
@@ -108,7 +109,7 @@ public final class FeiShuSender {
         if (alertData.getContent() != null) {
 
             List<Map> list = JSONUtils.toList(alertData.getContent(), Map.class);
-            if (list.isEmpty()) {
+            if (CollectionUtils.isEmpty(list)) {
                 return alertData.getTitle() + alertData.getContent();
             }
 

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-webexteams/src/main/java/org/apache/dolphinscheduler/plugin/alert/webexteams/WebexTeamsAlertChannel.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-webexteams/src/main/java/org/apache/dolphinscheduler/plugin/alert/webexteams/WebexTeamsAlertChannel.java
@@ -17,11 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.alert.webexteams;
 
-import org.apache.commons.collections.MapUtils;
 import org.apache.dolphinscheduler.alert.api.AlertChannel;
 import org.apache.dolphinscheduler.alert.api.AlertData;
 import org.apache.dolphinscheduler.alert.api.AlertInfo;
 import org.apache.dolphinscheduler.alert.api.AlertResult;
+
+import org.apache.commons.collections.MapUtils;
 
 import java.util.Map;
 

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-webexteams/src/main/java/org/apache/dolphinscheduler/plugin/alert/webexteams/WebexTeamsAlertChannel.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-webexteams/src/main/java/org/apache/dolphinscheduler/plugin/alert/webexteams/WebexTeamsAlertChannel.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.alert.webexteams;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.dolphinscheduler.alert.api.AlertChannel;
 import org.apache.dolphinscheduler.alert.api.AlertData;
 import org.apache.dolphinscheduler.alert.api.AlertInfo;
@@ -30,7 +31,7 @@ public final class WebexTeamsAlertChannel implements AlertChannel {
     public AlertResult process(AlertInfo alertInfo) {
         AlertData alertData = alertInfo.getAlertData();
         Map<String, String> alertParams = alertInfo.getAlertParams();
-        if (alertParams == null || alertParams.size() == 0) {
+        if (MapUtils.isEmpty(alertParams)) {
             return new AlertResult("false", "WebexTeams alert params is empty");
         }
 

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api.test/utils/JSONUtils.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api.test/utils/JSONUtils.java
@@ -331,7 +331,7 @@ public class JSONUtils {
 
     public static ObjectNode parseObject(String text) {
         try {
-            if (text.isEmpty()) {
+            if (StringUtils.isEmpty(text)) {
                 return parseObject(text, ObjectNode.class);
             } else {
                 return (ObjectNode) objectMapper.readTree(text);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/TaskTypeConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/TaskTypeConfiguration.java
@@ -17,10 +17,11 @@
 
 package org.apache.dolphinscheduler.api.configuration;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.api.dto.FavTaskDto;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.config.YamlPropertySourceFactory;
+
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/TaskTypeConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/TaskTypeConfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.api.configuration;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.api.dto.FavTaskDto;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.config.YamlPropertySourceFactory;
@@ -55,7 +56,7 @@ public class TaskTypeConfiguration {
     private static final List<FavTaskDto> defaultTaskTypes = new ArrayList<>();
 
     public List<FavTaskDto> getDefaultTaskTypes() {
-        if (!defaultTaskTypes.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(defaultTaskTypes)) {
             return defaultTaskTypes;
         }
         printDefaultTypes();

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -114,7 +114,7 @@ public class ResourcePermissionCheckServiceImpl
             originResSet.removeAll(ownResSets);
             if (CollectionUtils.isNotEmpty(originResSet))
                 logger.warn("User does not have resource permission on associated resources, userId:{}", userId);
-            return originResSet.isEmpty();
+            return CollectionUtils.isEmpty(originResSet);
         }
         return true;
     }
@@ -180,7 +180,7 @@ public class ResourcePermissionCheckServiceImpl
                 return Collections.emptySet();
             }
             List<Queue> queues = queueMapper.selectList(null);
-            return queues.isEmpty() ? Collections.emptySet() : queues.stream().map(Queue::getId).collect(toSet());
+            return CollectionUtils.isEmpty(queues) ? Collections.emptySet() : queues.stream().map(Queue::getId).collect(toSet());
         }
     }
 
@@ -266,7 +266,7 @@ public class ResourcePermissionCheckServiceImpl
         @Override
         public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
             List<UdfFunc> udfFuncList = udfFuncMapper.listAuthorizedUdfByUserId(userId);
-            if (udfFuncList.isEmpty()) {
+            if (CollectionUtils.isEmpty(udfFuncList)) {
                 return Collections.emptySet();
             }
             return udfFuncList.stream().map(UdfFunc::getId).collect(toSet());
@@ -295,7 +295,7 @@ public class ResourcePermissionCheckServiceImpl
         @Override
         public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
             List<TaskGroup> taskGroupList = taskGroupMapper.listAuthorizedResource(userId);
-            if (taskGroupList.isEmpty()) {
+            if (CollectionUtils.isEmpty(taskGroupList)) {
                 return Collections.emptySet();
             }
             return taskGroupList.stream().map(TaskGroup::getId).collect(Collectors.toSet());
@@ -354,7 +354,7 @@ public class ResourcePermissionCheckServiceImpl
         @Override
         public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
             List<Environment> environments = environmentMapper.queryAllEnvironmentList();
-            if (environments.isEmpty()) {
+            if (CollectionUtils.isEmpty(environments)) {
                 return Collections.emptySet();
             }
             return environments.stream().map(Environment::getId).collect(Collectors.toSet());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -180,7 +180,8 @@ public class ResourcePermissionCheckServiceImpl
                 return Collections.emptySet();
             }
             List<Queue> queues = queueMapper.selectList(null);
-            return CollectionUtils.isEmpty(queues) ? Collections.emptySet() : queues.stream().map(Queue::getId).collect(toSet());
+            return CollectionUtils.isEmpty(queues) ? Collections.emptySet()
+                    : queues.stream().map(Queue::getId).collect(toSet());
         }
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -968,7 +968,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         Set<Long> diffCode =
                 definitionCodes.stream().filter(code -> !queryCodes.contains(code)).collect(Collectors.toSet());
 
-        if (!diffCode.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(diffCode)) {
             logger.error("Process definition does not exist, processCodes:{}.",
                     diffCode.stream().map(String::valueOf).collect(Collectors.joining(Constants.COMMA)));
             throw new ServiceException(Status.BATCH_DELETE_PROCESS_DEFINE_BY_CODES_ERROR,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessInstanceServiceImpl.java
@@ -889,7 +889,7 @@ public class ProcessInstanceServiceImpl extends BaseServiceImpl implements Proce
         ganttDto.setTaskNames(nodeList);
 
         List<Task> taskList = new ArrayList<>();
-        if (!nodeList.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(nodeList)) {
             List<Long> taskCodes = nodeList.stream().map(Long::parseLong).collect(Collectors.toList());
             List<TaskInstance> taskInstances = taskInstanceMapper.queryByProcessInstanceIdsAndTaskCodes(
                     Collections.singletonList(processInstanceId), taskCodes);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -25,7 +25,6 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_DEFINITION;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_SWITCH_TO_THIS_VERSION;
 
-import org.apache.commons.collections.MapUtils;
 import org.apache.dolphinscheduler.api.dto.task.TaskCreateRequest;
 import org.apache.dolphinscheduler.api.dto.task.TaskFilterRequest;
 import org.apache.dolphinscheduler.api.dto.task.TaskUpdateRequest;
@@ -67,6 +66,7 @@ import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.apache.dolphinscheduler.service.task.TaskPluginManager;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.InvocationTargetException;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -25,6 +25,7 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_DEFINITION;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_SWITCH_TO_THIS_VERSION;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.dolphinscheduler.api.dto.task.TaskCreateRequest;
 import org.apache.dolphinscheduler.api.dto.task.TaskFilterRequest;
 import org.apache.dolphinscheduler.api.dto.task.TaskUpdateRequest;
@@ -150,7 +151,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         }
 
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionJson, TaskDefinitionLog.class);
-        if (taskDefinitionLogs.isEmpty()) {
+        if (CollectionUtils.isEmpty(taskDefinitionLogs)) {
             logger.warn("Parameter taskDefinitionJson is invalid.");
             putMsg(result, Status.DATA_IS_NOT_VALID, taskDefinitionJson);
             return result;
@@ -336,7 +337,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
             // upstreamTaskCodes - queryUpStreamTaskCodes
             Set<Long> diffCode = upstreamTaskCodes.stream().filter(code -> !queryUpStreamTaskCodes.contains(code))
                     .collect(Collectors.toSet());
-            if (!diffCode.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(diffCode)) {
                 String taskCodes = StringUtils.join(diffCode, Constants.COMMA);
                 logger.error("Some task definitions with parameter upstreamCodes do not exist, taskDefinitionCodes:{}.",
                         taskCodes);
@@ -438,7 +439,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         // Whether task have downstream tasks
         List<ProcessTaskRelation> processTaskRelationList =
                 processTaskRelationMapper.queryDownstreamByTaskCode(taskDefinition.getCode());
-        if (!processTaskRelationList.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(processTaskRelationList)) {
             Set<Long> postTaskCodes = processTaskRelationList
                     .stream()
                     .map(ProcessTaskRelation::getPostTaskCode)
@@ -474,7 +475,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         // Delete task upstream tasks if exists
         List<ProcessTaskRelation> taskRelationList =
                 processTaskRelationMapper.queryUpstreamByCode(taskDefinition.getProjectCode(), taskCode);
-        if (!taskRelationList.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(taskRelationList)) {
             logger.debug(
                     "Task definition has upstream tasks, start handle them after delete task, taskDefinitionCode:{}.",
                     taskCode);
@@ -540,7 +541,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         }
         List<ProcessTaskRelation> taskRelationList =
                 processTaskRelationMapper.queryUpstreamByCode(projectCode, taskCode);
-        if (!taskRelationList.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(taskRelationList)) {
             logger.info(
                     "Task definition has upstream tasks, start handle them after update task, taskDefinitionCode:{}.",
                     taskCode);
@@ -614,7 +615,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
 
         List<ProcessTaskRelation> taskRelationList =
                 processTaskRelationMapper.queryUpstreamByCode(taskDefinitionUpdate.getProjectCode(), taskCode);
-        if (!taskRelationList.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(taskRelationList)) {
             logger.info(
                     "Task definition has upstream tasks, start handle them after update task, taskDefinitionCode:{}.",
                     taskCode);
@@ -794,13 +795,13 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
             }
         }
         Map<Long, TaskDefinition> queryUpStreamTaskCodeMap;
-        if (!upstreamTaskCodes.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(upstreamTaskCodes)) {
             List<TaskDefinition> upstreamTaskDefinitionList = taskDefinitionMapper.queryByCodeList(upstreamTaskCodes);
             queryUpStreamTaskCodeMap = upstreamTaskDefinitionList.stream()
                     .collect(Collectors.toMap(TaskDefinition::getCode, taskDefinition -> taskDefinition));
             // upstreamTaskCodes - queryUpStreamTaskCodeMap.keySet
             upstreamTaskCodes.removeAll(queryUpStreamTaskCodeMap.keySet());
-            if (!upstreamTaskCodes.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(upstreamTaskCodes)) {
                 String notExistTaskCodes = StringUtils.join(upstreamTaskCodes, Constants.COMMA);
                 logger.error("Some task definitions in parameter upstreamTaskCodes do not exist, notExistTaskCodes:{}.",
                         notExistTaskCodes);
@@ -810,7 +811,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         } else {
             queryUpStreamTaskCodeMap = new HashMap<>();
         }
-        if (!upstreamTaskRelations.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(upstreamTaskCodes)) {
             ProcessTaskRelation taskRelation = upstreamTaskRelations.get(0);
             List<ProcessTaskRelation> processTaskRelations =
                     processTaskRelationMapper.queryByProcessCode(projectCode, taskRelation.getProcessDefinitionCode());
@@ -834,7 +835,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                 taskRelation.setPreTaskVersion(queryUpStreamTask.getValue().getVersion());
                 processTaskRelationList.add(taskRelation);
             }
-            if (queryUpStreamTaskCodeMap.isEmpty() && !processTaskRelationList.isEmpty()) {
+            if (MapUtils.isEmpty(queryUpStreamTaskCodeMap) && CollectionUtils.isNotEmpty(processTaskRelationList)) {
                 processTaskRelationList.add(processTaskRelationList.get(0));
             }
             updateDag(loginUser, taskRelation.getProcessDefinitionCode(), processTaskRelations,
@@ -888,7 +889,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         if (switchVersion > 0) {
             List<ProcessTaskRelation> taskRelationList =
                     processTaskRelationMapper.queryUpstreamByCode(projectCode, taskCode);
-            if (!taskRelationList.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(taskRelationList)) {
                 logger.info(
                         "Task definition has upstream tasks, start handle them after switch task, taskDefinitionCode:{}.",
                         taskCode);
@@ -1022,7 +1023,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                 taskDefinitionMapper.queryDefineListPaging(page, projectCode, searchWorkflowName,
                         searchTaskName, taskType, taskExecuteType);
         List<TaskMainInfo> records = taskMainInfoIPage.getRecords();
-        if (!records.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(records)) {
             Map<Long, TaskMainInfo> taskMainInfoMap = new HashMap<>();
             for (TaskMainInfo info : records) {
                 taskMainInfoMap.compute(info.getTaskCode(), (k, v) -> {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -23,6 +23,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.READ_UNKNOWN
 import static com.fasterxml.jackson.databind.MapperFeature.REQUIRE_SETTERS_FOR_GETTERS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.Constants;
 
 import java.io.IOException;
@@ -339,7 +340,7 @@ public class JSONUtils {
 
     public static ObjectNode parseObject(String text) {
         try {
-            if (text.isEmpty()) {
+            if (StringUtils.isEmpty(text)) {
                 return parseObject(text, ObjectNode.class);
             } else {
                 return (ObjectNode) objectMapper.readTree(text);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -23,8 +23,9 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.READ_UNKNOWN
 import static com.fasterxml.jackson.databind.MapperFeature.REQUIRE_SETTERS_FOR_GETTERS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.Constants;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -19,9 +19,9 @@ package org.apache.dolphinscheduler.common.utils;
 
 import static java.util.Collections.emptyList;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.Constants;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.http.conn.util.InetAddressUtils;
 
 import java.io.IOException;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.common.utils;
 
 import static java.util.Collections.emptyList;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.Constants;
 
 import org.apache.http.conn.util.InetAddressUtils;
@@ -266,7 +267,7 @@ public class NetUtils {
     }
 
     private static NetworkInterface findAddress(List<NetworkInterface> validNetworkInterfaces) {
-        if (validNetworkInterfaces.isEmpty()) {
+        if (CollectionUtils.isEmpty(validNetworkInterfaces)) {
             return null;
         }
         String networkPriority = PropertyUtils.getString(Constants.DOLPHIN_SCHEDULER_NETWORK_PRIORITY_STRATEGY,

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
@@ -241,7 +241,7 @@ public class OSUtils {
         int startPos = 0;
         int endPos = lines.length - 2;
         for (int i = 0; i < lines.length; i++) {
-            if (lines[i].isEmpty()) {
+            if (StringUtils.isEmpty(lines[i])) {
                 continue;
             }
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/PropertyUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/PropertyUtils.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.common.utils;
 
 import static org.apache.dolphinscheduler.common.Constants.COMMON_PROPERTIES_PATH;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ResUploadType;
 
@@ -280,7 +281,7 @@ public class PropertyUtils {
             return null;
         }
         Set<Object> keys = properties.keySet();
-        if (keys.isEmpty()) {
+        if (CollectionUtils.isEmpty(keys)) {
             return null;
         }
         Map<String, String> propertiesMap = new HashMap<>();

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/PropertyUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/PropertyUtils.java
@@ -19,9 +19,10 @@ package org.apache.dolphinscheduler.common.utils;
 
 import static org.apache.dolphinscheduler.common.Constants.COMMON_PROPERTIES_PATH;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ResUploadType;
+
+import org.apache.commons.collections.CollectionUtils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/dolphinscheduler-scheduler-plugin/dolphinscheduler-scheduler-quartz/src/main/java/org/apache/dolphinscheduler/scheduler/quartz/ProcessScheduleTask.java
+++ b/dolphinscheduler-scheduler-plugin/dolphinscheduler-scheduler-quartz/src/main/java/org/apache/dolphinscheduler/scheduler/quartz/ProcessScheduleTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.scheduler.quartz;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
@@ -26,6 +25,8 @@ import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.scheduler.quartz.utils.QuartzTaskUtils;
 import org.apache.dolphinscheduler.service.process.ProcessService;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Date;
 

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.service.expand;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.PARAMETER_TASK_EXECUTE_PATH;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.PARAMETER_TASK_INSTANCE_ID;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
@@ -147,7 +148,7 @@ public class CuringGlobalParams implements CuringParamsService {
         parameters.setVarPool(taskInstance.getVarPool());
         Map<String, Property> varParams = parameters.getVarPoolMap();
 
-        if (globalParams.isEmpty() && localParams.isEmpty() && varParams.isEmpty()) {
+        if (MapUtils.isEmpty(globalParams) && MapUtils.isEmpty(localParams) && MapUtils.isEmpty(varParams)) {
             return null;
         }
         // if it is a complement,
@@ -166,10 +167,10 @@ public class CuringGlobalParams implements CuringParamsService {
         }
         params.put(PARAMETER_TASK_INSTANCE_ID, Integer.toString(taskInstance.getId()));
 
-        if (varParams.size() != 0) {
+        if (MapUtils.isNotEmpty(varParams)) {
             globalParams.putAll(varParams);
         }
-        if (localParams.size() != 0) {
+        if (MapUtils.isNotEmpty(localParams)) {
             globalParams.putAll(localParams);
         }
 

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringGlobalParams.java
@@ -20,7 +20,6 @@ package org.apache.dolphinscheduler.service.expand;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.PARAMETER_TASK_EXECUTE_PATH;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.PARAMETER_TASK_INSTANCE_ID;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -32,8 +32,6 @@ import static org.apache.dolphinscheduler.plugin.task.api.enums.DataType.VARCHAR
 import static org.apache.dolphinscheduler.plugin.task.api.enums.Direct.IN;
 import static org.apache.dolphinscheduler.plugin.task.api.utils.DataQualityConstants.TASK_INSTANCE_ID;
 
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.CommandType;
@@ -139,6 +137,8 @@ import org.apache.dolphinscheduler.service.utils.DagHelper;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -417,7 +417,9 @@ public class ProcessServiceImpl implements ProcessService {
         // add command timezone
         Schedule schedule = scheduleMapper.queryByProcessDefinitionCode(command.getProcessDefinitionCode());
         if (schedule != null) {
-            Map<String, String> commandParams = StringUtils.isNotBlank(command.getCommandParam()) ? JSONUtils.toMap(command.getCommandParam()) : new HashMap<>();
+            Map<String, String> commandParams =
+                    StringUtils.isNotBlank(command.getCommandParam()) ? JSONUtils.toMap(command.getCommandParam())
+                            : new HashMap<>();
             commandParams.put(Constants.SCHEDULE_TIMEZONE, schedule.getTimezoneId());
             command.setCommandParam(JSONUtils.toJsonString(commandParams));
         }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -32,6 +32,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.enums.DataType.VARCHAR
 import static org.apache.dolphinscheduler.plugin.task.api.enums.Direct.IN;
 import static org.apache.dolphinscheduler.plugin.task.api.utils.DataQualityConstants.TASK_INSTANCE_ID;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
@@ -744,7 +745,7 @@ public class ProcessServiceImpl implements ProcessService {
                     queryReleaseSchedulerListByProcessDefinitionCode(command.getProcessDefinitionCode());
             List<Date> complementDateList = CronUtils.getSelfFireDateList(start, end, schedules);
 
-            if (complementDateList.size() > 0) {
+            if (CollectionUtils.isNotEmpty(complementDateList)) {
                 scheduleTime = complementDateList.get(0);
             } else {
                 logger.error("set scheduler time error: complement date list is empty, command: {}",
@@ -839,7 +840,7 @@ public class ProcessServiceImpl implements ProcessService {
         // set start param into global params
         Map<String, String> globalMap = processDefinition.getGlobalParamMap();
         List<Property> globalParamList = processDefinition.getGlobalParamList();
-        if (startParamMap.size() > 0 && globalMap != null) {
+        if (MapUtils.isNotEmpty(startParamMap) && globalMap != null) {
             // start param to overwrite global param
             for (Map.Entry<String, String> param : globalMap.entrySet()) {
                 String val = startParamMap.get(param.getKey());
@@ -1157,7 +1158,7 @@ public class ProcessServiceImpl implements ProcessService {
             complementDate = CronUtils.getSelfScheduleDateList(cmdParam);
         }
 
-        if (complementDate.size() > 0 && Flag.NO == processInstance.getIsSubProcess()) {
+        if (CollectionUtils.isNotEmpty(complementDate) && Flag.NO == processInstance.getIsSubProcess()) {
             processInstance.setScheduleTime(complementDate.get(0));
         }
 
@@ -1471,7 +1472,7 @@ public class ProcessServiceImpl implements ProcessService {
             }
             processMapStr = JSONUtils.toJsonString(cmdParam);
         }
-        if (fatherParams.size() != 0) {
+        if (MapUtils.isNotEmpty(fatherParams)) {
             cmdParam.put(CMD_PARAM_FATHER_PARAMS, JSONUtils.toJsonString(fatherParams));
             processMapStr = JSONUtils.toJsonString(cmdParam);
         }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtils.java
@@ -266,7 +266,7 @@ public class TimePlaceholderUtils {
             if (Character.isDigit(expression.charAt(i))) {
                 num = num + expression.charAt(i);
             } else {
-                if (!num.isEmpty()) {
+                if (!StringUtils.isEmpty(num)) {
                     result.add(num);
                 }
                 result.add(expression.charAt(i) + "");

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-switch/src/main/java/org/apache/dolphinscheduler/plugin/task/switchtask/SwitchParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-switch/src/main/java/org/apache/dolphinscheduler/plugin/task/switchtask/SwitchParameters.java
@@ -17,11 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.task.switchtask;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
 import org.apache.dolphinscheduler.spi.utils.StringUtils;
+
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.List;
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-switch/src/main/java/org/apache/dolphinscheduler/plugin/task/switchtask/SwitchParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-switch/src/main/java/org/apache/dolphinscheduler/plugin/task/switchtask/SwitchParameters.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.task.switchtask;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
@@ -86,7 +87,7 @@ public class SwitchParameters extends AbstractParameters {
         }
         // validate conditions must have next node
         List<SwitchCondition> conditions = this.switchResult.getDependTaskList();
-        if (conditions != null && conditions.size() != 0) {
+        if (CollectionUtils.isNotEmpty(conditions)) {
             if (conditions.stream()
                     .anyMatch(e -> (StringUtils.isNotEmpty(e.getCondition()) && e.getNextNode() == null))) {
                 return false;

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/message/MessageRetryRunner.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/message/MessageRetryRunner.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.server.worker.message;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.lifecycle.ServerLifeCycleManager;
 import org.apache.dolphinscheduler.common.thread.BaseDaemonThread;
@@ -101,7 +102,7 @@ public class MessageRetryRunner extends BaseDaemonThread {
     public void run() {
         while (!ServerLifeCycleManager.isStopped()) {
             try {
-                if (needToRetryMessages.isEmpty()) {
+                if (MapUtils.isEmpty(needToRetryMessages)) {
                     Thread.sleep(MESSAGE_RETRY_WINDOW);
                 }
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/message/MessageRetryRunner.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/message/MessageRetryRunner.java
@@ -17,13 +17,14 @@
 
 package org.apache.dolphinscheduler.server.worker.message;
 
-import org.apache.commons.collections.MapUtils;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.lifecycle.ServerLifeCycleManager;
 import org.apache.dolphinscheduler.common.thread.BaseDaemonThread;
 import org.apache.dolphinscheduler.remote.command.BaseCommand;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.service.utils.LoggerUtils;
+
+import org.apache.commons.collections.MapUtils;
 
 import java.time.Duration;
 import java.util.HashMap;


### PR DESCRIPTION
close:#12416
## Purpose of the pull request
- use ```CollectionUtils.isNotEmpty``` to instead of ```list.size=0``` and ``` list.isEmpty```
- use ```MapUtils.isNotEmpty``` to instead of ```map.size=0``` and ``` map.isEmpty```
- close #12416 
avoid NPE




## Verify this pull request
This pull request is code cleanup without any test coverage.

