### PR TITLE
Use common response for sync request

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/TaskKillResponseProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/processor/TaskKillResponseProcessor.java
@@ -52,7 +52,7 @@ public class TaskKillResponseProcessor implements NettyRequestProcessor {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.TASK_KILL_RESPONSE;
+        return MessageType.RESPONSE;
     }
 
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskKillResponseProcessorTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/processor/TaskKillResponseProcessorTest.java
@@ -64,7 +64,7 @@ public class TaskKillResponseProcessorTest {
     @Test
     public void testProcess() {
         Message message = taskKillResponse.convert2Command(1);
-        Assertions.assertEquals(MessageType.TASK_KILL_RESPONSE, message.getType());
+        Assertions.assertEquals(MessageType.RESPONSE, message.getType());
         taskKillResponseProcessor.process(channel, message);
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/MessageType.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/MessageType.java
@@ -19,27 +19,17 @@ package org.apache.dolphinscheduler.remote.command;
 
 public enum MessageType {
 
+    RESPONSE,
+
     GET_APP_ID_REQUEST,
-    GET_APP_ID_RESPONSE,
 
     REMOVE_TAK_LOG_REQUEST,
 
-    REMOVE_TAK_LOG_RESPONSE,
-
     ROLL_VIEW_LOG_REQUEST,
-
-    ROLL_VIEW_LOG_RESPONSE,
 
     VIEW_WHOLE_LOG_REQUEST,
 
-    VIEW_WHOLE_LOG_RESPONSE,
-
     GET_LOG_BYTES_REQUEST,
-
-    GET_LOG_BYTES_RESPONSE,
-
-    WORKER_REQUEST,
-    MASTER_RESPONSE,
 
     /**
      * task execute start, from api to master
@@ -73,8 +63,6 @@ public enum MessageType {
 
     TASK_KILL_REQUEST,
 
-    TASK_KILL_RESPONSE,
-
     TASK_REJECT,
 
     TASK_REJECT_MESSAGE_ACK,
@@ -84,11 +72,6 @@ public enum MessageType {
      */
     TASK_SAVEPOINT_REQUEST,
 
-    /**
-     * task savepoint ack, for stream task
-     */
-    TASK_SAVEPOINT_RESPONSE,
-
     HEART_BEAT,
 
     PING,
@@ -97,10 +80,7 @@ public enum MessageType {
 
     ALERT_SEND_REQUEST,
 
-    ALERT_SEND_RESPONSE,
-
     WORKFLOW_HOST_CHANGE_REQUEST,
-    WORKFLOW_HOST_CHANGE_RESPONSE,
 
     /**
      * state event request
@@ -133,11 +113,6 @@ public enum MessageType {
      * update taskInstance's PID response ack, from master to worker
      */
     TASK_UPDATE_PID__MESSAGE_ACK,
-
-    /**
-     * workflow executing data response, from master to api
-     */
-    WORKFLOW_EXECUTING_DATA_RESPONSE,
 
     WORKFLOW_METRICS_CLEANUP;
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/alert/AlertSendResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/alert/AlertSendResponse.java
@@ -42,7 +42,7 @@ public class AlertSendResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.ALERT_SEND_RESPONSE;
+        return MessageType.RESPONSE;
     }
 
     @Data

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/GetAppIdResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/GetAppIdResponse.java
@@ -35,6 +35,6 @@ public class GetAppIdResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.GET_APP_ID_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/GetLogBytesResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/GetLogBytesResponse.java
@@ -39,7 +39,7 @@ public class GetLogBytesResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.GET_LOG_BYTES_RESPONSE;
+        return MessageType.RESPONSE;
     }
 
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/RemoveTaskLogResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/RemoveTaskLogResponse.java
@@ -39,6 +39,6 @@ public class RemoveTaskLogResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.REMOVE_TAK_LOG_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/RollViewLogResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/RollViewLogResponse.java
@@ -39,6 +39,6 @@ public class RollViewLogResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.ROLL_VIEW_LOG_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/ViewLogResponseResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/ViewLogResponseResponse.java
@@ -39,6 +39,6 @@ public class ViewLogResponseResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.VIEW_WHOLE_LOG_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/task/TaskKillResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/task/TaskKillResponse.java
@@ -52,6 +52,6 @@ public class TaskKillResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.TASK_KILL_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/task/TaskSavePointResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/task/TaskSavePointResponse.java
@@ -39,6 +39,6 @@ public class TaskSavePointResponse implements RequestMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.TASK_SAVEPOINT_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/task/WorkflowHostChangeResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/task/WorkflowHostChangeResponse.java
@@ -45,6 +45,6 @@ public class WorkflowHostChangeResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.WORKFLOW_HOST_CHANGE_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/workflow/WorkflowExecutingDataResponse.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/workflow/WorkflowExecutingDataResponse.java
@@ -37,6 +37,6 @@ public class WorkflowExecutingDataResponse implements ResponseMessageBuilder {
 
     @Override
     public MessageType getCommandType() {
-        return MessageType.WORKFLOW_EXECUTING_DATA_RESPONSE;
+        return MessageType.RESPONSE;
     }
 }

--- a/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/remote/command/alert/AlertSendResponseTest.java
+++ b/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/remote/command/alert/AlertSendResponseTest.java
@@ -44,6 +44,6 @@ public class AlertSendResponseTest {
         alertSendResponse.setResResults(responseResults);
 
         Message message = alertSendResponse.convert2Command(1);
-        Assertions.assertEquals(MessageType.ALERT_SEND_RESPONSE, message.getType());
+        Assertions.assertEquals(MessageType.RESPONSE, message.getType());
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

The sync request will use opaque to inject the response, and it doesn't rely on processor to deal with the command.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
