### PR TITLE
[Feature-11488]Datax can submit to YARN

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -312,9 +312,10 @@ public abstract class AbstractCommandExecutor {
             return;
         }
 
-        if (StringUtils.isNotBlank(appId)){
+        if (StringUtils.isNotBlank(appId)) {
             String commandFile = String.format("%s/%s.kill", taskRequest.getExecutePath(), appId);
-            YarnApplicationManager.execYarnKillCommand(taskRequest.getTenantCode(), appId, commandFile, "yarn application -kill " + appId);
+            YarnApplicationManager.execYarnKillCommand(taskRequest.getTenantCode(), appId, commandFile,
+                    "yarn application -kill " + appId);
         }
 
         // soft kill
@@ -387,9 +388,9 @@ public abstract class AbstractCommandExecutor {
                         logBuffer.add(line);
                         taskResultString = line;
                     }
-                    if (StringUtils.isBlank(appId)){
+                    if (StringUtils.isBlank(appId)) {
                         String appId = LogUtils.getAppIdsFromLogLine(line);
-                        if (StringUtils.isNotBlank(appId)){
+                        if (StringUtils.isNotBlank(appId)) {
                             this.appId = appId;
                         }
                     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/am/YarnApplicationManager.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/am/YarnApplicationManager.java
@@ -160,8 +160,8 @@ public class YarnApplicationManager implements ApplicationManager {
      * @param commandFile command file
      * @param cmd cmd
      */
-    private void execYarnKillCommand(String tenantCode, String appId, String commandFile,
-                                     String cmd) {
+    public static void execYarnKillCommand(String tenantCode, String appId, String commandFile,
+                                           String cmd) {
         try {
             StringBuilder sb = new StringBuilder();
             sb.append("#!/bin/sh\n");

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
@@ -184,7 +184,8 @@ public class LogUtils {
     }
 
     public String getAppIdsFromLogLine(String logLine) {
-        if (StringUtils.isBlank(logLine)) return null;
+        if (StringUtils.isBlank(logLine))
+            return null;
         Matcher matcher = APPLICATION_REGEX.matcher(logLine);
         if (matcher.find()) {
             String appId = matcher.group();

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
@@ -183,6 +183,16 @@ public class LogUtils {
         }
     }
 
+    public String getAppIdsFromLogLine(String logLine) {
+        if (StringUtils.isBlank(logLine)) return null;
+        Matcher matcher = APPLICATION_REGEX.matcher(logLine);
+        if (matcher.find()) {
+            String appId = matcher.group();
+            return appId;
+        }
+        return null;
+    }
+
     public static String getTaskInstanceLogFullPathMdc() {
         return MDC.get(TASK_INSTANCE_LOG_FULL_PATH_MDC_KEY);
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxParameters.java
@@ -106,6 +106,19 @@ public class DataxParameters extends AbstractParameters {
     private int xmx;
 
     /**
+     * 0:default/1:yarn
+     */
+    private int yarn;
+
+    public int getYarn() {
+        return yarn;
+    }
+
+    public void setYarn(int yarn) {
+        this.yarn = yarn;
+    }
+
+    /**
      * resource list
      */
     private List<ResourceInfo> resourceList;

--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -578,6 +578,7 @@ export default {
     datax_job_runtime_memory: 'Runtime Memory Limits',
     datax_job_runtime_memory_xms: 'Low Limit Value',
     datax_job_runtime_memory_xmx: 'High Limit Value',
+    datax_job_runtime_operation_mode: 'operation mode(optional yarn)',
     datax_job_runtime_memory_unit: 'G',
     chunjun_json_template: 'JSON script',
     current_hour: 'CurrentHour',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -570,6 +570,7 @@ export default {
     datax_job_runtime_memory: '运行内存',
     datax_job_runtime_memory_xms: '最小内存',
     datax_job_runtime_memory_xmx: '最大内存',
+    datax_job_runtime_operation_mode: '运行模式(可选yarn)',
     datax_job_runtime_memory_unit: 'G',
     chunjun_json_template: 'JSON 脚本',
     current_hour: '当前小时',

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
@@ -77,6 +77,15 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
       value: 3000
     }
   ]
+  const yarnOptions = [
+    {
+      label: 'default',
+      value: 0
+    },    {
+      label: 'yarn',
+      value: 1
+    }
+  ]
   const memoryLimitOptions = [
     {
       label: '1G',
@@ -295,6 +304,14 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
       span: 12,
       options: memoryLimitOptions,
       value: 1
+    },
+    {
+      type: 'select',
+      field: 'yarn',
+      name: t('project.node.datax_job_runtime_operation_mode'),
+      span: 12,
+      options: yarnOptions,
+      value: 0
     },
     ...useCustomParams({ model, field: 'localParams', isSimple: true })
   ]

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -272,6 +272,7 @@ export function formatParams(data: INodeData): {
     }
     taskParams.xms = data.xms
     taskParams.xmx = data.xmx
+    taskParams.yarn = data.yarn
   }
   if (data.taskType === 'DEPENDENT') {
     taskParams.dependence = {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
@@ -311,6 +311,7 @@ interface ITaskParams {
   jobSpeedRecord?: number
   xms?: number
   xmx?: number
+  yarn?: number
   sparkParameters?: ISparkParameters
   ruleId?: number
   ruleInputParameter?: IRuleParameters


### PR DESCRIPTION
https://github.com/apache/dolphinscheduler/issues/11488

Instructions:

Configure the environment variables DATAX_ON_YARN_JAR and YARN_BIN to run DATAX ON YARN

Parameter explanation:
DATAX_ON_YARN_JAR:
https://github.com/duhanmin/datax-on-yarn Compile and package

YARN_BIN:
The default value is yarn, which is used to limit the memory of yarn submission to the client

DATAX_HOME:
datax decompression directory, or s3/hdfs compression package directory

```shell
DATAX_HOME=/Users/duhanmin/IdeaProjects/daima/DataX/target/datax/datax
YARN_BIN=HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn
DATAX_ON_YARN_JAR=/opt/soft/datax/datax-on-yarn-1.0.0.jar
```