### PR TITLE
[fix-#13956] [Master]```taskId is null``` cause NPE

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -1936,6 +1936,7 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatus> {
                 log.info("The dependResult of task {} is success, so ready to submit to execute", task.getName());
                 Optional<TaskInstance> taskInstanceOptional = submitTaskExec(task);
                 if (!taskInstanceOptional.isPresent()) {
+                    task.setId(0);
                     this.taskFailedSubmit = true;
                     // Remove and add to complete map and error map
                     if (!removeTaskFromStandbyList(task)) {


### PR DESCRIPTION
## Purpose of the pull request
this close
- #13956 
- #12440 
- #13942 
## Brief change log
  This judgment seems to be on the surface if taskInstacne is null, only to enter,
after task insert failed , id is null
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/33984497/233303410-2c7d5736-61e5-4fa3-a6b7-8a2febc73efe.png">
I remember that id used to be of type int, but it was later changed to type Integer. My personal opinion is that the above reason caused the exception.
## Verify this pull request




