### PR TITLE
[fix][task plugin][task sql] fix parsing error while using variables …

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractTask.java
@@ -43,7 +43,7 @@ public abstract class AbstractTask {
     protected final Logger logger =
             LoggerFactory.getLogger(String.format(TaskConstants.TASK_LOG_LOGGER_NAME_FORMAT, getClass()));
 
-    public String rgex = "['\"]*\\$\\{(.*?)\\}['\"]*";
+    public String rgex = "['\"]?\\$\\{(.*?)\\}['\"]?";
 
     /**
      * varPool string


### PR DESCRIPTION
## Purpose of the pull request

This pull request fix parsing error while using variables in sql like `load inpath '/path/paramName=${paramValue}'`.
Currently, all quotes around param defenition are removed after replacing, but sometimes quotes are part of a sql, for example, when load data into hive table, hive load syntax looks like `LOAD DATA [LOCAL] INPATH 'filepath' [OVERWRITE] INTO TABLE tablename...... `.

<img width="344" alt="企业微信截图_16734192512423" src="https://user-images.githubusercontent.com/17078980/211740324-f8386e45-0ee4-4fb2-ad67-aac27417491c.png">
<img width="547" alt="企业微信截图_16734193757609" src="https://user-images.githubusercontent.com/17078980/211740347-02490e8a-b08b-49c6-8359-11cc2a601923.png">


## Brief change log

using '?' rather than '*' when matching quotes around param defenition

## Verify this pull request

Verified manually.
