### PR TITLE
[Fix-12832][API] Fix update worker group exception group name already exists.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -113,15 +113,11 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             return result;
         }
         Date now = new Date();
-        WorkerGroup workerGroup;
+        WorkerGroup workerGroup = null;
         if (id != 0) {
             workerGroup = workerGroupMapper.selectById(id);
-            // check exist
-            if (workerGroup == null) {
-                workerGroup = new WorkerGroup();
-                workerGroup.setCreateTime(now);
-            }
-        } else {
+        }
+        if (workerGroup == null) {
             workerGroup = new WorkerGroup();
             workerGroup.setCreateTime(now);
         }
@@ -165,20 +161,20 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
      * @return boolean
      */
     private boolean checkWorkerGroupNameExists(WorkerGroup workerGroup) {
+        // check database
         List<WorkerGroup> workerGroupList = workerGroupMapper.queryWorkerGroupByName(workerGroup.getName());
         if (CollectionUtils.isNotEmpty(workerGroupList)) {
-            // new group has same name
+            // create group, the same group name exists in the database
             if (workerGroup.getId() == null) {
                 return true;
             }
-            // check group id
-            for (WorkerGroup group : workerGroupList) {
-                if (Objects.equals(group.getId(), workerGroup.getId())) {
-                    return true;
-                }
+            // update group, the database exists with the same group name except itself
+            Optional<WorkerGroup> sameNameWorkGroupOptional = workerGroupList.stream().filter(group -> !Objects.equals(group.getId(), workerGroup.getId())).findFirst();
+            if (sameNameWorkGroupOptional.isPresent()) {
+                return true;
             }
         }
-        // check zookeeper
+        // check registry server
         String workerGroupPath =
                 Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SINGLE_SLASH + workerGroup.getName();
         return registryClient.exists(workerGroupPath);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -169,7 +169,8 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
                 return true;
             }
             // update group, the database exists with the same group name except itself
-            Optional<WorkerGroup> sameNameWorkGroupOptional = workerGroupList.stream().filter(group -> !Objects.equals(group.getId(), workerGroup.getId())).findFirst();
+            Optional<WorkerGroup> sameNameWorkGroupOptional = workerGroupList.stream()
+                    .filter(group -> !Objects.equals(group.getId(), workerGroup.getId())).findFirst();
             if (sameNameWorkGroupOptional.isPresent()) {
                 return true;
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -175,10 +175,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
                 return true;
             }
         }
-        // check registry server
-        String workerGroupPath =
-                Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SINGLE_SLASH + workerGroup.getName();
-        return registryClient.exists(workerGroupPath);
+        return false;
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -153,9 +153,6 @@ public class WorkerGroupServiceTest {
                 baseServiceLogger)).thenReturn(true);
         Mockito.when(workerGroupMapper.selectById(1)).thenReturn(null);
         Mockito.when(workerGroupMapper.queryWorkerGroupByName(GROUP_NAME)).thenReturn(null);
-        String workerGroupPath =
-                Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SINGLE_SLASH + GROUP_NAME;
-        Mockito.when(registryClient.exists(workerGroupPath)).thenReturn(false);
         Map<String, String> serverMaps = new HashMap<>();
         serverMaps.put("localhost1:0000", "");
         Mockito.when(registryClient.getServerMaps(NodeType.WORKER)).thenReturn(serverMaps);
@@ -176,9 +173,6 @@ public class WorkerGroupServiceTest {
 
         Mockito.when(workerGroupMapper.selectById(1)).thenReturn(null);
         Mockito.when(workerGroupMapper.queryWorkerGroupByName(GROUP_NAME)).thenReturn(null);
-        String workerGroupPath =
-                Constants.REGISTRY_DOLPHINSCHEDULER_WORKERS + Constants.SINGLE_SLASH + GROUP_NAME;
-        Mockito.when(registryClient.exists(workerGroupPath)).thenReturn(false);
         Map<String, String> serverMaps = new HashMap<>();
         serverMaps.put("localhost:0000", "");
         Mockito.when(registryClient.getServerMaps(NodeType.WORKER)).thenReturn(serverMaps);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
this pr closes: #12832 

Fix update worker group exception group name already exists.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
