### PR TITLE
[fix-12054][server] fix bug that date parameters replaced failed 

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -481,6 +481,10 @@ public class SqlTask extends AbstractTask {
         // combining local and global parameters
         Map<String, Property> paramsMap = taskExecutionContext.getPrepareParamsMap();
 
+        // new
+        // replace variable TIME with $[YYYYmmddd...] in sql when history run job and batch complement job
+        sql = ParameterUtils.replaceScheduleTime(sql,
+                DateUtils.timeStampToDate(taskExecutionContext.getScheduleTime()));
         // spell SQL according to the final user-defined variable
         if (paramsMap == null) {
             sqlBuilder.append(sql);
@@ -494,10 +498,6 @@ public class SqlTask extends AbstractTask {
             sqlParameters.setTitle(title);
         }
 
-        // new
-        // replace variable TIME with $[YYYYmmddd...] in sql when history run job and batch complement job
-        sql = ParameterUtils.replaceScheduleTime(sql,
-                DateUtils.timeStampToDate(taskExecutionContext.getScheduleTime()));
         // special characters need to be escaped, ${} needs to be escaped
         setSqlParamsMap(sql, rgex, sqlParamsMap, paramsMap, taskExecutionContext.getTaskInstanceId());
         // Replace the original value in sql ！{...} ，Does not participate in precompilation


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
version 3.1.2

i try to fix #12054 
<img width="580" alt="image" src="https://user-images.githubusercontent.com/20807051/209790776-64093c5f-8824-4f65-ae40-0f940a577e78.png">

sql task which uses param like `$[yyyy-MM-dd]` will be failed, because it has no params map. 
so this pr replaces variable time at first.


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
replaces variable time at first.


<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.
