### PR TITLE
[fix] Remove tenant arg in workflow definition

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -226,7 +226,6 @@ public class PythonGateway {
      * @param timeout timeout for workflow working, if running time longer than timeout,
      * task will mark as fail
      * @param workerGroup run task in which worker group
-     * @param tenantCode tenantCode
      * @param taskRelationJson relation json for nodes
      * @param taskDefinitionJson taskDefinitionJson
      * @param otherParamsJson otherParamsJson handle other params
@@ -242,13 +241,16 @@ public class PythonGateway {
                                        int warningGroupId,
                                        int timeout,
                                        String workerGroup,
-                                       String tenantCode,
                                        int releaseState,
                                        String taskRelationJson,
                                        String taskDefinitionJson,
                                        String otherParamsJson,
                                        String executionType) {
         User user = usersService.queryUser(userName);
+        if (user.getTenantCode() == null) {
+            throw new RuntimeException("Can not create or update workflow for user who not related to any tenant.");
+        }
+
         Project project = projectMapper.queryByName(projectName);
         long projectCode = project.getCode();
 
@@ -263,12 +265,12 @@ public class PythonGateway {
                     ReleaseState.OFFLINE);
             processDefinitionService.updateProcessDefinition(user, projectCode, name,
                     processDefinitionCode, description, globalParams,
-                    null, timeout, tenantCode, taskRelationJson, taskDefinitionJson, otherParamsJson,
+                    null, timeout, user.getTenantCode(), taskRelationJson, taskDefinitionJson, otherParamsJson,
                     executionTypeEnum);
         } else {
             Map<String, Object> result = processDefinitionService.createProcessDefinition(user, projectCode, name,
                     description, globalParams,
-                    null, timeout, tenantCode, taskRelationJson, taskDefinitionJson, otherParamsJson,
+                    null, timeout, user.getTenantCode(), taskRelationJson, taskDefinitionJson, otherParamsJson,
                     executionTypeEnum);
             processDefinition = (ProcessDefinition) result.get(Constants.DATA_LIST);
             processDefinitionCode = processDefinition.getCode();


### PR DESCRIPTION
current tenant in workflow only work when the first time user do not exist, when user change the tenant in workflow but tenant exist, it will be ignore, so we try to remove it from workflow, and in https://github.com/apache/dolphinscheduler-sdk-python/pull/40 we try to create both user and tenant vis cli instead of auto create

