### PR TITLE
[Fix-13496] [Worker] When the task request has not set the current execution status, an error will cause an NPE exception

### DIFF
--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/task/TaskExecutionContextCacheManager.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/task/TaskExecutionContextCacheManager.java
@@ -74,8 +74,8 @@ public class TaskExecutionContextCacheManager {
 
     public static boolean statusIsStop(Integer taskInstanceId) {
         TaskRequest taskRequest = taskRequestContextCache.get(taskInstanceId);
-        if (taskRequest == null) {
-            return true;
+        if (taskRequest == null || taskRequest.getCurrentExecutionStatus() == null) {
+            return false;
         }
         return taskRequest.getCurrentExecutionStatus().typeIsStop();
     }


### PR DESCRIPTION
Fix #13496 