### PR TITLE
[bug][UI]Fixed a bug where the environment name of a task could not be changed when a workflow was created(issue-12457)

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -48,7 +48,9 @@ export function useEnvironmentName(
     loading.value = false
     if (options.value.length === 0) {
       model.environmentCode = null
-    } 
+    } else {
+      isCreate && (model.environmentCode = options.value[0].value)
+    }
   }
 
   const filterByWorkerGroup = (option: IEnvironmentNameOption) => {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -85,6 +85,6 @@ export function useEnvironmentName(
       loading: loading,
       clearable: true
     },
-    options: options,
+    options: options
   }
 }

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -48,9 +48,7 @@ export function useEnvironmentName(
     loading.value = false
     if (options.value.length === 0) {
       model.environmentCode = null
-    } else {
-      isCreate && (model.environmentCode = options.value[0].value)
-    }
+    } 
   }
 
   const filterByWorkerGroup = (option: IEnvironmentNameOption) => {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -49,7 +49,6 @@ export function useEnvironmentName(
     if (options.value.length === 0) {
       model.environmentCode = null
     } else {
-      debugger
       (isCreate && !model.environmentCode)  && (model.environmentCode = options.value[0].value)
     }
   }

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -49,7 +49,8 @@ export function useEnvironmentName(
     if (options.value.length === 0) {
       model.environmentCode = null
     } else {
-      isCreate && (model.environmentCode = options.value[0].value)
+      debugger
+      (isCreate && !model.environmentCode)  && (model.environmentCode = options.value[0].value)
     }
   }
 
@@ -85,6 +86,6 @@ export function useEnvironmentName(
       loading: loading,
       clearable: true
     },
-    options: options
+    options: options,
   }
 }


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

close #12457 

When creating a workflow definition, either by creating or modifying a task node, the environment name is always reset to the first item in the environment options when the task details window is opened again and it cause by 

<img width="511" alt="截屏2022-12-10 15 46 52" src="https://user-images.githubusercontent.com/35210666/206839299-9aa9761b-edbc-4ba1-8b1a-ca8884bdc3bc.png">






