### PR TITLE
Fix the bug which fails DS to acquire lock in ZK registry

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManager.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/ServerNodeManager.java
@@ -311,12 +311,14 @@ public class ServerNodeManager implements InitializingBean {
     }
 
     private void updateMasterNodes() {
-        MASTER_SLOT = 0;
-        MASTER_SIZE = 0;
-        this.masterNodes.clear();
+
         String nodeLock = Constants.REGISTRY_DOLPHINSCHEDULER_LOCK_MASTERS;
         try {
             registryClient.getLock(nodeLock);
+
+            MASTER_SLOT = 0;
+            MASTER_SIZE = 0;
+            this.masterNodes.clear();
             Collection<String> currentNodes = registryClient.getMasterNodesDirectly();
             List<Server> masterNodes = registryClient.getServerList(NodeType.MASTER);
             syncMasterNodes(currentNodes, masterNodes);

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
@@ -219,7 +219,7 @@ public final class ZookeeperRegistry implements Registry {
 
     @Override
     public boolean releaseLock(String key) {
-        if (null == threadLocalLockMap.get().get(key)) {
+        if (threadLocalLockMap.get()==null || null == threadLocalLockMap.get().get(key)) {
             return false;
         }
         try {


### PR DESCRIPTION
This change added tests and can be verified as follows:

-  if can not getlock in updateMasterNodes,donot update master info in ServerNodeManager
-  if releaseLock will null when can not acquireLock in ZookeeperRegistry