### PR TITLE
[Feature][API]make api-server swagger doc can set Authorizition(issue-12975)

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OpenAPIConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OpenAPIConfiguration.java
@@ -23,8 +23,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 /**
  * swager2 config class
@@ -40,7 +42,10 @@ public class OpenAPIConfiguration implements WebMvcConfigurer {
                 .info(new Info()
                         .title("Dolphin Scheduler Api Docs")
                         .description("Dolphin Scheduler Api Docs")
-                        .version("V1"));
+                        .version("V1"))
+                .components(new Components()
+                        .addSecuritySchemes("sessionId", new SecurityScheme().type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer").bearerFormat("JWT")));
     }
 
     @Bean


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

close #12975

make api-server swagger doc can set authorizition

before：
![05057495a83366af4e79df971350910](https://user-images.githubusercontent.com/35210666/204280447-e99230bb-ea43-42ba-a650-38ee3c25e34e.png)

after:
can set a session id to authorizition

![25950021595c050eac69a04697a488b](https://user-images.githubusercontent.com/35210666/204281058-3edc24e2-97ce-4149-a6dc-d81f1de978b6.png)
![aea1ed163e51ea1822cf81a746f8748](https://user-images.githubusercontent.com/35210666/204280832-36c393e8-2e0a-48f3-bfab-1fe6e4c5dde0.png)


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

make api-server swagger doc can set Authorizition

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
