### PR TITLE
[Feature-12942][task-dataquality]The Data Quality Plugin supports the Resource Center

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/dataquality/DataQualityParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/dataquality/DataQualityParameters.java
@@ -22,7 +22,6 @@ import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters
 import org.apache.dolphinscheduler.plugin.task.api.parameters.dataquality.spark.SparkParameters;
 import org.apache.dolphinscheduler.plugin.task.api.utils.MapUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +47,11 @@ public class DataQualityParameters extends AbstractParameters {
      * spark parameters
      */
     private SparkParameters sparkParameters;
+
+    /**
+     * resource list
+     */
+    private List<ResourceInfo> resourceList;
 
     public int getRuleId() {
         return ruleId;
@@ -86,9 +90,17 @@ public class DataQualityParameters extends AbstractParameters {
         return sparkParameters != null;
     }
 
+    public List<ResourceInfo> getResourceList() {
+        return resourceList;
+    }
+
+    public void setResourceList(List<ResourceInfo> resourceList) {
+        this.resourceList = resourceList;
+    }
+
     @Override
     public List<ResourceInfo> getResourceFilesList() {
-        return new ArrayList<>();
+        return resourceList;
     }
 
     public SparkParameters getSparkParameters() {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-data-quality.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/tasks/use-data-quality.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Ref, reactive } from 'vue'
+import {Ref, reactive, ref} from 'vue'
 import { useI18n } from 'vue-i18n'
 import * as Fields from '../fields/index'
 import type { IJsonItem, INodeData, ITaskData } from '../types'
@@ -36,6 +36,7 @@ export function useDataQuality({
   updateElements: () => void
 }) {
   const { t } = useI18n()
+  const useResourcesSpan = ref(24)
   const model = reactive({
     taskType: 'DATA_QUALITY',
     name: '',
@@ -97,6 +98,7 @@ export function useDataQuality({
         field: 'localParams',
         isSimple: true
       }),
+      Fields.useResources(useResourcesSpan),
       Fields.usePreTasks()
     ] as IJsonItem[],
     model


### PR DESCRIPTION
The resource center plays a great role when the Spark cluster using the data quality plug-in needs to use keytab file authentication or when submitting Spark tasks requires the use of third-party JAR.

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
