### PR TITLE
remove duplicate dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,17 +199,6 @@
 
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
-                <artifactId>dolphinscheduler-registry-api</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.dolphinscheduler</groupId>
-                <artifactId>dolphinscheduler-registry-all</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.dolphinscheduler</groupId>
                 <artifactId>dolphinscheduler-scheduler-api</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
fix duplicate declaration of `org.apache.dolphinscheduler:dolphinscheduler-registry-api` and `org.apache.dolphinscheduler:dolphinscheduler-registry-all` in pom.xml