### PR TITLE
Remove the log path check

### DIFF
--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/log/LoggerRequestProcessorTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/log/LoggerRequestProcessorTest.java
@@ -25,7 +25,6 @@ import org.apache.dolphinscheduler.remote.processor.LoggerRequestProcessor;
 import org.apache.dolphinscheduler.service.utils.LoggerUtils;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,9 +79,7 @@ public class LoggerRequestProcessorTest {
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
         LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            loggerRequestProcessor.process(channel, command);
-        });
+        loggerRequestProcessor.process(channel, command);
     }
 
     @Test
@@ -98,9 +95,7 @@ public class LoggerRequestProcessorTest {
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
         LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            loggerRequestProcessor.process(channel, command);
-        });
+        loggerRequestProcessor.process(channel, command);
     }
 
     @Test
@@ -115,8 +110,6 @@ public class LoggerRequestProcessorTest {
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
         LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            loggerRequestProcessor.process(channel, command);
-        });
+        loggerRequestProcessor.process(channel, command);
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

When we upgrade ds, the ds home might be change, this will cause the old log cannot be read due to the security path check failed.

We can remove the log path security check, since the log path is written by ds, and we query the log by task instance id, rather than log path.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
