### PR TITLE
[Fix-13596][Task Instance] Throw an error message to tell the user that the file cannot be found instead of NPE during task execution

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -1772,9 +1772,7 @@ public class ProcessServiceImpl implements ProcessService {
                         JSONUtils.toJsonString(mainJarObj),
                         ResourceInfo.class);
                 ResourceInfo resourceInfo = updateResourceInfo(mainJar);
-                if (resourceInfo != null) {
-                    taskParameters.put("mainJar", resourceInfo);
-                }
+                taskParameters.put("mainJar", resourceInfo);
             }
             // update resourceList information
             if (taskParameters.containsKey("resourceList")) {
@@ -1810,6 +1808,10 @@ public class ProcessServiceImpl implements ProcessService {
             resourceInfo = new ResourceInfo();
             // get resource from database, only one resource should be returned
             Resource resource = getResourceById(resourceId);
+            if (Objects.isNull(resource)) {
+                logger.error("resource not found, resourceId: {}", resourceId);
+                return null;
+            }
             resourceInfo.setId(resourceId);
             resourceInfo.setRes(resource.getFileName());
             resourceInfo.setResourceName(resource.getFullName());


### PR DESCRIPTION
…at the file cannot be found instead of NPE during task execution

<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Throw an error message to tell the user that the file cannot be found instead of NPE during task execution.

fix: https://github.com/apache/dolphinscheduler/issues/13596



## Brief change log

modify: org.apache.dolphinscheduler.service.process.ProcessServiceImpl#updateTaskDefinitionResources
modify: org.apache.dolphinscheduler.service.process.ProcessServiceImpl#updateResourceInfo

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

if contains mainJar field:
![image](https://user-images.githubusercontent.com/53458004/230285259-6c46b531-39e4-468a-b21e-0623f4396b9f.png)

if contains resourceList information:
![image](https://user-images.githubusercontent.com/53458004/230285314-dcb797d9-c3fd-451f-ad9a-38b834d7e9e9.png)


(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
