### PR TITLE
[fix-13504] Display the current project name on the left corner of the page

### DIFF
--- a/dolphinscheduler-ui/src/layouts/content/components/sidebar/use-menuClick.ts
+++ b/dolphinscheduler-ui/src/layouts/content/components/sidebar/use-menuClick.ts
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-import { useRouter } from 'vue-router'
+import {LocationQueryRaw, useRouter} from 'vue-router'
 import type { Router } from 'vue-router'
 import { MenuOption } from 'naive-ui'
 
 export function useMenuClick() {
   const router: Router = useRouter()
 
-  const handleMenuClick = (key: string, unused: MenuOption) => {
-    // console.log(key, item)
-    router.push({ path: `${key}` })
+  const handleMenuClick = (key: string, menuOption: MenuOption) => {
+    router.push({
+      path: `${key}`,
+      query: menuOption.payload? menuOption.payload as LocationQueryRaw: {}
+    })
   }
 
   return {

--- a/dolphinscheduler-ui/src/layouts/content/index.tsx
+++ b/dolphinscheduler-ui/src/layouts/content/index.tsx
@@ -77,7 +77,6 @@ const Content = defineComponent({
           }
 
           getSideMenu(state)
-
           const currentSide = (
             route.meta.activeSide
               ? route.meta.activeSide

--- a/dolphinscheduler-ui/src/layouts/content/use-dataList.ts
+++ b/dolphinscheduler-ui/src/layouts/content/use-dataList.ts
@@ -89,6 +89,7 @@ export function useDataList() {
 
   const changeMenuOption = (state: any) => {
     const projectCode = route.params.projectCode || ''
+    const projectName = route.query.projectName || ''
     state.menuOptions = [
       {
         label: () => h(NEllipsis, null, { default: () => t('menu.home') }),
@@ -101,9 +102,10 @@ export function useDataList() {
         icon: renderIcon(ProfileOutlined),
         children: [
           {
-            label: t('menu.project_overview'),
+            label: t('menu.project_overview') + (projectName? `[${projectName}]` : ''),
             key: `/projects/${projectCode}`,
-            icon: renderIcon(FundProjectionScreenOutlined)
+            icon: renderIcon(FundProjectionScreenOutlined),
+            payload: {projectName:projectName}
           },
           {
             label: t('menu.workflow'),
@@ -112,15 +114,18 @@ export function useDataList() {
             children: [
               {
                 label: t('menu.workflow_relation'),
-                key: `/projects/${projectCode}/workflow/relation`
+                key: `/projects/${projectCode}/workflow/relation`,
+                payload: {projectName:projectName}
               },
               {
                 label: t('menu.workflow_definition'),
-                key: `/projects/${projectCode}/workflow-definition`
+                key: `/projects/${projectCode}/workflow-definition`,
+                payload: {projectName:projectName}
               },
               {
                 label: t('menu.workflow_instance'),
-                key: `/projects/${projectCode}/workflow/instances`
+                key: `/projects/${projectCode}/workflow/instances`,
+                payload: {projectName:projectName}
               }
             ]
           },
@@ -131,11 +136,13 @@ export function useDataList() {
             children: [
               {
                 label: t('menu.task_definition'),
-                key: `/projects/${projectCode}/task/definitions`
+                key: `/projects/${projectCode}/task/definitions`,
+                payload: {projectName:projectName}
               },
               {
                 label: t('menu.task_instance'),
-                key: `/projects/${projectCode}/task/instances`
+                key: `/projects/${projectCode}/task/instances`,
+                payload: {projectName:projectName}
               }
             ]
           }

--- a/dolphinscheduler-ui/src/views/projects/list/use-table.ts
+++ b/dolphinscheduler-ui/src/views/projects/list/use-table.ts
@@ -82,7 +82,10 @@ export function useTable() {
             ButtonLink,
             {
               onClick: () => {
-                router.push({ path: `/projects/${row.code}` })
+                router.push({
+                  path: `/projects/${row.code}`,
+                  query: {projectName: row.name}
+                })
               }
             },
             {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

[fix-13504] Display the current project name on the left corner of the page.

Releated PR: #13504 

After fixing, the result would be as follows:
![image](https://user-images.githubusercontent.com/99702568/219364013-b72d7a4f-219f-437c-ab94-55e1dac5ec3f.png)



## Brief change log

[fix-13504] Display the current project name on the left corner of the page.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
