### PR TITLE
[Improvement-12528] achieve config task log base path out of the dolphinscheduler install path

### DIFF
--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -120,6 +120,13 @@ master:
 server:
   port: 5679
 
+task:
+  logger-dir:
+    # The task log directory currently in use
+    current: logs
+    # The task log directory used in the past; You can have multiple values, separated by commas;
+    past: logs
+
 management:
   endpoints:
     web:

--- a/dolphinscheduler-master/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-master/src/main/resources/logback-spring.xml
@@ -18,6 +18,8 @@
 
 <configuration scan="true" scanPeriod="120 seconds">
     <property name="log.base" value="logs"/>
+    <springProperty scope="context" name="TASK_LOG_HOME" source="task.logger-dir.current" defaultValue="logs"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
@@ -33,11 +35,11 @@
         <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">
             <key>taskAppId</key>
-            <logBase>${log.base}</logBase>
+            <logBase>${TASK_LOG_HOME}</logBase>
         </Discriminator>
         <sift>
             <appender name="FILE-${taskAppId}" class="ch.qos.logback.core.FileAppender">
-                <file>${log.base}/${taskAppId}.log</file>
+                <file>${TASK_LOG_HOME}/${taskAppId}.log</file>
                 <encoder>
                     <pattern>
                         [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %messsage%n

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/log/LoggerRequestProcessorTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/log/LoggerRequestProcessorTest.java
@@ -33,6 +33,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import io.netty.channel.Channel;
 
+import java.util.LinkedList;
+import java.util.List;
+
 @RunWith(MockitoJUnitRunner.class)
 public class LoggerRequestProcessorTest {
 
@@ -61,7 +64,7 @@ public class LoggerRequestProcessorTest {
         command.setType(CommandType.VIEW_WHOLE_LOG_REQUEST);
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
-        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
+        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor("logs", null);
         loggerRequestProcessor.process(channel, command);
     }
 
@@ -77,7 +80,7 @@ public class LoggerRequestProcessorTest {
         command.setType(CommandType.VIEW_WHOLE_LOG_REQUEST);
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
-        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
+        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor("logs", null);
         loggerRequestProcessor.process(channel, command);
     }
 
@@ -93,7 +96,7 @@ public class LoggerRequestProcessorTest {
         command.setType(CommandType.VIEW_WHOLE_LOG_REQUEST);
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
-        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
+        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor("logs", null);
         loggerRequestProcessor.process(channel, command);
     }
 
@@ -108,7 +111,32 @@ public class LoggerRequestProcessorTest {
         command.setType(CommandType.VIEW_WHOLE_LOG_REQUEST);
         command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
 
-        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor();
+        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor("logs", null);
+        loggerRequestProcessor.process(channel, command);
+    }
+
+    @Test
+    public void testProcessViewWholeLogRequestStartWithSpecifyDirs() {
+        System.setProperty("DOLPHINSCHEDULER_WORKER_HOME", System.getProperty("user.dir"));
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(LoggerUtils.readWholeFileContent(Mockito.anyString())).thenReturn("");
+
+        String dir1 = "/var/log/dolphinscheduler";
+        String dir2 = "/var/log/dolphinscheduler_01";
+        String dir3 = "/var/log/dolphinscheduler_02";
+        List<String> pastDirs = new LinkedList<>();
+        pastDirs.add(dir2);
+        pastDirs.add(dir3);
+        LoggerRequestProcessor loggerRequestProcessor = new LoggerRequestProcessor(dir1, pastDirs);
+
+        ViewLogRequestCommand logRequestCommand = new ViewLogRequestCommand(dir1 + "/20220101/task01.log");
+        Command command = new Command();
+        command.setType(CommandType.VIEW_WHOLE_LOG_REQUEST);
+        command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
+        loggerRequestProcessor.process(channel, command);
+
+        logRequestCommand = new ViewLogRequestCommand(dir2 + "/20220101/task02.log");
+        command.setBody(JSONUtils.toJsonByteArray(logRequestCommand));
         loggerRequestProcessor.process(channel, command);
     }
 }

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -81,6 +81,13 @@ worker:
 server:
   port: 1235
 
+task:
+  logger-dir:
+    # The task log directory currently in use
+    current: logs
+    # The task log directory used in the past; You can have multiple values, separated by commas;
+    past: logs
+
 management:
   endpoints:
     web:

--- a/dolphinscheduler-worker/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-worker/src/main/resources/logback-spring.xml
@@ -18,6 +18,7 @@
 
 <configuration scan="true" scanPeriod="120 seconds">
     <property name="log.base" value="logs"/>
+    <springProperty scope="context" name="TASK_LOG_HOME" source="task.logger-dir.current" defaultValue="logs"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -34,11 +35,11 @@
         <filter class="org.apache.dolphinscheduler.service.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.service.log.TaskLogDiscriminator">
             <key>taskAppId</key>
-            <logBase>${log.base}</logBase>
+            <logBase>${TASK_LOG_HOME}</logBase>
         </Discriminator>
         <sift>
             <appender name="FILE-${taskAppId}" class="ch.qos.logback.core.FileAppender">
-                <file>${log.base}/${taskAppId}.log</file>
+                <file>${TASK_LOG_HOME}/${taskAppId}.log</file>
                 <encoder>
                     <pattern>
                         [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %messsage%n


### PR DESCRIPTION



<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Achieve config task log base path out of the dolphinscheduler install path;
This closes issue #12528 #12703. And it can also solve the problem mentioned by pr #13280 which cause a security problem（#13460）  

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
