### PR TITLE
[Refactor][UI]Add a back button when viewing an error file

### DIFF
--- a/dolphinscheduler-ui/src/service/service.ts
+++ b/dolphinscheduler-ui/src/service/service.ts
@@ -72,9 +72,9 @@ const err = (err: AxiosError): Promise<AxiosError> => {
 }
 
 service.interceptors.request.use((config: AxiosRequestConfig<any>) => {
-  config.headers && (config.headers.sessionId = userStore.getSessionId)
-  const language = cookies.get('language')
   config.headers = config.headers || {}
+  config.headers.sessionId = userStore.getSessionId
+  const language = cookies.get('language')
   if (language) config.headers.language = language
 
   return config

--- a/dolphinscheduler-ui/src/views/resource/file/edit/index.tsx
+++ b/dolphinscheduler-ui/src/views/resource/file/edit/index.tsx
@@ -109,7 +109,21 @@ export default defineComponent({
           </div>
         ) : (
           <NSpace justify='center'>
-            <NSpin show={true} />
+            <NSpace vertical>
+              <NSpin show={true} />
+              <NSpace>
+                <NButton
+                  type='info'
+                  size='small'
+                  text
+                  style={{ marginRight: '15px' }}
+                  onClick={this.handleReturn}
+                  class='btn-cancel'
+                >
+                  {t('resource.file.return')}
+                </NButton>
+              </NSpace>
+            </NSpace>
           </NSpace>
         )}
       </Card>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

- *make dolphinscheduler-ui/src/service/service.ts look friendly*
- *Add a back button when viewing an error file*

## Brief change log

- *make dolphinscheduler-ui/src/service/service.ts look friendly*

 Before
![service1](https://user-images.githubusercontent.com/20340304/211186978-0afed3aa-582c-4011-badf-857c450d1117.jpg)
 After

![service3](https://user-images.githubusercontent.com/20340304/211188187-97bbf0f3-5215-4ebf-aebb-19f9ae7defaf.jpg)



- *Add a back button when viewing an error file*

 Before
![resource1](https://user-images.githubusercontent.com/20340304/211186721-4368cb9c-dbb7-4370-a073-20b6957f6f1a.jpg)
 After
![resource2](https://user-images.githubusercontent.com/20340304/211186743-65bad24a-7987-4d0d-af5c-269f8d33aef8.jpg)




## Verify this pull request

This change added tests and can be verified as follows:

- *Manually verified the change by testing locally.* 

