### PR TITLE
[Improvement-12650][Permission] Improve the check of resourcePermissionCheck()

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -113,10 +113,11 @@ public class ResourcePermissionCheckServiceImpl
         if (Objects.nonNull(needChecks) && needChecks.length > 0) {
             Set<?> originResSet = new HashSet<>(Arrays.asList(needChecks));
             Set<?> ownResSets = RESOURCE_LIST_MAP.get(authorizationType).listAuthorizedResource(userId, logger);
-            originResSet.removeAll(ownResSets);
-            if (CollectionUtils.isNotEmpty(originResSet))
+            boolean checkResult = ownResSets != null && ownResSets.containsAll(originResSet);
+            if (!checkResult) {
                 logger.warn("User does not have resource permission on associated resources, userId:{}", userId);
-            return CollectionUtils.isEmpty(originResSet);
+            }
+            return checkResult;
         }
         return true;
     }


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12650 

## Brief change log

Use `containsAll()` rather than `removeAll()` and `Collections.isNotEmpty()` to check the resource Permission.

## Verify this pull request

