### PR TITLE
[Fix][Alert] Fix when auth is false and user || pwd null can't send email excection

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/MailSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/MailSender.java
@@ -108,7 +108,7 @@ public final class MailSender {
         mailPasswd = config.get(MailParamsConstants.NAME_MAIL_PASSWD);
 
         // Needs to check user && password only if enableSmtpAuth is true
-        if(Constants.STRING_TRUE.equals(enableSmtpAuth)) {
+        if (Constants.STRING_TRUE.equals(enableSmtpAuth)) {
             requireNonNull(mailUser, MailParamsConstants.NAME_MAIL_USER + mustNotNull);
             requireNonNull(mailPasswd, MailParamsConstants.NAME_MAIL_PASSWD + mustNotNull);
         }

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/MailSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/MailSender.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import org.apache.dolphinscheduler.alert.api.AlertConstants;
 import org.apache.dolphinscheduler.alert.api.AlertResult;
 import org.apache.dolphinscheduler.alert.api.ShowType;
+import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.plugin.alert.email.exception.AlertEmailException;
 import org.apache.dolphinscheduler.plugin.alert.email.template.AlertTemplate;
 import org.apache.dolphinscheduler.plugin.alert.email.template.DefaultHTMLTemplate;
@@ -103,12 +104,14 @@ public final class MailSender {
         requireNonNull(mailSenderEmail, MailParamsConstants.NAME_MAIL_SENDER + mustNotNull);
 
         enableSmtpAuth = config.get(MailParamsConstants.NAME_MAIL_SMTP_AUTH);
-
         mailUser = config.get(MailParamsConstants.NAME_MAIL_USER);
-        requireNonNull(mailUser, MailParamsConstants.NAME_MAIL_USER + mustNotNull);
-
         mailPasswd = config.get(MailParamsConstants.NAME_MAIL_PASSWD);
-        requireNonNull(mailPasswd, MailParamsConstants.NAME_MAIL_PASSWD + mustNotNull);
+
+        // Needs to check user && password only if enableSmtpAuth is true
+        if(Constants.STRING_TRUE.equals(enableSmtpAuth)) {
+            requireNonNull(mailUser, MailParamsConstants.NAME_MAIL_USER + mustNotNull);
+            requireNonNull(mailPasswd, MailParamsConstants.NAME_MAIL_PASSWD + mustNotNull);
+        }
 
         mailUseStartTLS = config.get(MailParamsConstants.NAME_MAIL_SMTP_STARTTLS_ENABLE);
         requireNonNull(mailUseStartTLS, MailParamsConstants.NAME_MAIL_SMTP_STARTTLS_ENABLE + mustNotNull);

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
@@ -94,13 +94,13 @@ public class MailUtilsTest {
         mailSender = new MailSender(emailConfig);
         mailSender.sendMails(title, content);
 
-        try{
+        try {
             // test auth true and user null will throw exception
             emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_AUTH, "true");
             emailConfig.put(MailParamsConstants.NAME_MAIL_USER, null);
             mailSender = new MailSender(emailConfig);
             mailSender.sendMails(title, content);
-        }catch(Exception e){
+        } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().contains(MailParamsConstants.NAME_MAIL_USER));
         }
 

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,35 @@ public class MailUtilsTest {
         mailSender.sendMails(
                 "Mysql Exception",
                 content);
+    }
+
+    @Test
+    public void testAuthCheck() {
+        String title = "Auth Exception";
+        String content = list2String();
+
+        // test auth false and user && pwd null will pass
+        emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_AUTH, "false");
+        emailConfig.put(MailParamsConstants.NAME_MAIL_USER, null);
+        emailConfig.put(MailParamsConstants.NAME_MAIL_PASSWD, null);
+        mailSender = new MailSender(emailConfig);
+        mailSender.sendMails(title, content);
+
+        try{
+            // test auth true and user null will throw exception
+            emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_AUTH, "true");
+            emailConfig.put(MailParamsConstants.NAME_MAIL_USER, null);
+            mailSender = new MailSender(emailConfig);
+            mailSender.sendMails(title, content);
+        }catch(Exception e){
+            Assertions.assertTrue(e.getMessage().contains(MailParamsConstants.NAME_MAIL_USER));
+        }
+
+        // test auth true and user && pwd not null will pass
+        emailConfig.put(MailParamsConstants.NAME_MAIL_USER, "user");
+        emailConfig.put(MailParamsConstants.NAME_MAIL_PASSWD, "passwd");
+        mailSender = new MailSender(emailConfig);
+        mailSender.sendMails(title, content);
     }
 
     public String list2String() {

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
@@ -83,7 +83,7 @@ public class MailUtilsTest {
     }
 
     @Test
-    public void testAuthCheck() {
+    void testAuthCheck() {
         String title = "Auth Exception";
         String content = list2String();
 


### PR DESCRIPTION
- close #11455
- part of #10721
- This part fixes this error
- Feature can support auth choose false and hide user && pwd input filed, etc