### PR TITLE
fix(ui): update node fill color after run flag changes

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-cell-update.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-cell-update.ts
@@ -55,7 +55,7 @@ export function useCellUpdate(options: Options) {
    * @param {string} id
    * @param {string} flag
    */
-  function setNodeFlag(id: string, flag: string) {
+  function setNodeFlag(id: string, flag?: string) {
     const node = graph.value?.getCellById(id);
     if (node) {
       node.attr('rect/fill', flag === 'NO' ? '#f3f3f5' : '#ffffff');

--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-cell-update.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-cell-update.ts
@@ -50,7 +50,18 @@ export function useCellUpdate(options: Options) {
       node.setData({ taskName: newName })
     }
   }
-
+  /**
+   * Set node flag by id 
+   * @param {string} id
+   * @param {string} flag
+   */
+  function setNodeFlag(id: string, flag: string) {
+    const node = graph.value?.getCellById(id);
+    if (node) {
+      node.attr('rect/fill', flag === 'NO' ? '#f3f3f5' : '#ffffff');
+      node.setData({ flag });
+    }
+  }
   /**
    * Add a node to the graph
    * @param {string} id
@@ -128,6 +139,7 @@ export function useCellUpdate(options: Options) {
     addNode,
     removeNode,
     getSources,
-    getTargets
+    getTargets,
+    setNodeFlag
   }
 }

--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
@@ -47,7 +47,8 @@ export function useTaskEdit(options: Options) {
     getSources,
     getTargets,
     setNodeName,
-    setNodeEdge
+    setNodeEdge,
+    setNodeFlag
   } = useCellUpdate({
     graph
   })
@@ -167,7 +168,7 @@ export function useTaskEdit(options: Options) {
       processDefinition.value.taskDefinitionList.map((task) => {
         if (task.code === currTask.value?.code) {
           setNodeName(task.code + '', taskDef.name)
-
+          setNodeFlag(task.code + '', taskDef.flag);
           setNodeEdge(String(task.code), data.preTasks)
           updatePreTasks(data.preTasks, task.code)
           return {

--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
@@ -168,7 +168,7 @@ export function useTaskEdit(options: Options) {
       processDefinition.value.taskDefinitionList.map((task) => {
         if (task.code === currTask.value?.code) {
           setNodeName(task.code + '', taskDef.name)
-          setNodeFlag(task.code + '', taskDef.flag);
+          setNodeFlag(task.code + '', taskDef?.flag);
           setNodeEdge(String(task.code), data.preTasks)
           updatePreTasks(data.preTasks, task.code)
           return {

--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
@@ -168,7 +168,7 @@ export function useTaskEdit(options: Options) {
       processDefinition.value.taskDefinitionList.map((task) => {
         if (task.code === currTask.value?.code) {
           setNodeName(task.code + '', taskDef.name)
-          setNodeFlag(task.code + '', taskDef?.flag);
+          setNodeFlag(task.code + '', taskDef.flag);
           setNodeEdge(String(task.code), data.preTasks)
           updatePreTasks(data.preTasks, task.code)
           return {


### PR DESCRIPTION
## Purpose of the pull request

fix(ui): update node fill color after run flag changes

## Brief change log

add setNodeFlag to dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-cell-update.ts

## Verify this pull request

Manually verified the change by testing locally.
