### PR TITLE
[Bug-13882][Worker] Upgrade kubernetes-client version to 6.0.0

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/k8s/K8sManager.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/k8s/K8sManager.java
@@ -31,8 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
 /**
  * use multiple environment feature
@@ -107,7 +107,7 @@ public class K8sManager {
 
         String k8sConfig = ClusterConfUtils.getK8sConfig(cluster.getConfig());
         if (k8sConfig != null) {
-            DefaultKubernetesClient client = null;
+            KubernetesClient client = null;
             try {
                 client = getClient(k8sConfig);
                 clientMap.put(clusterCode, client);
@@ -118,10 +118,10 @@ public class K8sManager {
         }
     }
 
-    private DefaultKubernetesClient getClient(String configYaml) throws RemotingException {
+    private KubernetesClient getClient(String configYaml) throws RemotingException {
         try {
             Config config = Config.fromKubeconfig(configYaml);
-            return new DefaultKubernetesClient(config);
+            return new KubernetesClientBuilder().withConfig(config).build();
         } catch (Exception e) {
             log.error("Fail to get k8s ApiClient", e);
             throw new RemotingException("fail to get k8s ApiClient:" + e.getMessage());

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -107,6 +107,7 @@
         <azure-resourcemanager-datafactory.version>1.0.0-beta.19</azure-resourcemanager-datafactory.version>
         <google-cloud-storage.version>2.18.0</google-cloud-storage.version>
         <sshd.version>2.8.0</sshd.version>
+        <fabric8.client.version>6.0.0</fabric8.client.version>
     </properties>
 
     <dependencyManagement>
@@ -840,6 +841,11 @@
                 <artifactId>aws-java-sdk-redshift</artifactId>
                 <version>${aws-java-sdk-redshift.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client</artifactId>
+                <version>${fabric8.client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -402,7 +402,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     prometheus client_java(simpleclient) 0.15.0: https://github.com/prometheus/client_java, Apache 2.0
     snowflake snowflake-2010: https://github.com/twitter-archive/snowflake/tree/snowflake-2010, Apache 2.0
     trino-jdbc 402: https://mvnrepository.com/artifact/io.trino/trino-jdbc/402, Apache 2.0
-    kubernetes-client 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-client/5.10.2, Apache 2.0
+    kubernetes-client 6.0.0: https://mvnrepository.com/artifact/io.fabric8/kubernetes-client/6.0.0, Apache 2.0
     kubernetes-model-admissionregistration 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-admissionregistration/5.10.2, Apache 2.0
     kubernetes-model-apiextensions 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-apiextensions/5.10.2, Apache 2.0
     kubernetes-model-apps 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-apps/5.10.2, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -403,6 +403,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     snowflake snowflake-2010: https://github.com/twitter-archive/snowflake/tree/snowflake-2010, Apache 2.0
     trino-jdbc 402: https://mvnrepository.com/artifact/io.trino/trino-jdbc/402, Apache 2.0
     kubernetes-client 6.0.0: https://mvnrepository.com/artifact/io.fabric8/kubernetes-client/6.0.0, Apache 2.0
+    kubernetes-client-api 6.0.0: https://mvnrepository.com/artifact/io.fabric8/kubernetes-client-api/6.0.0, Apache 2.0
+    kubernetes-httpclient-okhttp 6.0.0: https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-okhttp/6.0.0, Apache 2.0
     kubernetes-model-admissionregistration 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-admissionregistration/5.10.2, Apache 2.0
     kubernetes-model-apiextensions 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-apiextensions/5.10.2, Apache 2.0
     kubernetes-model-apps 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-apps/5.10.2, Apache 2.0
@@ -424,7 +426,6 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     kubernetes-model-scheduling 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-scheduling/5.10.2, Apache 2.0
     kubernetes-model-storageclass 5.10.2: https://mvnrepository.com/artifact/io.fabric8/kubernetes-model-storageclass/5.10.2, Apache 2.0
     zjsonpatch 0.3.0 https://mvnrepository.com/artifact/io.fabric8/zjsonpatch/0.3.0, Apache 2.0
-    generex 1.0.2 https://mvnrepository.com/artifact/com.github.mifmif/generex/1.0.2, Apache 2.0
     jackson-dataformat-yaml 2.13.0 https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.13.0, Apache 2.0
     logging-interceptor 4.9.3 https://mvnrepository.com/artifact/com.squareup.okhttp3/logging-interceptor/4.9.3, Apache 2.0
     okhttp 3.14.3 https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/3.14.3, Apache 2.0
@@ -581,7 +582,6 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     LatencyUtils 2.0.3: https://github.com/LatencyUtils/LatencyUtils, BSD-2-Clause
     janino 3.0.16: https://mvnrepository.com/artifact/org.codehaus.janino/janino/3.0.16, BSD 3-clause
     commons-compiler 3.1.7: https://mvnrepository.com/artifact/org.codehaus.janino/janino/3.0.16, BSD 3-clause
-    automaton 1.11-8 https://mvnrepository.com/artifact/dk.brics.automaton/automaton/1.11-8, BSD 2-clause
     protobuf-java 3.17.2: https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/3.17.2 BSD 3-clause
     protobuf-java-util 3.17.2: https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util/3.17.2 BSD 3-clause
     api-common 2.6.0: https://mvnrepository.com/artifact/com.google.api/api-common/2.6.0, BSD

--- a/dolphinscheduler-dist/release-docs/licenses/LICENSE-kubernetes-client.txt
+++ b/dolphinscheduler-dist/release-docs/licenses/LICENSE-kubernetes-client.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/pom.xml
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/pom.xml
@@ -288,7 +288,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/am/KubernetesApplicationManager.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/am/KubernetesApplicationManager.java
@@ -38,10 +38,11 @@ import com.google.auto.service.AutoService;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 
 @Slf4j
 @AutoService(ApplicationManager.class)
@@ -65,7 +66,8 @@ public class KubernetesApplicationManager implements ApplicationManager {
 
         boolean isKill;
         String labelValue = kubernetesApplicationManagerContext.getLabelValue();
-        FilterWatchListDeletable<Pod, PodList> watchList = getDriverPod(kubernetesApplicationManagerContext);
+        FilterWatchListDeletable<Pod, PodList, PodResource> watchList =
+                getDriverPod(kubernetesApplicationManagerContext);
         try {
             if (getApplicationStatus(kubernetesApplicationManagerContext, watchList).isFailure()) {
                 log.error("Driver pod is in FAILED or UNKNOWN status.");
@@ -95,13 +97,12 @@ public class KubernetesApplicationManager implements ApplicationManager {
      * @param kubernetesApplicationManagerContext
      * @return
      */
-    private FilterWatchListDeletable<Pod, PodList> getDriverPod(KubernetesApplicationManagerContext kubernetesApplicationManagerContext) {
+    private FilterWatchListDeletable<Pod, PodList, PodResource> getDriverPod(KubernetesApplicationManagerContext kubernetesApplicationManagerContext) {
         KubernetesClient client = getClient(kubernetesApplicationManagerContext);
         String labelValue = kubernetesApplicationManagerContext.getLabelValue();
-        FilterWatchListDeletable<Pod, PodList> watchList =
-                client.pods()
-                        .inNamespace(kubernetesApplicationManagerContext.getK8sTaskExecutionContext().getNamespace())
-                        .withLabel(UNIQUE_LABEL_NAME, labelValue);
+        FilterWatchListDeletable<Pod, PodList, PodResource> watchList = client.pods()
+                .inNamespace(kubernetesApplicationManagerContext.getK8sTaskExecutionContext().getNamespace())
+                .withLabel(UNIQUE_LABEL_NAME, labelValue);
         List<Pod> podList = watchList.list().getItems();
         if (podList.size() != 1) {
             log.warn("Expected driver pod 1, but get {}.", podList.size());
@@ -119,7 +120,8 @@ public class KubernetesApplicationManager implements ApplicationManager {
         K8sTaskExecutionContext k8sTaskExecutionContext =
                 kubernetesApplicationManagerContext.getK8sTaskExecutionContext();
         return cacheClientMap.computeIfAbsent(kubernetesApplicationManagerContext.getLabelValue(),
-                key -> new DefaultKubernetesClient(Config.fromKubeconfig(k8sTaskExecutionContext.getConfigYaml())));
+                key -> new KubernetesClientBuilder()
+                        .withConfig(Config.fromKubeconfig(k8sTaskExecutionContext.getConfigYaml())).build());
     }
 
     public void removeCache(String cacheKey) {
@@ -147,7 +149,7 @@ public class KubernetesApplicationManager implements ApplicationManager {
      * @throws TaskException
      */
     private TaskExecutionStatus getApplicationStatus(KubernetesApplicationManagerContext kubernetesApplicationManagerContext,
-                                                     FilterWatchListDeletable<Pod, PodList> watchList) throws TaskException {
+                                                     FilterWatchListDeletable<Pod, PodList, PodResource> watchList) throws TaskException {
         String phase;
         try {
             if (Objects.isNull(watchList)) {
@@ -178,7 +180,8 @@ public class KubernetesApplicationManager implements ApplicationManager {
      */
     public LogWatch getPodLogWatcher(KubernetesApplicationManagerContext kubernetesApplicationManagerContext) {
         KubernetesClient client = getClient(kubernetesApplicationManagerContext);
-        FilterWatchListDeletable<Pod, PodList> watchList = getDriverPod(kubernetesApplicationManagerContext);
+        FilterWatchListDeletable<Pod, PodList, PodResource> watchList =
+                getDriverPod(kubernetesApplicationManagerContext);
         List<Pod> driverPod = watchList.list().getItems();
         if (CollectionUtils.isEmpty(driverPod)) {
             return null;

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/K8sUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/K8sUtils.java
@@ -29,8 +29,8 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 
@@ -114,7 +114,7 @@ public class K8sUtils {
     public void buildClient(String configYaml) {
         try {
             Config config = Config.fromKubeconfig(configYaml);
-            client = new DefaultKubernetesClient(config);
+            client = new KubernetesClientBuilder().withConfig(config).build();
         } catch (Exception e) {
             throw new TaskException("fail to build k8s ApiClient", e);
         }

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -14,7 +14,6 @@ aspectjweaver-1.9.7.jar
 aspectjrt-1.9.7.jar
 auth-2.17.282.jar
 audience-annotations-0.12.0.jar
-automaton-1.11-8.jar
 avro-1.7.7.jar
 aws-core-2.17.282.jar
 aws-java-sdk-core-1.12.300.jar
@@ -74,7 +73,6 @@ druid-1.2.4.jar
 eventstream-1.0.1.jar
 error_prone_annotations-2.5.1.jar
 failureaccess-1.0.1.jar
-generex-1.0.2.jar
 gson-2.9.1.jar
 guava-31.1-jre.jar
 guava-retrying-2.0.0.jar
@@ -189,7 +187,9 @@ kotlin-stdlib-1.6.21.jar
 kotlin-stdlib-common-1.6.21.jar
 kotlin-stdlib-jdk7-1.6.21.jar
 kotlin-stdlib-jdk8-1.6.21.jar
-kubernetes-client-5.10.2.jar
+kubernetes-client-6.0.0.jar
+kubernetes-client-api-6.0.0.jar
+kubernetes-httpclient-okhttp-6.0.0.jar
 kubernetes-model-admissionregistration-5.10.2.jar
 kubernetes-model-apiextensions-5.10.2.jar
 kubernetes-model-apps-5.10.2.jar


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

- This PR closes https://github.com/apache/dolphinscheduler/issues/13882
- Upgrade kubernetes-client version to 6.0.0, which solve the bug mentioned in above issue, it no longer uses `PipedInputStream` and `PipedOutputStream` which are replaced by `Channel` in new version, which can also solve other potential bugs.
## Brief change log

- Replace usages of deprecated `DefaultKubernetesClient` and build client in a recommended way.
- Clean the logic of pod log collection in `AbstractCommandExecutor`.

## Verify this pull request

- Manually tested, the same bug will never happen.
