### PR TITLE
[fix][sql] Add unique key to process_definition_log avoid TooManyResultExpection

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
@@ -460,7 +460,8 @@ CREATE TABLE t_ds_process_definition_log
     operate_time     datetime     DEFAULT NULL,
     create_time      datetime NOT NULL,
     update_time      datetime     DEFAULT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_idx_code_version (code, version) USING BTREE
 );
 
 -- ----------------------------

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
@@ -461,7 +461,8 @@ CREATE TABLE `t_ds_process_definition_log` (
   `operate_time` datetime DEFAULT NULL COMMENT 'operate time',
   `create_time` datetime NOT NULL COMMENT 'create time',
   `update_time` datetime NOT NULL COMMENT 'update time',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_idx_code_version` (`code`,`version`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- ----------------------------

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
@@ -379,7 +379,7 @@ CREATE TABLE t_ds_process_definition_log (
   PRIMARY KEY (id)
 ) ;
 
-create UNIQUE index idx_process_definition_log_code_version on t_ds_process_definition_log (code,version);
+create UNIQUE index uniq_idx_code_version on t_ds_process_definition_log (code,version);
 
 --
 -- Table structure for table t_ds_task_definition

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
@@ -379,6 +379,8 @@ CREATE TABLE t_ds_process_definition_log (
   PRIMARY KEY (id)
 ) ;
 
+create UNIQUE index idx_process_definition_log_code_version on t_ds_process_definition_log (code,version);
+
 --
 -- Table structure for table t_ds_task_definition
 --

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/mysql/dolphinscheduler_ddl.sql
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
+
+
+-- add unique key to t_ds_process_definition_log
+drop PROCEDURE if EXISTS add_t_ds_process_definition_log_uk_uniq_idx_code_version;
+delimiter d//
+CREATE PROCEDURE add_t_ds_process_definition_log_uk_uniq_idx_code_version()
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_NAME='t_ds_process_definition_log'
+        AND TABLE_SCHEMA=(SELECT DATABASE())
+        AND INDEX_NAME='uniq_idx_code_version')
+    THEN
+ALTER TABLE t_ds_process_definition_log ADD UNIQUE KEY uniq_idx_code_version(`code`,`version`);
+END IF;
+END;
+
+d//
+
+delimiter ;
+CALL add_t_ds_process_definition_log_uk_uniq_idx_code_version;
+DROP PROCEDURE add_t_ds_process_definition_log_uk_uniq_idx_code_version;

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/mysql/dolphinscheduler_dml.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/mysql/dolphinscheduler_dml.sql
@@ -1,0 +1,16 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/postgresql/dolphinscheduler_ddl.sql
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+-- add unique key to t_ds_process_definition_log
+create UNIQUE index IF NOT EXISTS uniq_idx_code_version on t_ds_process_definition_log (code,version);

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/postgresql/dolphinscheduler_dml.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.0.2_schema/postgresql/dolphinscheduler_dml.sql
@@ -1,0 +1,16 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -120,3 +120,23 @@ d//
 delimiter ;
 CALL uc_dolphin_T_t_ds_task_instance_R_test_flag;
 DROP PROCEDURE uc_dolphin_T_t_ds_task_instance_R_test_flag;
+
+-- add unique key to t_ds_process_definition_log
+drop PROCEDURE if EXISTS add_t_ds_process_definition_log_uk_uniq_idx_code_version;
+delimiter d//
+CREATE PROCEDURE add_t_ds_process_definition_log_uk_uniq_idx_code_version()
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_NAME='t_ds_process_definition_log'
+        AND TABLE_SCHEMA=(SELECT DATABASE())
+        AND INDEX_NAME='uniq_idx_code_version')
+    THEN
+ALTER TABLE t_ds_process_definition_log ADD UNIQUE KEY uniq_idx_code_version(`code`,`version`);
+END IF;
+END;
+
+d//
+
+delimiter ;
+CALL add_t_ds_process_definition_log_uk_uniq_idx_code_version;
+DROP PROCEDURE add_t_ds_process_definition_log_uk_uniq_idx_code_version;

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -120,23 +120,3 @@ d//
 delimiter ;
 CALL uc_dolphin_T_t_ds_task_instance_R_test_flag;
 DROP PROCEDURE uc_dolphin_T_t_ds_task_instance_R_test_flag;
-
--- add unique key to t_ds_process_definition_log
-drop PROCEDURE if EXISTS add_t_ds_process_definition_log_uk_uniq_idx_code_version;
-delimiter d//
-CREATE PROCEDURE add_t_ds_process_definition_log_uk_uniq_idx_code_version()
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE TABLE_NAME='t_ds_process_definition_log'
-        AND TABLE_SCHEMA=(SELECT DATABASE())
-        AND INDEX_NAME='uniq_idx_code_version')
-    THEN
-ALTER TABLE t_ds_process_definition_log ADD UNIQUE KEY uniq_idx_code_version(`code`,`version`);
-END IF;
-END;
-
-d//
-
-delimiter ;
-CALL add_t_ds_process_definition_log_uk_uniq_idx_code_version;
-DROP PROCEDURE add_t_ds_process_definition_log_uk_uniq_idx_code_version;

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -119,6 +119,3 @@ d//
 delimiter ;
 select uc_dolphin_T_t_ds_task_instance_R_test_flag();
 DROP FUNCTION uc_dolphin_T_t_ds_task_instance_R_test_flag();
-
-
-create UNIQUE index IF NOT EXISTS uniq_idx_code_version on t_ds_process_definition_log (code,version);

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -121,4 +121,4 @@ select uc_dolphin_T_t_ds_task_instance_R_test_flag();
 DROP FUNCTION uc_dolphin_T_t_ds_task_instance_R_test_flag();
 
 
-create UNIQUE index IF NOT EXISTS idx_process_definition_log_code_version on t_ds_process_definition_log (code,version);
+create UNIQUE index IF NOT EXISTS uniq_idx_code_version on t_ds_process_definition_log (code,version);

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.2.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -119,3 +119,6 @@ d//
 delimiter ;
 select uc_dolphin_T_t_ds_task_instance_R_test_flag();
 DROP FUNCTION uc_dolphin_T_t_ds_task_instance_R_test_flag();
+
+
+create UNIQUE index IF NOT EXISTS idx_process_definition_log_code_version on t_ds_process_definition_log (code,version);


### PR DESCRIPTION
After I edit the workflow, I save it.
The interface response speed is too slow.
Let me think I didn't save it，So I saved it again.
The result saved successfully both times.
But in the t_ds_process_definition_log table, the version values are the same.
Causes the list interface to report an error.
![image](https://user-images.githubusercontent.com/24449799/197372734-2eab45e0-46ad-4308-abe0-77949b8de390.png)
This should be addressed first at the table structure level.
fix: #12504 