### PR TITLE
[Feature][UI]make status and schedule publish status display together (issue-12834)

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/use-table.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/use-table.ts
@@ -143,31 +143,6 @@ export function useTable() {
             : t('project.workflow.down_line')
       },
       {
-        title: t('project.workflow.create_time'),
-        key: 'createTime',
-        ...COLUMN_WIDTH_CONFIG['time']
-      },
-      {
-        title: t('project.workflow.update_time'),
-        key: 'updateTime',
-        ...COLUMN_WIDTH_CONFIG['time']
-      },
-      {
-        title: t('project.workflow.description'),
-        key: 'description',
-        ...COLUMN_WIDTH_CONFIG['note']
-      },
-      {
-        title: t('project.workflow.create_user'),
-        key: 'userName',
-        ...COLUMN_WIDTH_CONFIG['userName']
-      },
-      {
-        title: t('project.workflow.modify_user'),
-        key: 'modifyBy',
-        ...COLUMN_WIDTH_CONFIG['userName']
-      },
-      {
         title: t('project.workflow.schedule_publish_status'),
         key: 'scheduleReleaseState',
         ...COLUMN_WIDTH_CONFIG['state'],
@@ -192,6 +167,31 @@ export function useTable() {
             return '-'
           }
         }
+      },
+      {
+        title: t('project.workflow.create_time'),
+        key: 'createTime',
+        ...COLUMN_WIDTH_CONFIG['time']
+      },
+      {
+        title: t('project.workflow.update_time'),
+        key: 'updateTime',
+        ...COLUMN_WIDTH_CONFIG['time']
+      },
+      {
+        title: t('project.workflow.description'),
+        key: 'description',
+        ...COLUMN_WIDTH_CONFIG['note']
+      },
+      {
+        title: t('project.workflow.create_user'),
+        key: 'userName',
+        ...COLUMN_WIDTH_CONFIG['userName']
+      },
+      {
+        title: t('project.workflow.modify_user'),
+        key: 'modifyBy',
+        ...COLUMN_WIDTH_CONFIG['userName']
       },
       {
         title: t('project.workflow.operation'),
@@ -289,7 +289,7 @@ export function useTable() {
     })
   }
 
-  const batchCopyWorkflow = () => {}
+  const batchCopyWorkflow = () => { }
 
   const releaseWorkflow = (row: any) => {
     const data = {

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/use-table.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/use-table.ts
@@ -139,8 +139,20 @@ export function useTable() {
         ...COLUMN_WIDTH_CONFIG['state'],
         render: (row) =>
           row.releaseState === 'ONLINE'
-            ? t('project.workflow.up_line')
-            : t('project.workflow.down_line')
+            ? h(
+              NTag,
+              { type: 'success', size: 'small' },
+              {
+                default: () => t('project.workflow.up_line')
+              }
+            )
+            : h(
+              NTag,
+              { type: 'warning', size: 'small' },
+              {
+                default: () => t('project.workflow.down_line')
+              }
+            )
       },
       {
         title: t('project.workflow.schedule_publish_status'),


### PR DESCRIPTION
make status and schedule publish status display together in workflow definition list page (issue-12834)

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

close #12834 

Currently,status and schedule publish status display together

![7636aaea545f56f7f0eeefc20ee05cd](https://user-images.githubusercontent.com/35210666/202445225-b2f6ea1a-ef81-4555-ae93-48126b28c450.png)
![aadd8d7e699083692e366fd23f2894e](https://user-images.githubusercontent.com/35210666/202445243-4ef8d3ae-bfd7-48ee-a130-27c32530eed4.png)


## Brief change log

Modified the order of headers, no backend changes

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
