### PR TITLE
Fix Bug #13136，list param expand caught NPE, when sql has ?

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtils.java
@@ -154,12 +154,12 @@ public class ParameterUtils {
         }
     }
 
-    public static String expandListParameter(Map<Integer, Property> params, String sql) {
+    public static String expandListParameter(Map<Integer, Property> params, String sql, String rgex) {
         Map<Integer, Property> expandMap = new HashMap<>();
         if (params == null || params.isEmpty()) {
             return sql;
         }
-        String[] split = sql.split("\\?");
+        String[] split = sql.split(rgex);
         if (split.length == 0) {
             return sql;
         }
@@ -203,7 +203,7 @@ public class ParameterUtils {
             }
             ret.append(split[i]);
         }
-        if (PARAM_REPLACE_CHAR == sql.charAt(sql.length() - 1)) {
+        if (sql.matches(".+" + rgex + "$")) {
             ret.append(PARAM_REPLACE_CHAR);
             expandMap.put(index, params.get(split.length));
         }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
@@ -17,15 +17,17 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.parser;
 
-import com.google.common.collect.Lists;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Lists;
 
 public class ParameterUtilsTest {
 
@@ -47,7 +49,8 @@ public class ParameterUtilsTest {
         Map<Integer, Property> params2 = new HashMap<>();
         params2.put(1, new Property(null, null, DataType.LIST, JSONUtils.toJsonString(Lists.newArrayList("c1"))));
         params2.put(2, new Property(null, null, DataType.DATE, "2020-06-30"));
-        String sql2 = ParameterUtils.expandListParameter(params2, "select * from test where col1 in (${1}) and date=${2}", rgex);
+        String sql2 = ParameterUtils.expandListParameter(params2,
+                "select * from test where col1 in (${1}) and date=${2}", rgex);
         Assertions.assertEquals("select * from test where col1 in (?) and date=?", sql2);
         Assertions.assertEquals(2, params2.size());
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/ParameterUtilsTest.java
@@ -17,19 +17,19 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.parser;
 
+import com.google.common.collect.Lists;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Lists;
-
 public class ParameterUtilsTest {
+
+    private String rgex = "['\"]*\\$\\{(.*?)\\}['\"]*";
 
     @Test
     public void expandListParameter() {
@@ -40,14 +40,14 @@ public class ParameterUtilsTest {
         params.put(3, new Property(null, null, DataType.LIST,
                 JSONUtils.toJsonString(Lists.newArrayList(3.1415, 2.44, 3.44))));
         String sql = ParameterUtils.expandListParameter(params,
-                "select * from test where col1 in (?) and date=? and col2 in (?)");
+                "select * from test where col1 in (${1}) and date=${2} and col2 in (${3})", rgex);
         Assertions.assertEquals("select * from test where col1 in (?,?,?) and date=? and col2 in (?,?,?)", sql);
         Assertions.assertEquals(7, params.size());
 
         Map<Integer, Property> params2 = new HashMap<>();
         params2.put(1, new Property(null, null, DataType.LIST, JSONUtils.toJsonString(Lists.newArrayList("c1"))));
         params2.put(2, new Property(null, null, DataType.DATE, "2020-06-30"));
-        String sql2 = ParameterUtils.expandListParameter(params2, "select * from test where col1 in (?) and date=?");
+        String sql2 = ParameterUtils.expandListParameter(params2, "select * from test where col1 in (${1}) and date=${2}", rgex);
         Assertions.assertEquals("select * from test where col1 in (?) and date=?", sql2);
         Assertions.assertEquals(2, params2.size());
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -506,7 +506,7 @@ public class SqlTask extends AbstractTask {
         // replace the ${} of the SQL statement with the Placeholder
         String formatSql = sql.replaceAll(rgex, "?");
         // Convert the list parameter
-        formatSql = ParameterUtils.expandListParameter(sqlParamsMap, formatSql);
+        formatSql = ParameterUtils.expandListParameter(sqlParamsMap, sql, rgex);
         sqlBuilder.append(formatSql);
         // print replace sql
         printReplacedSql(sql, formatSql, rgex, sqlParamsMap);


### PR DESCRIPTION
Fix list param expand caught NPE, when sql has ?, it conflict with PARAM_REPLACE_CHAR (#13136)

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
This pull request fix a bug (#13136)
## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
1. Change org.apache.dolphinscheduler.plugin.task.api.parser.ParameterUtils#expandListParameter
    1.1. change param `formatSql` to `sql`，origin sql has more param info, not on `?`;
    1.2. add param `rgex`, this constant has defined in SqlTask.java；
    1.3. change `split("\\?")` to rgex, this is main purpose;
    1.5. change `end with ?` to regex like `.+\\${xxx}$`;
2. Compatible with unit tests, org.apache.dolphinscheduler.plugin.task.api.parser.ParameterUtilsTest, Test OK.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is already covered by existing tests, such as *(please describe tests)*.
org.apache.dolphinscheduler.plugin.task.api.parser.ParameterUtilsTest#expandListParameter