### PR TITLE
Remove entity in QueryWrapper constructor

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/AlertDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/AlertDao.java
@@ -56,7 +56,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
@@ -282,7 +281,7 @@ public class AlertDao {
     }
 
     public List<Alert> listAlerts(int processInstanceId) {
-        LambdaQueryWrapper<Alert> wrapper = new QueryWrapper<>(new Alert()).lambda()
+        LambdaQueryWrapper<Alert> wrapper = new LambdaQueryWrapper<Alert>()
                 .eq(Alert::getProcessInstanceId, processInstanceId);
         return alertMapper.selectList(wrapper);
     }

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/upgrader/v320/V320DolphinSchedulerUpgrader.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/upgrader/v320/V320DolphinSchedulerUpgrader.java
@@ -77,7 +77,7 @@ public class V320DolphinSchedulerUpgrader implements DolphinSchedulerUpgrader {
                 .collect(Collectors.toMap(User::getId, User::getUserName));
 
         while (true) {
-            LambdaQueryWrapper<ProcessInstance> wrapper = new QueryWrapper<>(new ProcessInstance())
+            LambdaQueryWrapper<ProcessInstance> wrapper = new QueryWrapper<ProcessInstance>()
                     .lambda()
                     .eq(ProcessInstance::getProjectCode, null)
                     .last("limit 1000");
@@ -109,7 +109,7 @@ public class V320DolphinSchedulerUpgrader implements DolphinSchedulerUpgrader {
 
     private void upgradeTaskInstance() {
         while (true) {
-            LambdaQueryWrapper<TaskInstance> wrapper = new QueryWrapper<>(new TaskInstance())
+            LambdaQueryWrapper<TaskInstance> wrapper = new QueryWrapper<TaskInstance>()
                     .lambda()
                     .eq(TaskInstance::getProjectCode, null)
                     .last("limit 1000");


### PR DESCRIPTION
## Purpose of the pull request

The entity will used in where, so we shouldn't use in constructor unless we want to use this for condition.
https://baomidou.com/pages/10c804/#querywrapper

If the entity has non null field, there may exist bug.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
