### PR TITLE
[Bug][Deployment] Fix minio version in helm chart

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -61,6 +61,6 @@ dependencies:
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: mysql.enabled
 - name: minio
-  version: 2022.10.29
+  version: 11.10.13
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: minio.enabled


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* In current helm chart, the version of `minio` seems wired. When performing `helm dependency update .`, we will get error message like `Error: can't get a valid version for repositories minio. Try changing the version constraint in Chart.yaml`. 
* The version released on Oct. 29th, 2022 is `11.10.13`.

![image](https://user-images.githubusercontent.com/34905992/211563669-08b65e6c-d37b-4a45-8fc6-3e4db8948d89.png)

## Brief change log

* Already stated above.

## Verify this pull request

* Verified manually.