### PR TITLE
[fix-13583]  Task could not get resources when resource file was deleted and re-uploaded again

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -518,7 +518,8 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         taskDefinitionToUpdate.setUserId(taskDefinition.getUserId());
         taskDefinitionToUpdate.setVersion(++version);
         taskDefinitionToUpdate.setTaskType(taskDefinitionToUpdate.getTaskType().toUpperCase());
-        taskDefinitionToUpdate.setResourceIds(processService.getResourceIds(taskDefinitionToUpdate));
+        processService.modifyResourceInfoIfNeeded(taskDefinitionToUpdate);
+
         taskDefinitionToUpdate.setUpdateTime(now);
         int update = taskDefinitionMapper.updateById(taskDefinitionToUpdate);
         taskDefinitionToUpdate.setOperator(loginUser.getId());

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -219,8 +219,7 @@ public interface ProcessService {
     int switchProcessTaskRelationVersion(ProcessDefinition processDefinition);
 
     int switchTaskDefinitionVersion(long taskCode, int taskVersion);
-
-    String getResourceIds(TaskDefinition taskDefinition);
+    void modifyResourceInfoIfNeeded(TaskDefinition taskDefinition);
 
     int saveTaskDefine(User operator, long projectCode, List<TaskDefinitionLog> taskDefinitionLogs, Boolean syncDefine);
 

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/process/ProcessServiceTest.java
@@ -103,6 +103,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * process service test
@@ -752,29 +753,45 @@ public class ProcessServiceTest {
         List<ProcessTaskRelationLog> list = new ArrayList<>();
         list.add(processTaskRelation);
 
-        TaskDefinitionLog taskDefinition = new TaskDefinitionLog();
-        taskDefinition.setCode(3L);
-        taskDefinition.setName("1-test");
-        taskDefinition.setProjectCode(1L);
-        taskDefinition.setTaskType("SHELL");
-        taskDefinition.setUserId(1);
-        taskDefinition.setVersion(2);
-        taskDefinition.setCreateTime(new Date());
-        taskDefinition.setUpdateTime(new Date());
+        TaskDefinitionLog taskDefinition1 = new TaskDefinitionLog();
+        taskDefinition1.setId(1);
+        taskDefinition1.setCode(3L);
+        taskDefinition1.setName("1-test");
+        taskDefinition1.setProjectCode(1L);
+        taskDefinition1.setTaskType("SHELL");
+        taskDefinition1.setUserId(1);
+        taskDefinition1.setVersion(2);
+        taskDefinition1.setCreateTime(new Date());
+        taskDefinition1.setUpdateTime(new Date());
 
-        TaskDefinitionLog td2 = new TaskDefinitionLog();
-        td2.setCode(2L);
-        td2.setName("unit-test");
-        td2.setProjectCode(1L);
-        td2.setTaskType("SHELL");
-        td2.setUserId(1);
-        td2.setVersion(1);
-        td2.setCreateTime(new Date());
-        td2.setUpdateTime(new Date());
+        // cause taskDefintion2's id is bigger than taskDefinition1 => genDagGraph should use taskDefintion2
+        TaskDefinitionLog taskDefintion2 = new TaskDefinitionLog();
+        taskDefintion2.setId(2);
+        taskDefintion2.setCode(3L);
+        taskDefintion2.setName("1-test");
+        taskDefintion2.setProjectCode(1L);
+        taskDefintion2.setTaskType("SHELL");
+        taskDefintion2.setTaskParams("{\"name\":\"dolphinscheduler\"}");
+        taskDefintion2.setUserId(1);
+        taskDefintion2.setVersion(2);
+        taskDefintion2.setCreateTime(new Date());
+        taskDefintion2.setUpdateTime(new Date());
+
+        TaskDefinitionLog taskDefinition3 = new TaskDefinitionLog();
+        taskDefinition3.setId(3);
+        taskDefinition3.setCode(2L);
+        taskDefinition3.setName("unit-test");
+        taskDefinition3.setProjectCode(1L);
+        taskDefinition3.setTaskType("SHELL");
+        taskDefinition3.setUserId(1);
+        taskDefinition3.setVersion(1);
+        taskDefinition3.setCreateTime(new Date());
+        taskDefinition3.setUpdateTime(new Date());
 
         List<TaskDefinitionLog> taskDefinitionLogs = new ArrayList<>();
-        taskDefinitionLogs.add(taskDefinition);
-        taskDefinitionLogs.add(td2);
+        taskDefinitionLogs.add(taskDefinition1);
+        taskDefinitionLogs.add(taskDefintion2);
+        taskDefinitionLogs.add(taskDefinition3);
 
         Mockito.when(taskDefinitionLogMapper.queryByTaskDefinitions(any())).thenReturn(taskDefinitionLogs);
         Mockito.when(processTaskRelationLogMapper.queryByProcessCodeAndVersion(Mockito.anyLong(), Mockito.anyInt()))
@@ -783,6 +800,8 @@ public class ProcessServiceTest {
         DAG<String, TaskNode, TaskNodeRelation> stringTaskNodeTaskNodeRelationDAG =
                 processService.genDagGraph(processDefinition);
         Assert.assertEquals(1, stringTaskNodeTaskNodeRelationDAG.getNodesCount());
+        ObjectNode objectNode = JSONUtils.parseObject(stringTaskNodeTaskNodeRelationDAG.getNode("3").getTaskParams());
+        Assert.assertEquals("dolphinscheduler", objectNode.get("name").asText());
     }
 
     @Test


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Task could should get resources when resource file was deleted and re-uploaded again.

## Related PR: #13583 

## Brief change log

Task could not get resources when resource file was deleted and re-uploaded again.
When user get task definition, the PR would fix the resource info in t_ds_task_definition.
It has better performance than deleting resource directly removing all related info located in t_ds_task_definition.

Before fixing:
![image](https://user-images.githubusercontent.com/99702568/220856556-559a2292-b006-48e4-9644-86b8ed48b327.png)
After fixing:
There's no more error message and the task would run normally.
![image](https://user-images.githubusercontent.com/99702568/220856740-b07ab22f-f222-4561-8778-09c39f1aff09.png)


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
