### PR TITLE
complete datasource-setting.md

### DIFF
--- a/docs/docs/zh/guide/howto/datasource-setting.md
+++ b/docs/docs/zh/guide/howto/datasource-setting.md
@@ -96,6 +96,7 @@ export SPRING_DATASOURCE_PASSWORD={password}
 ```
 
 完成上述步骤后，您已经为 DolphinScheduler 创建一个新数据库，现在你可以通过快速的 Shell 脚本来初始化数据库
+如果使用的mysql数据库，你需要手动下载 [mysql-connector-java 驱动][mysql] (8.0.16) 并移动到 DolphinScheduler 的tools模块的 libs 目录下`tools/libs/`。
 
 ```shell
 bash tools/bin/upgrade-schema.sh


### PR DESCRIPTION
当使用mysql作为数据源时，在初始化数据库的时候，如果不在tools/libs下放入mysql-connector-java的驱动的话，会报驱动类找不到的异常，所以在初始化之前加入了引入依赖的说明
