### PR TITLE
[Improvement][api-sql] Optimize the sql for paging query project

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -84,7 +84,8 @@
         select
         <include refid="baseSqlV2">
             <property name="alias" value="p"/>
-        </include>,
+        </include>
+        ,
         u.user_name as user_name,
         count(distinct def.id) AS def_count,
         count(distinct inst.id) as inst_running_count

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -87,12 +87,15 @@
         </include>
         ,
         u.user_name as user_name,
-        (SELECT COUNT(*) FROM t_ds_process_definition AS def WHERE def.project_code = p.code) AS def_count,
-        (SELECT COUNT(*) FROM t_ds_process_definition_log def, t_ds_process_instance inst WHERE def.code =
-        inst.process_definition_code and def.version = inst.process_definition_version AND def.project_code = p.code
-        AND inst.state=1 ) as inst_running_count
+        count(distinct def.id) AS def_count,
+        count(distinct inst.id) as inst_running_count
         from t_ds_project p
         left join t_ds_user u on u.id=p.user_id
+        left join t_ds_process_definition def
+        on def.project_code = p.code
+        left join t_ds_process_instance inst
+        on inst.process_definition_code = def.code
+        and inst.state = 1
         where 1=1
         <if test="projectsIds != null and projectsIds.size() > 0">
             and p.id  in
@@ -105,7 +108,8 @@
             OR p.description LIKE concat('%', #{searchName}, '%')
             )
         </if>
-        order by p.create_time desc
+        group by p.id
+        order by p.id desc
     </select>
     <select id="queryAuthedProjectListByUserId" resultType="org.apache.dolphinscheduler.dao.entity.Project">
         select

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -84,8 +84,7 @@
         select
         <include refid="baseSqlV2">
             <property name="alias" value="p"/>
-        </include>
-        ,
+        </include> ,
         u.user_name as user_name,
         count(distinct def.id) AS def_count,
         count(distinct inst.id) as inst_running_count

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -84,7 +84,8 @@
         select
         <include refid="baseSqlV2">
             <property name="alias" value="p"/>
-        </include> ,
+        </include>
+        ,
         u.user_name as user_name,
         count(distinct def.id) AS def_count,
         count(distinct inst.id) as inst_running_count

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -95,6 +95,7 @@
         on def.project_code = p.code
         left join t_ds_process_instance inst
         on inst.process_definition_code = def.code
+        and inst.process_definition_version = def.version
         and inst.state = 1
         where 1=1
         <if test="projectsIds != null and projectsIds.size() > 0">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProjectMapper.xml
@@ -84,8 +84,7 @@
         select
         <include refid="baseSqlV2">
             <property name="alias" value="p"/>
-        </include>
-        ,
+        </include>,
         u.user_name as user_name,
         count(distinct def.id) AS def_count,
         count(distinct inst.id) as inst_running_count


### PR DESCRIPTION
When I open the home page, I always feel slow, I wonder why a paging query project interface is so slow.
```  
select
        <include refid="baseSqlV2">
            <property name="alias" value="p"/>
        </include>
        ,
        u.user_name as user_name,
        (SELECT COUNT(*) FROM t_ds_process_definition AS def WHERE def.project_code = p.code) AS def_count,
        (SELECT COUNT(*) FROM t_ds_process_definition_log def, t_ds_process_instance inst WHERE def.code =
        inst.process_definition_code and def.version = inst.process_definition_version AND def.project_code = p.code
        AND inst.state=1 ) as inst_running_count
```
This sql should produce many sub-queries that affect the efficiency of the sql execution.
So I did some optimization .

Queries that used to take about 4 seconds can be reduced to 1 second, and the results are exactly the same