### PR TITLE
[3.0.2-prepare][cherry-pick] Fix dependent task can not predicate the status of the corresponding task correctly

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/DependentDateUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/DependentDateUtils.java
@@ -128,16 +128,17 @@ public class DependentDateUtils {
     }
 
     /**
-     * get interval on first/last day of the last month
+     * get interval on first/last day of the needed month
      * @param businessDate businessDate
      * @param isBeginDay isBeginDay
      * @return DateInterval list
      */
-    public static List<DateInterval> getLastMonthBeginInterval(Date businessDate,
-                                                               boolean isBeginDay) {
+    public static List<DateInterval> getNeededMonthBeginInterval(Date businessDate,
+                                                                 boolean isBeginDay,
+                                                                 int neededMonth) {
 
         Date firstDayThisMonth = DateUtils.getFirstDayOfMonth(businessDate);
-        Date lastDay = DateUtils.getSomeDay(firstDayThisMonth, -1);
+        Date lastDay = DateUtils.getSomeDay(firstDayThisMonth, neededMonth);
         Date firstDay = DateUtils.getFirstDayOfMonth(lastDay);
         if (isBeginDay) {
             return getDateIntervalListBetweenTwoDates(firstDay, firstDay);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/DependentUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/DependentUtils.java
@@ -130,14 +130,20 @@ public class DependentUtils {
             case "thisMonth":
                 result = DependentDateUtils.getThisMonthInterval(businessDate);
                 break;
+            case "thisMonthBegin":
+                result = DependentDateUtils.getNeededMonthBeginInterval(businessDate, true, 0);
+                break;
+            case "thisMonthEnd":
+                result = DependentDateUtils.getNeededMonthBeginInterval(businessDate, false, 0);
+                break;
             case "lastMonth":
                 result = DependentDateUtils.getLastMonthInterval(businessDate);
                 break;
             case "lastMonthBegin":
-                result = DependentDateUtils.getLastMonthBeginInterval(businessDate, true);
+                result = DependentDateUtils.getNeededMonthBeginInterval(businessDate, true, -1);
                 break;
             case "lastMonthEnd":
-                result = DependentDateUtils.getLastMonthBeginInterval(businessDate, false);
+                result = DependentDateUtils.getNeededMonthBeginInterval(businessDate, false, -1);
                 break;
             default:
                 break;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* Cherry-pick #12253 to `3.0.2-prepare`.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
