### PR TITLE
[Fix-12451][k8s] Read the kubeconfig from cluster conf

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/k8s/K8sManager.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/k8s/K8sManager.java
@@ -17,10 +17,10 @@
 
 package org.apache.dolphinscheduler.api.k8s;
 
-import org.apache.dolphinscheduler.api.utils.ClusterConfUtils;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
 import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
 import org.apache.dolphinscheduler.remote.exceptions.RemotingException;
+import org.apache.dolphinscheduler.service.utils.ClusterConfUtils;
 
 import java.util.Hashtable;
 import java.util.Map;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceImpl.java
@@ -21,7 +21,6 @@ import org.apache.dolphinscheduler.api.dto.ClusterDto;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.k8s.K8sManager;
 import org.apache.dolphinscheduler.api.service.ClusterService;
-import org.apache.dolphinscheduler.api.utils.ClusterConfUtils;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
@@ -33,6 +32,7 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
 import org.apache.dolphinscheduler.remote.exceptions.RemotingException;
+import org.apache.dolphinscheduler.service.utils.ClusterConfUtils;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -133,6 +133,7 @@ import org.apache.dolphinscheduler.service.expand.CuringParamsService;
 import org.apache.dolphinscheduler.service.log.LogClient;
 import org.apache.dolphinscheduler.service.model.TaskNode;
 import org.apache.dolphinscheduler.service.task.TaskPluginManager;
+import org.apache.dolphinscheduler.service.utils.ClusterConfUtils;
 import org.apache.dolphinscheduler.service.utils.DagHelper;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
@@ -2922,7 +2923,7 @@ public class ProcessServiceImpl implements ProcessService {
         QueryWrapper<Cluster> nodeWrapper = new QueryWrapper<>();
         nodeWrapper.eq("name", clusterName);
         Cluster cluster = clusterMapper.selectOne(nodeWrapper);
-        return cluster == null ? null : cluster.getConfig();
+        return cluster == null ? null : ClusterConfUtils.getK8sConfig(cluster.getConfig());
     }
 
     @Override

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ClusterConfUtils.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ClusterConfUtils.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.utils;
+package org.apache.dolphinscheduler.service.utils;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12451 
* related: #12358 Thanks for the comment from @danielfree 


Since `cluster.getConfig()` will return `{"k8s": "<kubeconfig>"}` rather than return the `<kubeconfig>` directly.
We need to use `ClusterConfUtils.getK8sConfig(cluster.getConfig())` to extract the `<kubeconfig>` from the json string.

Note that although `cluster.getConfig()` cannot return the correct kubeconfig now, `DefaultKubernetesClient(config)` will automatically read the kubeconfig from `~/.kube/config` instead. So the bug that existed in #12358 may not be seen by user.
 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log


move `ClusterConfUtils.java` from `dolphinscheduler-api` to `dolphinscheduler-service` to avoid the circular dependency

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

manually tested
