### PR TITLE
[Improvement][Deployment] Use minio as defaut storage if deployed in k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Dolphin Scheduler Official Website
 ==================================================================
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![codecov](https://codecov.io/gh/apache/dolphinscheduler/branch/dev/graph/badge.svg)](https://codecov.io/gh/apache/dolphinscheduler/branch/dev)
+[![codecov](https://app.codecov.io/gh/apache/dolphinscheduler/tree/dev/graph/badge.svg)](https://app.codecov.io/gh/apache/dolphinscheduler/tree/dev)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=apache-dolphinscheduler&metric=alert_status)](https://sonarcloud.io/dashboard?id=apache-dolphinscheduler)
 [![Twitter Follow](https://img.shields.io/twitter/follow/dolphinschedule.svg?style=social&label=Follow)](https://twitter.com/dolphinschedule)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://s.apache.org/dolphinscheduler-slack)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -3,7 +3,7 @@ Dolphin Scheduler Official Website
 ==================================================================
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![codecov](https://codecov.io/gh/apache/dolphinscheduler/branch/dev/graph/badge.svg)](https://codecov.io/gh/apache/dolphinscheduler/branch/dev)
+[![codecov](https://app.codecov.io/gh/apache/dolphinscheduler/tree/dev/graph/badge.svg)](https://app.codecov.io/gh/apache/dolphinscheduler/tree/dev)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=apache-dolphinscheduler&metric=alert_status)](https://sonarcloud.io/dashboard?id=apache-dolphinscheduler)
 
 [![Stargazers over time](https://starchart.cc/apache/dolphinscheduler.svg)](https://starchart.cc/apache/dolphinscheduler)

--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -35,11 +35,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.0
+version: latest
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.0
+appVersion: latest
 
 dependencies:
 - name: postgresql

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -58,7 +58,7 @@ mysql:
       storageClass: "-"
 
 minio:
-  enabled: false
+  enabled: true
   auth:
     rootUser: minioadmin
     rootPassword: minioadmin
@@ -100,7 +100,7 @@ conf:
     data.basedir.path: /tmp/dolphinscheduler
 
     # resource storage type: HDFS, S3, NONE
-    resource.storage.type: NONE
+    resource.storage.type: S3
 
     # resource store on HDFS/S3 path, resource file will store to this base path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
     resource.storage.upload.base.path: /dolphinscheduler


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* Set `minio` as DS default storage when deployed in K8S, in this way, users could use resource center out-of-the-box.

## Brief change log

* Already described above.

## Verify this pull request

* Verified manually.