### PR TITLE
Fix-13708 [Bug] [Resouces] Resource file search paging error

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -769,7 +769,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         List<StorageEntity> slicedResourcesList = filteredResourceList.stream().skip((long) (pageNo - 1) * pageSize)
                 .limit(pageSize).collect(Collectors.toList());
 
-        pageInfo.setTotal(resourcesList.size());
+        pageInfo.setTotal(filteredResourceList.size());
         pageInfo.setTotalList(slicedResourcesList);
         result.setData(pageInfo);
         putMsg(result, Status.SUCCESS);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
The issue is #13708
This modification is to fix the bug with incorrect paging code in the case of conditional search in the resource module

## Brief change log

change queryResourceListPaging method of ResourcesServiceImpl class ，Change the variable of total to filteredResourceList

## Verify this pull request
This change added tests and can be verified as follows:
<img width="720" alt="88b4bb471a046d73a7ba01a86dc5a1b" src="https://user-images.githubusercontent.com/28818582/223756414-12850c60-9480-4b82-b518-611115f02643.png">

You can perform the search as above
