### PR TITLE
[Bug] [Data Quality] Oracle Can't Connect Database Different With Username #12214

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -665,7 +665,9 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
                 schemaPattern = connectionParam.getDatabase();
                 break;
             case ORACLE:
-                schemaPattern = connectionParam.getUser();
+                Map<String, String> props = connectionParam.getProps();
+                String specifiedSchema = props.get(Constants.SCHEMA);
+                schemaPattern = StringUtils.isEmpty(specifiedSchema) ? connectionParam.getUser() : specifiedSchema;
                 if (null != schemaPattern) {
                     schemaPattern = schemaPattern.toUpperCase();
                 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
@@ -204,6 +204,7 @@ public final class Constants {
 
     public static final String ADDRESS = "address";
     public static final String DATABASE = "database";
+    public static final String SCHEMA = "schema";
     public static final String OTHER = "other";
     public static final String USER = "user";
     public static final String JDBC_URL = "jdbcUrl";

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/main/java/org/apache/dolphinscheduler/plugin/datasource/oracle/param/OracleDataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-oracle/src/main/java/org/apache/dolphinscheduler/plugin/datasource/oracle/param/OracleDataSourceProcessor.java
@@ -103,7 +103,13 @@ public class OracleDataSourceProcessor extends AbstractDataSourceProcessor {
 
     @Override
     public ConnectionParam createConnectionParams(String connectionJson) {
-        return JSONUtils.parseObject(connectionJson, OracleConnectionParam.class);
+        OracleConnectionParam oracleConnectionParam = JSONUtils.parseObject(connectionJson, OracleConnectionParam.class);
+        Map<String, String> props = oracleConnectionParam.getProps();
+        String specifiedSchema = props.get(Constants.SCHEMA);
+        if (StringUtils.isNotEmpty(specifiedSchema)) {
+            oracleConnectionParam.setDatabase(specifiedSchema);
+        }
+        return oracleConnectionParam;
     }
 
     @Override

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-dataquality/src/main/java/org/apache/dolphinscheduler/plugin/task/dq/utils/RuleParserUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-dataquality/src/main/java/org/apache/dolphinscheduler/plugin/task/dq/utils/RuleParserUtils.java
@@ -60,6 +60,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.utils.DataQualityConst
 import static org.apache.dolphinscheduler.plugin.task.api.utils.DataQualityConstants.USER;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.data.quality.Constants;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.task.api.DataQualityTaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.dp.ExecuteSqlType;
@@ -115,15 +116,17 @@ public class RuleParserUtils {
             sourceBaseConfig.setType(dataQualityTaskExecutionContext.getSourceConnectorType());
             Map<String, Object> config = new HashMap<>();
             if (sourceDataSource != null) {
-                config.put(DATABASE, sourceDataSource.getDatabase());
-                config.put(TABLE, inputParameterValue.get(SRC_TABLE));
+                String tableName = inputParameterValue.get(SRC_TABLE);
+                String database = sourceDataSource.getDatabase();
+                config.put(DATABASE, database);
+                config.put(TABLE, database.concat(Constants.DOTS).concat(tableName));
                 config.put(URL, DataSourceUtils.getJdbcUrl(DbType.of(dataQualityTaskExecutionContext.getSourceType()),
                         sourceDataSource));
                 config.put(USER, sourceDataSource.getUser());
                 config.put(PASSWORD, sourceDataSource.getPassword());
                 config.put(DRIVER, DataSourceUtils
                         .getDatasourceDriver(DbType.of(dataQualityTaskExecutionContext.getSourceType())));
-                String outputTable = sourceDataSource.getDatabase() + "_" + inputParameterValue.get(SRC_TABLE);
+                String outputTable = database + "_" + tableName;
                 config.put(OUTPUT_TABLE, outputTable);
                 inputParameterValue.put(SRC_TABLE, outputTable);
             }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
fix #12214 that oracle can't connect to database which name is different with username.

## Description
Different with MySQL, Oracle can't specify a database by jdbc  url.
So, it will connect to the database equals to username, but one user may have serval database to access.
We found this problem in `dataquality` module, for example, we have an user named `bddb` and we want to use database `product`, it currently not available.
![image](https://user-images.githubusercontent.com/48941586/198553763-b48e74b3-4689-46ba-b0a6-e4f91edbf740.png)
So I made a little change that I can specify a schema in jdbc params.
Another way is to add an select option and let us choose from the frontend, this would be the best way.

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
