### PR TITLE
[docker] Add SQOOP_HOME to dolphinscheduler_env.sh file 

### DIFF
--- a/.github/workflows/cluster-test/mysql/dolphinscheduler_env.sh
+++ b/.github/workflows/cluster-test/mysql/dolphinscheduler_env.sh
@@ -42,7 +42,7 @@ export PYTHON_HOME=${PYTHON_HOME:-/opt/soft/python}
 export HIVE_HOME=${HIVE_HOME:-/opt/soft/hive}
 export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
 export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
-export SQOOP_HOME=${DATAX_HOME:-/opt/soft/sqoop}
+export SQOOP_HOME=${SQOOP_HOME:-/opt/soft/sqoop}
 
 export PATH=$HADOOP_HOME/bin:$SPARK_HOME/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$SQOOP_HOME/bin:$PATH
 

--- a/.github/workflows/cluster-test/mysql/dolphinscheduler_env.sh
+++ b/.github/workflows/cluster-test/mysql/dolphinscheduler_env.sh
@@ -42,8 +42,9 @@ export PYTHON_HOME=${PYTHON_HOME:-/opt/soft/python}
 export HIVE_HOME=${HIVE_HOME:-/opt/soft/hive}
 export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
 export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
+export SQOOP_HOME=${DATAX_HOME:-/opt/soft/sqoop}
 
-export PATH=$HADOOP_HOME/bin:$SPARK_HOME/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$PATH
+export PATH=$HADOOP_HOME/bin:$SPARK_HOME/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$SQOOP_HOME/bin:$PATH
 
 # applicationId auto collection related configuration, the following configurations are unnecessary if setting appId.collect=log
 #export HADOOP_CLASSPATH=`hadoop classpath`:${DOLPHINSCHEDULER_HOME}/tools/libs/*


### PR DESCRIPTION
Now there is no SQOOP_HOME in the dolphinscheduler_env.sh file.
Now if I use dolphinscheduler through docker, I need to replace the dolphinscheduler_env.sh file.It's not very convenient