### PR TITLE
[Bug] [Server] Once click online schedule time, task will be automatically scheduled

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -405,6 +405,7 @@ public enum Status {
     COMMAND_STATE_COUNT_ERROR(80001, "task instance state count error", "查询各状态任务实例数错误"),
     NEGTIVE_SIZE_NUMBER_ERROR(80002, "query size number error", "查询size错误"),
     START_TIME_BIGGER_THAN_END_TIME_ERROR(80003, "start time bigger than end time error", "开始时间在结束时间之后错误"),
+    START_TIME_BEFORE_CURRENT_TIME_ERROR(80004, "start time before current time error", "开始时间在当前时间之前错误"),
     QUEUE_COUNT_ERROR(90001, "queue count error", "查询队列数据错误"),
 
     KERBEROS_STARTUP_STATE(100001, "get kerberos startup state error", "获取kerberos启动状态错误"),

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -480,6 +480,13 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
             return result;
         }
         if (scheduleStatus == ReleaseState.ONLINE) {
+            // check schedule start time
+            Date now = new Date();
+            if (now.after(scheduleObj.getStartTime())) {
+                logger.warn("The start time must be later than current time.");
+                putMsg(result, Status.START_TIME_BEFORE_CURRENT_TIME_ERROR);
+                return result;
+            }
             // check process definition release state
             if (processDefinition.getReleaseState() != ReleaseState.ONLINE) {
                 logger.warn("Only process definition state is {} can change schedule state, processDefinitionCode:{}.",

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -172,7 +172,9 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
 
         ScheduleParam scheduleParam = JSONUtils.parseObject(schedule, ScheduleParam.class);
         if (now.after(scheduleParam.getStartTime())) {
-            scheduleParam.setStartTime(now);
+            logger.warn("The start time must be later than current time.");
+            putMsg(result, Status.START_TIME_BEFORE_CURRENT_TIME_ERROR);
+            return result;
         }
         if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
             logger.warn("The start time must not be the same as the end or time can not be null.");
@@ -180,7 +182,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
             return result;
         }
         if (scheduleParam.getStartTime().getTime() > scheduleParam.getEndTime().getTime()) {
-            logger.warn("The start time must smaller than end time");
+            logger.warn("The start time must be smaller than end time.");
             putMsg(result, Status.START_TIME_BIGGER_THAN_END_TIME_ERROR);
             return result;
         }
@@ -239,7 +241,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         }
         Date now = new Date();
         if (now.after(scheduleParam.getStartTime())) {
-            scheduleParam.setStartTime(now);
+            throw new ServiceException(Status.START_TIME_BEFORE_CURRENT_TIME_ERROR);
         }
         if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
             throw new ServiceException(Status.SCHEDULE_START_TIME_END_TIME_SAME);
@@ -841,7 +843,9 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                 return;
             }
             if (now.after(scheduleParam.getStartTime())) {
-                scheduleParam.setStartTime(now);
+                logger.warn("The start time must be later than current time.");
+                putMsg(result, Status.START_TIME_BEFORE_CURRENT_TIME_ERROR);
+                return;
             }
             if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
                 logger.warn("The start time must not be the same as the end or time can not be null.");
@@ -849,7 +853,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                 return;
             }
             if (scheduleParam.getStartTime().getTime() > scheduleParam.getEndTime().getTime()) {
-                logger.warn("The start time must smaller than end time");
+                logger.warn("The start time must be smaller than end time.");
                 putMsg(result, Status.START_TIME_BIGGER_THAN_END_TIME_ERROR);
                 return;
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -171,6 +171,9 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         scheduleObj.setProcessDefinitionName(processDefinition.getName());
 
         ScheduleParam scheduleParam = JSONUtils.parseObject(schedule, ScheduleParam.class);
+        if (now.after(scheduleParam.getStartTime())) {
+            scheduleParam.setStartTime(now);
+        }
         if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
             logger.warn("The start time must not be the same as the end or time can not be null.");
             putMsg(result, Status.SCHEDULE_START_TIME_END_TIME_SAME);
@@ -233,6 +236,10 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         ScheduleParam scheduleParam = JSONUtils.parseObject(scheduleParamStr, ScheduleParam.class);
         if (scheduleParam == null) {
             throw new ServiceException(Status.PARSE_SCHEDULE_PARAM_ERROR, scheduleParamStr);
+        }
+        Date now = new Date();
+        if (now.after(scheduleParam.getStartTime())) {
+            scheduleParam.setStartTime(now);
         }
         if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
             throw new ServiceException(Status.SCHEDULE_START_TIME_END_TIME_SAME);
@@ -832,6 +839,9 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                 logger.warn("Parameter scheduleExpression is invalid, so parse cron error.");
                 putMsg(result, Status.PARSE_TO_CRON_EXPRESSION_ERROR);
                 return;
+            }
+            if (now.after(scheduleParam.getStartTime())) {
+                scheduleParam.setStartTime(now);
             }
             if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
                 logger.warn("The start time must not be the same as the end or time can not be null.");

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
@@ -210,16 +210,24 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
         Assertions.assertEquals(Status.QUERY_ENVIRONMENT_BY_CODE_ERROR.getCode(),
                 ((ServiceException) exception).getCode());
 
+        // error schedule parameter start time before current time
+        String badStartTime = "2020-01-01 12:13:14";
+        scheduleCreateRequest.setStartTime(badStartTime);
+        Mockito.when(environmentMapper.queryByEnvironmentCode(environmentCode)).thenReturn(this.getEnvironment());
+        exception = Assertions.assertThrows(ServiceException.class,
+                () -> schedulerService.createSchedulesV2(user, scheduleCreateRequest));
+        Assertions.assertEquals(Status.START_TIME_BEFORE_CURRENT_TIME_ERROR.getCode(),
+                ((ServiceException) exception).getCode());
+
         // error schedule parameter same start time and end time
         scheduleCreateRequest.setStartTime(endTime);
-        Mockito.when(environmentMapper.queryByEnvironmentCode(environmentCode)).thenReturn(this.getEnvironment());
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.createSchedulesV2(user, scheduleCreateRequest));
         Assertions.assertEquals(Status.SCHEDULE_START_TIME_END_TIME_SAME.getCode(),
                 ((ServiceException) exception).getCode());
 
-        // error schedule parameter same start time after than end time
-        String badStartTime = "2222-01-01 12:13:14";
+        // error schedule parameter start time after than end time
+        badStartTime = "2222-01-01 12:13:14";
         scheduleCreateRequest.setStartTime(badStartTime);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.createSchedulesV2(user, scheduleCreateRequest));
@@ -363,17 +371,25 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
                 () -> schedulerService.updateSchedulesV2(user, scheduleId, scheduleUpdateRequest));
         Assertions.assertEquals(Status.SCHEDULE_NOT_EXISTS.getCode(), ((ServiceException) exception).getCode());
 
-        // error schedule parameter same start time and end time
+        // error schedule parameter start time before current time
+        String badStartTime = "2020-01-01 12:13:14";
+        scheduleUpdateRequest.setStartTime(badStartTime);
         scheduleUpdateRequest.setEndTime(endTime);
-        scheduleUpdateRequest.setStartTime(endTime);
         Mockito.when(scheduleMapper.selectById(scheduleId)).thenReturn(this.getSchedule());
+        exception = Assertions.assertThrows(ServiceException.class,
+                () -> schedulerService.updateSchedulesV2(user, scheduleId, scheduleUpdateRequest));
+        Assertions.assertEquals(Status.START_TIME_BEFORE_CURRENT_TIME_ERROR.getCode(),
+                ((ServiceException) exception).getCode());
+
+        // error schedule parameter same start time and end time
+        scheduleUpdateRequest.setStartTime(endTime);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.updateSchedulesV2(user, scheduleId, scheduleUpdateRequest));
         Assertions.assertEquals(Status.SCHEDULE_START_TIME_END_TIME_SAME.getCode(),
                 ((ServiceException) exception).getCode());
 
-        // error schedule parameter same start time after than end time
-        String badStartTime = "2222-01-01 12:13:14";
+        // error schedule parameter start time after than end time
+        badStartTime = "2222-01-01 12:13:14";
         scheduleUpdateRequest.setStartTime(badStartTime);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.updateSchedulesV2(user, scheduleId, scheduleUpdateRequest));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
@@ -105,8 +105,8 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
     private static final int processDefinitionVersion = 3;
     private static final int scheduleId = 3;
     private static final long environmentCode = 4L;
-    private static final String startTime = "2020-01-01 12:13:14";
-    private static final String endTime = "2020-02-01 12:13:14";
+    private static final String startTime = "2220-01-01 12:13:14";
+    private static final String endTime = "2220-02-01 12:13:14";
     private static final String crontab = "0 0 * * * ? *";
 
     @BeforeEach
@@ -175,6 +175,8 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
         ScheduleCreateRequest scheduleCreateRequest = new ScheduleCreateRequest();
         scheduleCreateRequest.setProcessDefinitionCode(processDefinitionCode);
         scheduleCreateRequest.setEnvironmentCode(environmentCode);
+        scheduleCreateRequest.setStartTime(startTime);
+        scheduleCreateRequest.setEndTime(endTime);
 
         // error process definition not exists
         exception = Assertions.assertThrows(ServiceException.class,
@@ -209,6 +211,7 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
                 ((ServiceException) exception).getCode());
 
         // error schedule parameter same start time and end time
+        scheduleCreateRequest.setStartTime(endTime);
         Mockito.when(environmentMapper.queryByEnvironmentCode(environmentCode)).thenReturn(this.getEnvironment());
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.createSchedulesV2(user, scheduleCreateRequest));
@@ -216,8 +219,7 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
                 ((ServiceException) exception).getCode());
 
         // error schedule parameter same start time after than end time
-        scheduleCreateRequest.setEndTime(endTime);
-        String badStartTime = "2022-01-01 12:13:14";
+        String badStartTime = "2222-01-01 12:13:14";
         scheduleCreateRequest.setStartTime(badStartTime);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.createSchedulesV2(user, scheduleCreateRequest));
@@ -371,7 +373,7 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
                 ((ServiceException) exception).getCode());
 
         // error schedule parameter same start time after than end time
-        String badStartTime = "2022-01-01 12:13:14";
+        String badStartTime = "2222-01-01 12:13:14";
         scheduleUpdateRequest.setStartTime(badStartTime);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.updateSchedulesV2(user, scheduleId, scheduleUpdateRequest));

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/use-form.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/use-form.ts
@@ -95,7 +95,7 @@ export const useForm = () => {
     timingFormRef: ref(),
     timingForm: {
       startEndTime: [
-        new Date(year, month, day),
+        new Date(year, month, day + 1),
         new Date(year + 100, month, day)
       ],
       crontab: '0 0 * * * ? *',


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
- This PR closes https://github.com/apache/dolphinscheduler/issues/13089

## Brief change log
Current mis-fire strategy is to process cron job immediately. The strategy will be triggered if setting scheduler’s start time earlier than current time. 
- Add check when creating and updating schedule, set the start time to current time if it's earlier than current time. 
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
