### PR TITLE
Clear the task group data when delete a project/workflowInstance

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupQueueService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupQueueService.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,7 +69,13 @@ public interface TaskGroupQueueService {
      */
     boolean deleteByTaskId(int taskId);
 
+    void deleteByTaskInstanceIds(List<Integer> taskInstanceIds);
+
+    void deleteByWorkflowInstanceId(Integer workflowInstanceId);
+
     void forceStartTask(int queueId, int forceStart);
 
     void modifyPriority(Integer queueId, Integer priority);
+
+    void deleteByTaskGroupIds(List<Integer> taskGroupIds);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupService.java
@@ -139,4 +139,6 @@ public interface TaskGroupService {
     Map<String, Object> forceStartTask(User loginUser, int taskId);
 
     Map<String, Object> modifyPriority(User loginUser, Integer queueId, Integer priority);
+
+    void deleteTaskGroupByProjectCode(long projectCode);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -104,6 +104,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -135,6 +136,7 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
     @Autowired
     private ProcessInstanceMapper processInstanceMapper;
 
+    @Lazy()
     @Autowired
     private ProcessService processService;
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -24,6 +24,7 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.ProjectService;
+import org.apache.dolphinscheduler.api.service.TaskGroupService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
@@ -60,6 +61,7 @@ import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,6 +75,10 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class ProjectServiceImpl extends BaseServiceImpl implements ProjectService {
 
     private static final Logger logger = LoggerFactory.getLogger(ProjectServiceImpl.class);
+
+    @Lazy
+    @Autowired
+    private TaskGroupService taskGroupService;
 
     @Autowired
     private ProjectMapper projectMapper;
@@ -446,6 +452,9 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             putMsg(result, Status.DELETE_PROJECT_ERROR_DEFINES_NOT_NULL);
             return result;
         }
+        // delete the task group
+        taskGroupService.deleteTaskGroupByProjectCode(project.getCode());
+
         int delete = projectMapper.deleteById(project.getId());
         if (delete > 0) {
             logger.info("Project is deleted and id is :{}.", project.getId());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupQueueServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupQueueServiceImpl.java
@@ -28,6 +28,8 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupQueueMapper;
 
+import org.apache.commons.collections4.CollectionUtils;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +148,19 @@ public class TaskGroupQueueServiceImpl extends BaseServiceImpl implements TaskGr
     }
 
     @Override
+    public void deleteByTaskInstanceIds(List<Integer> taskInstanceIds) {
+        if (CollectionUtils.isEmpty(taskInstanceIds)) {
+            return;
+        }
+        taskGroupQueueMapper.deleteByTaskInstanceIds(taskInstanceIds);
+    }
+
+    @Override
+    public void deleteByWorkflowInstanceId(Integer workflowInstanceId) {
+        taskGroupQueueMapper.deleteByWorkflowInstanceId(workflowInstanceId);
+    }
+
+    @Override
     public void forceStartTask(int queueId, int forceStart) {
         taskGroupQueueMapper.updateForceStart(queueId, forceStart);
     }
@@ -153,5 +168,13 @@ public class TaskGroupQueueServiceImpl extends BaseServiceImpl implements TaskGr
     @Override
     public void modifyPriority(Integer queueId, Integer priority) {
         taskGroupQueueMapper.modifyPriority(queueId, priority);
+    }
+
+    @Override
+    public void deleteByTaskGroupIds(List<Integer> taskGroupIds) {
+        if (CollectionUtils.isEmpty(taskGroupIds)) {
+            return;
+        }
+        taskGroupQueueMapper.deleteByTaskGroupIds(taskGroupIds);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
@@ -29,8 +29,8 @@ import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
-import org.apache.dolphinscheduler.service.process.ProcessService;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,9 +63,6 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
 
     @Autowired
     private TaskGroupQueueService taskGroupQueueService;
-
-    @Autowired
-    private ProcessService processService;
 
     @Autowired
     private ExecutorService executorService;
@@ -428,5 +426,18 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         logger.info("Modify task group queue priority complete, queueId:{}, priority:{}.", queueId, priority);
         putMsg(result, Status.SUCCESS);
         return result;
+    }
+
+    @Override
+    public void deleteTaskGroupByProjectCode(long projectCode) {
+        List<TaskGroup> taskGroups = taskGroupMapper.selectByProjectCode(projectCode);
+        if (CollectionUtils.isEmpty(taskGroups)) {
+            return;
+        }
+        List<Integer> taskGroupIds = taskGroups.stream()
+                .map(TaskGroup::getId)
+                .collect(Collectors.toList());
+        taskGroupQueueService.deleteByTaskGroupIds(taskGroupIds);
+        taskGroupMapper.deleteBatchIds(taskGroupIds);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
@@ -24,6 +24,7 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import org.apache.dolphinscheduler.api.dto.taskInstance.TaskInstanceRemoveCacheResponse;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.ProjectService;
+import org.apache.dolphinscheduler.api.service.TaskGroupQueueService;
 import org.apache.dolphinscheduler.api.service.TaskInstanceService;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
@@ -106,6 +107,9 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
 
     @Autowired
     private DqExecuteResultDao dqExecuteResultDao;
+
+    @Autowired
+    private TaskGroupQueueService taskGroupQueueService;
 
     /**
      * query task list by project, process instance, task name, task start time, task end time, task status, keyword paging
@@ -384,7 +388,9 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
                 }
             }
         }
+
         dqExecuteResultDao.deleteByWorkflowInstanceId(workflowInstanceId);
+        taskGroupQueueService.deleteByWorkflowInstanceId(workflowInstanceId);
         taskInstanceDao.deleteByWorkflowInstanceId(workflowInstanceId);
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -96,6 +96,9 @@ public class ProjectServiceTest {
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
 
+    @Mock
+    private TaskGroupService taskGroupService;
+
     private String projectName = "ProjectServiceTest";
 
     private String userName = "ProjectServiceTest";

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/TaskGroup.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/TaskGroup.java
@@ -72,7 +72,7 @@ public class TaskGroup implements Serializable {
      */
     private Date updateTime;
     /**
-     * project Id
+     * project code
      */
     private long projectCode;
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupMapper.java
@@ -82,8 +82,11 @@ public interface TaskGroupMapper extends BaseMapper<TaskGroup> {
 
     /**
      * listAuthorizedResource
+     *
      * @param userId
      * @return
      */
     List<TaskGroup> listAuthorizedResource(@Param("userId") int userId);
+
+    List<TaskGroup> selectByProjectCode(@Param("projectCode") long projectCode);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
@@ -99,4 +99,10 @@ public interface TaskGroupQueueMapper extends BaseMapper<TaskGroupQueue> {
                                                                  @Param("status") Integer status,
                                                                  @Param("groupId") int groupId,
                                                                  @Param("projects") List<Project> projects);
+
+    void deleteByTaskInstanceIds(@Param("taskInstanceIds") List<Integer> taskInstanceIds);
+
+    void deleteByWorkflowInstanceId(@Param("workflowInstanceId") Integer workflowInstanceId);
+
+    void deleteByTaskGroupIds(@Param("taskGroupIds") List<Integer> taskGroupIds);
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupMapper.xml
@@ -69,8 +69,15 @@
                 #{i}
             </foreach>
         </if>
-        and project_code in ( #{projectCode} ,  0)
+        and project_code in ( #{projectCode} , 0)
         order by update_time desc
+    </select>
+
+    <select id="selectByProjectCode" resultType="org.apache.dolphinscheduler.dao.entity.TaskGroup">
+        select
+        <include refid="baseSql"/>
+        from t_ds_task_group
+        where project_code = #{projectCode}
     </select>
 
     <!--modify data by id-->

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
@@ -157,4 +157,27 @@
         order by queue.update_time desc
     </select>
 
+    <delete id="deleteByTaskIds">
+        delete from t_ds_task_group_queue
+        where task_id in
+        <foreach collection="taskInstanceIds" index="index" item="i" open="(" separator="," close=")">
+            #{i}
+        </foreach>
+    </delete>
+
+    <delete id="deleteByWorkflowInstanceId">
+        delete
+        from t_ds_task_group_queue
+        where process_id = #{workflowInstanceId}
+    </delete>
+
+    <delete id="deleteByTaskGroupIds">
+        delete
+        from t_ds_task_group_queue
+        where group_id in
+        <foreach collection="taskGroupIds" index="index" item="i" open="(" separator="," close=")">
+            #{i}
+        </foreach>
+    </delete>
+
 </mapper>


### PR DESCRIPTION
## Purpose of the pull request

fix #13382

## Brief change log

- Delete the taskGroupQueue data when delete a workflow instance
- Delete the taskGroup data when delete a project

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
