### PR TITLE
[Improvement][Master] Validate same content of input file when using task cache

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
@@ -327,6 +327,9 @@ public final class Constants {
     public static final String THREAD_NAME_WORKER_SERVER = "Worker-Server";
     public static final String THREAD_NAME_ALERT_SERVER = "Alert-Server";
 
+    // suffix of crc file
+    public final static String CRC_SUFFIX = ".crc";
+
     /**
      * complement date default cron string
      */

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
@@ -328,7 +328,7 @@ public final class Constants {
     public static final String THREAD_NAME_ALERT_SERVER = "Alert-Server";
 
     // suffix of crc file
-    public final static String CRC_SUFFIX = ".crc";
+    public static final String CRC_SUFFIX = ".crc";
 
     /**
      * complement date default cron string

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -269,31 +269,34 @@ public class FileUtils {
 
     /**
      * Calculate file checksum with CRC32 algorithm
-     *
      * @param pathName
-     * @return
-     * @throws IOException
+     * @return checksum of file/dir
      */
-    public static String getFileChecksum(String pathName) {
+    public static String getFileChecksum(String pathName) throws IOException {
         CRC32 crc32 = new CRC32();
         File file = new File(pathName);
         String crcString = "";
         if (file.isDirectory()) {
             // file system interface remains the same order
             String[] subPaths = file.list();
+            StringBuilder concatenatedCRC = new StringBuilder();
             for (String subPath : subPaths) {
-                crcString += getFileChecksum(pathName + FOLDER_SEPARATOR + subPath);
+                concatenatedCRC.append(getFileChecksum(pathName + FOLDER_SEPARATOR + subPath));
             }
+            crcString = concatenatedCRC.toString();
         } else {
             FileInputStream fileInputStream = null;
+            CheckedInputStream checkedInputStream = null;
             try {
                 fileInputStream = new FileInputStream(pathName);
-                CheckedInputStream checkedInputStream = new CheckedInputStream(fileInputStream, crc32);
+                checkedInputStream = new CheckedInputStream(fileInputStream, crc32);
                 while (checkedInputStream.read() != -1) {
                 }
             } catch (IOException e) {
-                logger.error(e.getMessage(), e);
-                return crcString;
+                throw new IOException("Calculate checksum error.");
+            } finally {
+                fileInputStream.close();
+                checkedInputStream.close();
             }
             crcString = Long.toHexString(crc32.getValue());
         }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -285,18 +285,13 @@ public class FileUtils {
             }
             crcString = concatenatedCRC.toString();
         } else {
-            FileInputStream fileInputStream = null;
-            CheckedInputStream checkedInputStream = null;
-            try {
-                fileInputStream = new FileInputStream(pathName);
-                checkedInputStream = new CheckedInputStream(fileInputStream, crc32);
+            try (
+                    FileInputStream fileInputStream = new FileInputStream(pathName);
+                    CheckedInputStream checkedInputStream = new CheckedInputStream(fileInputStream, crc32);) {
                 while (checkedInputStream.read() != -1) {
                 }
             } catch (IOException e) {
                 throw new IOException("Calculate checksum error.");
-            } finally {
-                fileInputStream.close();
-                checkedInputStream.close();
             }
             crcString = Long.toHexString(crc32.getValue());
         }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -28,11 +28,14 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -262,6 +265,40 @@ public class FileUtils {
         } catch (IOException e) {
             return true;
         }
+    }
+
+    /**
+     * Calculate file checksum with CRC32 algorithm
+     *
+     * @param pathName
+     * @return
+     * @throws IOException
+     */
+    public static String getFileChecksum(String pathName) {
+        CRC32 crc32 = new CRC32();
+        File file = new File(pathName);
+        String crcString = "";
+        if (file.isDirectory()) {
+            // file system interface remains the same order
+            String[] subPaths = file.list();
+            for (String subPath : subPaths) {
+                crcString += getFileChecksum(pathName + FOLDER_SEPARATOR + subPath);
+            }
+        } else {
+            FileInputStream fileInputStream = null;
+            try {
+                fileInputStream = new FileInputStream(pathName);
+                CheckedInputStream checkedInputStream = new CheckedInputStream(fileInputStream, crc32);
+                while (checkedInputStream.read() != -1) {
+                }
+            } catch (IOException e) {
+                logger.error(e.getMessage(), e);
+                return crcString;
+            }
+            crcString = Long.toHexString(crc32.getValue());
+        }
+
+        return crcString;
     }
 
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java
@@ -118,4 +118,28 @@ public class FileUtilsTest {
         Assertions.assertTrue(FileUtils.directoryTraversal(path));
     }
 
+    @Test
+    void testGetFileChecksum() throws Exception {
+        String filePath1 = "test/testFile1.txt";
+        String filePath2 = "test/testFile2.txt";
+        String filePath3 = "test/testFile3.txt";
+        String content1 = "正正正faffdasfasdfas，한국어； 한글……にほんご\nfrançais";
+        String content2 = "正正正faffdasfasdfas，한국어； 한글……にほん\nfrançais";
+        FileUtils.writeContent2File(content1, filePath1);
+        FileUtils.writeContent2File(content2, filePath2);
+        FileUtils.writeContent2File(content1, filePath3);
+
+        String checksum1 = FileUtils.getFileChecksum(filePath1);
+        String checksum2 = FileUtils.getFileChecksum(filePath2);
+        String checksum3 = FileUtils.getFileChecksum(filePath3);
+
+        Assertions.assertNotEquals(checksum1, checksum2);
+        Assertions.assertEquals(checksum1, checksum3);
+
+        String dirPath = "test/";
+
+        Assertions.assertDoesNotThrow(
+                () -> FileUtils.getFileChecksum(dirPath));
+    }
+
 }

--- a/dolphinscheduler-dao/pom.xml
+++ b/dolphinscheduler-dao/pom.xml
@@ -112,6 +112,10 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-storage-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/TaskCacheUtils.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/TaskCacheUtils.java
@@ -190,7 +190,7 @@ public class TaskCacheUtils {
             crcString = FileUtils.readFile2Str(new FileInputStream(targetPath));
             fileProperty.setValue(crcString);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Replace checksum failed for file property {}.", fileProperty.getProp());
         }
         return crcString;
     }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/TaskCacheUtils.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/TaskCacheUtils.java
@@ -51,7 +51,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class TaskCacheUtils {
 
-    protected final static Logger logger = LoggerFactory.getLogger(TaskCacheUtils.class);
+    protected static final Logger logger = LoggerFactory.getLogger(TaskCacheUtils.class);
 
     private TaskCacheUtils() {
         throw new IllegalStateException("Utility class");

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/TaskCacheUtils.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/utils/TaskCacheUtils.java
@@ -17,9 +17,14 @@
 
 package org.apache.dolphinscheduler.dao.utils;
 
+import static org.apache.dolphinscheduler.common.constants.Constants.CRC_SUFFIX;
+
+import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperate;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 
@@ -27,8 +32,11 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,9 +44,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class TaskCacheUtils {
+
+    protected final static Logger logger = LoggerFactory.getLogger(TaskCacheUtils.class);
 
     private TaskCacheUtils() {
         throw new IllegalStateException("Utility class");
@@ -54,15 +67,17 @@ public class TaskCacheUtils {
      * 4. input VarPool, from upstream task and workflow global parameters
      * @param taskInstance task instance
      * @param taskExecutionContext taskExecutionContext
+     * @param storageOperate storageOperate
      * @return cache key
      */
-    public static String generateCacheKey(TaskInstance taskInstance, TaskExecutionContext taskExecutionContext) {
+    public static String generateCacheKey(TaskInstance taskInstance, TaskExecutionContext taskExecutionContext,
+                                          StorageOperate storageOperate) {
         List<String> keyElements = new ArrayList<>();
         keyElements.add(String.valueOf(taskInstance.getTaskCode()));
         keyElements.add(String.valueOf(taskInstance.getTaskDefinitionVersion()));
         keyElements.add(String.valueOf(taskInstance.getIsCache().getCode()));
         keyElements.add(String.valueOf(taskInstance.getEnvironmentConfig()));
-        keyElements.add(getTaskInputVarPoolData(taskInstance, taskExecutionContext));
+        keyElements.add(getTaskInputVarPoolData(taskInstance, taskExecutionContext, storageOperate));
         String data = StringUtils.join(keyElements, "_");
         return DigestUtils.sha256Hex(data);
     }
@@ -109,7 +124,8 @@ public class TaskCacheUtils {
      * @param taskInstance task instance
      * taskExecutionContext taskExecutionContext
      */
-    public static String getTaskInputVarPoolData(TaskInstance taskInstance, TaskExecutionContext context) {
+    public static String getTaskInputVarPoolData(TaskInstance taskInstance, TaskExecutionContext context,
+                                                 StorageOperate storageOperate) {
         JsonNode taskParams = JSONUtils.parseObject(taskInstance.getTaskParams());
 
         // The set of input values considered from localParams in the taskParams
@@ -122,6 +138,12 @@ public class TaskCacheUtils {
 
         // var pool value from upstream task
         List<Property> varPool = JSONUtils.toList(taskInstance.getVarPool(), Property.class);
+
+        Map<String, String> fileCheckSumMap = new HashMap<>();
+        List<Property> fileInput = varPool.stream().filter(property -> property.getType().equals(DataType.FILE))
+                .collect(Collectors.toList());
+        fileInput.forEach(
+                property -> fileCheckSumMap.put(property.getProp(), getValCheckSum(property, context, storageOperate)));
 
         // var pool value from workflow global parameters
         if (context.getPrepareParamsMap() != null) {
@@ -139,7 +161,38 @@ public class TaskCacheUtils {
                 .filter(property -> propertyInSet.contains(property.getProp()))
                 .sorted(Comparator.comparing(Property::getProp))
                 .collect(Collectors.toList());
+
+        varPool.forEach(property -> {
+            if (property.getType() == DataType.FILE) {
+                property.setValue(fileCheckSumMap.get(property.getValue()));
+            }
+        });
         return JSONUtils.toJsonString(varPool);
+    }
+
+    /**
+     * get checksum from crc32 file of file property in varPool
+     * cache can be used if content of upstream output files are the same
+     * @param fileProperty
+     * @param context
+     * @param storageOperate
+     */
+    public static String getValCheckSum(Property fileProperty, TaskExecutionContext context,
+                                        StorageOperate storageOperate) {
+        String resourceCRCPath = fileProperty.getValue() + CRC_SUFFIX;
+        String resourceCRCWholePath = storageOperate.getResourceFileName(context.getTenantCode(), resourceCRCPath);
+        String targetPath = String.format("%s/%s", context.getExecutePath(), resourceCRCPath);
+        logger.info("{} --- Remote:{} to Local:{}", "CRC file", resourceCRCWholePath, targetPath);
+        String crcString = "";
+        try {
+            storageOperate.download(context.getTenantCode(), resourceCRCWholePath, targetPath, false,
+                    true);
+            crcString = FileUtils.readFile2Str(new FileInputStream(targetPath));
+            fileProperty.setValue(crcString);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return crcString;
     }
 
     /**

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
@@ -25,6 +25,7 @@ import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.utils.TaskCacheUtils;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperate;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.TaskDispatchCommand;
@@ -103,6 +104,9 @@ public class TaskPriorityQueueConsumer extends BaseDaemonThread {
      */
     @Autowired
     private TaskEventService taskEventService;
+
+    @Autowired
+    private StorageOperate storageOperate;
 
     /**
      * consumer thread pool
@@ -298,7 +302,7 @@ public class TaskPriorityQueueConsumer extends BaseDaemonThread {
                 return false;
             }
             // check if task is cache execution
-            String cacheKey = TaskCacheUtils.generateCacheKey(taskInstance, context);
+            String cacheKey = TaskCacheUtils.generateCacheKey(taskInstance, context, storageOperate);
             TaskInstance cacheTaskInstance = taskInstanceDao.findTaskInstanceByCacheKey(cacheKey);
             // if we can find the cache task instance, we will add cache event, and return true.
             if (cacheTaskInstance != null) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
@@ -105,7 +105,10 @@ public class TaskPriorityQueueConsumer extends BaseDaemonThread {
     @Autowired
     private TaskEventService taskEventService;
 
-    @Autowired
+    /**
+     * storage operator
+     */
+    @Autowired(required = false)
     private StorageOperate storageOperate;
 
     /**

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
@@ -92,7 +92,11 @@ public class TaskFilesTransferUtils {
 
             // get crc file path
             String srcCRCPath = srcPath + CRC_SUFFIX;
-            FileUtils.writeContent2File(FileUtils.getFileChecksum(path), srcCRCPath);
+            try {
+                FileUtils.writeContent2File(FileUtils.getFileChecksum(path), srcCRCPath);
+            } catch (IOException ex) {
+                throw new TaskException(ex.getMessage(), ex);
+            }
 
             // get remote file path
             String resourcePath = getResourcePath(taskExecutionContext, new File(srcPath).getName());

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
@@ -17,7 +17,10 @@
 
 package org.apache.dolphinscheduler.server.worker.utils;
 
+import static org.apache.dolphinscheduler.common.constants.Constants.CRC_SUFFIX;
+
 import org.apache.dolphinscheduler.common.utils.DateUtils;
+import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperate;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
@@ -84,16 +87,27 @@ public class TaskFilesTransferUtils {
         logger.info("Upload output files ...");
         for (Property property : localParamsProperty) {
             // get local file path
-            String srcPath =
-                    packIfDir(String.format("%s/%s", taskExecutionContext.getExecutePath(), property.getValue()));
+            String path = String.format("%s/%s", taskExecutionContext.getExecutePath(), property.getValue());
+            String srcPath = packIfDir(path);
+
+            // get crc file path
+            String srcCRCPath = srcPath + CRC_SUFFIX;
+            FileUtils.writeContent2File(FileUtils.getFileChecksum(path), srcCRCPath);
+
             // get remote file path
             String resourcePath = getResourcePath(taskExecutionContext, new File(srcPath).getName());
+            String resourceCRCPath = resourcePath + CRC_SUFFIX;
             try {
                 // upload file to storage
                 String resourceWholePath =
                         storageOperate.getResourceFileName(taskExecutionContext.getTenantCode(), resourcePath);
+                String resourceCRCWholePath =
+                        storageOperate.getResourceFileName(taskExecutionContext.getTenantCode(), resourceCRCPath);
                 logger.info("{} --- Local:{} to Remote:{}", property, srcPath, resourceWholePath);
                 storageOperate.upload(taskExecutionContext.getTenantCode(), srcPath, resourceWholePath, false, true);
+                logger.info("{} --- Local:{} to Remote:{}", "CRC file", srcCRCPath, resourceCRCWholePath);
+                storageOperate.upload(taskExecutionContext.getTenantCode(), srcCRCPath, resourceCRCWholePath, false,
+                        true);
             } catch (IOException ex) {
                 throw new TaskException("Upload file to storage error", ex);
             }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
- This PR closes https://github.com/apache/dolphinscheduler/issues/13223.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- Add function `getFileChecksum` in `FileUtils` available for both file and directory. When calculate checksum for a directory, it will calculate all files checksum under the directory and concatenate them together, the order is provided by file-system interface.
- Upload checksum file (with suffix `.crc`) together with output file when uploading for task file transfer.
- Download checksum file and replace the value of file property with content of checksum file.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

- Already add some UT.