### PR TITLE
[Improvement][Security]Add CSRF protection(issue-12931)

### DIFF
--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api.test/pages/security/TenantPage.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api.test/pages/security/TenantPage.java
@@ -35,6 +35,7 @@ public final class TenantPage {
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.SESSION_ID_KEY, sessionId);
+        headers.put(Constants.CSRF_TOKEN_ID,new StringBuilder(sessionId).reverse().toString());
 
         RequestClient requestClient = new RequestClient();
 
@@ -44,6 +45,7 @@ public final class TenantPage {
     public HttpResponse getTenantListPaging(String sessionId, Integer pageNo, Integer pageSize, String searchVal) {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.SESSION_ID_KEY, sessionId);
+        headers.put(Constants.CSRF_TOKEN_ID,new StringBuilder(sessionId).reverse().toString());
 
         Map<String, Object> params = new HashMap<>();
         params.put("pageSize", pageSize);
@@ -58,6 +60,7 @@ public final class TenantPage {
     public HttpResponse deleteTenant(String sessionId, Integer tenantId) {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.SESSION_ID_KEY, sessionId);
+        headers.put(Constants.CSRF_TOKEN_ID,new StringBuilder(sessionId).reverse().toString());
 
         RequestClient requestClient = new RequestClient();
 

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-core/src/main/java/org/apache/dolphinscheduler/api/test/core/Constants.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-core/src/main/java/org/apache/dolphinscheduler/api/test/core/Constants.java
@@ -37,6 +37,7 @@ public final class Constants {
      */
     public static final String SESSION_ID_KEY = "sessionId";
 
+    public static final String CSRF_TOKEN_ID = "X-CSRF-TOKEN";
     /**
      * simple date format
      */

--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -143,10 +143,7 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.springframework.boot</groupId>-->
-        <!--            <artifactId>spring-boot-starter-security</artifactId>-->
-        <!--        </dependency>-->
+
         <!-- just for test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -143,7 +143,10 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>
-
+        <!--        <dependency>-->
+        <!--            <groupId>org.springframework.boot</groupId>-->
+        <!--            <artifactId>spring-boot-starter-security</artifactId>-->
+        <!--        </dependency>-->
         <!-- just for test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -17,7 +17,7 @@
 
 package org.apache.dolphinscheduler.api.configuration;
 
-import org.apache.dolphinscheduler.api.interceptor.CsrfInterceptor;
+import org.apache.dolphinscheduler.api.interceptor.CsrfTokenInterceptor;
 import org.apache.dolphinscheduler.api.interceptor.LocaleChangeInterceptor;
 import org.apache.dolphinscheduler.api.interceptor.LoginHandlerInterceptor;
 import org.apache.dolphinscheduler.api.interceptor.RateLimitInterceptor;
@@ -70,8 +70,8 @@ public class AppConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public CsrfInterceptor csrfInterceptor() {
-        return new CsrfInterceptor();
+    public CsrfTokenInterceptor csrfInterceptor() {
+        return new CsrfTokenInterceptor();
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -106,17 +106,17 @@ public class AppConfiguration implements WebMvcConfigurer {
         if (trafficConfiguration.isGlobalSwitch() || trafficConfiguration.isTenantSwitch()) {
             registry.addInterceptor(createRateLimitInterceptor());
         }
+        String[] excludePathPatterns = {LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN,
+                "/swagger-resources/**", "/webjars/**", "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
+                "/doc.html", "/swagger-ui/**", "*.html", "/ui/**", "/error"};
+
         registry.addInterceptor(loginInterceptor())
                 .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
-                .excludePathPatterns(LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN,
-                        "/swagger-resources/**", "/webjars/**", "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
-                        "/doc.html", "/swagger-ui/**", "*.html", "/ui/**", "/error");
+                .excludePathPatterns(excludePathPatterns);
 
         registry.addInterceptor(csrfInterceptor())
                 .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
-                .excludePathPatterns(LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN, "/swagger-resources/**", "/webjars/**",
-                        "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
-                        "/doc.html", "/swagger-ui/**", "*.html", "/ui/**", "/error");
+                .excludePathPatterns(excludePathPatterns);
     }
 
     @Override

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -47,13 +47,13 @@ public class AppConfiguration implements WebMvcConfigurer {
 
     public static final String LOGIN_INTERCEPTOR_PATH_PATTERN = "/**/*";
     public static final String LOGIN_PATH_PATTERN = "/login";
-    public static final String UI_PATH_PATTERN = "/ui/**";
-    public static final String[] SWAGGER_PATH_PATTERN = {"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
+    protected static final String UI_PATH_PATTERN = "/ui/**";
+    protected static final String[] SWAGGER_PATH_PATTERN = {"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
             "/swagger-ui/**", "/swagger-resources/**",};
-    public static final String WEBJARS_PATH_PATTERN = "/webjars/**";
-    public static final String DOC_PATH_PATTERN = "/doc.html";
-    public static final String HTML_PATH_PATTERN = "*.html";
-    public static final String ERROR_PATH_PATTERN = "/error";
+    protected static final String WEBJARS_PATH_PATTERN = "/webjars/**";
+    protected static final String DOC_PATH_PATTERN = "/doc.html";
+    protected static final String HTML_PATH_PATTERN = "*.html";
+    protected static final String ERROR_PATH_PATTERN = "/error";
     public static final String REGISTER_PATH_PATTERN = "/users/register";
     public static final String PATH_PATTERN = "/**";
     public static final String LOCALE_LANGUAGE_COOKIE = "language";

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -48,7 +48,7 @@ public class AppConfiguration implements WebMvcConfigurer {
     public static final String LOGIN_INTERCEPTOR_PATH_PATTERN = "/**/*";
     public static final String LOGIN_PATH_PATTERN = "/login";
     protected static final String UI_PATH_PATTERN = "/ui/**";
-    protected static final String[] SWAGGER_PATH_PATTERN = {"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
+    protected static final String[] SWAGGER_PATH_PATTERNS = {"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
             "/swagger-ui/**", "/swagger-resources/**",};
     protected static final String WEBJARS_PATH_PATTERN = "/webjars/**";
     protected static final String DOC_PATH_PATTERN = "/doc.html";
@@ -120,14 +120,14 @@ public class AppConfiguration implements WebMvcConfigurer {
                 .excludePathPatterns(ArrayUtil.add(
                         new String[]{LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN, DOC_PATH_PATTERN,
                                 HTML_PATH_PATTERN, WEBJARS_PATH_PATTERN, UI_PATH_PATTERN, ERROR_PATH_PATTERN},
-                        SWAGGER_PATH_PATTERN));
+                        SWAGGER_PATH_PATTERNS));
 
         registry.addInterceptor(csrfInterceptor())
                 .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
                 .excludePathPatterns(ArrayUtil.add(
                         new String[]{LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN, DOC_PATH_PATTERN,
                                 HTML_PATH_PATTERN, WEBJARS_PATH_PATTERN, UI_PATH_PATTERN, ERROR_PATH_PATTERN},
-                        SWAGGER_PATH_PATTERN));
+                        SWAGGER_PATH_PATTERNS));
 
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.api.configuration;
 
+import org.apache.dolphinscheduler.api.interceptor.CsrfInterceptor;
 import org.apache.dolphinscheduler.api.interceptor.LocaleChangeInterceptor;
 import org.apache.dolphinscheduler.api.interceptor.LoginHandlerInterceptor;
 import org.apache.dolphinscheduler.api.interceptor.RateLimitInterceptor;
@@ -68,6 +69,11 @@ public class AppConfiguration implements WebMvcConfigurer {
         return new LoginHandlerInterceptor();
     }
 
+    @Bean
+    public CsrfInterceptor csrfInterceptor() {
+        return new CsrfInterceptor();
+    }
+
     /**
      * Cookie
      * @return local resolver
@@ -104,6 +110,12 @@ public class AppConfiguration implements WebMvcConfigurer {
                 .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
                 .excludePathPatterns(LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN,
                         "/swagger-resources/**", "/webjars/**", "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
+                        "/doc.html", "/swagger-ui/**", "*.html", "/ui/**", "/error");
+
+        registry.addInterceptor(csrfInterceptor())
+                .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
+                .excludePathPatterns(LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN, "/swagger-resources/**", "/webjars/**",
+                        "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
                         "/doc.html", "/swagger-ui/**", "*.html", "/ui/**", "/error");
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/AppConfiguration.java
@@ -24,6 +24,7 @@ import org.apache.dolphinscheduler.api.interceptor.RateLimitInterceptor;
 
 import java.util.Locale;
 
+import org.eclipse.jetty.util.ArrayUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,6 +47,13 @@ public class AppConfiguration implements WebMvcConfigurer {
 
     public static final String LOGIN_INTERCEPTOR_PATH_PATTERN = "/**/*";
     public static final String LOGIN_PATH_PATTERN = "/login";
+    public static final String UI_PATH_PATTERN = "/ui/**";
+    public static final String[] SWAGGER_PATH_PATTERN = {"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
+            "/swagger-ui/**", "/swagger-resources/**",};
+    public static final String WEBJARS_PATH_PATTERN = "/webjars/**";
+    public static final String DOC_PATH_PATTERN = "/doc.html";
+    public static final String HTML_PATH_PATTERN = "*.html";
+    public static final String ERROR_PATH_PATTERN = "/error";
     public static final String REGISTER_PATH_PATTERN = "/users/register";
     public static final String PATH_PATTERN = "/**";
     public static final String LOCALE_LANGUAGE_COOKIE = "language";
@@ -106,25 +114,30 @@ public class AppConfiguration implements WebMvcConfigurer {
         if (trafficConfiguration.isGlobalSwitch() || trafficConfiguration.isTenantSwitch()) {
             registry.addInterceptor(createRateLimitInterceptor());
         }
-        String[] excludePathPatterns = {LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN,
-                "/swagger-resources/**", "/webjars/**", "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html",
-                "/doc.html", "/swagger-ui/**", "*.html", "/ui/**", "/error"};
 
         registry.addInterceptor(loginInterceptor())
                 .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
-                .excludePathPatterns(excludePathPatterns);
+                .excludePathPatterns(ArrayUtil.add(
+                        new String[]{LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN, DOC_PATH_PATTERN,
+                                HTML_PATH_PATTERN, WEBJARS_PATH_PATTERN, UI_PATH_PATTERN, ERROR_PATH_PATTERN},
+                        SWAGGER_PATH_PATTERN));
 
         registry.addInterceptor(csrfInterceptor())
                 .addPathPatterns(LOGIN_INTERCEPTOR_PATH_PATTERN)
-                .excludePathPatterns(excludePathPatterns);
+                .excludePathPatterns(ArrayUtil.add(
+                        new String[]{LOGIN_PATH_PATTERN, REGISTER_PATH_PATTERN, DOC_PATH_PATTERN,
+                                HTML_PATH_PATTERN, WEBJARS_PATH_PATTERN, UI_PATH_PATTERN, ERROR_PATH_PATTERN},
+                        SWAGGER_PATH_PATTERN));
+
     }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/static/**").addResourceLocations("classpath:/static/");
         registry.addResourceHandler("doc.html").addResourceLocations("classpath:/META-INF/resources/");
-        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
-        registry.addResourceHandler("/ui/**").addResourceLocations("file:ui/");
+        registry.addResourceHandler(WEBJARS_PATH_PATTERN)
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
+        registry.addResourceHandler(UI_PATH_PATTERN).addResourceLocations("file:ui/");
     }
 
     @Override

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/CsrfInterceptor.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/CsrfInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.interceptor;
+
+import org.apache.http.HttpStatus;
+
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.WebUtils;
+
+public class CsrfInterceptor implements HandlerInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(CsrfInterceptor.class);
+
+    private static final String DEFAULT_CSRF_HEADER_NAME = "X-CSRF-TOKEN";
+
+    private static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String token = request.getHeader("token");
+        if (token != null) {
+            return true;
+        }
+        String csrfToken = Optional.ofNullable(request.getHeader(DEFAULT_CSRF_HEADER_NAME))
+                .orElse(request.getParameter(DEFAULT_CSRF_PARAMETER_NAME));
+        if (csrfToken == null) {
+            response.setStatus(HttpStatus.SC_FORBIDDEN);
+            logger.info("csrf token is null");
+            return false;
+        }
+        String realCsrfToken = Optional.ofNullable(request).map(req -> WebUtils.getCookie(req, "sessionId"))
+                .map(Cookie::getValue).map(e -> new StringBuilder(e).reverse().toString()).orElse(null);
+        if (!csrfToken.equals(realCsrfToken)) {
+            response.setStatus(HttpStatus.SC_FORBIDDEN);
+            logger.info("csrf token is error");
+            return false;
+        }
+        return true;
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/CsrfTokenInterceptor.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/CsrfTokenInterceptor.java
@@ -34,7 +34,6 @@ import org.springframework.web.util.WebUtils;
 public class CsrfTokenInterceptor implements HandlerInterceptor {
 
     private static final Logger logger = LoggerFactory.getLogger(CsrfTokenInterceptor.class);
-
     private static final String DEFAULT_CSRF_HEADER_NAME = "X-CSRF-TOKEN";
 
     private static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AbstractControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AbstractControllerTest.java
@@ -69,6 +69,8 @@ public abstract class AbstractControllerTest {
 
     protected String sessionId;
 
+    protected String csrfToken;
+
     @BeforeEach
     public void setUp() {
         user = usersService.queryUser(1);
@@ -86,8 +88,12 @@ public abstract class AbstractControllerTest {
 
         String session = sessionService.createSession(loginUser, "127.0.0.1");
         sessionId = session;
-
+        csrfToken = generateCsrfToken(sessionId);
         Assertions.assertFalse(StringUtils.isEmpty(session));
+    }
+
+    private String generateCsrfToken(String sessionId) {
+        return new StringBuilder(sessionId).reverse().toString();
     }
 
     public Map<String, Object> success() {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AccessTokenControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AccessTokenControllerTest.java
@@ -51,7 +51,8 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         paramsMap.add("expireTime", "2019-12-18 00:00:00");
         paramsMap.add("token", "607f5aeaaa2093dbdff5d5522ce00510");
         MvcResult mvcResult = mockMvc.perform(post("/access-tokens")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -71,6 +72,7 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         MvcResult mvcResult = this.mockMvc
                 .perform(post("/access-tokens")
                         .header("sessionId", this.sessionId)
+                        .header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -88,7 +90,8 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         paramsMap.add("expireTime", "2019-12-18 00:00:00");
         paramsMap.add("token", "507f5aeaaa2093dbdff5d5522ce00510");
         MvcResult mvcResult = mockMvc.perform(post("/access-tokens")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -104,7 +107,8 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         paramsMap.add("userId", "4");
         paramsMap.add("expireTime", "2019-12-28 00:00:00");
         MvcResult mvcResult = mockMvc.perform(post("/access-tokens/generate")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -122,6 +126,7 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         paramsMap.add("searchVal", "");
         MvcResult mvcResult = mockMvc.perform(get("/access-tokens")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -148,7 +153,8 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
     public void testDelAccessTokenById() throws Exception {
         testCreateToken();
         MvcResult mvcResult = mockMvc.perform(delete("/access-tokens/1")
-                .header("sessionId", sessionId))
+                .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -166,6 +172,7 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         paramsMap.add("token", "cxctoken123update");
         MvcResult mvcResult = mockMvc.perform(put("/access-tokens/1")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -187,6 +194,7 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         MvcResult mvcResult = this.mockMvc
                 .perform(put("/access-tokens/2")
                         .header("sessionId", this.sessionId)
+                        .header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AccessTokenV2ControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AccessTokenV2ControllerTest.java
@@ -50,6 +50,7 @@ public class AccessTokenV2ControllerTest extends AbstractControllerTest {
         paramsMap.put("token", "607f5aeaaa2093dbdff5d5522ce00510");
         MvcResult mvcResult = mockMvc.perform(post("/v2/access-tokens")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(paramsMap)))
                 .andExpect(status().isCreated())
@@ -70,6 +71,7 @@ public class AccessTokenV2ControllerTest extends AbstractControllerTest {
         MvcResult mvcResult = this.mockMvc
                 .perform(post("/v2/access-tokens")
                         .header("sessionId", this.sessionId)
+                        .header("X-CSRF-TOKEN", csrfToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(JSONUtils.toJsonString(paramsMap)))
                 .andExpect(status().isCreated())
@@ -89,6 +91,7 @@ public class AccessTokenV2ControllerTest extends AbstractControllerTest {
         paramsMap.put("token", "507f5aeaaa2093dbdff5d5522ce00510");
         MvcResult mvcResult = mockMvc.perform(post("/v2/access-tokens")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(paramsMap)))
                 .andExpect(status().isCreated())

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertGroupControllerTest.java
@@ -80,7 +80,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         paramsMap.add("description", "cxc junit test alert description");
         paramsMap.add("alertInstanceIds", "");
         MvcResult mvcResult = mockMvc.perform(post("/alert-groups")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -95,7 +96,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         createEntity();
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         MvcResult mvcResult = mockMvc.perform(get("/alert-groups/list")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -114,7 +116,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         paramsMap.add("searchVal", "email");
         paramsMap.add("pageSize", "1");
         MvcResult mvcResult = mockMvc.perform(get("/alert-groups")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -130,7 +133,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         paramsMap.add("id", Integer.toString(entityId));
         MvcResult mvcResult = mockMvc.perform(post("/alert-groups/query")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -149,7 +153,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         paramsMap.add("description", "update alter group");
         paramsMap.add("alertInstanceIds", "");
         MvcResult mvcResult = mockMvc.perform(put("/alert-groups/" + entityId)
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -164,7 +169,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         paramsMap.add("groupName", defaultTestAlertGroupName);
         MvcResult mvcResult = mockMvc.perform(get("/alert-groups/verify-name")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -179,7 +185,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         paramsMap.add("groupName", "cxc test group name xx");
         MvcResult mvcResult = mockMvc.perform(get("/alert-groups/verify-name")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -194,7 +201,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
         int entityId = createEntity();
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         MvcResult mvcResult = mockMvc.perform(delete("/alert-groups/" + entityId)
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -208,7 +216,8 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
     public void test090DelAlertGroupById() throws Exception {
         MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         MvcResult mvcResult = mockMvc.perform(delete("/alert-groups/1")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceControllerTest.java
@@ -75,6 +75,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/alert-plugin-instances")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -101,6 +102,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc.perform(put("/alert-plugin-instances/{id}", pluginDefineId)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -126,6 +128,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc.perform(delete("/alert-plugin-instances/{id}", pluginDefineId)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -149,6 +152,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc.perform(get("/alert-plugin-instances/{id}", pluginDefineId)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -168,7 +172,8 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
 
         // When
         final MvcResult mvcResult = mockMvc.perform(get("/alert-plugin-instances/list")
-                .header(SESSION_ID, sessionId))
+                .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -195,6 +200,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc.perform(get("/alert-plugin-instances/verify-name")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -222,7 +228,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
 
         // When
         final MvcResult mvcResult = mockMvc.perform(get("/alert-plugin-instances/verify-name")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -252,7 +258,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
 
         // When
         final MvcResult mvcResult = mockMvc.perform(get("/alert-plugin-instances")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -279,7 +285,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
 
         // When
         final MvcResult mvcResult = mockMvc.perform(get("/alert-plugin-instances")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AuditLogControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AuditLogControllerTest.java
@@ -48,7 +48,7 @@ public class AuditLogControllerTest extends AbstractControllerTest {
         paramsMap.add("pageSize", "10");
 
         MvcResult mvcResult = mockMvc.perform(get("/projects/audit/audit-log-list")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ClusterControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ClusterControllerTest.java
@@ -68,6 +68,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/cluster/create")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -94,6 +95,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/cluster/update")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -113,6 +115,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(get("/cluster/query-by-code")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -136,6 +139,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(get("/cluster/list-paging")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -153,6 +157,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(get("/cluster/query-cluster-list")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -172,6 +177,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/cluster/verify-cluster")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -192,6 +198,7 @@ public class ClusterControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/cluster/delete")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/DataAnalysisControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/DataAnalysisControllerTest.java
@@ -69,6 +69,7 @@ public class DataAnalysisControllerTest extends AbstractControllerTest {
         paramsMap.add("projectCode", "16");
         MvcResult mvcResult = mockMvc.perform(get("/projects/analysis/task-state-count")
                 .header("sessionId", sessionId)
+
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/DataSourceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/DataSourceControllerTest.java
@@ -78,6 +78,7 @@ public class DataSourceControllerTest extends AbstractControllerTest {
         paramsMap.put("bindTestId", null);
         MvcResult mvcResult = mockMvc.perform(post("/datasources")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(paramsMap)))
                 .andExpect(status().isCreated())
@@ -107,6 +108,7 @@ public class DataSourceControllerTest extends AbstractControllerTest {
         paramsMap.put("bindTestId", 1);
         MvcResult mvcResult = mockMvc.perform(put("/datasources/2")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .content(JSONUtils.toJsonString(paramsMap)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -139,6 +141,7 @@ public class DataSourceControllerTest extends AbstractControllerTest {
         paramsMap.add("testFlag", "0");
         MvcResult mvcResult = mockMvc.perform(get("/datasources/list")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -156,6 +159,7 @@ public class DataSourceControllerTest extends AbstractControllerTest {
         paramsMap.add("pageSize", "1");
         MvcResult mvcResult = mockMvc.perform(get("/datasources")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -181,6 +185,7 @@ public class DataSourceControllerTest extends AbstractControllerTest {
         paramsMap.put("bindTestId", null);
         MvcResult mvcResult = mockMvc.perform(post("/datasources/connect")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .content(JSONUtils.toJsonString(paramsMap)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/EnvironmentControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/EnvironmentControllerTest.java
@@ -72,6 +72,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/environment/create")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -98,6 +99,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/environment/update")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -117,6 +119,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(get("/environment/query-by-code")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -140,6 +143,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(get("/environment/list-paging")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -157,6 +161,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(get("/environment/query-environment-list")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -176,6 +181,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/environment/verify-environment")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -196,6 +202,7 @@ public class EnvironmentControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/environment/delete")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecutorControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ExecutorControllerTest.java
@@ -121,7 +121,7 @@ public class ExecutorControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc
                 .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
+                        .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -164,7 +164,7 @@ public class ExecutorControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc
                 .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
+                        .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -206,7 +206,7 @@ public class ExecutorControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc
                 .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
+                        .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -235,7 +235,7 @@ public class ExecutorControllerTest extends AbstractControllerTest {
         // When
         final MvcResult mvcResult = mockMvc
                 .perform(post("/projects/{projectCode}/executors/start-process-instance", projectCode)
-                        .header("sessionId", sessionId)
+                        .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -268,7 +268,7 @@ public class ExecutorControllerTest extends AbstractControllerTest {
 
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/executors/execute", projectCode)
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -286,7 +286,7 @@ public class ExecutorControllerTest extends AbstractControllerTest {
                 .thenReturn(executeServiceResult);
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/executors/start-check", projectCode)
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .param("processDefinitionCode", String.valueOf(processDefinitionCode)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/K8sNamespaceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/K8sNamespaceControllerTest.java
@@ -72,6 +72,7 @@ public class K8sNamespaceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/k8s-namespace")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated()) // it can
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -92,6 +93,7 @@ public class K8sNamespaceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(put("/k8s-namespace/{id}", 1)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -112,6 +114,7 @@ public class K8sNamespaceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/k8s-namespace/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -127,6 +130,7 @@ public class K8sNamespaceControllerTest extends AbstractControllerTest {
         paramsMap.add("clusterCode", "100");
         mvcResult = mockMvc.perform(post("/k8s-namespace/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -144,6 +148,7 @@ public class K8sNamespaceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/k8s-namespace/delete")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/LoginControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/LoginControllerTest.java
@@ -70,6 +70,7 @@ public class LoginControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/signOut")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessInstanceControllerTest.java
@@ -186,7 +186,8 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/process-instances/query-parent-by-sub", "1113")
-                        .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
+                        .header(SESSION_ID, sessionId)
+                        .header("X-CSRF-TOKEN", csrfToken)
                         .param("subId", "1204"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -223,7 +224,8 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
                 .thenReturn(mockResult);
 
         MvcResult mvcResult = mockMvc.perform(delete("/projects/{projectCode}/process-instances/{id}", "1113", "123")
-                .header(SESSION_ID, sessionId))
+                .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessInstanceControllerTest.java
@@ -72,7 +72,7 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
         paramsMap.add("pageSize", "2");
 
         MvcResult mvcResult = mockMvc.perform(get("/projects/1113/process-instances")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -128,7 +128,7 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
         paramsMap.add("tenantCode", "123");
 
         MvcResult mvcResult = mockMvc.perform(put("/projects/{projectCode}/process-instances/{id}", "1113", "123")
-                .header("sessionId", sessionId)
+                .header("sessionId", sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -165,7 +165,7 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/process-instances/query-sub-by-parent", "1113")
-                        .header(SESSION_ID, sessionId)
+                        .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                         .param("taskId", "1203"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -186,7 +186,7 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/process-instances/query-parent-by-sub", "1113")
-                        .header(SESSION_ID, sessionId)
+                        .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                         .param("subId", "1204"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -242,7 +242,7 @@ public class ProcessInstanceControllerTest extends AbstractControllerTest {
                 processInstanceService.deleteProcessInstanceById(Mockito.any(), Mockito.anyLong(), Mockito.anyInt()))
                 .thenReturn(mockResult);
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/process-instances/batch-delete", "1113")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .param("processInstanceIds", "1205,1206"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/QueueControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/QueueControllerTest.java
@@ -92,6 +92,7 @@ public class QueueControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/queues")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -112,6 +113,7 @@ public class QueueControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(put("/queues/{id}", 1)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -133,6 +135,7 @@ public class QueueControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/queues/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -150,6 +153,7 @@ public class QueueControllerTest extends AbstractControllerTest {
 
         mvcResult = mockMvc.perform(post("/queues/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -166,6 +170,7 @@ public class QueueControllerTest extends AbstractControllerTest {
 
         mvcResult = mockMvc.perform(post("/queues/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/QueueV2ControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/QueueV2ControllerTest.java
@@ -73,7 +73,7 @@ public class QueueV2ControllerTest extends AbstractControllerTest {
         queueQueryRequest.setPageSize(20);
 
         MvcResult mvcResult = mockMvc.perform(get("/v2/queues")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .accept(MediaType.ALL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(queueQueryRequest)))
@@ -92,6 +92,7 @@ public class QueueV2ControllerTest extends AbstractControllerTest {
         queueCreateRequest.setQueueName(QUEUE_NAME_CREATE_NAME);
         MvcResult mvcResult = mockMvc.perform(post("/v2/queues")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .accept(MediaType.ALL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(queueCreateRequest)))
@@ -111,6 +112,7 @@ public class QueueV2ControllerTest extends AbstractControllerTest {
         queueUpdateRequest.setQueueName(QUEUE_NAME_MODIFY_NAME);
         MvcResult mvcResult = mockMvc.perform(put("/v2/queues/{id}", 1)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .accept(MediaType.ALL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(queueUpdateRequest)))
@@ -131,6 +133,7 @@ public class QueueV2ControllerTest extends AbstractControllerTest {
         queueVerifyRequest.setQueueName(NOT_EXISTS_NAME);
         MvcResult mvcResult = mockMvc.perform(post("/v2/queues/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .accept(MediaType.ALL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(queueVerifyRequest)))
@@ -146,6 +149,7 @@ public class QueueV2ControllerTest extends AbstractControllerTest {
         queueVerifyRequest.setQueueName(QUEUE_NAME_CREATE_NAME);
         mvcResult = mockMvc.perform(post("/v2/queues/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .accept(MediaType.ALL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(queueVerifyRequest)))
@@ -160,6 +164,7 @@ public class QueueV2ControllerTest extends AbstractControllerTest {
         queueVerifyRequest.setQueueName(NOT_EXISTS_NAME);
         mvcResult = mockMvc.perform(post("/v2/queues/verify")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .accept(MediaType.ALL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSONUtils.toJsonString(queueVerifyRequest)))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ResourcesControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ResourcesControllerTest.java
@@ -154,7 +154,7 @@ public class ResourcesControllerTest extends AbstractControllerTest {
         paramsMap.add("tenantCode", "123");
 
         MvcResult mvcResult = mockMvc.perform(get("/resources/view")
-                .header(SESSION_ID, sessionId)
+                .header(SESSION_ID, sessionId).header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -186,6 +186,7 @@ public class ResourcesControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/resources/online-create")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -213,6 +214,7 @@ public class ResourcesControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(put("/resources/update-content")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -263,6 +265,7 @@ public class ResourcesControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/resources/udf-func")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -317,6 +320,7 @@ public class ResourcesControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(put("/resources/udf-func/{id}", "456")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -470,7 +474,8 @@ public class ResourcesControllerTest extends AbstractControllerTest {
         Mockito.when(udfFuncService.delete(Mockito.any(), Mockito.anyInt())).thenReturn(mockResult);
 
         MvcResult mvcResult = mockMvc.perform(delete("/resources/udf-func/{id}", "123")
-                .header(SESSION_ID, sessionId))
+                .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -493,6 +498,7 @@ public class ResourcesControllerTest extends AbstractControllerTest {
         paramsMap.add("tenantCode", "123");
         MvcResult mvcResult = mockMvc.perform(delete("/resources")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/SchedulerControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/SchedulerControllerTest.java
@@ -75,6 +75,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/", 123)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -105,6 +106,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(put("/projects/{projectCode}/schedules/{id}", 123, 37)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -125,6 +127,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/{id}/online", 123, 37)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -145,6 +148,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/{id}/offline", 123, 28)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -186,7 +190,8 @@ public class SchedulerControllerTest extends AbstractControllerTest {
         Mockito.when(schedulerService.queryScheduleList(isA(User.class), isA(Long.class))).thenReturn(success());
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/list", 123)
-                .header(SESSION_ID, sessionId))
+                .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -203,6 +208,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/preview", 123)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .param("schedule",
                         "{'startTime':'2019-06-10 00:00:00','endTime':'2019-06-13 00:00:00','crontab':'0 0 3/6 * * ? *','timezoneId':'Asia/Shanghai'}"))
                 .andExpect(status().isCreated())
@@ -223,6 +229,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(delete("/projects/{projectCode}/schedules/{id}", 123, 37)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TaskGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TaskGroupControllerTest.java
@@ -107,6 +107,7 @@ public class TaskGroupControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/task-group/create")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -123,6 +124,7 @@ public class TaskGroupControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult1 = mockMvc.perform(post("/task-group/create")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -143,6 +145,7 @@ public class TaskGroupControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/task-group/update")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -161,6 +164,7 @@ public class TaskGroupControllerTest extends AbstractControllerTest {
         paramsMap.add("id", "1");
         MvcResult mvcResult = mockMvc.perform(post("/task-group/close-task-group")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -175,6 +179,7 @@ public class TaskGroupControllerTest extends AbstractControllerTest {
         paramsMap.add("id", "1");
         MvcResult mvcResult1 = mockMvc.perform(post("/task-group/start-task-group")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TaskInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TaskInstanceControllerTest.java
@@ -87,6 +87,7 @@ public class TaskInstanceControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectName}/task-instance/force-success", "cxc_1113")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TenantControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TenantControllerTest.java
@@ -58,6 +58,7 @@ public class TenantControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/tenants")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -98,6 +99,7 @@ public class TenantControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(put("/tenants/{id}", 9)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -149,7 +151,8 @@ public class TenantControllerTest extends AbstractControllerTest {
     public void testQueryTenantlist() throws Exception {
 
         MvcResult mvcResult = mockMvc.perform(get("/tenants/list")
-                .header(SESSION_ID, sessionId))
+                .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -167,6 +170,7 @@ public class TenantControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(delete("/tenants/{id}", 64)
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UiPluginControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UiPluginControllerTest.java
@@ -66,6 +66,7 @@ public class UiPluginControllerTest extends AbstractControllerTest {
 
         final MvcResult mvcResult = mockMvc.perform(get("/ui-plugins/query-by-type")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UsersControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UsersControllerTest.java
@@ -58,6 +58,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/create")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -81,6 +82,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/update")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -98,6 +100,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/grant-project")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -153,6 +156,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/grant-file")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -171,6 +175,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/grant-udf-func")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -189,6 +194,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/grant-datasource")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -290,6 +296,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/delete")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -324,6 +331,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/register")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -341,6 +349,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = mockMvc.perform(post("/users/activate")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -359,6 +368,7 @@ public class UsersControllerTest extends AbstractControllerTest {
         String jsonUserNames = JSONUtils.toJsonString(userNames);
         MvcResult mvcResult = mockMvc.perform(post("/users/batch/activate")
                 .header(SESSION_ID, sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonUserNames))
                 .andExpect(status().isOk())

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UsersControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UsersControllerTest.java
@@ -120,6 +120,7 @@ public class UsersControllerTest extends AbstractControllerTest {
         MvcResult mvcResult = this.mockMvc
                 .perform(post("/users/grant-project-by-code")
                         .header(SESSION_ID, this.sessionId)
+                        .header("X-CSRF-TOKEN", csrfToken)
                         .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -138,6 +139,7 @@ public class UsersControllerTest extends AbstractControllerTest {
 
         MvcResult mvcResult = this.mockMvc.perform(post("/users/revoke-project")
                 .header(SESSION_ID, this.sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
@@ -75,6 +75,7 @@ public class WorkerGroupControllerTest extends AbstractControllerTest {
         paramsMap.add("otherParamsJson", "");
         MvcResult mvcResult = mockMvc.perform(post("/worker-groups")
                 .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken)
                 .params(paramsMap))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -118,7 +119,8 @@ public class WorkerGroupControllerTest extends AbstractControllerTest {
     @Test
     public void queryWorkerAddressList() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/worker-groups/worker-address-list")
-                .header("sessionId", sessionId))
+                .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -140,7 +142,8 @@ public class WorkerGroupControllerTest extends AbstractControllerTest {
         Mockito.when(processInstanceMapper.updateProcessInstanceByWorkerGroupName("测试", "")).thenReturn(1);
 
         MvcResult mvcResult = mockMvc.perform(delete("/worker-groups/{id}", "12")
-                .header("sessionId", sessionId))
+                .header("sessionId", sessionId)
+                .header("X-CSRF-TOKEN", csrfToken))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
@@ -119,8 +119,7 @@ public class WorkerGroupControllerTest extends AbstractControllerTest {
     @Test
     public void queryWorkerAddressList() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/worker-groups/worker-address-list")
-                .header("sessionId", sessionId)
-                .header("X-CSRF-TOKEN", csrfToken))
+                .header("sessionId", sessionId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();

--- a/dolphinscheduler-ui/src/service/service.ts
+++ b/dolphinscheduler-ui/src/service/service.ts
@@ -74,9 +74,12 @@ const err = (err: AxiosError): Promise<AxiosError> => {
 service.interceptors.request.use((config: AxiosRequestConfig<any>) => {
   config.headers && (config.headers.sessionId = userStore.getSessionId)
   const language = cookies.get('language')
+  const sessionId = cookies.get('sessionId')
   config.headers = config.headers || {}
   if (language) config.headers.language = language
-
+  if (sessionId) {
+    config.headers['X-CSRF-TOKEN'] = sessionId.split('').reverse().join('')
+  }
   return config
 }, err)
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

close issue #12931

Currently, the dolphinscheduler can be attacked by a CSRF in the following ways.

1. First, someone exits the Dolphinscheduler site but does not clear the cookie
2. The dolphinscheduler api can then be accessed via cookies by other sites or others to submit forms or obtain information without authorization. For example:
```tsx
import { defineComponent, ref } from "vue";

export default defineComponent({
  setup() {
  },
  render() {
    return (<div><form action="http://127.0.0.1:5173/dolphinscheduler/projects" method="post">
      <input type="hidden"
        name="projectName"
        value="dsadasdddddddd" />
      <input type="hidden"
        name="userName"
        value="admin" />
      <input type="submit"
        value="Win Money!" />
    </form></div>)
  }
})
```
![1671536386598](https://user-images.githubusercontent.com/35210666/208658487-6c8f9d6d-3072-4d3c-beee-442a06b9181c.png)
Once the dolphinscheduler user clicks the button in the diagram, a csrf attack completes

![1671536625047](https://user-images.githubusercontent.com/35210666/208659235-10bcfbc8-95ef-4a83-bd71-5a99a1b18555.png)

after this pr, when an attacker performs a CSRF attack, he will get a 403 exception.

## Brief change log

I thought it would take a lot of work to introduce Spring security dependencies, so I added a CsrfTokenInterceptor to implement csrf defense.
The CsrfTokenInterceptor does not intercept requests with the token in the http request header to ensure that the api is accessible through the token.
CsrfTokenInterceptor does not intercept http get requests.
The CsrfTokenInterceptor will get the X-CSRF-TOKEN from the http request header or the _csrf from the request paramter and verify their accuracy.
And changed the ui module to add the request header X-CSRF-TOKEN when making an http request
With the above approach, the dolphinscheduler is protected from CSRF attacks as long as the attacker cannot obtain the correct CSRF token.
In this pr, the csrfToken is obtained by inverting the sessionId.   If we need to, I can enhance the protection of the csrfToken, such as using the encryption algorithm or using other means to generate our csrfToken



