### PR TITLE
[Improvement-13824][Resource Center] User can only visit resources under tenant defaultPath

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ResourcesController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ResourcesController.java
@@ -772,4 +772,17 @@ public class ResourcesController extends BaseController {
 
         return resourceService.queryResourceByFullName(loginUser, fullName, tenantCode, type);
     }
+
+    @Operation(summary = "queryResourceBaseDir", description = "QUERY_RESOURCE_BASE_DIR")
+    @Parameters({
+            @Parameter(name = "type", description = "RESOURCE_TYPE", required = true, schema = @Schema(implementation = ResourceType.class))
+    })
+    @GetMapping(value = "/base-dir")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(RESOURCE_NOT_EXIST)
+    @AccessLogAnnotation
+    public Result<Object> queryResourceBaseDir(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                               @RequestParam(value = "type") ResourceType type) {
+        return resourceService.queryResourceBaseDir(loginUser, type);
+    }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -271,4 +271,13 @@ public interface ResourcesService {
     Result<Object> queryResourceByFullName(User loginUser, String fullName, String tenantCode,
                                            ResourceType type) throws IOException;
 
+    /**
+     * get resource base dir
+     *
+     * @param loginUser login user
+     * @param type      resource type
+     * @return
+     */
+    Result<Object> queryResourceBaseDir(User loginUser, ResourceType type);
+
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -574,8 +574,10 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         }
 
         String tenantCode = getTenantCode(user);
-
-        if (!isUserTenantValid(isAdmin(loginUser), tenantCode, resTenantCode)) {
+        String baseDir = isAdmin(loginUser) ? storageOperate.getDir(ResourceType.ALL, tenantCode)
+                : storageOperate.getDir(type, tenantCode);
+        if (!isUserTenantValid(isAdmin(loginUser), tenantCode, resTenantCode)
+                || (StringUtils.isNotBlank(fullName) && !StringUtils.startsWith(fullName, baseDir))) {
             log.error("current user does not have permission");
             putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);
             return result;
@@ -1676,6 +1678,40 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         log.info(jsonTreeStr);
         result.put(Constants.DATA_LIST, visitor.visit("").getChildren());
         putMsg(result, Status.SUCCESS);
+        return result;
+    }
+
+    /**
+     * get resource base dir
+     *
+     * @param loginUser login user
+     * @param type      resource type
+     * @return
+     */
+    @Override
+    public Result<Object> queryResourceBaseDir(User loginUser, ResourceType type) {
+        Result<Object> result = new Result<>();
+        User user = userMapper.selectById(loginUser.getId());
+        if (user == null) {
+            log.error("user {} not exists", loginUser.getId());
+            putMsg(result, Status.USER_NOT_EXIST, loginUser.getId());
+            return result;
+        }
+
+        String tenantCode = getTenantCode(user);
+
+        if (!isUserTenantValid(isAdmin(loginUser), tenantCode, "")) {
+            log.error("current user does not have permission");
+            putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);
+            return result;
+        }
+
+        String baseDir = isAdmin(loginUser) ? storageOperate.getDir(ResourceType.ALL, tenantCode)
+                : storageOperate.getDir(type, tenantCode);
+
+        putMsg(result, Status.SUCCESS);
+        result.setData(baseDir);
+
         return result;
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -892,6 +892,24 @@ public class ResourcesServiceTest {
             logger.error("hadoop error", e);
         }
     }
+
+    @Test
+    void testQueryBaseDir() {
+        User user = getUser();
+        Mockito.when(userMapper.selectById(user.getId())).thenReturn(getUser());
+        Mockito.when(tenantMapper.queryById(user.getTenantId())).thenReturn(getTenant());
+        Mockito.when(storageOperate.getDir(ResourceType.FILE, "123")).thenReturn("/dolphinscheduler/123/resources/");
+        try {
+            Mockito.when(storageOperate.getFileStatus(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+                    Mockito.any())).thenReturn(getStorageEntityResource());
+        } catch (Exception e) {
+            logger.error(e.getMessage() + " Resource path: {}", "/dolphinscheduler/123/resources/ResourcesServiceTest",
+                    e);
+        }
+        Result<Object> result = resourcesService.queryResourceBaseDir(user, ResourceType.FILE);
+        Assertions.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
+    }
+
     private List<Resource> getResourceList() {
 
         List<Resource> resources = new ArrayList<>();

--- a/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/enums/ResourceType.java
+++ b/dolphinscheduler-spi/src/main/java/org/apache/dolphinscheduler/spi/enums/ResourceType.java
@@ -28,7 +28,8 @@ public enum ResourceType {
      * 0 file, 1 udf
      */
     FILE(0, "file"),
-    UDF(1, "udf");
+    UDF(1, "udf"),
+    ALL(2, "all");
 
     ResourceType(int code, String descp) {
         this.code = code;

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/StorageOperate.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/StorageOperate.java
@@ -48,7 +48,6 @@ public interface StorageOperate {
      * @param tenantCode
      * @return
      */
-
     String getUdfDir(String tenantCode);
 
     /**

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gcs/src/main/java/org/apache/dolphinscheduler/plugin/storage/gcs/GcsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gcs/src/main/java/org/apache/dolphinscheduler/plugin/storage/gcs/GcsStorageOperator.java
@@ -252,6 +252,8 @@ public class GcsStorageOperator implements Closeable, StorageOperate {
                 return getUdfDir(tenantCode);
             case FILE:
                 return getResDir(tenantCode);
+            case ALL:
+                return getGcsDataBasePath();
             default:
                 return EMPTY_STRING;
         }

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.storage.hdfs;
 
+import static org.apache.dolphinscheduler.common.constants.Constants.EMPTY_STRING;
 import static org.apache.dolphinscheduler.common.constants.Constants.FOLDER_SEPARATOR;
 import static org.apache.dolphinscheduler.common.constants.Constants.FORMAT_S_S;
 import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_TYPE_FILE;
@@ -615,13 +616,16 @@ public class HdfsStorageOperator implements Closeable, StorageOperate {
      * @return hdfs resource dir
      */
     public static String getHdfsDir(ResourceType resourceType, String tenantCode) {
-        String hdfsDir = "";
-        if (resourceType.equals(ResourceType.FILE)) {
-            hdfsDir = getHdfsResDir(tenantCode);
-        } else if (resourceType.equals(ResourceType.UDF)) {
-            hdfsDir = getHdfsUdfDir(tenantCode);
+        switch (resourceType) {
+            case UDF:
+                return getHdfsUdfDir(tenantCode);
+            case FILE:
+                return getHdfsResDir(tenantCode);
+            case ALL:
+                return getHdfsDataBasePath();
+            default:
+                return EMPTY_STRING;
         }
-        return hdfsDir;
     }
 
     @Override

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
@@ -268,6 +268,8 @@ public class OssStorageOperator implements Closeable, StorageOperate {
                 return getUdfDir(tenantCode);
             case FILE:
                 return getResDir(tenantCode);
+            case ALL:
+                return getOssDataBasePath();
             default:
                 return "";
         }

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-s3/src/main/java/org/apache/dolphinscheduler/plugin/storage/s3/S3StorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-s3/src/main/java/org/apache/dolphinscheduler/plugin/storage/s3/S3StorageOperator.java
@@ -290,6 +290,8 @@ public class S3StorageOperator implements Closeable, StorageOperate {
                 return getUdfDir(tenantCode);
             case FILE:
                 return getResDir(tenantCode);
+            case ALL:
+                return getS3DataBasePath();
             default:
                 return "";
         }

--- a/dolphinscheduler-ui/src/layouts/content/components/user/use-dropdown.ts
+++ b/dolphinscheduler-ui/src/layouts/content/components/user/use-dropdown.ts
@@ -41,6 +41,8 @@ export function useDropDown() {
       userStore.setSessionId('')
       userStore.setSecurityConfigType('')
       userStore.setUserInfo({})
+      userStore.setBaseResDir('')
+      userStore.setBaseUdfDir('')
       cookies.remove('sessionId')
 
       router.push({ path: '/login' })

--- a/dolphinscheduler-ui/src/service/modules/resources/index.ts
+++ b/dolphinscheduler-ui/src/service/modules/resources/index.ts
@@ -45,6 +45,16 @@ export function queryResourceListPaging(
   })
 }
 
+export function queryBaseDir(
+    params: ResourceTypeReq
+): any {
+  return axios({
+    url: '/resources/base-dir',
+    method: 'get',
+    params
+  })
+}
+
 export function queryCurrentResourceByFileName(
   params: ResourceTypeReq & FileNameReq & TenantCodeReq,
 ): any {

--- a/dolphinscheduler-ui/src/service/service.ts
+++ b/dolphinscheduler-ui/src/service/service.ts
@@ -65,6 +65,8 @@ const err = (err: AxiosError): Promise<AxiosError> => {
     userStore.setSessionId('')
     userStore.setSecurityConfigType('')
     userStore.setUserInfo({})
+    userStore.setBaseResDir('')
+    userStore.setBaseUdfDir('')
     router.push({ path: '/login' })
   }
 

--- a/dolphinscheduler-ui/src/store/user/types.ts
+++ b/dolphinscheduler-ui/src/store/user/types.ts
@@ -20,6 +20,8 @@ import type { UserInfoRes } from '@/service/modules/users/types'
 interface UserState {
   sessionId: string
   securityConfigType: string
+  baseResDir: string
+  baseUdfDir: string
   userInfo: UserInfoRes | {}
 }
 

--- a/dolphinscheduler-ui/src/store/user/user.ts
+++ b/dolphinscheduler-ui/src/store/user/user.ts
@@ -58,11 +58,9 @@ export const useUserStore = defineStore({
     },
     setBaseResDir(baseResDir: string): void {
       this.baseResDir = baseResDir
-      console.log(baseResDir)
     },
     setBaseUdfDir(baseUdfDir: string): void {
       this.baseUdfDir = baseUdfDir
-      console.log(baseUdfDir)
     }
   }
 })

--- a/dolphinscheduler-ui/src/store/user/user.ts
+++ b/dolphinscheduler-ui/src/store/user/user.ts
@@ -24,6 +24,8 @@ export const useUserStore = defineStore({
   state: (): UserState => ({
     sessionId: '',
     securityConfigType: '',
+    baseResDir: '',
+    baseUdfDir: '',
     userInfo: {}
   }),
   persist: true,
@@ -36,6 +38,12 @@ export const useUserStore = defineStore({
     },
     getUserInfo(): UserInfoRes | {} {
       return this.userInfo
+    },
+    getBaseResDir(): string {
+      return this.baseResDir
+    },
+    getBaseUdfDir(): string {
+      return this.baseUdfDir
     }
   },
   actions: {
@@ -47,6 +55,14 @@ export const useUserStore = defineStore({
     },
     setUserInfo(userInfo: UserInfoRes | {}): void {
       this.userInfo = userInfo
+    },
+    setBaseResDir(baseResDir: string): void {
+      this.baseResDir = baseResDir
+      console.log(baseResDir)
+    },
+    setBaseUdfDir(baseUdfDir: string): void {
+      this.baseUdfDir = baseUdfDir
+      console.log(baseUdfDir)
     }
   }
 })

--- a/dolphinscheduler-ui/src/views/login/use-login.ts
+++ b/dolphinscheduler-ui/src/views/login/use-login.ts
@@ -25,6 +25,7 @@ import type { UserInfoRes } from '@/service/modules/users/types'
 import { useRouteStore } from '@/store/route/route'
 import { useTimezoneStore } from '@/store/timezone/timezone'
 import cookies from 'js-cookie'
+import {queryBaseDir} from "@/service/modules/resources";
 
 export function useLogin(state: any) {
   const router: Router = useRouter()
@@ -42,6 +43,15 @@ export function useLogin(state: any) {
 
         const userInfoRes: UserInfoRes = await getUserInfo()
         await userStore.setUserInfo(userInfoRes)
+
+        const baseResDir = await queryBaseDir({
+          type: 'FILE'
+        })
+        const baseUdfDir = await queryBaseDir({
+          type: 'UDF'
+        })
+        await userStore.setBaseResDir(baseResDir)
+        await userStore.setBaseUdfDir(baseUdfDir)
 
         const timezone = userInfoRes.timeZone ? userInfoRes.timeZone : 'UTC'
         await timezoneStore.setTimezone(timezone)

--- a/dolphinscheduler-ui/src/views/password/use-update.ts
+++ b/dolphinscheduler-ui/src/views/password/use-update.ts
@@ -42,6 +42,8 @@ export function useUpdate(state: any) {
         await userStore.setSessionId('')
         await userStore.setSecurityConfigType('')
         await userStore.setUserInfo({})
+        await userStore.setBaseResDir('')
+        await userStore.setBaseUdfDir('')
         await router.push({ path: 'login' })
       }
     })

--- a/dolphinscheduler-ui/src/views/resource/components/resource/index.tsx
+++ b/dolphinscheduler-ui/src/views/resource/components/resource/index.tsx
@@ -44,8 +44,9 @@ import ResourceUploadModal from './upload'
 import ResourceRenameModal from './rename'
 import styles from './index.module.scss'
 import type { Router } from 'vue-router'
-import Search from "@/components/input-search"
-import { ResourceType } from "@/views/resource/components/resource/types";
+import Search from '@/components/input-search'
+import { ResourceType } from '@/views/resource/components/resource/types'
+import { useUserStore } from '@/store/user/user'
 
 
 const props = {
@@ -72,6 +73,7 @@ export default defineComponent({
       handleCreateFile,
     } = useTable()
 
+    const userStore = useUserStore()
 
     variables.resourceType = props.resourceType
 
@@ -120,7 +122,8 @@ export default defineComponent({
 
     const goBread = (fullName: string) => {
       const { resourceType, tenantCode } = variables
-      if (fullName === '') {
+      const baseDir = resourceType === 'UDF' ? userStore.getBaseUdfDir : userStore.getBaseResDir
+      if (fullName === '' || !fullName.startsWith(baseDir)) {
         router.push({ name: resourceType === 'UDF' ? 'resource-manage' : 'file-manage' })
       } else {
         router.push({

--- a/dolphinscheduler-ui/src/views/resource/index.tsx
+++ b/dolphinscheduler-ui/src/views/resource/index.tsx
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-import { defineComponent, ref } from 'vue'
-import { queryBaseDir } from "@/service/modules/resources";
-import { ResourceType } from "@/views/resource/components/resource/types";
+import { defineComponent } from 'vue'
 
 const resource = defineComponent({
   name: 'resource',

--- a/dolphinscheduler-ui/src/views/resource/index.tsx
+++ b/dolphinscheduler-ui/src/views/resource/index.tsx
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
+import { queryBaseDir } from "@/service/modules/resources";
+import { ResourceType } from "@/views/resource/components/resource/types";
 
 const resource = defineComponent({
   name: 'resource',


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
- This PR closes https://github.com/apache/dolphinscheduler/issues/13824
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- Add new api `/resource/base-dir` for querying base resource dir which add constraint that breadcrumb navigation can only visit resources or files under tenant's resource paths.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request
- Add some UT.
