### PR TITLE
fix: docker auto push tag name

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -48,11 +48,13 @@ jobs:
             echo "DOCKER_USERNAME=${{ secrets.DOCKERHUB_USER }}" >> $GITHUB_ENV
             echo "DOCKER_PASSWORD=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
             echo "HUB=apache" >> $GITHUB_ENV
+            echo "DOCKER_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           else
             echo "DOCKER_REGISTRY=ghcr.io/apache/dolphinscheduler" >> $GITHUB_ENV
             echo "DOCKER_USERNAME=${{ github.actor }}" >> $GITHUB_ENV
             echo "DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
             echo "HUB=ghcr.io/apache/dolphinscheduler" >> $GITHUB_ENV
+            echo "DOCKER_TAG=${{ github.sha }}" >> $GITHUB_ENV
           fi
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -71,6 +73,6 @@ jobs:
           -Dmaven.javadoc.skip \
           -Dcheckstyle.skip=true \
           -Dmaven.deploy.skip \
-          -Ddocker.tag=${{ github.ref_name }} \
+          -Ddocker.tag=${{ env.DOCKER_TAG }} \
           -Ddocker.hub=${{ env.HUB }} \
           -Pdocker,release

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -71,6 +71,6 @@ jobs:
           -Dmaven.javadoc.skip \
           -Dcheckstyle.skip=true \
           -Dmaven.deploy.skip \
-          -Ddocker.tag=${{ github.sha }} \
+          -Ddocker.tag=${{ github.ref_name }} \
           -Ddocker.hub=${{ env.HUB }} \
           -Pdocker,release

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -48,7 +48,7 @@ jobs:
             echo "DOCKER_USERNAME=${{ secrets.DOCKERHUB_USER }}" >> $GITHUB_ENV
             echo "DOCKER_PASSWORD=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
             echo "HUB=apache" >> $GITHUB_ENV
-            echo "DOCKER_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "DOCKER_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
           else
             echo "DOCKER_REGISTRY=ghcr.io/apache/dolphinscheduler" >> $GITHUB_ENV
             echo "DOCKER_USERNAME=${{ github.actor }}" >> $GITHUB_ENV


### PR DESCRIPTION
use `github.sha` will be commit SHA and like
dc3c9651342529fcfde47dd0949a0ced18ce9e4a in
https://hub.docker.com/repository/docker/apache/dolphinscheduler-api/tags?page=1&ordering=last_updated

we should prefer use tag name instead of
commit SHA
