### PR TITLE
[Improvement][Install] Add ${zkRoot} description.

### DIFF
--- a/script/env/install_env.sh
+++ b/script/env/install_env.sh
@@ -58,4 +58,6 @@ installPath=${installPath:-"/tmp/dolphinscheduler"}
 deployUser=${deployUser:-"dolphinscheduler"}
 
 # The root of zookeeper, for now DolphinScheduler default registry server is zookeeper.
+# It will delete ${zkRoot} in the zookeeper, so please keep it same as registry.zookeeper.namespace in yml files.
+# Similarly, if you want to modify the value, please modify registry.zookeeper.namespace in yml files as well.
 zkRoot=${zkRoot:-"/dolphinscheduler"}

--- a/script/env/install_env.sh
+++ b/script/env/install_env.sh
@@ -58,6 +58,6 @@ installPath=${installPath:-"/tmp/dolphinscheduler"}
 deployUser=${deployUser:-"dolphinscheduler"}
 
 # The root of zookeeper, for now DolphinScheduler default registry server is zookeeper.
-# It will delete ${zkRoot} in the zookeeper, so please keep it same as registry.zookeeper.namespace in yml files.
+# It will delete ${zkRoot} in the zookeeper when you run install.sh, so please keep it same as registry.zookeeper.namespace in yml files.
 # Similarly, if you want to modify the value, please modify registry.zookeeper.namespace in yml files as well.
 zkRoot=${zkRoot:-"/dolphinscheduler"}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

The annotation of the configuration item `${zkRoot}` is not clear enough, and it is easy for users to misunderstand and modify the value to modify zk root path.
For example: https://github.com/apache/dolphinscheduler/issues/12516

1. Why not delete one of `${zkRoot}` in `install_env.sh` and `registry.zookeeper.namespace` in yml files?
Becuase the run configuration is  more clearer in yml files, and `install.sh` read yml file is diffcult and not recommended.
2. Why not change `${zkRoot}` to  `registry_zookeeper_namespace`?
It is not a good idea for the value of an environment variable to override the value in the YML file. So i think that just add some comments should be better.

## Brief change log

Just add some comments.



