### PR TITLE
[Fix-13144][UI] Worked out the issue with failing to query workflow instances by the incorrect workflow status.

### DIFF
--- a/dolphinscheduler-ui/src/common/common.ts
+++ b/dolphinscheduler-ui/src/common/common.ts
@@ -36,7 +36,7 @@ import {
 } from '@vicons/antd'
 import { format, parseISO } from 'date-fns'
 import _ from 'lodash'
-import { ITaskStateConfig } from './types'
+import { ITaskStateConfig, IWorkflowExecutionStateConfig } from './types'
 /**
  * Intelligent display kb m
  */
@@ -141,6 +141,21 @@ export const stateType = (t: any) => [
     label: item.desc
   }))
 ]
+
+/**
+ * State code table
+ */
+export const workflowExecutionStateType = (t: any) => [
+  {
+    value: '',
+    label: `${t('project.workflow.all_status')}`
+  },
+  ...Object.entries(workflowExecutionState(t)).map(([key, item]) => ({
+    value: key,
+    label: item.desc
+  }))
+]
+
 
 /**
  * Stream task state
@@ -310,6 +325,113 @@ export const tasksState = (t: any): ITaskStateConfig => ({
   PENDING: {
     id: 18,
     desc: `${t('project.workflow.pending')}`,
+    color: '#5101be',
+    icon: HistoryOutlined,
+    isSpin: false,
+    classNames: 'pending'
+  }
+})
+
+/**
+ * Workflow execution status
+ * @id id
+ * @desc tooltip
+ * @color color
+ * @icon icon
+ * @isSpin is loading (Need to execute the code block to write if judgment)
+ */
+export const workflowExecutionState = (t: any): IWorkflowExecutionStateConfig => ({
+  SUBMITTED_SUCCESS: {
+    id: 0,
+    desc: `${t('project.workflow.submit_success')}`,
+    color: '#A9A9A9',
+    icon: IssuesCloseOutlined,
+    isSpin: false,
+    classNames: 'submitted_success'
+  },
+  RUNNING_EXECUTION: {
+    id: 1,
+    desc: `${t('project.workflow.executing')}`,
+    color: '#0097e0',
+    icon: SettingFilled,
+    isSpin: true,
+    classNames: 'running_execution'
+  },
+  READY_PAUSE: {
+    id: 2,
+    desc: `${t('project.workflow.ready_to_pause')}`,
+    color: '#07b1a3',
+    icon: SettingOutlined,
+    isSpin: false,
+    classNames: 'ready_pause'
+  },
+  PAUSE: {
+    id: 3,
+    desc: `${t('project.workflow.pause')}`,
+    color: '#057c72',
+    icon: PauseCircleOutlined,
+    isSpin: false,
+    classNames: 'pause'
+  },
+  READY_STOP: {
+    id: 4,
+    desc: `${t('project.workflow.ready_to_stop')}`,
+    color: '#FE0402',
+    icon: StopFilled,
+    isSpin: false,
+    classNames: 'ready_stop'
+  },
+  STOP: {
+    id: 5,
+    desc: `${t('project.workflow.stop')}`,
+    color: '#e90101',
+    icon: StopOutlined,
+    isSpin: false,
+    classNames: 'stop'
+  },
+  FAILURE: {
+    id: 6,
+    desc: `${t('project.workflow.failed')}`,
+    color: '#000000',
+    icon: CloseCircleOutlined,
+    isSpin: false,
+    classNames: 'failed'
+  },
+  SUCCESS: {
+    id: 7,
+    desc: `${t('project.workflow.success')}`,
+    color: '#95DF96',
+    icon: CheckCircleOutlined,
+    isSpin: false,
+    classNames: 'success'
+  },
+  DELAY_EXECUTION: {
+    id: 12,
+    desc: `${t('project.workflow.delay_execution')}`,
+    color: '#5102ce',
+    icon: PauseCircleFilled,
+    isSpin: false,
+    classNames: 'delay_execution'
+  },
+  SERIAL_WAIT: {
+    id: 14,
+    desc: `${t('project.workflow.serial_wait')}`,
+    color: '#5102ce',
+    icon: Loading3QuartersOutlined,
+    isSpin: true,
+    classNames: 'serial_wait'
+  },
+  READY_BLOCK: {
+    id: 15,
+    desc: `${t('project.workflow.ready_to_block')}`,
+    color: '#5101be',
+    icon: SendOutlined,
+    isSpin: false,
+    classNames: 'pending'
+  },
+  BLOCK: {
+    id: 16,
+    desc: `${t('project.workflow.block')}`,
     color: '#5101be',
     icon: HistoryOutlined,
     isSpin: false,

--- a/dolphinscheduler-ui/src/common/types.ts
+++ b/dolphinscheduler-ui/src/common/types.ts
@@ -35,8 +35,33 @@ export type ITaskState =
   | 'DISPATCH'
   | 'PENDING'
 
+export type IWorkflowExecutionState =
+  | 'SUBMITTED_SUCCESS'
+  | 'RUNNING_EXECUTION'
+  | 'READY_PAUSE'
+  | 'PAUSE'
+  | 'READY_STOP'
+  | 'STOP'
+  | 'FAILURE'
+  | 'SUCCESS'
+  | 'DELAY_EXECUTION'
+  | 'SERIAL_WAIT'
+  | 'READY_BLOCK'
+  | 'BLOCK'
+
 export type ITaskStateConfig = {
   [key in ITaskState]: {
+    id: number
+    desc: string
+    color: string
+    icon: Component
+    isSpin: boolean
+    classNames?: string
+  }
+}
+
+export type IWorkflowExecutionStateConfig = {
+  [key in IWorkflowExecutionState]: {
     id: number
     desc: string
     color: string

--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -143,6 +143,7 @@ export default {
     switch_version: 'Switch To This Version',
     confirm_switch_version: 'Confirm Switch To This Version?',
     current_version: 'Current Version',
+    run_type: 'Run Type',
     scheduling_time: 'Scheduling Time',
     duration: 'Duration',
     run_times: 'Run Times',
@@ -212,7 +213,9 @@ export default {
     workflow_relation_no_data_result_title:
       'Can not find any relations of workflows.',
     workflow_relation_no_data_result_desc:
-      'There is not any workflows. Please create a workflow, and then visit this page again.'
+      'There is not any workflows. Please create a workflow, and then visit this page again.',
+    ready_to_block: 'Ready to block',
+    block: 'Block',
   },
   task: {
     on_line: 'Online',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -213,7 +213,9 @@ export default {
     project_tips: '请选择项目',
     workflow_relation_no_data_result_title: '工作流关系不存在',
     workflow_relation_no_data_result_desc:
-      '目前没有任何工作流，请先创建工作流，再访问该页面'
+      '目前没有任何工作流，请先创建工作流，再访问该页面',
+    ready_to_block: '准备锁定',
+    block: '锁定',
   },
   task: {
     on_line: '线上',

--- a/dolphinscheduler-ui/src/views/projects/workflow/instance/components/process-instance-condition.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/instance/components/process-instance-condition.tsx
@@ -20,7 +20,7 @@ import { NInput, NButton, NDatePicker, NSelect, NIcon, NSpace } from 'naive-ui'
 import { defineComponent, getCurrentInstance, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { format } from 'date-fns'
-import { stateType } from '@/common/common'
+import { workflowExecutionStateType } from '@/common/common'
 
 export default defineComponent({
   name: 'ProcessInstanceCondition',
@@ -88,7 +88,7 @@ export default defineComponent({
   },
   render() {
     const { t } = useI18n()
-    const options = stateType(t)
+    const options = workflowExecutionStateType(t)
 
     return (
       <NSpace justify='end'>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR will close #13144 .

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

This issue is not caused by backend api. The root cause is because there are a few differences of the workflow execution status between the frontend and backend. So I've just aligned the workflow execution status with those from the backend.

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request
This change added tests and can be verified as follows:
- *Manually verified the change by testing locally.* 

The test result is as follows:
![image](https://user-images.githubusercontent.com/4928204/208892145-58669249-d8f1-4553-8476-72eee5704101.png)
