### PR TITLE
[Bug] Fix tenant cannot touch file in task dir due to not permission

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -88,23 +88,29 @@ public class FileUtils {
     /**
      * directory of process execution
      *
-     * @param projectCode project code
-     * @param processDefineCode process definition Code
+     * @param tenant               tenant
+     * @param projectCode          project code
+     * @param processDefineCode    process definition Code
      * @param processDefineVersion process definition version
-     * @param processInstanceId process instance id
-     * @param taskInstanceId task instance id
+     * @param processInstanceId    process instance id
+     * @param taskInstanceId       task instance id
      * @return directory of process execution
      */
-    public static String getProcessExecDir(long projectCode, long processDefineCode, int processDefineVersion,
-                                           int processInstanceId, int taskInstanceId) {
-        String fileName = String.format("%s/exec/process/%d/%s/%d/%d", DATA_BASEDIR,
-                projectCode, processDefineCode + "_" + processDefineVersion, processInstanceId, taskInstanceId);
-        File file = new File(fileName);
-        if (!file.getParentFile().exists()) {
-            file.getParentFile().mkdirs();
-        }
-
-        return fileName;
+    public static String getProcessExecDir(String tenant,
+                                           long projectCode,
+                                           long processDefineCode,
+                                           int processDefineVersion,
+                                           int processInstanceId,
+                                           int taskInstanceId) {
+        return String.format(
+                "%s/exec/process/%s/%d/%d_%d/%d/%d",
+                DATA_BASEDIR,
+                tenant,
+                projectCode,
+                processDefineCode,
+                processDefineVersion,
+                processInstanceId,
+                taskInstanceId);
     }
 
     /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java
@@ -51,8 +51,8 @@ public class FileUtilsTest {
 
     @Test
     public void testGetProcessExecDir() {
-        String dir = FileUtils.getProcessExecDir(1L, 2L, 1, 3, 4);
-        Assertions.assertEquals("/tmp/dolphinscheduler/exec/process/1/2_1/3/4", dir);
+        String dir = FileUtils.getProcessExecDir("test", 1L, 2L, 1, 3, 4);
+        Assertions.assertEquals("/tmp/dolphinscheduler/exec/process/test/1/2_1/3/4", dir);
     }
 
     @Test

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ProcessUtils.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ProcessUtils.java
@@ -204,7 +204,9 @@ public class ProcessUtils {
             if (CollectionUtils.isNotEmpty(appIds)) {
                 if (StringUtils.isEmpty(taskExecutionContext.getExecutePath())) {
                     taskExecutionContext
-                            .setExecutePath(FileUtils.getProcessExecDir(taskExecutionContext.getProjectCode(),
+                            .setExecutePath(FileUtils.getProcessExecDir(
+                                    taskExecutionContext.getTenantCode(),
+                                    taskExecutionContext.getProjectCode(),
                                     taskExecutionContext.getProcessDefineCode(),
                                     taskExecutionContext.getProcessDefineVersion(),
                                     taskExecutionContext.getProcessInstanceId(),

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionCheckerUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionCheckerUtils.java
@@ -33,8 +33,13 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -45,23 +50,24 @@ public class TaskExecutionCheckerUtils {
 
     public static void checkTenantExist(WorkerConfig workerConfig, TaskExecutionContext taskExecutionContext) {
         try {
+            String tenantCode = taskExecutionContext.getTenantCode();
             boolean osUserExistFlag;
             // if Using distributed is true and Currently supported systems are linux,Should not let it
             // automatically
             // create tenants,so TenantAutoCreate has no effect
             if (workerConfig.isTenantDistributedUser() && SystemUtils.IS_OS_LINUX) {
                 // use the id command to judge in linux
-                osUserExistFlag = OSUtils.existTenantCodeInLinux(taskExecutionContext.getTenantCode());
+                osUserExistFlag = OSUtils.existTenantCodeInLinux(tenantCode);
             } else if (OSUtils.isSudoEnable() && workerConfig.isTenantAutoCreate()) {
                 // if not exists this user, then create
-                OSUtils.createUserIfAbsent(taskExecutionContext.getTenantCode());
-                osUserExistFlag = OSUtils.getUserList().contains(taskExecutionContext.getTenantCode());
+                OSUtils.createUserIfAbsent(tenantCode);
+                osUserExistFlag = OSUtils.getUserList().contains(tenantCode);
             } else {
-                osUserExistFlag = OSUtils.getUserList().contains(taskExecutionContext.getTenantCode());
+                osUserExistFlag = OSUtils.getUserList().contains(tenantCode);
             }
             if (!osUserExistFlag) {
                 throw new TaskException(
-                        String.format("TenantCode: %s doesn't exist", taskExecutionContext.getTenantCode()));
+                        String.format("TenantCode: %s doesn't exist", tenantCode));
             }
         } catch (TaskException ex) {
             throw ex;
@@ -75,13 +81,14 @@ public class TaskExecutionCheckerUtils {
         try {
             // local execute path
             String execLocalPath = FileUtils.getProcessExecDir(
+                    taskExecutionContext.getTenantCode(),
                     taskExecutionContext.getProjectCode(),
                     taskExecutionContext.getProcessDefineCode(),
                     taskExecutionContext.getProcessDefineVersion(),
                     taskExecutionContext.getProcessInstanceId(),
                     taskExecutionContext.getTaskInstanceId());
             taskExecutionContext.setExecutePath(execLocalPath);
-            FileUtils.createWorkDirIfAbsent(execLocalPath);
+            createDirectoryWithOwner(Paths.get(execLocalPath), taskExecutionContext.getTenantCode());
         } catch (Throwable ex) {
             throw new TaskException("Cannot create process execute dir", ex);
         }
@@ -129,6 +136,25 @@ public class TaskExecutionCheckerUtils {
                     throw new TaskException(String.format("Download resource file: %s error", fileDownload), e);
                 }
             }
+        }
+    }
+
+    private static void createDirectoryWithOwner(Path filePath, String tenant) {
+        if (Files.exists(filePath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(filePath);
+            if (!OSUtils.isSudoEnable()) {
+                // we need to open sudo, then we can change the owner.
+                return;
+            }
+            UserPrincipalLookupService userPrincipalLookupService =
+                    FileSystems.getDefault().getUserPrincipalLookupService();
+            UserPrincipal tenantPrincipal = userPrincipalLookupService.lookupPrincipalByName(tenant);
+            Files.setOwner(filePath, tenantPrincipal);
+        } catch (IOException e) {
+            throw new TaskException("Set tenant directory permission failed, tenant: " + tenant, e);
         }
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

Right now, we cannot touch file in our shell task, since the task directory's owner is created by deploy user not tenant.
And the directory permission is `755`, we need to change the task directory's owner to tenant.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
