### PR TITLE
[Fix-12828][api] Add permission check when query specific datasource

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
@@ -141,7 +141,7 @@ public class DataSourceController extends BaseController {
     public Result queryDataSource(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                   @PathVariable("id") int id) {
 
-        Map<String, Object> result = dataSourceService.queryDataSource(id);
+        Map<String, Object> result = dataSourceService.queryDataSource(id, loginUser);
         return returnDataList(result);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
@@ -55,7 +55,7 @@ public interface DataSourceService {
      * @param id datasource id
      * @return data source detail
      */
-    Map<String, Object> queryDataSource(int id);
+    Map<String, Object> queryDataSource(int id, User loginUser);
 
     /**
      * query datasource list by keyword

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.DATASOURCE;
+
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.permission.ResourcePermissionCheckService;
 import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
@@ -334,11 +336,19 @@ public class DataSourceServiceTest {
     @Test
     public void queryDataSourceTest() {
         Mockito.when(dataSourceMapper.selectById(Mockito.anyInt())).thenReturn(null);
-        Map<String, Object> result = dataSourceService.queryDataSource(Mockito.anyInt());
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setId(2);
+        Map<String, Object> result = dataSourceService.queryDataSource(Mockito.anyInt(), loginUser);
         Assertions.assertEquals(((Status) result.get(Constants.STATUS)).getCode(), Status.RESOURCE_NOT_EXIST.getCode());
 
-        Mockito.when(dataSourceMapper.selectById(Mockito.anyInt())).thenReturn(getOracleDataSource());
-        result = dataSourceService.queryDataSource(Mockito.anyInt());
+        DataSource dataSource = getOracleDataSource(1);
+        Mockito.when(dataSourceMapper.selectById(Mockito.anyInt())).thenReturn(dataSource);
+        Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.DATASOURCE,
+                loginUser.getId(), DATASOURCE, baseServiceLogger)).thenReturn(true);
+        Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.DATASOURCE,
+                new Object[]{dataSource.getId()}, loginUser.getId(), baseServiceLogger)).thenReturn(true);
+        result = dataSourceService.queryDataSource(dataSource.getId(), loginUser);
         Assertions.assertEquals(((Status) result.get(Constants.STATUS)).getCode(), Status.SUCCESS.getCode());
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #12828 

Currently, User can query unauthorized datasource as below
1. send GET request `.../dolphinscheduler/dasources/<id>`
2. and get the datasource without permission check

<img width="1916" alt="截屏2022-11-09 11 21 47" src="https://user-images.githubusercontent.com/38122586/200731130-acd4d848-13a3-4ced-9899-2994c2ac741c.png">


## Brief change log

Add permission check when query specific datasource

## Verify this pull request

covered by UT


