### PR TITLE
[Fix-13913][Master] syncMasterNodes does not make current slot correctly after zookeeper reconnect

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterConnectionStateListener.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterConnectionStateListener.java
@@ -32,10 +32,12 @@ public class MasterConnectionStateListener implements ConnectionListener {
 
     private final String masterNodePath;
     private final RegistryClient registryClient;
+    private final MasterHeartBeatTask masterHeartBeatTask;
 
-    public MasterConnectionStateListener(String masterNodePath, RegistryClient registryClient) {
+    public MasterConnectionStateListener(String masterNodePath, RegistryClient registryClient, MasterHeartBeatTask masterHeartBeatTask) {
         this.masterNodePath = checkNotNull(masterNodePath);
         this.registryClient = checkNotNull(registryClient);
+        this.masterHeartBeatTask = checkNotNull(masterHeartBeatTask);
     }
 
     @Override
@@ -50,7 +52,7 @@ public class MasterConnectionStateListener implements ConnectionListener {
             case RECONNECTED:
                 logger.debug("registry connection state is {}, clean the node info", state);
                 registryClient.remove(masterNodePath);
-                registryClient.persistEphemeral(masterNodePath, "");
+                registryClient.persistEphemeral(masterNodePath, masterHeartBeatTask.getHeartBeatInfo());
                 break;
             case DISCONNECTED:
                 logger.warn("registry connection state is {}, ready to stop myself", state);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
- This pr closes https://github.com/apache/dolphinscheduler/issues/13913
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- Set initial master heartbeat.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
