### PR TITLE
Fix task instance will generate multiple times when retry interval is 0/s

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
@@ -57,10 +57,19 @@ public class TaskStateEventHandler implements StateEventHandler {
                 task.getState(), taskStateEvent.getStatus());
 
         Map<Long, Integer> completeTaskMap = workflowExecuteRunnable.getCompleteTaskMap();
+        if (task.getState().isFinished()
+                && (taskStateEvent.getStatus() != null && taskStateEvent.getStatus().isRunning())) {
+            String errorMessage = String.format(
+                    "The current task instance state is %s, but the task state event status is %s, so the task state event will be ignored",
+                    task.getState(),
+                    taskStateEvent.getStatus());
+            log.warn(errorMessage);
+            throw new StateEventHandleError(errorMessage);
+        }
 
         if (task.getState().isFinished()) {
             if (completeTaskMap.containsKey(task.getTaskCode())
-                    && completeTaskMap.get(task.getTaskCode()) == task.getId()) {
+                    && completeTaskMap.get(task.getTaskCode()).equals(task.getId())) {
                 log.warn("The task instance is already complete, stateEvent: {}", stateEvent);
                 return true;
             }


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

When we set the retry interval to 0/s, the task instance will generate multiple times(Not the retry times), this is due to when we handle the running event, the task instance might already finished.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
