### PR TITLE
[Feature][plugin] Datax can submit to YARN

### DIFF
--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -382,9 +382,17 @@ export FLINK_ENV_JAVA_OPTS="-javaagent:${DOLPHINSCHEDULER_HOME}/tools/libs/aspec
 
 ### Log related configuration
 
-|Service| Configuration file  |
-|--|--|
-|Master Server | `master-server/conf/logback-spring.xml`|
-|Api Server| `api-server/conf/logback-spring.xml`|
-|Worker Server| `worker-server/conf/logback-spring.xml`|
-|Alert Server| `alert-server/conf/logback-spring.xml`|
+| **Service**   | **Configuration file**                  |
+|---------------|-----------------------------------------|
+| Master Server | `master-server/conf/logback-spring.xml` |
+| Api Server    | `api-server/conf/logback-spring.xml`    |
+| Worker Server | `worker-server/conf/logback-spring.xml` |
+| Alert Server  | `alert-server/conf/logback-spring.xml`  |
+
+## common.properties [datax on yarn configs]
+
+| **Parameter**            | **Default Value** | **Description**                                                                                                                                                          |
+|--------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| datax.yarn.jar           | None              | Download and compile jar from [url](https://github.com/duhanmin/datax-on-yarn)                                                                                           |
+| datax.yarn.bin           | yarn              | datax yarn does not require much memory, global configuration may affect hadoop/spark/flink process, opinion configuration: HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn |
+| datax.yarn.default.queue | default           | specifies datax run queue on yarn, front-end configuration has the highest priority                                                                                      |

--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -382,7 +382,7 @@ export FLINK_ENV_JAVA_OPTS="-javaagent:${DOLPHINSCHEDULER_HOME}/tools/libs/aspec
 
 ### Log related configuration
 
-| **Service**   | **Configuration file**                  |
+|  **Service**  |         **Configuration file**          |
 |---------------|-----------------------------------------|
 | Master Server | `master-server/conf/logback-spring.xml` |
 | Api Server    | `api-server/conf/logback-spring.xml`    |
@@ -391,8 +391,9 @@ export FLINK_ENV_JAVA_OPTS="-javaagent:${DOLPHINSCHEDULER_HOME}/tools/libs/aspec
 
 ## common.properties [datax on yarn configs]
 
-| **Parameter**            | **Default Value** | **Description**                                                                                                                                                          |
+|      **Parameter**       | **Default Value** |                                                                             **Description**                                                                              |
 |--------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | datax.yarn.jar           | None              | Download and compile jar from [url](https://github.com/duhanmin/datax-on-yarn)                                                                                           |
 | datax.yarn.bin           | yarn              | datax yarn does not require much memory, global configuration may affect hadoop/spark/flink process, opinion configuration: HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn |
 | datax.yarn.default.queue | default           | specifies datax run queue on yarn, front-end configuration has the highest priority                                                                                      |
+

--- a/docs/docs/en/guide/task/datax.md
+++ b/docs/docs/en/guide/task/datax.md
@@ -6,6 +6,28 @@ DataX task type for executing DataX programs. For DataX nodes, the worker will e
 
 By default, the datax.py will be executed by python2.7, if you want to use other python version, you can set the `DATAX_PYTHON` environment variable to specify a version.
 
+If yarn is required to run datax tasks, you also need to perform common.properties dependencies and configurations, as described below.
+
+## datax on yarn configuration
+
+- dolphinscheduler_env.sh configs
+
+DATAX_HOME supports local, hdfs, and s3
+
+| **Type** | **Description**                     |
+|----------|-------------------------------------|
+| local    | /opt/datax/                         |
+| hdfs     | /tmp/hadoop/datax.tar.gz            |
+| s3       | s3://bucket/tmp/hadoop/datax.tar.gz |
+
+- common.properties configs
+
+| **Parameters**           | **Example**                                  | **Description**                                                                                       |
+|--------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| datax.yarn.jar           | /mnt/dss/datax-on-yarn-1.0.0.jar             | Download and compile jar from [url](https://github.com/duhanmin/datax-on-yarn) can                    |
+| datax.yarn.bin           | HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn | datax yarn does not require much memory, global configuration may affect hadoop/spark/flink processes |
+| datax.yarn.default.queue | default                                      | specifies datax run queue on yarn, front-end configuration has the highest priority                   |
+
 ## Create Task
 
 - Click `Project Management -> Project Name -> Workflow Definition`, and click the `Create Workflow` button to enter the DAG editing page.

--- a/docs/docs/en/guide/task/datax.md
+++ b/docs/docs/en/guide/task/datax.md
@@ -14,7 +14,7 @@ If yarn is required to run datax tasks, you also need to perform common.properti
 
 DATAX_HOME supports local, hdfs, and s3
 
-| **Type** | **Description**                     |
+| **Type** |           **Description**           |
 |----------|-------------------------------------|
 | local    | /opt/datax/                         |
 | hdfs     | /tmp/hadoop/datax.tar.gz            |
@@ -22,7 +22,7 @@ DATAX_HOME supports local, hdfs, and s3
 
 - common.properties configs
 
-| **Parameters**           | **Example**                                  | **Description**                                                                                       |
+|      **Parameters**      |                 **Example**                  |                                            **Description**                                            |
 |--------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | datax.yarn.jar           | /mnt/dss/datax-on-yarn-1.0.0.jar             | Download and compile jar from [url](https://github.com/duhanmin/datax-on-yarn) can                    |
 | datax.yarn.bin           | HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn | datax yarn does not require much memory, global configuration may affect hadoop/spark/flink processes |

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -372,7 +372,7 @@ export FLINK_ENV_JAVA_OPTS="-javaagent:${DOLPHINSCHEDULER_HOME}/tools/libs/aspec
 
 ## 日志相关配置
 
-| **服务名称**      | **配置文件**                                |
+|   **服务名称**    |                **配置文件**                 |
 |---------------|-----------------------------------------|
 | Master Server | `master-server/conf/logback-spring.xml` |
 | Api Server    | `api-server/conf/logback-spring.xml`    |
@@ -381,8 +381,9 @@ export FLINK_ENV_JAVA_OPTS="-javaagent:${DOLPHINSCHEDULER_HOME}/tools/libs/aspec
 
 ## common.properties [datax on yarn配置]
 
-| **参数**                   | **默认值** | **描述**                                                                                            |
+|          **参数**          | **默认值** |                                              **描述**                                               |
 |--------------------------|---------|---------------------------------------------------------------------------------------------------|
 | datax.yarn.jar           | 无       | 从[url](https://github.com/duhanmin/datax-on-yarn)下载并编译获取jar即可                                     |
 | datax.yarn.bin           | yarn    | datax yarn不需要太多内存，全局配置可能会影响hadoop/spark/flink进程,意见配置:HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn |
 | datax.yarn.default.queue | default | 指定datax在yarn上运行队列，前端配置具有最高优先级                                                                     |
+

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -372,9 +372,17 @@ export FLINK_ENV_JAVA_OPTS="-javaagent:${DOLPHINSCHEDULER_HOME}/tools/libs/aspec
 
 ## 日志相关配置
 
-|服务名称| 配置文件 |
-|--|--|
-|Master Server | `master-server/conf/logback-spring.xml`|
-|Api Server| `api-server/conf/logback-spring.xml`|
-|Worker Server| `worker-server/conf/logback-spring.xml`|
-|Alert Server| `alert-server/conf/logback-spring.xml`|
+| **服务名称**      | **配置文件**                                |
+|---------------|-----------------------------------------|
+| Master Server | `master-server/conf/logback-spring.xml` |
+| Api Server    | `api-server/conf/logback-spring.xml`    |
+| Worker Server | `worker-server/conf/logback-spring.xml` |
+| Alert Server  | `alert-server/conf/logback-spring.xml`  |
+
+## common.properties [datax on yarn配置]
+
+| **参数**                   | **默认值** | **描述**                                                                                            |
+|--------------------------|---------|---------------------------------------------------------------------------------------------------|
+| datax.yarn.jar           | 无       | 从[url](https://github.com/duhanmin/datax-on-yarn)下载并编译获取jar即可                                     |
+| datax.yarn.bin           | yarn    | datax yarn不需要太多内存，全局配置可能会影响hadoop/spark/flink进程,意见配置:HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn |
+| datax.yarn.default.queue | default | 指定datax在yarn上运行队列，前端配置具有最高优先级                                                                     |

--- a/docs/docs/zh/guide/task/datax.md
+++ b/docs/docs/zh/guide/task/datax.md
@@ -6,6 +6,28 @@ DataX 任务类型，用于执行 DataX 程序。对于 DataX 节点，worker �
 
 默认会使用python2.7去执行datax.py，如果需要使用其他版本的python去执行datax.py，需要在环境变量中配置`DATAX_PYTHON`。
 
+如果需要使用yarn运行datax任务，则还需要在common.properties相关依赖和配置,下面会详细介绍。
+
+## datax on yarn 配置
+
+- dolphinscheduler_env.sh配置
+
+  DATAX_HOME支持local/hdfs/s3
+
+| **类型** | **描述**                              |
+|--------|-------------------------------------|
+| local  | /opt/datax/                         |
+| hdfs   | /tmp/hadoop/datax.tar.gz            |
+| s3     | s3://bucket/tmp/hadoop/datax.tar.gz |
+
+- common.properties配置
+
+| **参数**                   | **示例**                                       | **描述**                                                        |
+|--------------------------|----------------------------------------------|---------------------------------------------------------------|
+| datax.yarn.jar           | /mnt/dss/datax-on-yarn-1.0.0.jar             | 从[url](https://github.com/duhanmin/datax-on-yarn)下载并编译获取jar即可 |
+| datax.yarn.bin           | HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn | datax yarn不需要太多内存，全局配置可能会影响hadoop/spark/flink进程               |
+| datax.yarn.default.queue | default                                      | 指定datax在yarn上运行队列，前端配置具有最高优先级                                 |
+
 ## 创建任务
 
 - 点击项目管理 -> 项目名称 -> 工作流定义，点击“创建工作流”按钮，进入 DAG 编辑页面；

--- a/docs/docs/zh/guide/task/datax.md
+++ b/docs/docs/zh/guide/task/datax.md
@@ -14,7 +14,7 @@ DataX 任务类型，用于执行 DataX 程序。对于 DataX 节点，worker �
 
   DATAX_HOME支持local/hdfs/s3
 
-| **类型** | **描述**                              |
+| **类型** |               **描述**                |
 |--------|-------------------------------------|
 | local  | /opt/datax/                         |
 | hdfs   | /tmp/hadoop/datax.tar.gz            |
@@ -22,7 +22,7 @@ DataX 任务类型，用于执行 DataX 程序。对于 DataX 节点，worker �
 
 - common.properties配置
 
-| **参数**                   | **示例**                                       | **描述**                                                        |
+|          **参数**          |                    **示例**                    |                            **描述**                             |
 |--------------------------|----------------------------------------------|---------------------------------------------------------------|
 | datax.yarn.jar           | /mnt/dss/datax-on-yarn-1.0.0.jar             | 从[url](https://github.com/duhanmin/datax-on-yarn)下载并编译获取jar即可 |
 | datax.yarn.bin           | HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn | datax yarn不需要太多内存，全局配置可能会影响hadoop/spark/flink进程               |

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -178,3 +178,9 @@ remote.logging.google.cloud.storage.credential=/path/to/credential
 # gcs bucket name, required if you set remote.logging.target=GCS
 remote.logging.google.cloud.storage.bucket.name=<your-bucket>
 
+# datax on yarn jar path https://github.com/duhanmin/datax-on-yarn
+datax.yarn.jar=
+# datax does not require that much memory, and configuration globally may affect the hadoop/spark/flink process
+datax.yarn.bin=HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn
+# specifies that datax runs queues on yarn,the front-end configuration has the highest priority
+datax.yarn.default.queue=default

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxConstants.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.datax;
+
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+
+public class DataxConstants {
+
+    private DataxConstants() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    private static final String DATAX_YARN_JAR_CONFIG = "datax.yarn.jar";
+
+    private static final String DATAX_YARN_BIN_CONFIG = "datax.yarn.bin";
+
+    private static final String DATAX_YARN_DEFAULT_QUEUE_CONFIG = "datax.yarn.default.queue";
+
+    /**
+     * datax on yarn jar path
+     */
+    public static final String DATAX_YARN_JAR = PropertyUtils.getString(DataxConstants.DATAX_YARN_JAR_CONFIG);
+
+    /**
+     * example: HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn
+     */
+    public static final String DATAX_YARN_BIN = PropertyUtils.getString(DataxConstants.DATAX_YARN_BIN_CONFIG, "yarn");
+
+    public static final String DATAX_YARN_DEFAULT_QUEUE =
+            PropertyUtils.getString(DataxConstants.DATAX_YARN_DEFAULT_QUEUE_CONFIG, "default");
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxDeployModeEnum.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxDeployModeEnum.java
@@ -19,12 +19,12 @@ package org.apache.dolphinscheduler.plugin.task.datax;
 
 import com.baomidou.mybatisplus.annotation.EnumValue;
 
-public enum DataxYarnEnum {
+public enum DataxDeployModeEnum {
 
     DEFAULT(0, "default java process"),
     YARN(1, "execution on yarn");
 
-    DataxYarnEnum(int code, String descp) {
+    DataxDeployModeEnum(int code, String descp) {
         this.code = code;
         this.descp = descp;
     }
@@ -39,14 +39,5 @@ public enum DataxYarnEnum {
 
     public String getDescp() {
         return descp;
-    }
-
-    public static DataxYarnEnum of(int status) {
-        for (DataxYarnEnum dye : values()) {
-            if (dye.getCode() == status) {
-                return dye;
-            }
-        }
-        throw new IllegalArgumentException("invalid status : " + status);
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxParameters.java
@@ -106,6 +106,29 @@ public class DataxParameters extends AbstractParameters {
     private int xmx;
 
     /**
+     * 0:default/1:yarn
+     */
+    private int yarn;
+
+    private String yarnQueue;
+
+    public String getYarnQueue() {
+        return yarnQueue;
+    }
+
+    public void setYarnQueue(String yarnQueue) {
+        this.yarnQueue = yarnQueue;
+    }
+
+    public int getYarn() {
+        return yarn;
+    }
+
+    public void setYarn(int yarn) {
+        this.yarn = yarn;
+    }
+
+    /**
      * resource list
      */
     private List<ResourceInfo> resourceList;

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxParameters.java
@@ -108,7 +108,7 @@ public class DataxParameters extends AbstractParameters {
     /**
      * 0:default/1:yarn
      */
-    private int yarn;
+    private int dataxDeployMode;
 
     private String yarnQueue;
 
@@ -120,12 +120,12 @@ public class DataxParameters extends AbstractParameters {
         this.yarnQueue = yarnQueue;
     }
 
-    public int getYarn() {
-        return yarn;
+    public int getDataxDeployMode() {
+        return dataxDeployMode;
     }
 
-    public void setYarn(int yarn) {
-        this.yarn = yarn;
+    public void setDataxDeployMode(int dataxDeployMode) {
+        this.dataxDeployMode = dataxDeployMode;
     }
 
     /**

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
@@ -154,7 +154,7 @@ public class DataxTask extends AbstractYarnTask {
         // run datax processDataSourceService
         String jsonFilePath = buildDataxJsonFile(paramsMap);
         String shellCommandFilePath;
-        if (DataxYarnEnum.YARN.getCode() == dataXParameters.getYarn()) {
+        if (DataxDeployModeEnum.YARN.getCode() == dataXParameters.getDataxDeployMode()) {
             if (StringUtils.isNotBlank(DataxConstants.DATAX_YARN_JAR)) {
                 shellCommandFilePath = buildYarnShellCommandFile(jsonFilePath, paramsMap);
             } else {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxYarnEnum.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxYarnEnum.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.datax;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+
+public enum DataxYarnEnum {
+
+    DEFAULT(0, "default java process"),
+    YARN(1, "execution on yarn");
+
+    DataxYarnEnum(int code, String descp) {
+        this.code = code;
+        this.descp = descp;
+    }
+
+    @EnumValue
+    private final int code;
+    private final String descp;
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDescp() {
+        return descp;
+    }
+
+    public static DataxYarnEnum of(int status) {
+        for (DataxYarnEnum dye : values()) {
+            if (dye.getCode() == status) {
+                return dye;
+            }
+        }
+        throw new IllegalArgumentException("invalid status : " + status);
+    }
+}

--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -579,6 +579,8 @@ export default {
     datax_job_runtime_memory: 'Runtime Memory Limits',
     datax_job_runtime_memory_xms: 'Low Limit Value',
     datax_job_runtime_memory_xmx: 'High Limit Value',
+    datax_job_runtime_operation_mode: 'operation mode(optional yarn)',
+    datax_job_runtime_queue: 'yarn queue',
     datax_job_runtime_memory_unit: 'G',
     chunjun_json_template: 'JSON script',
     current_hour: 'CurrentHour',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -571,6 +571,8 @@ export default {
     datax_job_runtime_memory: '运行内存',
     datax_job_runtime_memory_xms: '最小内存',
     datax_job_runtime_memory_xmx: '最大内存',
+    datax_job_runtime_operation_mode: '运行模式(可选yarn)',
+    datax_job_runtime_queue: 'yarn队列',
     datax_job_runtime_memory_unit: 'G',
     chunjun_json_template: 'JSON 脚本',
     current_hour: '当前小时',

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
@@ -77,6 +77,15 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
       value: 3000
     }
   ]
+  const yarnOptions = [
+    {
+      label: 'default',
+      value: 0
+    },    {
+      label: 'yarn',
+      value: 1
+    }
+  ]
   const memoryLimitOptions = [
     {
       label: '1G',
@@ -295,6 +304,20 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
       span: 12,
       options: memoryLimitOptions,
       value: 1
+    },
+    {
+      type: 'select',
+      field: 'yarn',
+      name: t('project.node.datax_job_runtime_operation_mode'),
+      span: 12,
+      options: yarnOptions,
+      value: 0
+    },
+    {
+      type: 'input',
+      field: 'yarnQueue',
+      name: t('project.node.datax_job_runtime_queue'),
+      span: 12
     },
     ...useCustomParams({ model, field: 'localParams', isSimple: true })
   ]

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
@@ -77,7 +77,7 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
       value: 3000
     }
   ]
-  const yarnOptions = [
+  const deployModeOptions = [
     {
       label: 'default',
       value: 0
@@ -307,10 +307,10 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
     },
     {
       type: 'select',
-      field: 'yarn',
+      field: 'dataxDeployMode',
       name: t('project.node.datax_job_runtime_operation_mode'),
       span: 12,
-      options: yarnOptions,
+      options: deployModeOptions,
       value: 0
     },
     {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -276,6 +276,8 @@ export function formatParams(data: INodeData): {
     }
     taskParams.xms = data.xms
     taskParams.xmx = data.xmx
+    taskParams.yarn = data.yarn
+    taskParams.yarnQueue = data.yarnQueue
   }
   if (data.taskType === 'DEPENDENT') {
     taskParams.dependence = {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -276,7 +276,7 @@ export function formatParams(data: INodeData): {
     }
     taskParams.xms = data.xms
     taskParams.xmx = data.xmx
-    taskParams.yarn = data.yarn
+    taskParams.dataxDeployMode = data.dataxDeployMode
     taskParams.yarnQueue = data.yarnQueue
   }
   if (data.taskType === 'DEPENDENT') {

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
@@ -311,6 +311,8 @@ interface ITaskParams {
   jobSpeedRecord?: number
   xms?: number
   xmx?: number
+  yarn?: number
+  yarnQueue?: string
   sparkParameters?: ISparkParameters
   ruleId?: number
   ruleInputParameter?: IRuleParameters

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
@@ -311,7 +311,7 @@ interface ITaskParams {
   jobSpeedRecord?: number
   xms?: number
   xmx?: number
-  yarn?: number
+  dataxDeployMode?: number
   yarnQueue?: string
   sparkParameters?: ISparkParameters
   ruleId?: number


### PR DESCRIPTION
close https://github.com/apache/dolphinscheduler/issues/11488

DATAX_HOME supports local/hdfs/s3(dolphinscheduler_env.sh)
```shell
local: DATAX_HOME=/opt/datax/
hdfs: /tmp/hadoop/datax.tar.gz
s3: s3://bucket/tmp/hadoop/datax.tar.gz
```

New parameter(common.properties)
```shell
# datax on yarn jar path https://github.com/duhanmin/datax-on-yarn
datax.yarn.jar=
# datax does not require that much memory, and configuration globally may affect the hadoop/spark/flink process
datax.yarn.bin=HADOOP_OPTS="-Xms32m -Xmx128m" /usr/bin/yarn
# specifies that datax runs queues on yarn,the front-end configuration has the highest priority
datax.yarn.default.queue=default
```

Have to have modified requirements mentioned in https://github.com/apache/dolphinscheduler/pull/13939, and added new functions