### PR TITLE
[Bug-13008] [UI] When using the complement function, turn on the dependent mode to generate multiple unrelated workflow instances

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-dependent.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-dependent.ts
@@ -239,7 +239,6 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
   watch(
     () => model.dependTaskList,
     (value) => {
-      debugger
       selectOptions.value = []
       value.forEach((item: IDependTask, taskIndex: number) => {
         if (!item.dependItemList?.length) return
@@ -290,7 +289,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
                 const itemListOptions = options?.dependItemList || []
                 const itemOptions = {} as IDependentItemOptions
                 itemOptions.definitionCodeOptions = await getProcessList(projectCode)
-                itemListOptions[j] = itemOptions;
+                itemListOptions[j] = itemOptions
                 options.dependItemList = itemListOptions
                 selectOptions.value[i] = options
                 item.depTaskCode = null
@@ -347,7 +346,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
               filterable: true
             },
             options:
-                selectOptions.value[i]?.dependItemList[j]?.depTaskCodeOptions ||
+              selectOptions.value[i]?.dependItemList[j]?.depTaskCodeOptions ||
               [],
             path: `dependTaskList.${i}.dependItemList.${j}.depTaskCode`,
             rule: {
@@ -390,7 +389,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
             span: 10,
             name: ' ',
             options:
-                selectOptions.value[i]?.dependItemList[j]?.dateOptions || [],
+              selectOptions.value[i]?.dependItemList[j]?.dateOptions || [],
             path: `dependTaskList.${i}.dependItemList.${j}.dateValue`,
             rule: {
               trigger: ['input', 'blur'],

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-dependent.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-dependent.ts
@@ -29,7 +29,9 @@ import {
 import { Router, useRouter } from 'vue-router'
 import type {
   IJsonItem,
-  IDependpendItem,
+  IDependentItem,
+  IDependentItemOptions,
+  IDependTaskOptions,
   IDependTask,
   ITaskState,
   IDateType
@@ -49,6 +51,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
   const taskCache = {} as {
     [key: number]: { label: string; value: number }[]
   }
+  const selectOptions = ref([] as IDependTaskOptions[])
 
   const CYCLE_LIST = [
     {
@@ -236,25 +239,31 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
   watch(
     () => model.dependTaskList,
     (value) => {
-      value.forEach((item: IDependTask) => {
+      debugger
+      selectOptions.value = []
+      value.forEach((item: IDependTask, taskIndex: number) => {
         if (!item.dependItemList?.length) return
 
-        item.dependItemList?.forEach(async (dependItem: IDependpendItem) => {
+        const itemListOptions = ref([] as IDependentItemOptions[])
+        item.dependItemList?.forEach(async (dependItem: IDependentItem, itemIndex: number) => {
+          itemListOptions.value[itemIndex] = {}
           if (dependItem.projectCode) {
-            dependItem.definitionCodeOptions = await getProcessList(
+            itemListOptions.value[itemIndex].definitionCodeOptions = await getProcessList(
               dependItem.projectCode
             )
           }
           if (dependItem.projectCode && dependItem.definitionCode) {
-            dependItem.depTaskCodeOptions = await getTaskList(
+            itemListOptions.value[itemIndex].depTaskCodeOptions = await getTaskList(
               dependItem.projectCode,
               dependItem.definitionCode
             )
           }
           if (dependItem.cycle) {
-            dependItem.dateOptions = DATE_LIST[dependItem.cycle]
+            itemListOptions.value[itemIndex].dateOptions = DATE_LIST[dependItem.cycle]
           }
         })
+        selectOptions.value[taskIndex] = {} as IDependTaskOptions
+        selectOptions.value[taskIndex].dependItemList = itemListOptions.value
       })
     }
   )
@@ -277,7 +286,13 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
               filterable: true,
               onUpdateValue: async (projectCode: number) => {
                 const item = model.dependTaskList[i].dependItemList[j]
-                item.definitionCodeOptions = await getProcessList(projectCode)
+                const options = selectOptions?.value[i] || {}
+                const itemListOptions = options?.dependItemList || []
+                const itemOptions = {} as IDependentItemOptions
+                itemOptions.definitionCodeOptions = await getProcessList(projectCode)
+                itemListOptions[j] = itemOptions;
+                options.dependItemList = itemListOptions
+                selectOptions.value[i] = options
                 item.depTaskCode = null
                 item.definitionCode = null
               }
@@ -303,16 +318,15 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
               filterable: true,
               onUpdateValue: async (processCode: number) => {
                 const item = model.dependTaskList[i].dependItemList[j]
-                item.depTaskCodeOptions = await getTaskList(
+                selectOptions.value[i].dependItemList[j].depTaskCodeOptions = await getTaskList(
                   item.projectCode,
                   processCode
                 )
                 item.depTaskCode = 0
               }
             },
-            options:
-              model.dependTaskList[i]?.dependItemList[j]
-                ?.definitionCodeOptions || [],
+            options: selectOptions.value[i]?.dependItemList[j]
+                    ?.definitionCodeOptions || [],
             path: `dependTaskList.${i}.dependItemList.${j}.definitionCode`,
             rule: {
               required: true,
@@ -333,7 +347,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
               filterable: true
             },
             options:
-              model.dependTaskList[i]?.dependItemList[j]?.depTaskCodeOptions ||
+                selectOptions.value[i]?.dependItemList[j]?.depTaskCodeOptions ||
               [],
             path: `dependTaskList.${i}.dependItemList.${j}.depTaskCode`,
             rule: {
@@ -353,7 +367,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
             name: t('project.node.cycle_time'),
             props: {
               onUpdateValue: (value: IDateType) => {
-                model.dependTaskList[i].dependItemList[j].dateOptions =
+                selectOptions.value[i].dependItemList[j].dateOptions =
                   DATE_LIST[value]
                 model.dependTaskList[i].dependItemList[j].dateValue = null
               }
@@ -376,7 +390,7 @@ export function useDependent(model: { [field: string]: any }): IJsonItem[] {
             span: 10,
             name: ' ',
             options:
-              model.dependTaskList[i]?.dependItemList[j]?.dateOptions || [],
+                selectOptions.value[i]?.dependItemList[j]?.dateOptions || [],
             path: `dependTaskList.${i}.dependItemList.${j}.dateValue`,
             rule: {
               trigger: ['input', 'blur'],

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -270,21 +270,9 @@ export function formatParams(data: INodeData): {
     taskParams.xmx = data.xmx
   }
   if (data.taskType === 'DEPENDENT') {
-    const dependTaskList = cloneDeep(data.dependTaskList)?.map(
-      (taskItem: IDependTask) => {
-        if (taskItem.dependItemList?.length) {
-          taskItem.dependItemList.forEach((dependItem) => {
-            delete dependItem.definitionCodeOptions
-            delete dependItem.depTaskCodeOptions
-            delete dependItem.dateOptions
-          })
-        }
-        return taskItem
-      }
-    )
     taskParams.dependence = {
       relation: data.relation,
-      dependTaskList: dependTaskList
+      dependTaskList: data.dependTaskList
     }
   }
   if (data.taskType === 'DATA_QUALITY') {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 
-import { omit, cloneDeep } from 'lodash'
+import { omit } from 'lodash'
 import type {
   INodeData,
   ITaskData,
   ITaskParams,
   ISqoopTargetParams,
   ISqoopSourceParams,
-  ILocalParam,
-  IDependTask
+  ILocalParam
 } from './types'
 
 export function formatParams(data: INodeData): {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
@@ -66,12 +66,19 @@ interface IResponseJsonItem extends Omit<IJsonItemParams, 'type'> {
   emit: 'change'[]
 }
 
-interface IDependpendItem {
-  depTaskCode?: number
-  status?: 'SUCCESS' | 'FAILURE'
+interface IDependentItemOptions {
   definitionCodeOptions?: IOption[]
   depTaskCodeOptions?: IOption[]
   dateOptions?: IOption[]
+}
+
+interface IDependTaskOptions {
+  dependItemList: IDependentItemOptions[]
+}
+
+interface IDependentItem {
+  depTaskCode?: number
+  status?: 'SUCCESS' | 'FAILURE'
   projectCode?: number
   definitionCode?: number
   cycle?: 'month' | 'week' | 'day' | 'hour'
@@ -82,7 +89,7 @@ interface IDependTask {
   condition?: string
   nextNode?: number
   relation?: RelationType
-  dependItemList?: IDependpendItem[]
+  dependItemList?: IDependentItem[]
 }
 
 interface ISwitchResult {
@@ -481,7 +488,9 @@ export {
   ISqoopSourceParams,
   ISqoopTargetParams,
   IDependTask,
-  IDependpendItem,
+  IDependentItem,
+  IDependentItemOptions,
+  IDependTaskOptions,
   IFormItem,
   IJsonItem,
   FormRules,


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

this pr closes: #13008 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
