### PR TITLE
Change command file permission to 755

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -17,20 +17,20 @@
 
 package org.apache.dolphinscheduler.plugin.task.api;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.dolphinscheduler.plugin.task.api.utils.FileUtils;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
 import org.slf4j.Logger;
-
-import com.google.common.base.Strings;
 
 /**
  * shell command executor
@@ -80,42 +80,45 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
      */
     @Override
     protected void createCommandFileIfNotExists(String execCommand, String commandFile) throws IOException {
-        logger.info("tenantCode user:{}, task dir:{}", taskRequest.getTenantCode(),
-                taskRequest.getTaskAppId());
-
         // create if non existence
-        if (!Files.exists(Paths.get(commandFile))) {
-            logger.info("create command file:{}", commandFile);
+        logger.info("Begin to create command file:{}", commandFile);
 
-            StringBuilder sb = new StringBuilder();
-            if (SystemUtils.IS_OS_WINDOWS) {
-                sb.append("@echo off\n");
-                sb.append("cd /d %~dp0\n");
-                if (!Strings.isNullOrEmpty(taskRequest.getEnvironmentConfig())) {
-                    sb.append(taskRequest.getEnvironmentConfig()).append("\n");
-                } else {
-                    if (taskRequest.getEnvFile() != null) {
-                        sb.append("call ").append(taskRequest.getEnvFile()).append("\n");
-                    }
-                }
+        Path commandFilePath = Paths.get(commandFile);
+        if (Files.exists(commandFilePath)) {
+            logger.warn("The command file: {} is already exist, will not create a again", commandFile);
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (SystemUtils.IS_OS_WINDOWS) {
+            sb.append("@echo off\n");
+            sb.append("cd /d %~dp0\n");
+            if (StringUtils.isNotBlank(taskRequest.getEnvironmentConfig())) {
+                sb.append(taskRequest.getEnvironmentConfig()).append("\n");
             } else {
-                sb.append("#!/bin/bash\n");
-                sb.append("BASEDIR=$(cd `dirname $0`; pwd)\n");
-                sb.append("cd $BASEDIR\n");
-                if (!Strings.isNullOrEmpty(taskRequest.getEnvironmentConfig())) {
-                    sb.append(taskRequest.getEnvironmentConfig()).append("\n");
-                } else {
-                    if (taskRequest.getEnvFile() != null) {
-                        sb.append("source ").append(taskRequest.getEnvFile()).append("\n");
-                    }
+                if (taskRequest.getEnvFile() != null) {
+                    sb.append("call ").append(taskRequest.getEnvFile()).append("\n");
                 }
             }
-            sb.append(execCommand);
-            logger.info("command : {}", sb);
-
-            // write data to file
-            FileUtils.writeStringToFile(new File(commandFile), sb.toString(), StandardCharsets.UTF_8);
+        } else {
+            sb.append("#!/bin/sh\n");
+            sb.append("BASEDIR=$(cd `dirname $0`; pwd)\n");
+            sb.append("cd $BASEDIR\n");
+            if (StringUtils.isNotBlank(taskRequest.getEnvironmentConfig())) {
+                sb.append(taskRequest.getEnvironmentConfig()).append("\n");
+            } else {
+                if (taskRequest.getEnvFile() != null) {
+                    sb.append("source ").append(taskRequest.getEnvFile()).append("\n");
+                }
+            }
         }
+        sb.append(execCommand);
+        String commandContent = sb.toString();
+
+        FileUtils.createFileWith755(commandFilePath);
+        Files.write(commandFilePath, commandContent.getBytes(), StandardOpenOption.APPEND);
+
+        logger.info("Success create command file, command: {}", commandContent);
     }
 
     @Override

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/FileUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/FileUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.utils;
+
+import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.RWXR_XR_X;
+
+import org.apache.commons.lang3.SystemUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FileUtils {
+
+    private static final FileAttribute<Set<PosixFilePermission>> PERMISSION_755 =
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(RWXR_XR_X));
+
+    /**
+     * Create a file with '755'.
+     */
+    public static void createFileWith755(@NonNull Path path) throws IOException {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            Files.createFile(path);
+        } else {
+            Files.createFile(path, PERMISSION_755);
+        }
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-shell/src/main/java/org/apache/dolphinscheduler/plugin/task/shell/ShellTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-shell/src/main/java/org/apache/dolphinscheduler/plugin/task/shell/ShellTask.java
@@ -18,7 +18,6 @@
 package org.apache.dolphinscheduler.plugin.task.shell;
 
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EXIT_CODE_FAILURE;
-import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.RWXR_XR_X;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTask;
@@ -31,19 +30,15 @@ import org.apache.dolphinscheduler.plugin.task.api.model.TaskResponse;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parser.ParamUtils;
 import org.apache.dolphinscheduler.plugin.task.api.parser.ParameterUtils;
+import org.apache.dolphinscheduler.plugin.task.api.utils.FileUtils;
 
 import org.apache.commons.lang3.SystemUtils;
 
 import java.io.File;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * shell task
@@ -137,6 +132,8 @@ public class ShellTask extends AbstractTask {
         Path path = file.toPath();
 
         if (Files.exists(path)) {
+            // this shouldn't happen
+            logger.warn("The command file: {} is already exist", path);
             return fileName;
         }
 
@@ -147,22 +144,7 @@ public class ShellTask extends AbstractTask {
         logger.info("raw script : {}", shellParameters.getRawScript());
         logger.info("task execute path : {}", taskExecutionContext.getExecutePath());
 
-        Set<PosixFilePermission> perms = PosixFilePermissions.fromString(RWXR_XR_X);
-        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
-
-        if (SystemUtils.IS_OS_WINDOWS) {
-            Files.createFile(path);
-        } else {
-            if (!file.getParentFile().exists()) {
-                file.getParentFile().mkdirs();
-            }
-            try {
-                Files.createFile(path, attr);
-            } catch (FileAlreadyExistsException ex) {
-                // this is expected
-            }
-        }
-
+        FileUtils.createFileWith755(path);
         Files.write(path, shellParameters.getRawScript().getBytes(), StandardOpenOption.APPEND);
 
         return fileName;


### PR DESCRIPTION
(cherry picked from commit 95484d930762712f4ab68ece27ca3b65a2073ab2)

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

When create command file, set the permission to 755, the permission is the same with sh file, this will avoid tenant user doesn't have permission to execute the command file.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
