### PR TITLE
[Improvement-12528][logger] Achieve config task log base path out of the dolphinscheduler install path

### DIFF
--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -120,6 +120,13 @@ master:
 server:
   port: 5679
 
+task:
+  logger-dir:
+    # The task log directory currently in use
+    current: logs
+    # The task log directory used in the past; You can have multiple values, separated by commas;
+    past:
+
 management:
   endpoints:
     web:

--- a/dolphinscheduler-master/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-master/src/main/resources/logback-spring.xml
@@ -18,6 +18,8 @@
 
 <configuration scan="true" scanPeriod="120 seconds">
     <property name="log.base" value="logs"/>
+    <springProperty scope="context" name="TASK_LOG_HOME" source="task.logger-dir.current" defaultValue="logs"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
@@ -33,11 +35,11 @@
         <filter class="org.apache.dolphinscheduler.plugin.task.api.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.plugin.task.api.log.TaskLogDiscriminator">
             <key>taskAppId</key>
-            <logBase>${log.base}</logBase>
+            <logBase>${TASK_LOG_HOME}</logBase>
         </Discriminator>
         <sift>
             <appender name="FILE-${taskAppId}" class="ch.qos.logback.core.FileAppender">
-                <file>${log.base}/${taskAppId}.log</file>
+                <file>${TASK_LOG_HOME}/${taskAppId}.log</file>
                 <encoder>
                     <pattern>
                         [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %message%n

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -65,6 +65,13 @@ worker:
 server:
   port: 1235
 
+task:
+  logger-dir:
+    # The task log directory currently in use
+    current: logs
+    # The task log directory used in the past; You can have multiple values, separated by commas;
+    past:
+
 management:
   endpoints:
     web:

--- a/dolphinscheduler-worker/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-worker/src/main/resources/logback-spring.xml
@@ -18,6 +18,7 @@
 
 <configuration scan="true" scanPeriod="120 seconds">
     <property name="log.base" value="logs"/>
+    <springProperty scope="context" name="TASK_LOG_HOME" source="task.logger-dir.current" defaultValue="logs"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -34,11 +35,11 @@
         <filter class="org.apache.dolphinscheduler.plugin.task.api.log.TaskLogFilter"/>
         <Discriminator class="org.apache.dolphinscheduler.plugin.task.api.log.TaskLogDiscriminator">
             <key>taskAppId</key>
-            <logBase>${log.base}</logBase>
+            <logBase>${TASK_LOG_HOME}</logBase>
         </Discriminator>
         <sift>
             <appender name="FILE-${taskAppId}" class="ch.qos.logback.core.FileAppender">
-                <file>${log.base}/${taskAppId}.log</file>
+                <file>${TASK_LOG_HOME}/${taskAppId}.log</file>
                 <encoder>
                     <pattern>
                         [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %message%n


### PR DESCRIPTION
…hinscheduler install path;



<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Achieve config task log base path out of the dolphinscheduler install path; 

This closes issue This closes issue #12528 #12703 #13460 #13461

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

Add task log directory variable in `application.yaml` of Master and Worker ;  

```yaml
task:
  logger-dir:
    # The task log directory currently in use
    current: logs
    # The task log directory used in the past; You can have multiple values, separated by commas;
    past:
```
 

## Verify this pull request

This change added tests and can be verified as follows:

- [LoggerRequestProcessorTest.java](https://github.com/apache/dolphinscheduler/compare/dev...xxjingcd:dolphinscheduler:Improvement-12528?expand=1#diff-e124d8b3ada308c59781552346e9705aa5e0f5f0dd8c047973fc65377c2cb534)

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->
