### PR TITLE
[Improvement-12782][UT] Add UT for the 13 implementations of ResourceAcquisitionAndPermissionCheck

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -112,7 +112,7 @@ public class ResourcePermissionCheckServiceImpl
                                            Logger logger) {
         if (Objects.nonNull(needChecks) && needChecks.length > 0) {
             Set<?> originResSet = new HashSet<>(Arrays.asList(needChecks));
-            Set<?> ownResSets = RESOURCE_LIST_MAP.get(authorizationType).listAuthorizedResource(userId, logger);
+            Set<?> ownResSets = RESOURCE_LIST_MAP.get(authorizationType).listAuthorizedResourceIds(userId, logger);
             boolean checkResult = ownResSets != null && ownResSets.containsAll(originResSet);
             if (!checkResult) {
                 logger.warn("User does not have resource permission on associated resources, userId:{}", userId);
@@ -153,7 +153,7 @@ public class ResourcePermissionCheckServiceImpl
             logger.error("User does not exist, userId:{}.", userId);
             return Collections.emptySet();
         }
-        return (Set<Object>) RESOURCE_LIST_MAP.get(authorizationType).listAuthorizedResource(
+        return (Set<Object>) RESOURCE_LIST_MAP.get(authorizationType).listAuthorizedResourceIds(
                 user.getUserType().equals(UserType.ADMIN_USER) ? 0 : userId, logger);
     }
 
@@ -173,12 +173,11 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public boolean permissionCheck(int userId, String permissionKey, Logger logger) {
-            // admin can create projects
             return false;
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             if (userId != 0) {
                 return Collections.emptySet();
             }
@@ -208,7 +207,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             return projectMapper.listAuthorizedProjects(userId, null).stream().map(Project::getId).collect(toSet());
         }
     }
@@ -231,7 +230,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<Resource> relationResources;
             if (userId == 0) {
                 relationResources = new ArrayList<>();
@@ -267,7 +266,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<UdfFunc> udfFuncList = udfFuncMapper.listAuthorizedUdfByUserId(userId);
             return udfFuncList.stream().map(UdfFunc::getId).collect(toSet());
         }
@@ -293,7 +292,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<TaskGroup> taskGroupList = taskGroupMapper.listAuthorizedResource(userId);
             return taskGroupList.stream().map(TaskGroup::getId).collect(Collectors.toSet());
         }
@@ -305,11 +304,11 @@ public class ResourcePermissionCheckServiceImpl
     }
 
     @Component
-    public static class K8sNamespaceResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class K8sNamespaceResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final K8sNamespaceMapper k8sNamespaceMapper;
 
-        public K8sNamespaceResourceList(K8sNamespaceMapper k8sNamespaceMapper) {
+        public K8sNamespaceResourcePermissionCheck(K8sNamespaceMapper k8sNamespaceMapper) {
             this.k8sNamespaceMapper = k8sNamespaceMapper;
         }
 
@@ -324,18 +323,18 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<K8sNamespace> k8sNamespaces = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
             return k8sNamespaces.stream().map(K8sNamespace::getId).collect(Collectors.toSet());
         }
     }
 
     @Component
-    public static class EnvironmentResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class EnvironmentResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final EnvironmentMapper environmentMapper;
 
-        public EnvironmentResourceList(EnvironmentMapper environmentMapper) {
+        public EnvironmentResourcePermissionCheck(EnvironmentMapper environmentMapper) {
             this.environmentMapper = environmentMapper;
         }
 
@@ -350,18 +349,18 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<Environment> environments = environmentMapper.queryAllEnvironmentList();
             return environments.stream().map(Environment::getId).collect(Collectors.toSet());
         }
     }
 
     @Component
-    public static class WorkerGroupResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class WorkerGroupResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final WorkerGroupMapper workerGroupMapper;
 
-        public WorkerGroupResourceList(WorkerGroupMapper workerGroupMapper) {
+        public WorkerGroupResourcePermissionCheck(WorkerGroupMapper workerGroupMapper) {
             this.workerGroupMapper = workerGroupMapper;
         }
 
@@ -376,7 +375,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<WorkerGroup> workerGroups = workerGroupMapper.queryAllWorkerGroup();
             return workerGroups.stream().map(WorkerGroup::getId).collect(Collectors.toSet());
         }
@@ -386,11 +385,13 @@ public class ResourcePermissionCheckServiceImpl
      * AlertPluginInstance Resource
      */
     @Component
-    public static class AlertPluginInstanceResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class AlertPluginInstanceResourcePermissionCheck
+            implements
+                ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final AlertPluginInstanceMapper alertPluginInstanceMapper;
 
-        public AlertPluginInstanceResourceList(AlertPluginInstanceMapper alertPluginInstanceMapper) {
+        public AlertPluginInstanceResourcePermissionCheck(AlertPluginInstanceMapper alertPluginInstanceMapper) {
             this.alertPluginInstanceMapper = alertPluginInstanceMapper;
         }
 
@@ -405,7 +406,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             return Collections.emptySet();
         }
     }
@@ -414,11 +415,11 @@ public class ResourcePermissionCheckServiceImpl
      * AlertPluginInstance Resource
      */
     @Component
-    public static class AlertGroupResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class AlertGroupResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final AlertGroupMapper alertGroupMapper;
 
-        public AlertGroupResourceList(AlertGroupMapper alertGroupMapper) {
+        public AlertGroupResourcePermissionCheck(AlertGroupMapper alertGroupMapper) {
             this.alertGroupMapper = alertGroupMapper;
         }
 
@@ -433,7 +434,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<AlertGroup> alertGroupList = alertGroupMapper.queryAllGroupList();
             return alertGroupList.stream().map(AlertGroup::getId).collect(toSet());
         }
@@ -443,11 +444,11 @@ public class ResourcePermissionCheckServiceImpl
      * Tenant Resource
      */
     @Component
-    public static class TenantResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class TenantResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final TenantMapper tenantMapper;
 
-        public TenantResourceList(TenantMapper tenantMapper) {
+        public TenantResourcePermissionCheck(TenantMapper tenantMapper) {
             this.tenantMapper = tenantMapper;
         }
 
@@ -462,7 +463,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             List<Tenant> tenantList = tenantMapper.queryAll();
             return tenantList.stream().map(Tenant::getId).collect(Collectors.toSet());
         }
@@ -472,11 +473,11 @@ public class ResourcePermissionCheckServiceImpl
      * DataSource Resource
      */
     @Component
-    public static class DataSourceResourceList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class DataSourceResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final DataSourceMapper dataSourceMapper;
 
-        public DataSourceResourceList(DataSourceMapper dataSourceMapper) {
+        public DataSourceResourcePermissionCheck(DataSourceMapper dataSourceMapper) {
             this.dataSourceMapper = dataSourceMapper;
         }
 
@@ -491,7 +492,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             return dataSourceMapper.listAuthorizedDataSource(userId, null).stream().map(DataSource::getId)
                     .collect(toSet());
         }
@@ -501,11 +502,11 @@ public class ResourcePermissionCheckServiceImpl
      * AccessToken Resource
      */
     @Component
-    public static class AccessTokenList implements ResourceAcquisitionAndPermissionCheck<Integer> {
+    public static class AccessTokenResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
         private final AccessTokenMapper accessTokenMapper;
 
-        public AccessTokenList(AccessTokenMapper accessTokenMapper) {
+        public AccessTokenResourcePermissionCheck(AccessTokenMapper accessTokenMapper) {
             this.accessTokenMapper = accessTokenMapper;
         }
 
@@ -520,7 +521,7 @@ public class ResourcePermissionCheckServiceImpl
         }
 
         @Override
-        public Set<Integer> listAuthorizedResource(int userId, Logger logger) {
+        public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
             return accessTokenMapper.listAuthorizedAccessToken(userId, null).stream().map(AccessToken::getId)
                     .collect(toSet());
         }
@@ -540,7 +541,7 @@ public class ResourcePermissionCheckServiceImpl
          * @param userId
          * @return
          */
-        Set<T> listAuthorizedResource(int userId, Logger logger);
+        Set<T> listAuthorizedResourceIds(int userId, Logger logger);
 
         /**
          * permission check

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AccessTokenResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AccessTokenResourcePermissionCheckTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.AccessToken;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class AccessTokenResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(AccessTokenResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.AccessTokenResourcePermissionCheck accessTokenResourcePermissionCheck;
+
+    @Mock
+    private AccessTokenMapper accessTokenMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(accessTokenResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = accessTokenResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.ACCESS_TOKEN), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        AccessToken accessToken = new AccessToken();
+        Set<Integer> ids = new HashSet();
+        ids.add(accessToken.getId());
+        List<AccessToken> accessTokens = Arrays.asList(accessToken);
+
+        Mockito.when(accessTokenMapper.listAuthorizedAccessToken(user.getId(), null)).thenReturn(accessTokens);
+
+        Assertions.assertEquals(ids,
+                accessTokenResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AlertGroupResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AlertGroupResourcePermissionCheckTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.AlertGroup;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class AlertGroupResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(AlertGroupResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.AlertGroupResourcePermissionCheck alertGroupResourcePermissionCheck;
+
+    @Mock
+    private AlertGroupMapper alertGroupMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(alertGroupResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = alertGroupResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.ALERT_GROUP), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        AlertGroup alertGroup = new AlertGroup();
+        Set<Integer> ids = new HashSet();
+        ids.add(alertGroup.getId());
+        List<AlertGroup> alertGroups = Arrays.asList(alertGroup);
+
+        Mockito.when(alertGroupMapper.queryAllGroupList()).thenReturn(alertGroups);
+
+        Assertions.assertEquals(ids, alertGroupResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AlertPluginInstanceResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AlertPluginInstanceResourcePermissionCheckTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.User;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class AlertPluginInstanceResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(AlertPluginInstanceResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.AlertPluginInstanceResourcePermissionCheck alertPluginInstanceResourcePermissionCheck;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(alertPluginInstanceResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = alertPluginInstanceResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.ALERT_PLUGIN_INSTANCE), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+
+        Assertions.assertEquals(0,
+                alertPluginInstanceResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger).size());
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/DataSourceResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/DataSourceResourcePermissionCheckTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.DataSource;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class DataSourceResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DataSourceResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.DataSourceResourcePermissionCheck dataSourceResourcePermissionCheck;
+
+    @Mock
+    private DataSourceMapper dataSourceMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertTrue(dataSourceResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = dataSourceResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.DATASOURCE), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        DataSource dataSource = new DataSource();
+        Set<Integer> ids = new HashSet();
+        ids.add(dataSource.getId());
+        List<DataSource> dataSources = Arrays.asList(dataSource);
+
+        Mockito.when(dataSourceMapper.listAuthorizedDataSource(user.getId(), null)).thenReturn(dataSources);
+
+        Assertions.assertEquals(ids, dataSourceResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/EnvironmentResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/EnvironmentResourcePermissionCheckTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Environment;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.EnvironmentMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class EnvironmentResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(EnvironmentResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.EnvironmentResourcePermissionCheck environmentResourcePermissionCheck;
+
+    @Mock
+    private EnvironmentMapper environmentMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertTrue(environmentResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = environmentResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.ENVIRONMENT), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        Environment environment = new Environment();
+        Set<Integer> ids = new HashSet();
+        ids.add(environment.getId());
+        List<Environment> environments = Arrays.asList(environment);
+
+        Mockito.when(environmentMapper.queryAllEnvironmentList()).thenReturn(environments);
+
+        Assertions.assertEquals(ids,
+                environmentResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/FilePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/FilePermissionCheckTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Resource;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.ResourceMapper;
+import org.apache.dolphinscheduler.dao.mapper.ResourceUserMapper;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class FilePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(FilePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.FilePermissionCheck filePermissionCheck;
+
+    @Mock
+    private ResourceMapper resourceMapper;
+
+    @Mock
+    private ResourceUserMapper resourceUserMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertTrue(filePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = filePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Arrays.asList(AuthorizationType.RESOURCE_FILE_ID, AuthorizationType.UDF_FILE),
+                authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        // ADMIN_USER
+        User user = getAdminUser();
+        Resource resource = new Resource();
+        Set<Integer> ids = new HashSet();
+        ids.add(resource.getId());
+        List<Resource> resources = Arrays.asList(resource);
+
+        Mockito.when(resourceMapper.queryResourceListAuthored(user.getId(), -1)).thenReturn(resources);
+        Assertions.assertEquals(ids, filePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+
+        // GENERAL_USER
+        user = getLoginUser();
+        Resource resource1 = new Resource();
+        ids.add(resource1.getId());
+        Mockito.when(resourceMapper.queryResourceListAuthored(user.getId(), -1)).thenReturn(resources);
+        Mockito.when(resourceUserMapper.queryResourcesIdListByUserIdAndPerm(user.getId(), 0))
+                .thenReturn(Arrays.asList(resource1.getId()));
+
+        Assertions.assertEquals(ids, filePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+
+    private User getAdminUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.ADMIN_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(0);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/K8sNamespaceResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/K8sNamespaceResourcePermissionCheckTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class K8sNamespaceResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(K8sNamespaceResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.K8sNamespaceResourcePermissionCheck k8sNamespaceResourcePermissionCheck;
+
+    @Mock
+    private K8sNamespaceMapper k8sNamespaceMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(k8sNamespaceResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = k8sNamespaceResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.K8S_NAMESPACE), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        K8sNamespace k8sNamespace = new K8sNamespace();
+        Set<Integer> ids = new HashSet<>();
+        ids.add(k8sNamespace.getId());
+        List<K8sNamespace> k8sNamespaces = Arrays.asList(k8sNamespace);
+
+        Mockito.when(k8sNamespaceMapper.queryAuthedNamespaceListByUserId(user.getId())).thenReturn(k8sNamespaces);
+
+        Assertions.assertEquals(ids,
+                k8sNamespaceResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/ProjectsResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/ProjectsResourcePermissionCheckTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectsResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProjectsResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.ProjectsResourcePermissionCheck projectsResourcePermissionCheck;
+
+    @Mock
+    private ProjectMapper projectMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertTrue(projectsResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = projectsResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.PROJECTS), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        Project project = getProject();
+        Set<Integer> ids = new HashSet();
+        ids.add(project.getId());
+        List<Project> projects = Arrays.asList(project);
+
+        Mockito.when(projectMapper.listAuthorizedProjects(user.getId(), null)).thenReturn(projects);
+
+        Assertions.assertEquals(ids, projectsResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+
+    private Project getProject() {
+        Project project = new Project();
+        project.setCode(1L);
+        project.setId(1);
+        project.setName("projectName");
+        project.setUserId(1);
+        return project;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/QueueResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/QueueResourcePermissionCheckTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Queue;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class QueueResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(QueueResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.QueueResourcePermissionCheck queueResourcePermissionCheck;
+
+    @Mock
+    private QueueMapper queueMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(queueResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = queueResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.QUEUE), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        Queue queue = new Queue();
+        Mockito.when(queueMapper.selectList(null)).thenReturn(Arrays.asList(queue));
+        // GENERAL_USER
+        User user = getLoginUser();
+        Assertions.assertEquals(0, queueResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger).size());
+
+        // ADMIN_USER
+        user = getAdminUser();
+        Assertions.assertEquals(1, queueResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger).size());
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+
+    private User getAdminUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.ADMIN_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(0);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskGroupPermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskGroupPermissionCheckTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.TaskGroup;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskGroupPermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(TaskGroupPermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.TaskGroupPermissionCheck taskGroupPermissionCheck;
+
+    @Mock
+    private TaskGroupMapper taskGroupMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertTrue(taskGroupPermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = taskGroupPermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.TASK_GROUP), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        TaskGroup taskGroup = new TaskGroup();
+        Set<Integer> ids = new HashSet<>();
+        ids.add(taskGroup.getId());
+        List<TaskGroup> taskGroups = Arrays.asList(taskGroup);
+
+        Mockito.when(taskGroupMapper.listAuthorizedResource(user.getId())).thenReturn(taskGroups);
+
+        Assertions.assertEquals(ids, taskGroupPermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TenantResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TenantResourcePermissionCheckTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Tenant;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class TenantResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(TenantResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.TenantResourcePermissionCheck tenantResourcePermissionCheck;
+
+    @Mock
+    private TenantMapper tenantMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(tenantResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = tenantResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.TENANT), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        Tenant tenant = new Tenant();
+        Set<Integer> ids = new HashSet();
+        ids.add(tenant.getId());
+        List<Tenant> tenants = Arrays.asList(tenant);
+
+        Mockito.when(tenantMapper.queryAll()).thenReturn(tenants);
+
+        Assertions.assertEquals(ids, tenantResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/UdfFuncPermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/UdfFuncPermissionCheckTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.UdfFunc;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.UdfFuncMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class UdfFuncPermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(UdfFuncPermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.UdfFuncPermissionCheck udfFuncPermissionCheck;
+
+    @Mock
+    private UdfFuncMapper udfFuncMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertTrue(udfFuncPermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = udfFuncPermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.UDF), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        UdfFunc udfFunc = new UdfFunc();
+        Set<Integer> ids = new HashSet();
+        ids.add(udfFunc.getId());
+        List<UdfFunc> udfFuncs = Arrays.asList(udfFunc);
+
+        Mockito.when(udfFuncMapper.listAuthorizedUdfByUserId(user.getId())).thenReturn(udfFuncs);
+
+        Assertions.assertEquals(ids, udfFuncPermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+
+    private Project getProject() {
+        Project project = new Project();
+        project.setCode(1L);
+        project.setId(1);
+        project.setName("projectName");
+        project.setUserId(1);
+        return project;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/WorkerGroupResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/WorkerGroupResourcePermissionCheckTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
+import org.apache.dolphinscheduler.dao.mapper.WorkerGroupMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class WorkerGroupResourcePermissionCheckTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkerGroupResourcePermissionCheckTest.class);
+    @InjectMocks
+    private ResourcePermissionCheckServiceImpl.WorkerGroupResourcePermissionCheck workerGroupResourcePermissionCheck;
+
+    @Mock
+    private WorkerGroupMapper workerGroupMapper;
+
+    @Test
+    public void testPermissionCheck() {
+        User user = getLoginUser();
+        Assertions.assertFalse(workerGroupResourcePermissionCheck.permissionCheck(user.getId(), null, logger));
+    }
+
+    @Test
+    public void testAuthorizationTypes() {
+        List<AuthorizationType> authorizationTypes = workerGroupResourcePermissionCheck.authorizationTypes();
+        Assertions.assertEquals(Collections.singletonList(AuthorizationType.WORKER_GROUP), authorizationTypes);
+    }
+
+    @Test
+    public void testListAuthorizedResourceIds() {
+        User user = getLoginUser();
+        WorkerGroup workerGroup = new WorkerGroup();
+        Set<Integer> ids = new HashSet();
+        ids.add(workerGroup.getId());
+        List<WorkerGroup> workerGroups = Arrays.asList(workerGroup);
+
+        Mockito.when(workerGroupMapper.queryAllWorkerGroup()).thenReturn(workerGroups);
+
+        Assertions.assertEquals(ids,
+                workerGroupResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
+    }
+
+    private User getLoginUser() {
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName("test");
+        loginUser.setId(1);
+        return loginUser;
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12782 

## Brief change log

* Since `listAuthorizedResource()` returns the resource ids rather than the resource, rename this method to `listAuthorizedResourceIds()` to remove ambiguity
* Add UT for the 13 implementations of ResourceAcquisitionAndPermissionCheck
<img width="771" alt="image" src="https://user-images.githubusercontent.com/38122586/200281216-073cd963-ac8c-43b8-bf32-7b3789221f2a.png">


## Verify this pull request

<!--*(Please pick either of the following options)*-->

covered by UT