### PR TITLE
[Improvement][BatchQuery]Change query one by one to batch.

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -55,10 +55,7 @@ import org.apache.dolphinscheduler.service.exceptions.CronParseException;
 import org.apache.dolphinscheduler.service.model.TaskNode;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +84,8 @@ public interface ProcessService {
     ProcessDefinition findProcessDefineById(int processDefinitionId);
 
     ProcessDefinition findProcessDefinition(Long processDefinitionCode, int processDefinitionVersion);
+
+    List<ProcessDefinition> findProcessDefinitions(Map<Long, Integer> codeVersionMap);
 
     ProcessDefinition findProcessDefinitionByCode(Long processDefinitionCode);
 


### PR DESCRIPTION
Change query processInstance one by one to batch during failover.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Change query processInstance one by one to batch during failover.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is already covered by existing tests, such as *(please describe tests)*.


<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->