### PR TITLE
[Improvement] Fixed Possible JSON ordering permutations problem in Tests

### DIFF
--- a/dolphinscheduler-spi/src/test/java/org/apache/dolphinscheduler/spi/params/PluginParamsTransferTest.java
+++ b/dolphinscheduler-spi/src/test/java/org/apache/dolphinscheduler/spi/params/PluginParamsTransferTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.dolphinscheduler.spi.params;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import org.apache.dolphinscheduler.spi.params.base.DataType;
 import org.apache.dolphinscheduler.spi.params.base.ParamsOptions;
 import org.apache.dolphinscheduler.spi.params.base.PluginParams;
@@ -33,6 +31,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 /**
  * PluginParamsTransfer Tester.

--- a/dolphinscheduler-spi/src/test/java/org/apache/dolphinscheduler/spi/params/PluginParamsTransferTest.java
+++ b/dolphinscheduler-spi/src/test/java/org/apache/dolphinscheduler/spi/params/PluginParamsTransferTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.spi.params;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import org.apache.dolphinscheduler.spi.params.base.DataType;
 import org.apache.dolphinscheduler.spi.params.base.ParamsOptions;
 import org.apache.dolphinscheduler.spi.params.base.PluginParams;
@@ -178,7 +180,9 @@ public class PluginParamsTransferTest {
                 + ",\"disabled\":false},{\"label\":\"text\",\"value\":\"text\",\"disabled\":false},{\"label\""
                 + ":\"attachment\",\"value\":\"attachment\",\"disabled\":false},{\"label\":\"tableattachment\""
                 + ",\"value\":\"tableattachment\",\"disabled\":false}]}]";
-        Assertions.assertEquals(paramsJsonAssert, paramsJson);
+        JsonElement paramsJsonElement = JsonParser.parseString(paramsJson);
+        JsonElement paramsAssertJsonElement = JsonParser.parseString(paramsJsonAssert);
+        Assertions.assertEquals(paramsAssertJsonElement, paramsJsonElement);
     }
 
     @Test


### PR DESCRIPTION
## Purpose of the pull request
Flaky Test found using [NonDex](https://github.com/TestingResearchIllinois/NonDex) by running the command -
``` 
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.dolphinscheduler.spi.params.PluginParamsTransferTest#testGetParamsJson
```
The logged failure for the test
org.apache.dolphinscheduler.spi.params.PluginParamsTransferTest.testGetParamsJson was 
```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   PluginParamsTransferTest.testGetParamsJson:181 expected: <[{"props":null,"field":"field1","name":"field1","type":"input","title":"field1","value":null,"validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null},{"props":null,"field":"field2","name":"field2","type":"input","title":"field2","value":null,"validate":null,"emit":null},{"props":null,"field":"field3","name":"field3","type":"input","title":"field3","value":null,"validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null},{"props":null,"field":"field4","name":"field4","type":"input","title":"field4","value":null,"validate":[{"required":true,"message":null,"type":"number","trigger":"blur","min":null,"max":null}],"emit":null},{"props":null,"field":"field5","name":"field5","type":"input","title":"field5","value":null,"validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null},{"props":null,"field":"field6","name":"field6","type":"radio","title":"field6","value":true,"validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null,"options":[{"label":"YES","value":true,"disabled":false},{"label":"NO","value":false,"disabled":false}]},{"props":{"disabled":null,"type":null,"maxlength":null,"minlength":null,"clearable":null,"prefixIcon":null,"suffixIcon":null,"rows":null,"autosize":null,"autocomplete":null,"name":null,"readonly":null,"max":null,"min":null,"step":null,"resize":null,"autofocus":null,"form":null,"label":null,"tabindex":null,"validateEvent":null,"showPassword":null,"placeholder":"if enable use authentication, you need input user","size":"small"},"field":"field7","name":"field7","type":"input","title":"field7","value":null,"validate":null,"emit":null},{"field":"field8","name":"field8","props":{"disabled":null,"placeholder":"if enable use authentication, you need input password","size":"small"},"type":"input","title":"field8","value":null,"validate":null,"emit":null},{"props":null,"field":"field9","name":"field9","type":"radio","title":"field9","value":false,"validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null,"options":[{"label":"YES","value":true,"disabled":false},{"label":"NO","value":false,"disabled":false}]},{"props":null,"field":"field10","name":"field10","type":"radio","title":"field10","value":false,"validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null,"options":[{"label":"YES","value":true,"disabled":false},{"label":"NO","value":false,"disabled":false}]},{"props":null,"field":"field11","name":"field11","type":"input","title":"field11","value":"*","validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null},{"props":null,"field":"showType","name":"showType","type":"radio","title":"showType","value":"table","validate":[{"required":true,"message":null,"type":"string","trigger":"blur","min":null,"max":null}],"emit":null,"options":[{"label":"table","value":"table","disabled":false},{"label":"text","value":"text","disabled":false},{"label":"attachment","value":"attachment","disabled":false},{"label":"tableattachment","value":"tableattachment","disabled":false}]}]> but was: <[{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"value":null,"name":"field1","title":"field1","emit":null,"type":"input","field":"field1"},{"props":null,"validate":null,"value":null,"name":"field2","title":"field2","emit":null,"type":"input","field":"field2"},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"value":null,"name":"field3","title":"field3","emit":null,"type":"input","field":"field3"},{"props":null,"validate":[{"trigger":"blur","type":"number","min":null,"max":null,"message":null,"required":true}],"value":null,"name":"field4","title":"field4","emit":null,"type":"input","field":"field4"},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"value":null,"name":"field5","title":"field5","emit":null,"type":"input","field":"field5"},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"name":"field6","emit":null,"title":"field6","field":"field6","value":true,"type":"radio","options":[{"disabled":false,"label":"YES","value":true},{"disabled":false,"label":"NO","value":false}]},{"props":{"disabled":null,"readonly":null,"clearable":null,"name":null,"maxlength":null,"autofocus":null,"step":null,"autocomplete":null,"min":null,"autosize":null,"prefixIcon":null,"rows":null,"form":null,"minlength":null,"showPassword":null,"label":null,"suffixIcon":null,"resize":null,"tabindex":null,"type":null,"max":null,"validateEvent":null,"size":"small","placeholder":"if enable use authentication, you need input user"},"validate":null,"value":null,"name":"field7","title":"field7","emit":null,"type":"input","field":"field7"},{"validate":null,"title":"field8","props":{"disabled":null,"size":"small","placeholder":"if enable use authentication, you need input password"},"name":"field8","type":"input","emit":null,"field":"field8","value":null},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"name":"field9","emit":null,"title":"field9","field":"field9","value":false,"type":"radio","options":[{"disabled":false,"label":"YES","value":true},{"disabled":false,"label":"NO","value":false}]},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"name":"field10","emit":null,"title":"field10","field":"field10","value":false,"type":"radio","options":[{"disabled":false,"label":"YES","value":true},{"disabled":false,"label":"NO","value":false}]},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"value":"*","name":"field11","title":"field11","emit":null,"type":"input","field":"field11"},{"props":null,"validate":[{"trigger":"blur","type":"string","min":null,"max":null,"message":null,"required":true}],"name":"showType","emit":null,"title":"showType","field":"showType","value":"table","type":"radio","options":[{"disabled":false,"label":"table","value":"table"},{"disabled":false,"label":"text","value":"text"},{"disabled":false,"label":"attachment","value":"attachment"},{"disabled":false,"label":"tableattachment","value":"tableattachment"}]}]>
```
### Investigation
The test fails at PluginParamsTransferTest.testGetParamsJson:181 with a comparison error while comparing an expected string and the result from PluginParamsTransfer.transferParamsToJson function after converting it into String. The toString function of the Object class makes no guarantees as to the iteration order of the attributes in the object. This makes the test outcome non-deterministic and the test fails whenever the toString changes the order of the properties. To fix this, the expected and actual values should be checked in a more deterministic way so that the assertions do not fail.

## Brief change log

Expected and Actual values can be converted into [JsonElement](https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.5/com/google/gson/JsonElement.html) and then compared. As the JsonElements are compared without needing order, the test becomes deterministic and ensures that the flakiness from the test is removed.

The PR does not introduce a breaking change.

## Verify this pull request


This pull request is code cleanup without any test coverage.
