### PR TITLE
Set tenant as the the resource file owner

### DIFF
--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionCheckerUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionCheckerUtils.java
@@ -34,13 +34,9 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.attribute.UserPrincipal;
-import java.nio.file.attribute.UserPrincipalLookupService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -97,9 +93,9 @@ public class TaskExecutionCheckerUtils {
             taskExecutionContext.setExecutePath(execLocalPath);
             taskExecutionContext.setAppInfoPath(FileUtils.getAppInfoPath(execLocalPath));
             Path executePath = Paths.get(taskExecutionContext.getExecutePath());
-            createDirectory(executePath);
-            if (!TenantConstants.DEFAULT_TENANT_CODE.equals(taskExecutionContext.getTenantCode())) {
-                setOwner(executePath, taskExecutionContext.getTenantCode());
+            FileUtils.createDirectoryIfNotPresent(executePath);
+            if (OSUtils.isSudoEnable()) {
+                FileUtils.setFileOwner(executePath, taskExecutionContext.getTenantCode());
             }
         } catch (Throwable ex) {
             throw new TaskException("Cannot create process execute dir", ex);
@@ -126,7 +122,7 @@ public class TaskExecutionCheckerUtils {
             if (notExist) {
                 downloadFiles.add(Pair.of(fullName, fileName));
             } else {
-                log.info("file : {} exists ", resFile.getName());
+                log.warn("Resource file : {} already exists will not download again ", resFile.getName());
             }
         });
         if (!downloadFiles.isEmpty() && !PropertyUtils.isResourceStorageStartup()) {
@@ -141,8 +137,11 @@ public class TaskExecutionCheckerUtils {
                     log.info("get resource file from path:{}", fullName);
 
                     long resourceDownloadStartTime = System.currentTimeMillis();
-                    storageOperate.download(actualTenant, fullName,
-                            execLocalPath + File.separator + fileName, true);
+                    storageOperate.download(actualTenant, fullName, execLocalPath + File.separator + fileName, true);
+                    if (OSUtils.isSudoEnable()) {
+                        FileUtils.setFileOwner(Paths.get(execLocalPath, fileName),
+                                taskExecutionContext.getTenantCode());
+                    }
                     WorkerServerMetrics
                             .recordWorkerResourceDownloadTime(System.currentTimeMillis() - resourceDownloadStartTime);
                     WorkerServerMetrics.recordWorkerResourceDownloadSize(
@@ -156,29 +155,4 @@ public class TaskExecutionCheckerUtils {
         }
     }
 
-    private static void createDirectory(Path filePath) {
-        if (Files.exists(filePath)) {
-            return;
-        }
-        try {
-            Files.createDirectories(filePath);
-        } catch (IOException e) {
-            throw new TaskException("Create directory " + filePath + " failed ", e);
-        }
-    }
-
-    private static void setOwner(Path filePath, String tenant) {
-        try {
-            if (!OSUtils.isSudoEnable()) {
-                // we need to open sudo, then we can change the owner.
-                return;
-            }
-            UserPrincipalLookupService userPrincipalLookupService =
-                    FileSystems.getDefault().getUserPrincipalLookupService();
-            UserPrincipal tenantPrincipal = userPrincipalLookupService.lookupPrincipalByName(tenant);
-            Files.setOwner(filePath, tenantPrincipal);
-        } catch (IOException e) {
-            throw new TaskException("Set tenant directory " + filePath + " permission failed, tenant: " + tenant, e);
-        }
-    }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

When we download the resource file in worker, the file owner is the worker bootstrap user, this may cause the tenant doesn't has permission to r/w/x the file. This PR will set the resource file owner to tenant.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
