### PR TITLE
[Improvement-13751][Worker] Support real-time pod log collection

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -273,7 +273,7 @@ public abstract class AbstractCommandExecutor {
                     logger.error(msg);
                 }
             } catch (ExecutionException e) {
-                logger.info("Handle pod log error", e);
+                logger.error("Handle pod log error", e);
             }
         }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -349,14 +349,15 @@ public abstract class AbstractCommandExecutor {
                 } finally {
                     watcher.close();
                 }
+
+                podLogOutputIsSuccess = true;
             });
 
             collectPodLogExecutorService.shutdown();
         } else {
             podLogOutputFuture = CompletableFuture.completedFuture("The driver pod does not exist.");
+            podLogOutputIsSuccess = true;
         }
-
-        podLogOutputIsSuccess = true;
     }
 
     private void parseProcessOutput(Process process) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.task.api;
 
+import static org.apache.dolphinscheduler.common.constants.Constants.EMPTY_STRING;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EXIT_CODE_FAILURE;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EXIT_CODE_KILL;
 
@@ -113,7 +114,7 @@ public abstract class AbstractCommandExecutor {
         this.taskRequest = taskRequest;
         this.logger = logger;
         this.logBuffer = new LinkedBlockingQueue<>();
-        this.logBuffer.add("\n");
+        this.logBuffer.add(EMPTY_STRING);
 
         if (this.taskRequest != null) {
             // set logBufferEnable=true if the task uses logHandler and logBuffer to buffer log messages
@@ -396,7 +397,7 @@ public abstract class AbstractCommandExecutor {
                     if (logBuffer.size() > 1) {
                         logHandler.accept(logBuffer);
                         logBuffer.clear();
-                        logBuffer.add("\n");
+                        logBuffer.add(EMPTY_STRING);
                     } else {
                         Thread.sleep(TaskConstants.DEFAULT_LOG_FLUSH_INTERVAL);
                     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
 
 @Slf4j
 public final class ProcessUtils {
@@ -204,12 +205,12 @@ public final class ProcessUtils {
      * @param taskAppId
      * @return
      */
-    public static String getPodLog(K8sTaskExecutionContext k8sTaskExecutionContext, String taskAppId) {
+    public static LogWatch getPodLogWatcher(K8sTaskExecutionContext k8sTaskExecutionContext, String taskAppId) {
         KubernetesApplicationManager applicationManager =
                 (KubernetesApplicationManager) applicationManagerMap.get(ResourceManagerType.KUBERNETES);
 
         return applicationManager
-                .collectPodLog(new KubernetesApplicationManagerContext(k8sTaskExecutionContext, taskAppId));
+                .getPodLogWatcher(new KubernetesApplicationManagerContext(k8sTaskExecutionContext, taskAppId));
     }
 
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/pom.xml
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/pom.xml
@@ -54,5 +54,9 @@
             <artifactId>druid</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecuteRunnable.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecuteRunnable.java
@@ -298,17 +298,8 @@ public abstract class WorkerTaskExecuteRunnable implements Runnable {
         }
     }
 
-    protected void writePodLodIfNeeded() {
-        if (null == taskExecutionContext.getK8sTaskExecutionContext()) {
-            return;
-        }
-        log.info("The current task is k8s task, begin to write pod log");
-        ProcessUtils.getPodLog(taskExecutionContext.getK8sTaskExecutionContext(), taskExecutionContext.getTaskAppId());
-    }
-
     protected void closeLogAppender() {
         try {
-            writePodLodIfNeeded();
             if (RemoteLogUtils.isRemoteLoggingEnable()) {
                 RemoteLogUtils.sendRemoteLog(taskExecutionContext.getLogPath());
                 log.info("Log handler sends task log {} to remote storage asynchronously.",

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecuteRunnable.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecuteRunnable.java
@@ -306,10 +306,9 @@ public abstract class WorkerTaskExecuteRunnable implements Runnable {
                         taskExecutionContext.getLogPath());
             }
         } catch (Exception ex) {
-            log.error("Write k8s pod log failed", ex);
+            log.error("Send remote log failed", ex);
         } finally {
             log.info(FINALIZE_SESSION_MARKER, FINALIZE_SESSION_MARKER.toString());
-
         }
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
- This PR closes https://github.com/apache/dolphinscheduler/issues/13751
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- Use `LogWatch` to collect real-time pod logs.
- Add `EMPTY_STRING` ("") after clear logBuffer to make log format clearer.

```
[INFO] 2023-03-16 10:28:24.923 +0800 -  -> 
	23/03/16 10:28:24 INFO LoggingPodStatusWatcherImpl: Application status for spark-fdb9e53137854ea2ab6fc6c9a15761ac (phase: Running)
[INFO] 2023-03-16 10:28:25.924 +0800 -  -> 
	23/03/16 10:28:25 INFO LoggingPodStatusWatcherImpl: Application status for spark-fdb9e53137854ea2ab6fc6c9a15761ac (phase: Running)
[INFO] 2023-03-16 10:28:26.924 +0800 -  -> 
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:25 INFO KubernetesClusterSchedulerBackend$KubernetesDriverEndpoint: Registered executor NettyRpcEndpointRef(spark-client://Executor) (10.244.1.211:59826) with ID 2,  ResourceProfileId 0
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:25 INFO BlockManagerMasterEndpoint: Registering block manager 10.244.1.211:36305 with 1048.8 MiB RAM, BlockManagerId(2, 10.244.1.211, 36305, None)
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:26 INFO KubernetesClusterSchedulerBackend$KubernetesDriverEndpoint: Registered executor NettyRpcEndpointRef(spark-client://Executor) (10.244.2.151:36974) with ID 1,  ResourceProfileId 0
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:26 INFO KubernetesClusterSchedulerBackend: SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 0.8
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:26 INFO BlockManagerMasterEndpoint: Registering block manager 10.244.2.151:42145 with 1048.8 MiB RAM, BlockManagerId(1, 10.244.2.151, 42145, None)
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:26 INFO SparkContext: Starting job: reduce at SparkPi.scala:38
	[K8S-pod-log-spark-pi]: 23/03/16 02:28:26 INFO DAGScheduler: Got job 0 (reduce at SparkPi.scala:38) with 10 output partitions

```
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
