### PR TITLE
Upgrade clickhouse jdbc driver

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -70,7 +70,7 @@
         <hive-jdbc.version>2.3.9</hive-jdbc.version>
         <commons-io.version>2.11.0</commons-io.version>
         <oshi-core.version>6.1.1</oshi-core.version>
-        <clickhouse-jdbc.version>0.1.52</clickhouse-jdbc.version>
+        <clickhouse-jdbc.version>0.3.2-patch11</clickhouse-jdbc.version>
         <lz4-java.version>1.4.0</lz4-java.version>
         <mssql-jdbc.version>6.1.0.jre8</mssql-jdbc.version>
         <presto-jdbc.version>0.238.1</presto-jdbc.version>
@@ -550,7 +550,7 @@
             </dependency>
 
             <dependency>
-                <groupId>ru.yandex.clickhouse</groupId>
+                <groupId>com.clickhouse</groupId>
                 <artifactId>clickhouse-jdbc</artifactId>
                 <version>${clickhouse-jdbc.version}</version>
             </dependency>

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/DataSourceConstants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/DataSourceConstants.java
@@ -28,7 +28,7 @@ public class DataSourceConstants {
     public static final String COM_MYSQL_CJ_JDBC_DRIVER = "com.mysql.cj.jdbc.Driver";
     public static final String COM_MYSQL_JDBC_DRIVER = "com.mysql.jdbc.Driver";
     public static final String ORG_APACHE_HIVE_JDBC_HIVE_DRIVER = "org.apache.hive.jdbc.HiveDriver";
-    public static final String COM_CLICKHOUSE_JDBC_DRIVER = "ru.yandex.clickhouse.ClickHouseDriver";
+    public static final String COM_CLICKHOUSE_JDBC_DRIVER = "com.clickhouse.jdbc.ClickHouseDriver";
     public static final String COM_ORACLE_JDBC_DRIVER = "oracle.jdbc.OracleDriver";
     public static final String COM_SQLSERVER_JDBC_DRIVER = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     public static final String COM_DB2_JDBC_DRIVER = "com.ibm.db2.jcc.DB2Driver";

--- a/dolphinscheduler-data-quality/pom.xml
+++ b/dolphinscheduler-data-quality/pom.xml
@@ -106,7 +106,7 @@
         </dependency>
 
         <dependency>
-            <groupId>ru.yandex.clickhouse</groupId>
+            <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
             <exclusions>
                 <exclusion>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-clickhouse/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-clickhouse/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
 
         <dependency>
-            <groupId>ru.yandex.clickhouse</groupId>
+            <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
             <exclusions>
                 <exclusion>

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -224,7 +224,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     byte-buddy 1.9.16: https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy/1.9.16, Apache 2.0
     caffeine 2.9.3: https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine/2.9.3, Apache 2.0
     classmate 1.5.1: https://mvnrepository.com/artifact/com.fasterxml/classmate/1.5.1, Apache 2.0
-    clickhouse-jdbc 0.1.52: https://mvnrepository.com/artifact/ru.yandex.clickhouse/clickhouse-jdbc/0.1.52, Apache 2.0
+    clickhouse-jdbc 0.3.2-patch11: https://mvnrepository.com/artifact/com.clickhouse/clickhouse-jdbc/0.3.2-patch11, Apache 2.0
     lz4-java 1.4.0: https://mvnrepository.com/artifact/org.lz4/lz4-java/1.4.0, Apache 2.0
     commons-beanutils 1.9.4 https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils/1.9.4, Apache 2.0
     commons-cli 1.2: https://mvnrepository.com/artifact/commons-cli/commons-cli/1.2, Apache 2.0

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskConstants.java
@@ -339,7 +339,7 @@ public class TaskConstants {
     public static final String ORG_POSTGRESQL_DRIVER = "org.postgresql.Driver";
     public static final String COM_MYSQL_CJ_JDBC_DRIVER = "com.mysql.cj.jdbc.Driver";
     public static final String ORG_APACHE_HIVE_JDBC_HIVE_DRIVER = "org.apache.hive.jdbc.HiveDriver";
-    public static final String COM_CLICKHOUSE_JDBC_DRIVER = "ru.yandex.clickhouse.ClickHouseDriver";
+    public static final String COM_CLICKHOUSE_JDBC_DRIVER = "com.clickhouse.jdbc.ClickHouseDriver";
     public static final String COM_ORACLE_JDBC_DRIVER = "oracle.jdbc.driver.OracleDriver";
     public static final String COM_SQLSERVER_JDBC_DRIVER = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     public static final String COM_DB2_JDBC_DRIVER = "com.ibm.db2.jcc.DB2Driver";

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -35,6 +35,9 @@ checker-qual-3.5.0.jar
 classgraph-4.8.147.jar
 classmate-1.5.1.jar
 clickhouse-jdbc-0.3.2-patch11.jar
+clickhouse-cli-client-0.3.2-patch11-shaded.jar
+clickhouse-grpc-client-0.3.2-patch11-shaded.jar
+clickhouse-http-client-0.3.2-patch11-shaded.jar
 lz4-java-1.4.0.jar
 commons-beanutils-1.9.4.jar
 commons-cli-1.2.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -34,7 +34,7 @@ checker-qual-3.19.0.jar
 checker-qual-3.5.0.jar
 classgraph-4.8.147.jar
 classmate-1.5.1.jar
-clickhouse-jdbc-0.1.52.jar
+clickhouse-jdbc-0.3.2-patch11.jar
 lz4-java-1.4.0.jar
 commons-beanutils-1.9.4.jar
 commons-cli-1.2.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -217,7 +217,6 @@ log4j-1.2-api-2.17.2.jar
 logback-classic-1.2.11.jar
 logback-core-1.2.11.jar
 logging-interceptor-4.9.3.jar
-lz4-1.3.0.jar
 metrics-core-4.2.11.jar
 metrics-spi-2.17.282.jar
 micrometer-core-1.9.3.jar


### PR DESCRIPTION
## Purpose of the pull request

Upgrade clickhouse jdbc driver from the deprecated version 0.1.52 to the recommended latest 0.3.2-patch11

According to [the official announcement ](https://github.com/ClickHouse/clickhouse-jdbc)of clickhouse jdbc driver, `ru.yandex.clickhouse.ClickHouseDriver` is now considered deprecated, It's highly recommended to upgrade to 0.3.2+ now for improved performance and stability.

I am also experiencing problems (params not working, socket timeout etc...) with the legacy driver, really hope it could be get upgraded.

## Brief change log

- Change `ru.yandex.clickhouse.ClickHouseDriver 0.1.52` to `com.clickhouse.jdbc.ClickHouseDriver 0.3.2-patch11`

## Verify this pull request

Not sure how to test it, but I have run the build, it looks good to me.
