### PR TITLE
[Bug][Master] fix task failure continue

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -412,13 +412,13 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
                 retryTaskInstance(taskInstance);
             } else if (taskInstance.getState().isFailure()) {
                 completeTaskMap.put(taskInstance.getTaskCode(), taskInstance.getId());
-                errorTaskMap.put(taskInstance.getTaskCode(), taskInstance.getId());
                 // There are child nodes and the failure policy is: CONTINUE
                 if (processInstance.getFailureStrategy() == FailureStrategy.CONTINUE && DagHelper.haveAllNodeAfterNode(
                         Long.toString(taskInstance.getTaskCode()),
                         dag)) {
                     submitPostNode(Long.toString(taskInstance.getTaskCode()));
                 } else {
+                    errorTaskMap.put(taskInstance.getTaskCode(), taskInstance.getId());
                     if (processInstance.getFailureStrategy() == FailureStrategy.END) {
                         killAllTasks();
                     }


### PR DESCRIPTION
**What happened**
When it exists in the conditional node, that is, the task flow can execute and complete the DAG task correctly, at this time, the task flow status cannot be considered as a failure because of a node error in the task flow. This will cause dependent nodes not to correctly identify the task flow state
**What you expected to happen**
xxx

**How to reproduce**
1) Use conditional nodes
2) Let the task flow go to the failure branch of the conditions node

**Anything else**
No response

**Version**
3.0.3, 3.0.4, 3.1.x, dev