### PR TITLE
[doc][ci] Add http header to avoid github 403 in dlc

### DIFF
--- a/.dlc.json
+++ b/.dlc.json
@@ -20,7 +20,14 @@
       "replacement": "https://dolphinscheduler.apache.org/zh-cn/download/download.html"
     }
   ],
-
+  "httpHeaders": [
+    {
+      "urls": ["https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ],
   "timeout": "10s",
   "retryOn429": true,
   "retryCount": 10,

--- a/.dlc.json
+++ b/.dlc.json
@@ -20,6 +20,7 @@
       "replacement": "https://dolphinscheduler.apache.org/zh-cn/download/download.html"
     }
   ],
+
   "timeout": "10s",
   "retryOn429": true,
   "retryCount": 10,


### PR DESCRIPTION
see more detail in
https://github.com/tcort/markdown-link-check/issues/201 and we find can solve this by adding `httpHeaders` to fix it
