### PR TITLE
[3.1.3-release][SQL] Fix t_ds_fav table does not exist when rolling upgrade

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.3_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.3_schema/mysql/dolphinscheduler_ddl.sql
@@ -15,7 +15,7 @@
  * limitations under the License.
 */
 
-DROP PROCEDURE if EXISTS ut_dolphin_T_t_ds_fav;
+DROP PROCEDURE IF EXISTS ut_dolphin_T_t_ds_fav;
 delimiter d//
 CREATE PROCEDURE ut_dolphin_T_t_ds_fav()
 BEGIN

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.3_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.3_schema/mysql/dolphinscheduler_ddl.sql
@@ -14,3 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
+DROP PROCEDURE if EXISTS ut_dolphin_T_t_ds_fav;
+delimiter d//
+CREATE PROCEDURE ut_dolphin_T_t_ds_fav()
+BEGIN
+		IF EXISTS (SELECT 1 FROM information_schema.TABLES
+			WHERE TABLE_NAME='t_ds_fav'
+			AND TABLE_SCHEMA=(SELECT DATABASE()))
+		THEN
+ALTER TABLE t_ds_fav RENAME t_ds_fav_task;
+END IF;
+END;
+d//
+
+delimiter ;
+CALL ut_dolphin_T_t_ds_fav;
+DROP PROCEDURE ut_dolphin_T_t_ds_fav;
+
+CREATE TABLE IF NOT EXISTS t_ds_fav_task
+(
+    id        serial      NOT NULL,
+    task_name varchar(64) NOT NULL,
+    user_id   int         NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.3_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.3_schema/postgresql/dolphinscheduler_ddl.sql
@@ -14,4 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-ALTER TABLE t_ds_fav RENAME TO t_ds_fav_task;
+
+ALTER TABLE IF EXISTS t_ds_fav RENAME TO t_ds_fav_task;
+
+CREATE TABLE IF NOT EXISTS t_ds_fav_task
+(
+    id        serial      NOT NULL,
+    task_name varchar(64) NOT NULL,
+    user_id   int         NOT NULL,
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
