### PR TITLE
[Fix-13820][alert] Fix bodyParams is empty get error log

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -163,7 +163,10 @@ public final class HttpSender {
      */
     private void setMsgInRequestBody(String msg) {
         try {
-            ObjectNode objectNode = JSONUtils.parseObject(bodyParams);
+            ObjectNode objectNode = JSONUtils.createObjectNode();
+            if (StringUtils.isNotBlank(bodyParams)) {
+                objectNode = JSONUtils.parseObject(bodyParams);
+            }
             // set msg content field
             objectNode.put(contentField, msg);
             StringEntity entity = new StringEntity(JSONUtils.toJsonString(objectNode), DEFAULT_CHARSET);


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->


initialize a empty  objectNode to save contentField, if bodyParams is empty,will send message only include contentField

close #13820 
If ` bodyParams` is empty ,will get error log. `send http alert msg  exception: null`
```java
    private void setMsgInRequestBody(String msg) {
        try {
            ObjectNode objectNode = JSONUtils.parseObject(bodyParams);
            // set msg content field
            objectNode.put(contentField, msg);
            StringEntity entity = new StringEntity(JSONUtils.toJsonString(objectNode), DEFAULT_CHARSET);
            ((HttpPost) httpRequest).setEntity(entity);
        } catch (Exception e) {
            log.error("send http alert msg  exception : {}", e.getMessage());
        }
    }
```


fix  `ObjectNode objectNode = JSONUtils.createObjectNode();`  initialize a empty  objectNode, `bodyParams` if not input anything , it works
```java
 private void setMsgInRequestBody(String msg) {
        try {
            ObjectNode objectNode = JSONUtils.createObjectNode();
            if(StringUtils.isNotBlank(bodyParams)){
                 objectNode = JSONUtils.parseObject(bodyParams);
            }
            // set msg content field
            objectNode.put(contentField, msg);
            StringEntity entity = new StringEntity(JSONUtils.toJsonString(objectNode), DEFAULT_CHARSET);
            ((HttpPost) httpRequest).setEntity(entity);
        } catch (Exception e) {
            log.error("send http alert msg  exception : {}", e.getMessage());
        }
    }
```


## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
