### PR TITLE
[BUG][UI] Flink task display right version and deploy mode

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-flink.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-flink.ts
@@ -102,7 +102,7 @@ export function useFlink(model: { [field: string]: any }): IJsonItem[] {
   )
 
   watchEffect(() => {
-    model.flinkVersion = model.programType === 'SQL' ? '>=1.13' : '<1.10'
+    model.flinkVersion = model.programType === 'SQL' ? '>=1.13' : model.flinkVersion
   })
 
   return [


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
Existed flink task can not display the right flink version and deploy mode because the flink version is hard coded.

### Wrong display:
<img width="562" alt="image" src="https://user-images.githubusercontent.com/45198818/221365992-3d90fd01-8171-4cc7-8abe-cfc5b07498a9.png">

### Expected display:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/45198818/221366000-79956bd4-0868-4a74-ab04-14772d11cfba.png">

## Brief change log


<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
