### PR TITLE
[Improvement][Docker] Add a time zone configuration to the docker profile

### DIFF
--- a/deploy/docker/.env
+++ b/deploy/docker/.env
@@ -21,4 +21,5 @@ TAG=latest
 TZ=Asia/Shanghai
 DATABASE=postgresql
 SPRING_DATASOURCE_URL=jdbc:postgresql://dolphinscheduler-postgresql:5432/dolphinscheduler
+SPRING_JACKSON_TIME_ZONE=UTC
 REGISTRY_ZOOKEEPER_CONNECT_STRING=dolphinscheduler-zookeeper:2181


### PR DESCRIPTION
When I started Dolphin with docker, I was confused about how to set the time zone.
I adjusted the system's time zone, but it didn't seem to help.
Later I found the service startup script in the docker container and learned that the key to setting the time zone was SPRING_JACKSON_TIME_ZONE.
So it's a good idea to annotate this key in the.env file so users don't have to spend time looking for it