### PR TITLE
check for duplicate msg about rob taskGroup

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
@@ -49,6 +49,14 @@ public interface TaskGroupQueueMapper extends BaseMapper<TaskGroupQueue> {
     TaskGroupQueue queryByTaskId(@Param("taskId") int taskId);
 
     /**
+     * select task count by status
+     * @param queueId task queue id
+     * @param queueStatus queue status
+     * @return count(1) for the result
+     */
+    int selectCountByTaskIdAndStatus(@Param("queueId") int queueId,@Param("queueStatus") int queueStatus);
+
+    /**
      * query by status
      *
      * @param status status

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
@@ -54,7 +54,7 @@ public interface TaskGroupQueueMapper extends BaseMapper<TaskGroupQueue> {
      * @param queueStatus queue status
      * @return count(1) for the result
      */
-    int selectCountByTaskIdAndStatus(@Param("queueId") int queueId,@Param("queueStatus") int queueStatus);
+    int selectCountByIdAndStatus(@Param("queueId") int queueId, @Param("queueStatus") int... queueStatus);
 
     /**
      * query by status

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
@@ -124,11 +124,14 @@
         where task_id = #{taskId}
     </select>
 
-    <select id="selectCountByTaskIdAndStatus" resultType="java.lang.Integer">
+    <select id="selectCountByIdAndStatus" resultType="java.lang.Integer">
         select
         count(1)
         FROM t_ds_task_group_queue
-        where id = #{queueId} and status = #{queueStatus}
+        where id = #{queueId}
+        <foreach collection="queueStatus" open=" and status in(" close=")" item="queueStatus" separator=",">
+            #{queueStatus}
+        </foreach>
     </select>
 
     <select id="queryTaskGroupQueueByTaskGroupIdPaging" resultType="org.apache.dolphinscheduler.dao.entity.TaskGroupQueue">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
@@ -124,6 +124,13 @@
         where task_id = #{taskId}
     </select>
 
+    <select id="selectCountByTaskIdAndStatus" resultType="java.lang.Integer">
+        select
+        count(1)
+        FROM t_ds_task_group_queue
+        where id = #{queueId} and status = #{queueStatus}
+    </select>
+
     <select id="queryTaskGroupQueueByTaskGroupIdPaging" resultType="org.apache.dolphinscheduler.dao.entity.TaskGroupQueue">
         select
         queue.id, queue.task_name, queue.group_id, queue.process_id, queue.priority, queue.status

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapperTest.java
@@ -108,20 +108,20 @@ public class TaskGroupQueueMapperTest extends BaseDaoTest {
                         taskGroupQueue.getId(),
                         TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode(),
                         TaskGroupQueueStatus.WAIT_QUEUE.getCode());
-        Assertions.assertEquals(i, 1);
+        Assertions.assertEquals(1, i);
         int j =
                 taskGroupQueueMapper.selectCountByIdAndStatus(
                         taskGroupQueue.getId(), TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode());
-        Assertions.assertEquals(j, 1);
+        Assertions.assertEquals(1,j);
         int k =
                 taskGroupQueueMapper.selectCountByIdAndStatus(
                         taskGroupQueue.getId(),
                         TaskGroupQueueStatus.WAIT_QUEUE.getCode());
-        Assertions.assertEquals(k, 0);
+        Assertions.assertEquals(0, k);
         // no status means "select count by id "
         int l =
                 taskGroupQueueMapper.selectCountByIdAndStatus(
                         taskGroupQueue.getId());
-        Assertions.assertEquals(l, 1);
+        Assertions.assertEquals(1, l);
     }
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapperTest.java
@@ -99,4 +99,29 @@ public class TaskGroupQueueMapperTest extends BaseDaoTest {
         int i = taskGroupQueueMapper.deleteByTaskId(taskGroupQueue.getTaskId());
         Assertions.assertEquals(i, 1);
     }
+
+    @Test
+    public void selectCountByTaskIdAndStatus() {
+        TaskGroupQueue taskGroupQueue = insertOne();
+        int i =
+                taskGroupQueueMapper.selectCountByIdAndStatus(
+                        taskGroupQueue.getId(),
+                        TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode(),
+                        TaskGroupQueueStatus.WAIT_QUEUE.getCode());
+        Assertions.assertEquals(i, 1);
+        int j =
+                taskGroupQueueMapper.selectCountByIdAndStatus(
+                        taskGroupQueue.getId(), TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode());
+        Assertions.assertEquals(j, 1);
+        int k =
+                taskGroupQueueMapper.selectCountByIdAndStatus(
+                        taskGroupQueue.getId(),
+                        TaskGroupQueueStatus.WAIT_QUEUE.getCode());
+        Assertions.assertEquals(k, 0);
+        // no status means "select count by id "
+        int l =
+                taskGroupQueueMapper.selectCountByIdAndStatus(
+                        taskGroupQueue.getId());
+        Assertions.assertEquals(l, 1);
+    }
 }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -2488,6 +2488,11 @@ public class ProcessServiceImpl implements ProcessService {
             this.taskGroupQueueMapper.updateById(taskGroupQueue);
             this.taskGroupQueueMapper.updateInQueue(Flag.NO.getCode(), taskGroupQueue.getId());
             return true;
+        }else if (taskGroupQueueMapper.selectCountByTaskIdAndStatus(taskGroupQueue.getId(),
+                TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode()) == 1) {
+            logger.info("This is a duplicate message,will not rob taskGroup, taskInstanceId: {}, taskGroupId: {}",
+                    taskGroupQueue.getTaskId(), taskGroupQueue.getId());
+            return true;
         }
         logger.info("Failed to rob taskGroup, taskInstanceId: {}, taskGroupId: {}", taskGroupQueue.getTaskId(),
                 taskGroupQueue.getId());

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -2488,8 +2488,8 @@ public class ProcessServiceImpl implements ProcessService {
             this.taskGroupQueueMapper.updateById(taskGroupQueue);
             this.taskGroupQueueMapper.updateInQueue(Flag.NO.getCode(), taskGroupQueue.getId());
             return true;
-        }else if (taskGroupQueueMapper.selectCountByTaskIdAndStatus(taskGroupQueue.getId(),
-                TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode()) == 1) {
+        } else if (taskGroupQueueMapper.selectCountByIdAndStatus(taskGroupQueue.getId(),
+                TaskGroupQueueStatus.WAIT_QUEUE.getCode(), TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode()) == 1) {
             logger.info("This is a duplicate message,will not rob taskGroup, taskInstanceId: {}, taskGroupId: {}",
                     taskGroupQueue.getTaskId(), taskGroupQueue.getId());
             return true;


### PR DESCRIPTION

## Purpose of the pull request
when using task group for jobs,we get a bug. here is the log:
```
[INFO] 2022-10-25 09:00:00.140 +0800 org.apache.dolphinscheduler.service.process.ProcessServiceImpl:[2929] - [WorkflowInstance-798][TaskInstance-28719] - Failed to rob taskGroup, taskInstanceId: 28719, t
askGroupId: 26497
[INFO] 2022-10-25 09:00:00.140 +0800 org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteRunnable:[269] - [WorkflowInstance-798][TaskInstance-28719] - Begin to handle state event, StateEvent(
key=798-28719, type=WAIT_TASK_GROUP, executionStatus=null, taskInstanceId=28719, taskCode=0, processInstanceId=798, context=null, channel=null)
[INFO] 2022-10-25 09:00:00.159 +0800 org.apache.dolphinscheduler.service.process.ProcessServiceImpl:[2929] - [WorkflowInstance-798][TaskInstance-28719] - Failed to rob taskGroup, taskInstanceId: 28719, t
askGroupId: 26497
[INFO] 2022-10-25 09:00:00.159 +0800 org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteRunnable:[269] - [WorkflowInstance-798][TaskInstance-28719] - Begin to handle state event, StateEvent(
key=798-28719, type=WAIT_TASK_GROUP, executionStatus=null, taskInstanceId=28719, taskCode=0, processInstanceId=798, context=null, channel=null)
[INFO] 2022-10-25 09:00:00.178 +0800 org.apache.dolphinscheduler.service.process.ProcessServiceImpl:[2929] - [WorkflowInstance-798][TaskInstance-28719] - Failed to rob taskGroup, taskInstanceId: 28719, t
askGroupId: 26497
[INFO] 2022-10-25 09:00:00.179 +0800 org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteRunnable:[269] - [WorkflowInstance-798][TaskInstance-28719] - Begin to handle state event, StateEvent(
key=798-28719, type=WAIT_TASK_GROUP, executionStatus=null, taskInstanceId=28719, taskCode=0, processInstanceId=798, context=null, channel=null)
```
the log keeps recurring.
this makes the task group get the task instance status error.
I found out that it was caused by duplicate messages,so add code to check for duplicates

## Verify this pull request
This bug is hard to reproduce:  it only happens when we repeatedly receive the message about "rob taskGroup". (maybe the 
duplicate msg is a bug?)
and after few days,I got the logs in the actual run :
```
[INFO] 2022-10-28 04:02:51.179 +0800 org.apache.dolphinscheduler.server.master.processor.TaskEventProcessor:[64] - [WorkflowInstance-852][TaskInstance-32214] - Received task event change command, event: StateEvent(key=852-32214, type=WAIT_TASK_GROUP, executionStatus=null, taskInstanceId=32214, taskCode=0, processInstanceId=852, context=null, channel=null)
[INFO] 2022-10-28 04:02:51.179 +0800 org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteThreadPool:[98] - [WorkflowInstance-852][TaskInstance-32214] - Submit state event success, stateEvent: StateEvent(key=852-32214, type=WAIT_TASK_GROUP, executionStatus=null, taskInstanceId=32214, taskCode=0, processInstanceId=852, context=null, channel=null)
[INFO] 2022-10-28 04:02:51.197 +0800 org.apache.dolphinscheduler.service.process.ProcessServiceImpl:[2942] - [WorkflowInstance-854][TaskInstance-32211] - This is a duplicate message,will not rob taskGroup, taskInstanceId: 32211, taskGroupId: 29988
[INFO] 2022-10-28 04:02:51.198 +0800 TaskLogLogger-class org.apache.dolphinscheduler.server.master.runner.task.CommonTaskProcessor:[94] - [WorkflowInstance-854][TaskInstance-32211] - task ready to dispatch to worker: taskInstanceId: 32211
```

