### PR TITLE
[Bug] Task could not get resources when resource file was deleted and re-uploaded again

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -149,6 +149,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -158,6 +159,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -2292,7 +2294,9 @@ public class ProcessServiceImpl implements ProcessService {
             taskDefinitionLogs = taskDefinitionLogDao.getTaskDefineLogList(taskRelationList);
         }
         Map<Long, TaskDefinitionLog> taskDefinitionLogMap = taskDefinitionLogs.stream()
-                .collect(Collectors.toMap(TaskDefinitionLog::getCode, taskDefinitionLog -> taskDefinitionLog));
+                .collect(Collectors.toMap(TaskDefinitionLog::getCode, taskDefinitionLog -> taskDefinitionLog,
+                        BinaryOperator.maxBy(Comparator.comparingInt(TaskDefinitionLog::getId))));
+
         List<TaskNode> taskNodeList = new ArrayList<>();
         for (Entry<Long, List<Long>> code : taskCodeMap.entrySet()) {
             TaskDefinitionLog taskDefinitionLog = taskDefinitionLogMap.get(code.getKey());

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -104,6 +104,8 @@ import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 /**
  * process service test
  */
@@ -654,18 +656,34 @@ public class ProcessServiceTest {
         List<ProcessTaskRelationLog> list = new ArrayList<>();
         list.add(processTaskRelation);
 
-        TaskDefinitionLog taskDefinition = new TaskDefinitionLog();
-        taskDefinition.setCode(3L);
-        taskDefinition.setName("1-test");
-        taskDefinition.setProjectCode(1L);
-        taskDefinition.setTaskType("SHELL");
-        taskDefinition.setUserId(1);
-        taskDefinition.setVersion(2);
-        taskDefinition.setCreateTime(new Date());
-        taskDefinition.setUpdateTime(new Date());
-        taskDefinition.setIsCache(Flag.NO);
+        TaskDefinitionLog taskDefinition1 = new TaskDefinitionLog();
+        taskDefinition1.setId(1);
+        taskDefinition1.setCode(3L);
+        taskDefinition1.setName("1-test");
+        taskDefinition1.setProjectCode(1L);
+        taskDefinition1.setTaskType("SHELL");
+        taskDefinition1.setUserId(1);
+        taskDefinition1.setVersion(2);
+        taskDefinition1.setCreateTime(new Date());
+        taskDefinition1.setUpdateTime(new Date());
+        taskDefinition1.setIsCache(Flag.NO);
+
+        // cause taskDefintion2's id is bigger than taskDefinition1 => genDagGraph should use taskDefintion2
+        TaskDefinitionLog taskDefintion2 = new TaskDefinitionLog();
+        taskDefintion2.setId(2);
+        taskDefintion2.setCode(3L);
+        taskDefintion2.setName("1-test");
+        taskDefintion2.setProjectCode(1L);
+        taskDefintion2.setTaskType("SHELL");
+        taskDefintion2.setTaskParams("{\"name\":\"dolphinscheduler\"}");
+        taskDefintion2.setUserId(1);
+        taskDefintion2.setVersion(2);
+        taskDefintion2.setCreateTime(new Date());
+        taskDefintion2.setUpdateTime(new Date());
+        taskDefintion2.setIsCache(Flag.NO);
 
         TaskDefinitionLog td2 = new TaskDefinitionLog();
+        td2.setId(3);
         td2.setCode(2L);
         td2.setName("unit-test");
         td2.setProjectCode(1L);
@@ -676,7 +694,8 @@ public class ProcessServiceTest {
         td2.setUpdateTime(new Date());
 
         List<TaskDefinitionLog> taskDefinitionLogs = new ArrayList<>();
-        taskDefinitionLogs.add(taskDefinition);
+        taskDefinitionLogs.add(taskDefinition1);
+        taskDefinitionLogs.add(taskDefintion2);
         taskDefinitionLogs.add(td2);
 
         Mockito.when(taskDefinitionLogDao.getTaskDefineLogList(any())).thenReturn(taskDefinitionLogs);
@@ -686,6 +705,8 @@ public class ProcessServiceTest {
         DAG<String, TaskNode, TaskNodeRelation> stringTaskNodeTaskNodeRelationDAG =
                 processService.genDagGraph(processDefinition);
         Assertions.assertEquals(1, stringTaskNodeTaskNodeRelationDAG.getNodesCount());
+        ObjectNode objectNode = JSONUtils.parseObject(stringTaskNodeTaskNodeRelationDAG.getNode("3").getTaskParams());
+        Assertions.assertEquals("dolphinscheduler", objectNode.get("name").asText());
     }
 
     @Test

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/ShellCommandExecutor.java
@@ -97,7 +97,9 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
             sb.append("cd /d %~dp0").append(System.lineSeparator());
             if (CollectionUtils.isNotEmpty(ShellUtils.ENV_SOURCE_LIST)) {
                 for (String envSourceFile : ShellUtils.ENV_SOURCE_LIST) {
-                    sb.append("call ").append(envSourceFile).append("\n");
+                    if (StringUtils.isNotBlank(envSourceFile)) {
+                        sb.append("call ").append(envSourceFile).append("\n");
+                    }
                 }
             }
             if (StringUtils.isNotBlank(taskRequest.getEnvironmentConfig())) {
@@ -109,7 +111,9 @@ public class ShellCommandExecutor extends AbstractCommandExecutor {
             sb.append("cd $BASEDIR").append(System.lineSeparator());
             if (CollectionUtils.isNotEmpty(ShellUtils.ENV_SOURCE_LIST)) {
                 for (String envSourceFile : ShellUtils.ENV_SOURCE_LIST) {
-                    sb.append("source ").append(envSourceFile).append("\n");
+                    if (StringUtils.isNotBlank(envSourceFile)) {
+                        sb.append("source ").append(envSourceFile).append("\n");
+                    }
                 }
             }
             if (StringUtils.isNotBlank(taskRequest.getEnvironmentConfig())) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Task could not get resources when resource file was deleted and re-uploaded again.

## Related Issure: 
close https://github.com/apache/dolphinscheduler/issues/13583


## Brief change log
1. Task could not get resources when resource file was deleted and re-uploaded again. Same file was attached to task and deleted and then re-uploaded with same name again, which should been obtained by related task properly.
2. Shell command log fix.
Before fixing:
![1](https://user-images.githubusercontent.com/99702568/220279734-e1adf32b-218f-4eb3-83cd-a7f0515a4e28.png)
After fixing:
![2](https://user-images.githubusercontent.com/99702568/220279781-4957aad0-c96a-4422-a315-d64da9df05fc.png)
3. 
Before fixing:
![null](https://user-images.githubusercontent.com/99702568/220279912-27cf1f3c-67bc-49b2-a829-f1c858d93740.png)
Delete resource failed when related process/task info already removed.
After fixing:  We could delete resource normally when related process/task info already removed.



<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:
yes
<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
