### PR TITLE
[fix-#12932] when subprocess's processInstance is fail,not notify parent processInstance

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
@@ -122,6 +122,7 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
                 LoggerUtils.setWorkflowInstanceIdMDC(processInstanceId);
                 try {
                     logger.error("Workflow instance events handle failed", ex);
+                    notifyProcessChanged(workflowExecuteThread.getProcessInstance());
                     multiThreadFilterMap.remove(workflowExecuteThread.getKey());
                 } finally {
                     LoggerUtils.removeWorkflowInstanceIdMDC();


### PR DESCRIPTION
## Purpose of the pull request

## Brief change log
- #12932 
when subprocess's processInstance is fail,not notify parent processInstance

## Verify this pull request


This pull request is code cleanup without any test coverage.

this close : #12932 