### PR TITLE
[Document][Improvement] Add instructions on how to configure logging level for debugging purpose

### DIFF
--- a/docs/docs/en/contribute/log-specification.md
+++ b/docs/docs/en/contribute/log-specification.md
@@ -1,4 +1,4 @@
-# Log specification
+# Logging specification
 
 ## Preface
 
@@ -8,7 +8,7 @@ Apache DolphinScheduler uses the Logback logging framework to print logs accordi
 
 ## Specifications
 
-### Log level specification
+### Logging level specification
 
 Different levels of logs play different roles in the business process, and failure to use reasonable log levels for printing can cause great difficulties for system operations and maintenance.
 
@@ -17,7 +17,7 @@ Different levels of logs play different roles in the business process, and failu
 - WARN level is used to warn of problems that will occur during operation. For example, the checksum of API module parameters, etc.
 - ERROR level is used to record some unpredictable errors and exceptions that will affect the system process. For example, errors and exceptions that cause workflows and tasks to fail to complete properly.
 
-### Log content specification
+### Logging content specification
 
 The content of the logs determines whether the logs can completely restore the system behavior or state.
 
@@ -33,7 +33,7 @@ The content of the logs determines whether the logs can completely restore the s
   logger.error("description of current error, parameter is {}", parameter, e);
   ```
 
-### Log format specification
+### Logging format specification
 
 The logs of Master module and Worker module are printed using the following format.
 
@@ -42,6 +42,26 @@ The logs of Master module and Worker module are printed using the following form
 ```
 
 That is, the workflow instance ID and task instance ID are injected in the printed logs using MDC, so the developer needs to get the IDs and inject them before printing the logs related to the workflow instance and task instance in these two modules; after the printing is finished, the related IDs need to be removed.
+
+## Logging Configuration
+
+DolphinScheduler uses [LogBack](https://docs.spring.io/spring-boot/docs/2.1.8.RELEASE/reference/html/howto-logging.html) for logging. To change the logging level of a specific package, you need to modify the `logback-spring.xml` file for the corresponding module.
+For example, if you want to enable `DEBUG` logging for `org.springframework.web` package in `standalone` module, you need to add the following configurations in `apache-dolphinscheduler-dev-SNAPSHOT-bin/standalone-server/conf/logback-spring.xml`:
+
+```xml
+<configuration scan="true" scanPeriod="120 seconds">
+
+......
+
+  <logger name="org.springframework.web" level="DEBUG">
+    <appender-ref ref="STANDALONELOGFILE" />
+    <appender-ref ref="TASKLOGFILE"/>
+  </logger>
+
+......
+
+</configuration>
+```
 
 ## Cautions
 

--- a/docs/docs/zh/contribute/log-specification.md
+++ b/docs/docs/zh/contribute/log-specification.md
@@ -41,6 +41,26 @@ Master模块和Worker模块的日志打印使用如下格式。即在打印的�
 [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{96}:[%line] - [WorkflowInstance-%X{workflowInstanceId:-0}][TaskInstance-%X{taskInstanceId:-0}] - %msg%n
 ```
 
+## 日志配置修改
+
+DolphinScheduler使用[`LogBack`](https://docs.spring.io/spring-boot/docs/2.1.8.RELEASE/reference/html/howto-logging.html)作为日志工具。若您要修改某个包的日志打点级别，您需要修改对应模块的`logback-spring.xml`文件。
+举例来说，若您需要将`standalone`模式下`org.springframework.web`包日志提升到`DEBUG`级别，您需要在`apache-dolphinscheduler-dev-SNAPSHOT-bin/standalone-server/conf/logback-spring.xml`文件中加入如下配置：
+
+```xml
+<configuration scan="true" scanPeriod="120 seconds">
+
+......
+
+  <logger name="org.springframework.web" level="DEBUG">
+    <appender-ref ref="STANDALONELOGFILE" />
+    <appender-ref ref="TASKLOGFILE"/>
+  </logger>
+
+......
+
+</configuration>
+```
+
 ## 注意事项
 
 - 禁止使用标准输出打印日志。标准输出会极大影响系统性能。

--- a/dolphinscheduler-api/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-api/src/main/resources/logback-spring.xml
@@ -30,9 +30,6 @@
 
     <appender name="APILOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log.base}/dolphinscheduler-api.log</file>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${log.base}/dolphinscheduler-api.%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
             <maxHistory>168</maxHistory>

--- a/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml
@@ -30,9 +30,6 @@
 
     <appender name="STANDALONELOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log.base}/dolphinscheduler-standalone.log</file>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${log.base}/dolphinscheduler-standalone.%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
             <maxHistory>168</maxHistory>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* Add instructions on how to configure logging level for debugging purpose.
* We have already set root logging level to `INFO`, therefore, we do not need another filter to do so:
https://github.com/apache/dolphinscheduler/blob/e702beced5edb567c5f14bec19be3b1697890145/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml#L75-L83

* This PR closes: #12696


## Brief change log

* Described above.

## Verify this pull request

* Verified manually.