### PR TITLE
[Improvement-13476][*]  Improve DS load hdfs configuration automatically by using environment variable HADOOP_CONF_DIR

### DIFF
--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -339,23 +339,15 @@ The default configuration is as follows:
 
 ### dolphinscheduler_env.sh [load environment variables configs]
 
-When using shell to commit tasks, DolphinScheduler will export environment variables from `bin/env/dolphinscheduler_env.sh`. The
-mainly configuration including `JAVA_HOME` and other environment paths.
+Configure the running environment for the DS. The mainly configuration including `JAVA_HOME`,`HADOOP_HOME` and `HADOOP_CONF_DIR`.
 
 ```bash
 # JAVA_HOME, will use it to start DolphinScheduler server
 export JAVA_HOME=${JAVA_HOME:-/opt/soft/java}
 
-# Tasks related configurations, need to change the configuration if you use the related tasks.
+#DS will auto load HDFS configuration from environment
 export HADOOP_HOME=${HADOOP_HOME:-/opt/soft/hadoop}
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/opt/soft/hadoop/etc/hadoop}
-export SPARK_HOME=${SPARK_HOME:-/opt/soft/spark}
-export PYTHON_HOME=${PYTHON_HOME:-/opt/soft/python}
-export HIVE_HOME=${HIVE_HOME:-/opt/soft/hive}
-export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
-export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
-
-export PATH=$HADOOP_HOME/bin:$SPARK_HOME/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$PATH
 
 # applicationId auto collection related configuration, the following configurations are unnecessary if setting appId.collect=log
 export HADOOP_CLASSPATH=`hadoop classpath`:${DOLPHINSCHEDULER_HOME}/tools/libs/*

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -332,22 +332,15 @@ common.properties配置文件目前主要是配置hadoop/s3/yarn/applicationId�
 
 ## dolphinscheduler_env.sh [环境变量配置]
 
-通过类似shell方式提交任务的的时候，会加载该配置文件中的环境变量到主机中。涉及到的 `JAVA_HOME` 任务类型的环境配置，其中任务类型主要有: Shell任务、Python任务、Spark任务、Flink任务、Datax任务等等。
+配置DS的运行环境. 主要的环境变量配置包括 `JAVA_HOME`,`HADOOP_HOME`,`HADOOP_CONF_DIR`
 
 ```bash
 # JAVA_HOME, will use it to start DolphinScheduler server
 export JAVA_HOME=${JAVA_HOME:-/opt/soft/java}
 
-# Tasks related configurations, need to change the configuration if you use the related tasks.
+# DS will auto load HDFS configuration from environment
 export HADOOP_HOME=${HADOOP_HOME:-/opt/soft/hadoop}
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/opt/soft/hadoop/etc/hadoop}
-export SPARK_HOME=${SPARK_HOME:-/opt/soft/spark}
-export PYTHON_HOME=${PYTHON_HOME:-/opt/soft/python}
-export HIVE_HOME=${HIVE_HOME:-/opt/soft/hive}
-export FLINK_HOME=${FLINK_HOME:-/opt/soft/flink}
-export DATAX_HOME=${DATAX_HOME:-/opt/soft/datax}
-
-export PATH=$HADOOP_HOME/bin:$SPARK_HOME/bin:$PYTHON_HOME/bin:$JAVA_HOME/bin:$HIVE_HOME/bin:$FLINK_HOME/bin:$DATAX_HOME/bin:$PATH
 
 # applicationId auto collection related configuration, the following configurations are unnecessary if setting appId.collect=log
 export HADOOP_CLASSPATH=`hadoop classpath`:${DOLPHINSCHEDULER_HOME}/tools/libs/*

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -87,7 +87,7 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
 
                 @Override
                 public HdfsStorageOperator load(String key) throws Exception {
-                    return new HdfsStorageOperator(hdfsProperties);
+                    return new HdfsStorageOperator();
                 }
             });
 

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -85,7 +85,6 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
     public static final String HDFS_SITE_XML = "hdfs-site.xml";
     public static final String CORE_SITE_XML = "core-site.xml";
 
-
     private static final LoadingCache<String, HdfsStorageOperator> cache = CacheBuilder
             .newBuilder()
             .expireAfterWrite(HdfsStorageProperties.getKerberosExpireTime(), TimeUnit.HOURS)
@@ -149,7 +148,8 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
             // the default is the local file system
             if (StringUtils.isNotBlank(defaultFS)) {
                 configuration.set(Constants.HDFS_DEFAULT_FS, defaultFS);
-                // todo : question - Is this convenient for users to configure HDFS? And Whether it is convenient enough to configure environment variables `HADOOP_CONF_DIR`
+                // todo : question - Is this convenient for users to configure HDFS? And Whether it is convenient enough
+                // to configure environment variables `HADOOP_CONF_DIR`
                 Map<String, String> fsRelatedProps = PropertyUtils.getPrefixedProperties("resource.hdfs.fs.");
                 fsRelatedProps.forEach((key, value) -> configuration.set(key.substring(14), value));
             } else {

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -148,8 +148,6 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
             // the default is the local file system
             if (StringUtils.isNotBlank(defaultFS)) {
                 configuration.set(Constants.HDFS_DEFAULT_FS, defaultFS);
-                // todo : question - Is this convenient for users to configure HDFS? And Whether it is convenient enough
-                // to configure environment variables `HADOOP_CONF_DIR`
                 Map<String, String> fsRelatedProps = PropertyUtils.getPrefixedProperties("resource.hdfs.fs.");
                 fsRelatedProps.forEach((key, value) -> configuration.set(key.substring(14), value));
             } else {

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -199,8 +199,11 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
         if (StringUtils.isBlank(hadoopConfDirEnv) || !Files.exists(java.nio.file.Paths.get(hadoopConfDirEnv))) {
             if (StringUtils.isNotBlank(hadoopHomeEnv)) {
                 java.nio.file.Path confPath = Paths.get(hadoopHomeEnv, "conf");
+                java.nio.file.Path confPath2 = Paths.get(hadoopHomeEnv, "/etc/hadoop"); // hadoop 2.2
                 if (Files.exists(confPath)) {
                     hadoopConfPath = confPath.toString();
+                } else if (Files.exists(confPath2)) {
+                    hadoopConfPath = confPath2.toString();
                 }
             }
         } else {

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/test/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperatorTest.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/test/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperatorTest.java
@@ -20,7 +20,15 @@ package org.apache.dolphinscheduler.plugin.storage.hdfs;
 import org.apache.dolphinscheduler.common.utils.HttpUtils;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
@@ -74,6 +82,51 @@ public class HdfsStorageOperatorTest {
             logger.info(hdfsStorageOperator.getAppAddress("http://ds1:8088/ws/v1/cluster/apps/%s", "ds1,ds2"));
             Assertions.assertTrue(true);
         }
+    }
+
+    @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_CONF_DIR, and directory exist")
+    @Test
+    public void testGetHadoopConfPathFromEnvByHADOOP_CONF_DIR1() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        String hadoopConfDirEnv = System.getProperty("user.dir");
+        String hadoopHomeEnv = "/not_expected";
+        Assertions.assertEquals(hadoopConfDirEnv, invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));
+    }
+
+    @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_CONF_DIR, but directory not exist")
+    @Test
+    public void testGetHadoopConfPathFromEnvByHADOOP_CONF_DIR2() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        String hadoopConfDirEnv = "/not_exist";
+        String hadoopHomeEnv = null;
+        Assertions.assertNull(invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));
+    }
+
+    @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_HOME, and directory exist")
+    @Test
+    public void testGetHadoopConfPathFromEnvByHADOOP_HOME1() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, IOException {
+        String hadoopConfDirEnv = null;
+        String hadoopHomeEnv = System.getProperty("user.dir");
+        Path hoemConfPath = Paths.get(hadoopHomeEnv, "conf");
+        Files.createDirectory(hoemConfPath);
+        Assertions.assertEquals(hoemConfPath.toString(),
+                invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));
+        Files.delete(hoemConfPath);
+    }
+
+    @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_HOME, and directory not exist")
+    @Test
+    public void testGetHadoopConfPathFromEnvByHADOOP_HOME2() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        String hadoopConfDirEnv = null;
+        String hadoopHomeEnv = "/not_exist";
+        Assertions.assertNull(invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));
+    }
+
+    private String invokeGetHadoopConfPath(String hadoopConfDirEnv,
+                                               String hadoopHomeEnv) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method =
+                HdfsStorageOperator.class.getDeclaredMethod("getHadoopConfPath", String.class, String.class);
+        method.setAccessible(true);
+        HdfsStorageOperator hdfsStorageOperator = Mockito.mock(HdfsStorageOperator.class);
+        return (String) method.invoke(hdfsStorageOperator, hadoopConfDirEnv, hadoopHomeEnv);
     }
 
 }

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/test/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperatorTest.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/test/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperatorTest.java
@@ -121,7 +121,7 @@ public class HdfsStorageOperatorTest {
     }
 
     private String invokeGetHadoopConfPath(String hadoopConfDirEnv,
-                                               String hadoopHomeEnv) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+                                           String hadoopHomeEnv) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method method =
                 HdfsStorageOperator.class.getDeclaredMethod("getHadoopConfPath", String.class, String.class);
         method.setAccessible(true);

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/test/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperatorTest.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/test/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperatorTest.java
@@ -46,35 +46,35 @@ public class HdfsStorageOperatorTest {
     private static final Logger logger = LoggerFactory.getLogger(HdfsStorageOperatorTest.class);
 
     @Test
-    public void getHdfsTenantDir() {
+    void getHdfsTenantDir() {
         HdfsStorageOperator hdfsStorageOperator = new HdfsStorageOperator();
         logger.info(hdfsStorageOperator.getHdfsTenantDir("1234"));
         Assertions.assertTrue(true);
     }
 
     @Test
-    public void getHdfsUdfFileName() {
+    void getHdfsUdfFileName() {
         HdfsStorageOperator hdfsStorageOperator = new HdfsStorageOperator();
         logger.info(hdfsStorageOperator.getHdfsUdfFileName("admin", "file_name"));
         Assertions.assertTrue(true);
     }
 
     @Test
-    public void getHdfsResourceFileName() {
+    void getHdfsResourceFileName() {
         HdfsStorageOperator hdfsStorageOperator = new HdfsStorageOperator();
         logger.info(hdfsStorageOperator.getHdfsResourceFileName("admin", "file_name"));
         Assertions.assertTrue(true);
     }
 
     @Test
-    public void getHdfsFileName() {
+    void getHdfsFileName() {
         HdfsStorageOperator hdfsStorageOperator = new HdfsStorageOperator();
         logger.info(hdfsStorageOperator.getHdfsFileName(ResourceType.FILE, "admin", "file_name"));
         Assertions.assertTrue(true);
     }
 
     @Test
-    public void getAppAddress() {
+    void getAppAddress() {
         HdfsStorageOperator hdfsStorageOperator = new HdfsStorageOperator();
         try (MockedStatic<HttpUtils> mockedHttpUtils = Mockito.mockStatic(HttpUtils.class)) {
             mockedHttpUtils.when(() -> HttpUtils.get("http://ds1:8088/ws/v1/cluster/info"))
@@ -86,7 +86,7 @@ public class HdfsStorageOperatorTest {
 
     @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_CONF_DIR, and directory exist")
     @Test
-    public void testGetHadoopConfPathFromEnvByHADOOP_CONF_DIR1() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    void testGetHadoopConfPathFromEnvByHADOOP_CONF_DIR1() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         String hadoopConfDirEnv = System.getProperty("user.dir");
         String hadoopHomeEnv = "/not_expected";
         Assertions.assertEquals(hadoopConfDirEnv, invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));
@@ -94,7 +94,7 @@ public class HdfsStorageOperatorTest {
 
     @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_CONF_DIR, but directory not exist")
     @Test
-    public void testGetHadoopConfPathFromEnvByHADOOP_CONF_DIR2() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    void testGetHadoopConfPathFromEnvByHADOOP_CONF_DIR2() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         String hadoopConfDirEnv = "/not_exist";
         String hadoopHomeEnv = null;
         Assertions.assertNull(invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));
@@ -102,7 +102,7 @@ public class HdfsStorageOperatorTest {
 
     @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_HOME, and directory exist")
     @Test
-    public void testGetHadoopConfPathFromEnvByHADOOP_HOME1() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, IOException {
+    void testGetHadoopConfPathFromEnvByHADOOP_HOME1() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, IOException {
         String hadoopConfDirEnv = null;
         String hadoopHomeEnv = System.getProperty("user.dir");
         Path hoemConfPath = Paths.get(hadoopHomeEnv, "conf");
@@ -114,7 +114,7 @@ public class HdfsStorageOperatorTest {
 
     @DisplayName("test load Hdfs Configuration by env avaliable HADOOP_HOME, and directory not exist")
     @Test
-    public void testGetHadoopConfPathFromEnvByHADOOP_HOME2() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    void testGetHadoopConfPathFromEnvByHADOOP_HOME2() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         String hadoopConfDirEnv = null;
         String hadoopHomeEnv = "/not_exist";
         Assertions.assertNull(invokeGetHadoopConfPath(hadoopConfDirEnv, hadoopHomeEnv));

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -18,9 +18,6 @@
 
 # Never put sensitive config such as database password here in your production environment,
 
-# JAVA_HOME, will use it to start DolphinScheduler server
-export JAVA_HOME=${JAVA_HOME:-/opt/soft/java}
-
 #DS will auto load hdfs configuration from environment
 export HADOOP_HOME=${HADOOP_HOME:-/opt/soft/hadoop}
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/opt/soft/hadoop/etc/hadoop}

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -17,7 +17,10 @@
 
 
 # Never put sensitive config such as database password here in your production environment,
-# this file will be sourced everytime a new task is executed.
+
+# auto load hdfs configuration from environment
+#export HADOOP_HOME=${HADOOP_HOME:-/opt/soft/hadoop}
+#export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/opt/soft/hadoop/etc/hadoop}
 
 # applicationId auto collection related configuration, the following configurations are unnecessary if setting appId.collect=log
 #export HADOOP_CLASSPATH=`hadoop classpath`:${DOLPHINSCHEDULER_HOME}/tools/libs/*

--- a/script/env/dolphinscheduler_env.sh
+++ b/script/env/dolphinscheduler_env.sh
@@ -18,9 +18,12 @@
 
 # Never put sensitive config such as database password here in your production environment,
 
-# auto load hdfs configuration from environment
-#export HADOOP_HOME=${HADOOP_HOME:-/opt/soft/hadoop}
-#export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/opt/soft/hadoop/etc/hadoop}
+# JAVA_HOME, will use it to start DolphinScheduler server
+export JAVA_HOME=${JAVA_HOME:-/opt/soft/java}
+
+#DS will auto load hdfs configuration from environment
+export HADOOP_HOME=${HADOOP_HOME:-/opt/soft/hadoop}
+export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/opt/soft/hadoop/etc/hadoop}
 
 # applicationId auto collection related configuration, the following configurations are unnecessary if setting appId.collect=log
 #export HADOOP_CLASSPATH=`hadoop classpath`:${DOLPHINSCHEDULER_HOME}/tools/libs/*


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

Improve DS load hdfs configuration automatically by using common environment variables `HADOOP_CONF_DIR`  or `HADOOP_HOME` which are  usually  already configured in os;

It provides a more convenient choice. If the environment variable does not exist or is an error configuration, DS will load the configuration  as before;

This closes #13476

## Brief change log

- `HdfsStorageOperator`
- `dolphinscheduler_env.sh` : add tips for  environment variable`HADOOP_HOME` and `HADOOP_CONF_DIR`

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

This change added tests and can be verified as follows:

- `HdfsStorageOperatorTest`

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->
