### PR TITLE
[Bug][Worker] get worker status bug

### DIFF
--- a/docs/docs/en/architecture/load-balance.md
+++ b/docs/docs/en/architecture/load-balance.md
@@ -55,6 +55,6 @@ If either of these is lower than the configured item, then this worker will not 
 
 You can customise the configuration by changing the following properties in worker.properties
 
-- worker.max.cpuload.avg=-1 (worker max cpuload avg, only higher than the system cpu load average, worker server can be dispatched tasks. default value -1: the number of cpu cores * 2)
-- worker.reserved.memory=0.3 (worker reserved memory, only lower than system available memory, worker server can be dispatched tasks. default value 0.3, the unit is G)
+- worker.max.cpu.load.avg=-1 (worker max cpu load avg, only higher than the system cpu load average, worker server can be dispatched tasks. default value -1: the number of cpu cores * 2)
+- worker.reserved.memory=0.3 (worker reserved memory, only lower than system available memory, worker server can be dispatched tasks. default value 0.3, the unit is percentage)
 

--- a/docs/docs/zh/architecture/load-balance.md
+++ b/docs/docs/zh/architecture/load-balance.md
@@ -55,6 +55,6 @@ eg：master.host.selector=random（不区分大小写）
 
 你可以在 worker.properties 修改下面的属性来自定义配置
 
-* worker.max.cpuload.avg=-1 (worker最大cpuload均值，只有高于系统cpuload均值时，worker服务才能被派发任务. 默认值为-1: cpu cores * 2)
-* worker.reserved.memory=0.3 (worker预留内存，只有低于系统可用内存时，worker服务才能被派发任务，单位为G)
+* worker.max.cpu.load.avg=-1 (worker最大cpu load均值，只有高于系统cpu load均值时，worker服务才能被派发任务. 默认值为-1: cpu cores * 2)
+* worker.reserved.memory=0.3 (worker预留内存，只有低于系统可用内存时，worker服务才能被派发任务，单位为百分比)
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/task/WorkerHeartBeatTask.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/task/WorkerHeartBeatTask.java
@@ -96,7 +96,7 @@ public class WorkerHeartBeatTask extends BaseHeartBeatTask<WorkerHeartBeat> {
                                int workerWaitingTaskCount) {
         if (cpuUsagePercentage > maxCpuUsePercentage || (1 - memoryUsagePercentage) < reservedMemory) {
             log.warn(
-                    "current cpu load average {} is higher than {} max.cpuload.avg or available memory is lower than {} reserved.memory={}",
+                    "current cpu load average {} is higher than {} or available memory {} is lower than {}",
                     cpuUsagePercentage, maxCpuUsePercentage, 1 - memoryUsagePercentage, reservedMemory);
             return Constants.ABNORMAL_NODE_STATUS;
         } else if (workerWaitingTaskCount > workerExecThreadCount) {

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/task/WorkerHeartBeatTask.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/task/WorkerHeartBeatTask.java
@@ -94,10 +94,10 @@ public class WorkerHeartBeatTask extends BaseHeartBeatTask<WorkerHeartBeat> {
                                double reservedMemory,
                                int workerExecThreadCount,
                                int workerWaitingTaskCount) {
-        if (cpuUsagePercentage > maxCpuUsePercentage || memoryUsagePercentage < reservedMemory) {
+        if (cpuUsagePercentage > maxCpuUsePercentage || (1 - memoryUsagePercentage) < reservedMemory) {
             log.warn(
-                    "current cpu load average {} is higher than {} max.cpuload.avg or available memory {} is lower than {} reserved.memory={}",
-                    cpuUsagePercentage, maxCpuUsePercentage, memoryUsagePercentage, reservedMemory);
+                    "current cpu load average {} is higher than {} max.cpuload.avg or available memory is lower than {} reserved.memory={}",
+                    cpuUsagePercentage, maxCpuUsePercentage, 1 - memoryUsagePercentage, reservedMemory);
             return Constants.ABNORMAL_NODE_STATUS;
         } else if (workerWaitingTaskCount > workerExecThreadCount) {
             log.warn("current waiting task count {} is large than worker thread count {}, worker is busy",


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
- We should compare `1 - memoryUsagePercentage` and `reservedMemory`, rather `memoryUsagePercentage` and `reservedMemory`.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request