### PR TITLE
Pin pnpm@7 in CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -58,7 +58,7 @@ jobs:
           node-version: 16
       - name: Compile and Build
         run: |
-          npm install pnpm -g
+          npm install pnpm@7 -g
           pnpm install
           pnpm run lint
           pnpm run build:prod


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

This PR pins pnpm@7 in CI since the recent published pnpm 8.x is not compatible w/ existing lockfile.

```
added 1 package, and audited 2 packages in 722ms

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
 ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE  Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm

Try either:
1. Aligning the version of pnpm that generated the lockfile with the version that installs from it, or
2. Migrating the lockfile so that it is compatible with the newer version of pnpm, or
3. Using "pnpm install --no-frozen-lockfile".
Note that in CI environments, this setting is enabled by default.
```

## Brief change log

Pin pnpm@7 in CI

## Verify this pull request

Recover broken frontend CI
