### PR TITLE
[BUG][Resource Center] NPE caused by uninitialized hdfsProperties

### DIFF
--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -86,7 +86,7 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
 
                 @Override
                 public HdfsStorageOperator load(String key) throws Exception {
-                    return new HdfsStorageOperator(hdfsProperties);
+                    return new HdfsStorageOperator();
                 }
             });
 

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -76,7 +76,7 @@ import com.google.common.cache.LoadingCache;
 @Slf4j
 public class HdfsStorageOperator implements Closeable, StorageOperate {
 
-    private static HdfsStorageProperties hdfsProperties;
+    private static HdfsStorageProperties hdfsProperties = new HdfsStorageProperties();
     private static final String HADOOP_UTILS_KEY = "HADOOP_UTILS_KEY";
 
     private static final LoadingCache<String, HdfsStorageOperator> cache = CacheBuilder
@@ -85,8 +85,8 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
             .build(new CacheLoader<String, HdfsStorageOperator>() {
 
                 @Override
-                public HdfsStorageOperator load(String key) throws Exception {
-                    return new HdfsStorageOperator();
+                public HdfsStorageOperator load(String key) {
+                    return new HdfsStorageOperator(hdfsProperties);
                 }
             });
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
NPE caused by uninitialized `hdfsProperties`.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request