### PR TITLE
[fix][worker][bug] master/worker crash when registry recover from SUSPENDED to RECONNECTED

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterWaitingStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterWaitingStrategy.java
@@ -93,18 +93,22 @@ public class MasterWaitingStrategy implements MasterConnectStrategy {
 
     @Override
     public void reconnect() {
-        try {
-            ServerLifeCycleManager.recoverFromWaiting();
-            reStartMasterResource();
-            // reopen the resource
-            logger.info("Recover from waiting success, the current server status is {}",
-                    ServerLifeCycleManager.getServerStatus());
-        } catch (Exception e) {
-            String errorMessage =
-                    String.format("Recover from waiting failed, the current server status is %s, will stop the server",
-                            ServerLifeCycleManager.getServerStatus());
-            logger.error(errorMessage, e);
-            registryClient.getStoppable().stop(errorMessage);
+        if (ServerLifeCycleManager.isRunning()) {
+            logger.info("no need to reconnect, as the current server status is running");
+        } else {
+            try {
+                ServerLifeCycleManager.recoverFromWaiting();
+                reStartMasterResource();
+                logger.info("Recover from waiting success, the current server status is {}",
+                        ServerLifeCycleManager.getServerStatus());
+            } catch (Exception e) {
+                String errorMessage =
+                        String.format(
+                                "Recover from waiting failed, the current server status is %s, will stop the server",
+                                ServerLifeCycleManager.getServerStatus());
+                logger.error(errorMessage, e);
+                registryClient.getStoppable().stop(errorMessage);
+            }
         }
     }
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/registry/WorkerWaitingStrategy.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/registry/WorkerWaitingStrategy.java
@@ -93,19 +93,23 @@ public class WorkerWaitingStrategy implements WorkerConnectStrategy {
 
     @Override
     public void reconnect() {
-        try {
-            ServerLifeCycleManager.recoverFromWaiting();
-            reStartWorkerResource();
-            logger.info("Recover from waiting success, the current server status is {}",
-                    ServerLifeCycleManager.getServerStatus());
-        } catch (Exception e) {
-            String errorMessage =
-                    String.format("Recover from waiting failed, the current server status is %s, will stop the server",
-                            ServerLifeCycleManager.getServerStatus());
-            logger.error(errorMessage, e);
-            registryClient.getStoppable().stop(errorMessage);
+        if (ServerLifeCycleManager.isRunning()) {
+            logger.info("no need to reconnect, as the current server status is running");
+        } else {
+            try {
+                ServerLifeCycleManager.recoverFromWaiting();
+                reStartWorkerResource();
+                logger.info("Recover from waiting success, the current server status is {}",
+                        ServerLifeCycleManager.getServerStatus());
+            } catch (Exception e) {
+                String errorMessage =
+                        String.format(
+                                "Recover from waiting failed, the current server status is %s, will stop the server",
+                                ServerLifeCycleManager.getServerStatus());
+                logger.error(errorMessage, e);
+                registryClient.getStoppable().stop(errorMessage);
+            }
         }
-
     }
 
     @Override


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

try to fix #13310 

## Brief change log

check the master/worker status before reconnect, if the master/worker is still in RUNNING status, then no need to restart the master/worker itself.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.