### PR TITLE
[Improvement-13413] [Master] Empty dependency operation causes Master null pointer exception

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/dependent/DependentParameters.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/dependent/DependentParameters.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dolphinscheduler.common.task.dependent;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.dolphinscheduler.common.enums.DependentRelation;
 import org.apache.dolphinscheduler.common.model.DependentTaskModel;
 import org.apache.dolphinscheduler.common.process.ResourceInfo;
@@ -33,7 +34,7 @@ public class DependentParameters extends AbstractParameters {
 
     @Override
     public boolean checkParameters() {
-        return true;
+        return CollectionUtils.isNotEmpty(dependTaskList) && relation != null;
     }
 
     @Override


### PR DESCRIPTION
closed by #13413 