### PR TITLE
[Fix-13950][master] fix the key of master node failover

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/service/MasterFailoverService.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/service/MasterFailoverService.java
@@ -91,7 +91,7 @@ public class MasterFailoverService {
     }
 
     public void failoverMaster(String masterHost) {
-        String failoverPath = RegistryNodeType.MASTER_FAILOVER_LOCK + "/" + masterHost;
+        String failoverPath = RegistryNodeType.MASTER_FAILOVER_LOCK.getRegistryPath() + "/" + masterHost;
         try {
             registryClient.getLock(failoverPath);
             doFailoverMaster(masterHost);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

fix #13950 

## Brief change log

RegistryNodeType.MASTER_FAILOVER_LOCK.getRegistryPath()

## Verify this pull request

This pull request is already covered by existing tests, such as *FailoverServiceTest*.

