### PR TITLE
[Improvement-12700][Project]Improve the sql of listAuthorizedProjects

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -183,6 +183,12 @@
             and  dp.id in (select project_id from t_ds_relation_project_user  where user_id=#{userId}
             union select id as project_id  from t_ds_project where user_id=#{userId})
         </if>
+        <if test="projectsIds != null and projectsIds.size() > 0">
+            and dp.id  in
+            <foreach item="id" index="index" collection="projectsIds" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </if>
     </select>
 
     <select id="queryAllProjectForDependent" resultType="org.apache.dolphinscheduler.dao.entity.Project">


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12700 

## Brief change log

Currently, `projectIds` is not used in the SQL of listAuthorizedProjects() as below

https://github.com/apache/dolphinscheduler/blob/7d0e2cbbb9fcd2e1543f5166f0518eda03afae89/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.java#L139

https://github.com/apache/dolphinscheduler/blob/7d0e2cbbb9fcd2e1543f5166f0518eda03afae89/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml#L173-L182

So this PR restrict the SQL query scope to `projectIds`, just like in 

<img width="906" alt="截屏2022-11-04 14 46 41" src="https://user-images.githubusercontent.com/38122586/199909233-4df32c52-f625-4462-907c-9fb72107433d.png">


## Verify this pull request

manually tested
