### PR TITLE
Fix task log might delay until task finished due to batch flush

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -359,7 +359,7 @@ public abstract class AbstractCommandExecutor {
                 }
                 logOutputIsSuccess = true;
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                logger.error("Parse var pool error", e);
                 logOutputIsSuccess = true;
             }
         });
@@ -369,17 +369,16 @@ public abstract class AbstractCommandExecutor {
         ExecutorService parseProcessOutputExecutorService = newDaemonSingleThreadExecutor(threadLoggerInfoName);
         parseProcessOutputExecutorService.submit(() -> {
             try {
-                long lastFlushTime = System.currentTimeMillis();
-                while (logBuffer.size() > 0 || !logOutputIsSuccess) {
-                    if (logBuffer.size() > 0) {
-                        lastFlushTime = flush(lastFlushTime);
+                while (!logBuffer.isEmpty() || !logOutputIsSuccess) {
+                    if (!logBuffer.isEmpty()) {
+                        logHandler.accept(logBuffer);
+                        logBuffer.clear();
                     } else {
                         Thread.sleep(TaskConstants.DEFAULT_LOG_FLUSH_INTERVAL);
                     }
                 }
             } catch (Exception e) {
-                Thread.currentThread().interrupt();
-                logger.error(e.getMessage(), e);
+                logger.error("Output task log error", e);
             } finally {
                 clear();
             }
@@ -436,28 +435,6 @@ public abstract class AbstractCommandExecutor {
         }
 
         return processId;
-    }
-
-    /**
-     * when log buffer siz or flush time reach condition , then flush
-     *
-     * @param lastFlushTime last flush time
-     * @return last flush time
-     */
-    private long flush(long lastFlushTime) {
-        long now = System.currentTimeMillis();
-
-        /*
-         * when log buffer siz or flush time reach condition , then flush
-         */
-        if (logBuffer.size() >= TaskConstants.DEFAULT_LOG_ROWS_NUM
-                || now - lastFlushTime > TaskConstants.DEFAULT_LOG_FLUSH_INTERVAL) {
-            lastFlushTime = now;
-            logHandler.accept(logBuffer);
-
-            logBuffer.clear();
-        }
-        return lastFlushTime;
     }
 
     protected abstract String buildCommandFilePath();

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskConstants.java
@@ -135,11 +135,6 @@ public class TaskConstants {
     public static final String SH = "sh";
 
     /**
-     * default log cache rows num,output when reach the number
-     */
-    public static final int DEFAULT_LOG_ROWS_NUM = 4 * 16;
-
-    /**
      * log flush interval?output when reach the interval
      */
     public static final int DEFAULT_LOG_FLUSH_INTERVAL = 1000;


### PR DESCRIPTION
## Purpose of the pull request

If our task is 
```
echo "Begin to delete data......"
delete from xx (This part will cost 10mins).
echo "Finish delete data......"
```

The output "Begin to delete data......" will not log, due to we use batch mode.

And we don't need to use batch flush, since logback will batch flush.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
