### PR TITLE
Fix the waiting strategy cannot recovery if the serverstate is already in running

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/lifecycle/ServerLifeCycleManager.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/lifecycle/ServerLifeCycleManager.java
@@ -18,7 +18,9 @@
 package org.apache.dolphinscheduler.common.lifecycle;
 
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @UtilityClass
 public class ServerLifeCycleManager {
 
@@ -52,20 +54,24 @@ public class ServerLifeCycleManager {
             throw new ServerLifeCycleException("The current server is already stopped, cannot change to waiting");
         }
 
-        if (serverStatus != ServerStatus.RUNNING) {
-            throw new ServerLifeCycleException("The current server is not at running status, cannot change to waiting");
+        if (serverStatus == ServerStatus.WAITING) {
+            log.warn("The current server is already at waiting status, cannot change to waiting");
+            return;
         }
         serverStatus = ServerStatus.WAITING;
     }
 
     /**
      * Recover from {@link ServerStatus#WAITING} to {@link ServerStatus#RUNNING}.
-     *
-     * @throws ServerLifeCycleException if change failed
      */
     public static synchronized void recoverFromWaiting() throws ServerLifeCycleException {
-        if (serverStatus != ServerStatus.WAITING) {
-            throw new ServerLifeCycleException("The current server status is not waiting, cannot recover form waiting");
+        if (isStopped()) {
+            throw new ServerLifeCycleException("The current server is already stopped, cannot recovery");
+        }
+
+        if (serverStatus == ServerStatus.RUNNING) {
+            log.warn("The current server status is already running, cannot recover form waiting");
+            return;
         }
         serverStartupTime = System.currentTimeMillis();
         serverStatus = ServerStatus.RUNNING;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterWaitingStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterWaitingStrategy.java
@@ -64,7 +64,6 @@ public class MasterWaitingStrategy implements MasterConnectStrategy {
     public void disconnect() {
         try {
             ServerLifeCycleManager.toWaiting();
-            // todo: clear the current resource
             clearMasterResource();
             Duration maxWaitingTime = masterConfig.getRegistryDisconnectStrategy().getMaxWaitingTime();
             try {


### PR DESCRIPTION
## Purpose of the pull request

close #12414

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
