### PR TITLE
 Add source env list in common.properties

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -18,7 +18,9 @@
 package org.apache.dolphinscheduler.plugin.task.api;
 
 import org.apache.dolphinscheduler.plugin.task.api.utils.FileUtils;
+import org.apache.dolphinscheduler.plugin.task.api.utils.ShellUtils;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
@@ -93,6 +95,11 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
         if (SystemUtils.IS_OS_WINDOWS) {
             sb.append("@echo off").append(System.lineSeparator());
             sb.append("cd /d %~dp0").append(System.lineSeparator());
+            if (CollectionUtils.isNotEmpty(ShellUtils.ENV_SOURCE_LIST)) {
+                for (String envSourceFile : ShellUtils.ENV_SOURCE_LIST) {
+                    sb.append("call ").append(envSourceFile).append("\n");
+                }
+            }
             if (StringUtils.isNotBlank(taskRequest.getEnvironmentConfig())) {
                 sb.append(taskRequest.getEnvironmentConfig()).append(System.lineSeparator());
             }
@@ -100,6 +107,11 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
             sb.append("#!/bin/bash").append(System.lineSeparator());
             sb.append("BASEDIR=$(cd `dirname $0`; pwd)").append(System.lineSeparator());
             sb.append("cd $BASEDIR").append(System.lineSeparator());
+            if (CollectionUtils.isNotEmpty(ShellUtils.ENV_SOURCE_LIST)) {
+                for (String envSourceFile : ShellUtils.ENV_SOURCE_LIST) {
+                    sb.append("source ").append(envSourceFile).append("\n");
+                }
+            }
             if (StringUtils.isNotBlank(taskRequest.getEnvironmentConfig())) {
                 sb.append(taskRequest.getEnvironmentConfig()).append(System.lineSeparator());
             }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ShellUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ShellUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.utils;
+
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ShellUtils {
+
+    public List<String> ENV_SOURCE_LIST = Arrays.stream(
+            Optional.ofNullable(PropertyUtils.getString("shell.env_source_list"))
+                    .map(s -> s.split(",")).orElse(new String[0]))
+            .map(String::trim)
+            .collect(Collectors.toList());
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ShellUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ShellUtilsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.utils;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ShellUtilsTest {
+
+    @Test
+    public void testGetEnvSourceList() {
+        Assertions.assertEquals(new ArrayList<>(), ShellUtils.ENV_SOURCE_LIST);
+    }
+
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/resources/common.properties
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/resources/common.properties
@@ -127,4 +127,4 @@ ml.mlflow.preset_repository_version="main"
 appId.collect=log
 
 # The default env list will be load by Shell task, e.g. /etc/profile,~/.bash_profile
-shell.env_source_list=
+# shell.env_source_list=/etc/profile,~/.bash_profile


### PR DESCRIPTION
## Purpose of the pull request

Since use `sudo -u` to execute a shell task, the env will not load automatically, so we need to add default env list to load in shell task.

After this change, the env list will be loaded at the below order
```shell
source /etc/profile
source ~/.bash_profile
source user define profile
```

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
