### PR TITLE
[Refactor] [Code smell] remove all spring bean params in WorkflowExecuteRunnable

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerBootstrap.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerBootstrap.java
@@ -26,12 +26,8 @@ import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.dao.entity.Command;
 import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
-import org.apache.dolphinscheduler.dao.repository.ProcessInstanceDao;
-import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
-import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.server.master.cache.ProcessInstanceExecCacheManager;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
-import org.apache.dolphinscheduler.server.master.dispatch.executor.NettyExecutorManager;
 import org.apache.dolphinscheduler.server.master.event.WorkflowEvent;
 import org.apache.dolphinscheduler.server.master.event.WorkflowEventQueue;
 import org.apache.dolphinscheduler.server.master.event.WorkflowEventType;
@@ -39,9 +35,7 @@ import org.apache.dolphinscheduler.server.master.exception.MasterException;
 import org.apache.dolphinscheduler.server.master.metrics.MasterServerMetrics;
 import org.apache.dolphinscheduler.server.master.metrics.ProcessInstanceMetrics;
 import org.apache.dolphinscheduler.server.master.registry.ServerNodeManager;
-import org.apache.dolphinscheduler.service.alert.ProcessAlertManager;
 import org.apache.dolphinscheduler.service.command.CommandService;
-import org.apache.dolphinscheduler.service.expand.CuringParamsService;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.apache.dolphinscheduler.service.utils.LoggerUtils;
 
@@ -73,22 +67,7 @@ public class MasterSchedulerBootstrap extends BaseDaemonThread implements AutoCl
     private CommandService commandService;
 
     @Autowired
-    private ProcessInstanceDao processInstanceDao;
-
-    @Autowired
-    private TaskInstanceDao taskInstanceDao;
-
-    @Autowired
-    private TaskDefinitionLogDao taskDefinitionLogDao;
-
-    @Autowired
     private MasterConfig masterConfig;
-
-    @Autowired
-    private ProcessAlertManager processAlertManager;
-
-    @Autowired
-    private NettyExecutorManager nettyExecutorManager;
 
     /**
      * master prepare exec service
@@ -97,12 +76,6 @@ public class MasterSchedulerBootstrap extends BaseDaemonThread implements AutoCl
 
     @Autowired
     private ProcessInstanceExecCacheManager processInstanceExecCacheManager;
-
-    @Autowired
-    private StateWheelExecuteThread stateWheelExecuteThread;
-
-    @Autowired
-    private CuringParamsService curingGlobalParamsService;
 
     @Autowired
     private WorkflowEventQueue workflowEventQueue;
@@ -186,17 +159,7 @@ public class MasterSchedulerBootstrap extends BaseDaemonThread implements AutoCl
                             logger.error(
                                     "The workflow instance is already been cached, this case shouldn't be happened");
                         }
-                        WorkflowExecuteRunnable workflowRunnable = new WorkflowExecuteRunnable(processInstance,
-                                commandService,
-                                processService,
-                                processInstanceDao,
-                                nettyExecutorManager,
-                                processAlertManager,
-                                masterConfig,
-                                stateWheelExecuteThread,
-                                curingGlobalParamsService,
-                                taskInstanceDao,
-                                taskDefinitionLogDao);
+                        WorkflowExecuteRunnable workflowRunnable = new WorkflowExecuteRunnable(processInstance);
                         processInstanceExecCacheManager.cache(processInstance.getId(), workflowRunnable);
                         workflowEventQueue.addEvent(new WorkflowEvent(WorkflowEventType.START_WORKFLOW,
                                 processInstance.getId()));

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -80,6 +80,7 @@ import org.apache.dolphinscheduler.server.master.runner.task.ITaskProcessor;
 import org.apache.dolphinscheduler.server.master.runner.task.TaskAction;
 import org.apache.dolphinscheduler.server.master.runner.task.TaskProcessorFactory;
 import org.apache.dolphinscheduler.service.alert.ProcessAlertManager;
+import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.command.CommandService;
 import org.apache.dolphinscheduler.service.cron.CronUtils;
 import org.apache.dolphinscheduler.service.exceptions.CronParseException;
@@ -235,36 +236,19 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
 
     /**
      * @param processInstance         processInstance
-     * @param processService          processService
-     * @param processInstanceDao      processInstanceDao
-     * @param nettyExecutorManager    nettyExecutorManager
-     * @param processAlertManager     processAlertManager
-     * @param masterConfig            masterConfig
-     * @param stateWheelExecuteThread stateWheelExecuteThread
      */
-    public WorkflowExecuteRunnable(
-                                   @NonNull ProcessInstance processInstance,
-                                   @NonNull CommandService commandService,
-                                   @NonNull ProcessService processService,
-                                   @NonNull ProcessInstanceDao processInstanceDao,
-                                   @NonNull NettyExecutorManager nettyExecutorManager,
-                                   @NonNull ProcessAlertManager processAlertManager,
-                                   @NonNull MasterConfig masterConfig,
-                                   @NonNull StateWheelExecuteThread stateWheelExecuteThread,
-                                   @NonNull CuringParamsService curingParamsService,
-                                   @NonNull TaskInstanceDao taskInstanceDao,
-                                   @NonNull TaskDefinitionLogDao taskDefinitionLogDao) {
-        this.processService = processService;
-        this.commandService = commandService;
-        this.processInstanceDao = processInstanceDao;
+    public WorkflowExecuteRunnable(@NonNull ProcessInstance processInstance) {
+        this.processService = SpringApplicationContext.getBean(ProcessService.class);
+        this.commandService = SpringApplicationContext.getBean(CommandService.class);
+        this.processInstanceDao = SpringApplicationContext.getBean(ProcessInstanceDao.class);
         this.processInstance = processInstance;
-        this.nettyExecutorManager = nettyExecutorManager;
-        this.processAlertManager = processAlertManager;
-        this.stateWheelExecuteThread = stateWheelExecuteThread;
-        this.curingParamsService = curingParamsService;
-        this.taskInstanceDao = taskInstanceDao;
-        this.taskDefinitionLogDao = taskDefinitionLogDao;
-        this.masterAddress = NetUtils.getAddr(masterConfig.getListenPort());
+        this.nettyExecutorManager = SpringApplicationContext.getBean(NettyExecutorManager.class);
+        this.processAlertManager = SpringApplicationContext.getBean(ProcessAlertManager.class);
+        this.stateWheelExecuteThread = SpringApplicationContext.getBean(StateWheelExecuteThread.class);
+        this.curingParamsService = SpringApplicationContext.getBean(CuringParamsService.class);
+        this.taskInstanceDao = SpringApplicationContext.getBean(TaskInstanceDao.class);
+        this.taskDefinitionLogDao = SpringApplicationContext.getBean(TaskDefinitionLogDao.class);
+        this.masterAddress = NetUtils.getAddr(SpringApplicationContext.getBean(MasterConfig.class).getListenPort());
         TaskMetrics.registerTaskPrepared(readyToSubmitTaskQueue::size);
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

+ Code smell refactor : **Long Parameter List**.

## Brief change log

Long Parameter List in `WorkflowExecuteRunnable`, and the constructor of this class has more and more parameters, but all these params are Spring singleton bean, so we can remove these params.

And all Spring singleton bean should not be a constructor or method params.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is already covered by existing tests
