### PR TITLE
[fix-13734] [api] Fixed the problem that the corresponding task definition could not be queried after workflow import correctly(#13734)

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/TaskDefinitionLog.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/TaskDefinitionLog.java
@@ -58,6 +58,7 @@ public class TaskDefinitionLog extends TaskDefinition {
         this.setTaskParamList(taskDefinition.getTaskParamList());
         this.setTaskParamMap(taskDefinition.getTaskParamMap());
         this.setTaskPriority(taskDefinition.getTaskPriority());
+        this.setTaskExecuteType(taskDefinition.getTaskExecuteType());
         this.setTimeoutNotifyStrategy(taskDefinition.getTimeoutNotifyStrategy());
         this.setTaskType(taskDefinition.getTaskType());
         this.setTimeout(taskDefinition.getTimeout());


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
The taskExecuteType of the task definition was not set correctly after workflow import.

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
