### PR TITLE
[Fix-13928][UI] Fix repeat CustomParams input box

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-datax.ts
@@ -102,7 +102,6 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
     const destinationDatasourceSpan = ref(8)
     const otherStatementSpan = ref(22)
     const jobSpeedSpan = ref(12)
-    const customParameterSpan = ref(0)
     const useResourcesSpan = ref(0)
 
     const initConstants = () => {
@@ -113,7 +112,6 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
             destinationDatasourceSpan.value = 0
             otherStatementSpan.value = 0
             jobSpeedSpan.value = 0
-            customParameterSpan.value = 24
             useResourcesSpan.value = 24
         } else {
             sqlEditorSpan.value = 24
@@ -122,7 +120,6 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
             destinationDatasourceSpan.value = 8
             otherStatementSpan.value = 22
             jobSpeedSpan.value = 12
-            customParameterSpan.value = 0
             useResourcesSpan.value = 0
         }
     }
@@ -237,49 +234,6 @@ export function useDataX(model: { [field: string]: any }): IJsonItem[] {
             span: jobSpeedSpan,
             options: jobSpeedRecordOptions,
             value: 1000
-        },
-        {
-            type: 'custom-parameters',
-            field: 'localParams',
-            name: t('project.node.custom_parameters'),
-            span: customParameterSpan,
-            children: [
-                {
-                    type: 'input',
-                    field: 'prop',
-                    span: 10,
-                    props: {
-                        placeholder: t('project.node.prop_tips'),
-                        maxLength: 256
-                    },
-                    validate: {
-                        trigger: ['input', 'blur'],
-                        required: true,
-                        validator(validate: any, value: string) {
-                            if (!value) {
-                                return new Error(t('project.node.prop_tips'))
-                            }
-
-                            const sameItems = model.localParams.filter(
-                                (item: { prop: string }) => item.prop === value
-                            )
-
-                            if (sameItems.length > 1) {
-                                return new Error(t('project.node.prop_repeat'))
-                            }
-                        }
-                    }
-                },
-                {
-                    type: 'input',
-                    field: 'value',
-                    span: 10,
-                    props: {
-                        placeholder: t('project.node.value_tips'),
-                        maxLength: 256
-                    }
-                }
-            ]
         },
         {
             type: 'select',


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

Fix: #13928 

Before:

![Snipaste_2023-04-27_17-23-59](https://user-images.githubusercontent.com/41513919/234824500-8a0d0785-c040-461f-84e7-7c91c5a80e5e.png)

After fix:

![image](https://user-images.githubusercontent.com/41513919/234824727-cd091e36-a6e8-46cf-ad9f-5126db99a5d8.png)

Now all `CustomParams` seems use:

![image](https://user-images.githubusercontent.com/41513919/234827411-5b1dd75b-4f24-47de-8039-6383bc91dddf.png)

But forgot to remove the code about `CustomParams` written before, lead the repeat.

## Brief change log

remove repeat code of `CustomParams` input box in `datax` Custom Template mode

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.
