### PR TITLE
[Bug-13010] [Task] The Flink SQL task page selects the pre-job deployment mode, but the task executed by the worker is the Flink local mode

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -118,8 +118,7 @@ public class FlinkArgsUtilsTest {
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
-
-        Assertions.assertEquals(2, initOptions.size());
+        Assertions.assertEquals(6, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -115,7 +115,7 @@ public class FlinkArgsUtilsTest {
     }
 
     @Test
-    public void testInitOptionsInClusterMode() throws Exception {
+    public void testInitOptionsInLocalMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
         Assertions.assertEquals(2, initOptions.size());
@@ -124,7 +124,7 @@ public class FlinkArgsUtilsTest {
     }
 
     @Test
-    public void testInitOptionsInApplicationMode() throws Exception {
+    public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions = FlinkArgsUtils
                 .buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.CLUSTER));
         Assertions.assertEquals(6, initOptions.size());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -118,7 +118,6 @@ public class FlinkArgsUtilsTest {
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
-        Assertions.assertEquals(2, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -118,6 +118,7 @@ public class FlinkArgsUtilsTest {
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
+
         Assertions.assertEquals(2, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -118,6 +118,7 @@ public class FlinkArgsUtilsTest {
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
+        Assertions.assertEquals(2, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -118,7 +118,7 @@ public class FlinkArgsUtilsTest {
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
-        Assertions.assertEquals(6, initOptions.size());
+        Assertions.assertEquals(2, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink-stream/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -117,7 +117,7 @@ public class FlinkArgsUtilsTest {
     @Test
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
-                FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.CLUSTER));
+                FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
         Assertions.assertEquals(2, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));
@@ -126,7 +126,7 @@ public class FlinkArgsUtilsTest {
     @Test
     public void testInitOptionsInApplicationMode() throws Exception {
         List<String> initOptions = FlinkArgsUtils
-                .buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.APPLICATION));
+                .buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.CLUSTER));
         Assertions.assertEquals(6, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=yarn-per-job"));
         Assertions.assertTrue(initOptions.contains("set taskmanager.numberOfTaskSlots=4"));

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -126,9 +126,9 @@ public class FlinkArgsUtils {
         /**
          * Currently flink sql on yarn only supports yarn-per-job mode
          */
-        if (FlinkDeployMode.CLUSTER == deployMode) {
+        if (FlinkDeployMode.LOCAL == deployMode) {
             // execution.target
-            initOptions.add(String.format(FlinkConstants.FLINK_FORMAT_EXECUTION_TARGET, "local"));
+            initOptions.add(String.format(FlinkConstants.FLINK_FORMAT_EXECUTION_TARGET, FlinkConstants.FLINK_LOCAL));
         } else {
             // execution.target
             initOptions.add(

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkConstants.java
@@ -43,6 +43,7 @@ public class FlinkConstants {
     public static final String FLINK_YARN_CLUSTER = "yarn-cluster";
     public static final String FLINK_YARN_APPLICATION = "yarn-application";
     public static final String FLINK_YARN_PER_JOB = "yarn-per-job";
+    public static final String FLINK_LOCAL = "local";
     public static final String FLINK_RUN_MODE = "-m";
     public static final String FLINK_EXECUTION_TARGET = "-t";
     public static final String FLINK_YARN_SLOT = "-ys";

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -115,7 +115,7 @@ public class FlinkArgsUtilsTest {
     }
 
     @Test
-    public void testInitOptionsInClusterMode() throws Exception {
+    public void testInitOptionsInLocalMode() throws Exception {
         List<String> initOptions =
                 FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
         Assertions.assertEquals(2, initOptions.size());
@@ -124,7 +124,7 @@ public class FlinkArgsUtilsTest {
     }
 
     @Test
-    public void testInitOptionsInApplicationMode() throws Exception {
+    public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions = FlinkArgsUtils
                 .buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.CLUSTER));
         Assertions.assertEquals(6, initOptions.size());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/test/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtilsTest.java
@@ -117,7 +117,7 @@ public class FlinkArgsUtilsTest {
     @Test
     public void testInitOptionsInClusterMode() throws Exception {
         List<String> initOptions =
-                FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.CLUSTER));
+                FlinkArgsUtils.buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.LOCAL));
         Assertions.assertEquals(2, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=local"));
         Assertions.assertTrue(initOptions.contains("set parallelism.default=4"));
@@ -126,7 +126,7 @@ public class FlinkArgsUtilsTest {
     @Test
     public void testInitOptionsInApplicationMode() throws Exception {
         List<String> initOptions = FlinkArgsUtils
-                .buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.APPLICATION));
+                .buildInitOptionsForSql(buildTestFlinkParametersWithDeployMode(FlinkDeployMode.CLUSTER));
         Assertions.assertEquals(6, initOptions.size());
         Assertions.assertTrue(initOptions.contains("set execution.target=yarn-per-job"));
         Assertions.assertTrue(initOptions.contains("set taskmanager.numberOfTaskSlots=4"));

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-flink.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-flink.ts
@@ -44,6 +44,18 @@ export function useFlink(model: { [field: string]: any }): IJsonItem[] {
   const appNameSpan = computed(() => (model.deployMode !== 'local' ? 24 : 0))
 
   const deployModeOptions = computed(() => {
+    if (model.programType === 'SQL') {
+      return [
+        {
+          label: 'per-job/cluster',
+          value: 'cluster'
+        },
+        {
+          label: 'local',
+          value: 'local'
+        }
+      ]
+    }
     if (model.flinkVersion === '<1.10') {
       return [
         {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

this pr closes: #13010 
Currently flink sql on yarn only supports yarn-per-job mode.


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
