### PR TITLE
[Improvement][api]to improve the name information of each module in the pom. xml for the specific module corresponding name to facilitate the source maven structure view

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/pom.xml
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/pom.xml
@@ -24,7 +24,7 @@
         <version>3.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-alert-server</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-alert-server</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -24,7 +24,7 @@
         <version>3.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-api</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-api</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -25,7 +25,7 @@
         <version>dev-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-bom</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-bom</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/dolphinscheduler-dao/pom.xml
+++ b/dolphinscheduler-dao/pom.xml
@@ -24,7 +24,7 @@
         <version>3.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-dao</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-dao</name>
 
     <dependencies>
         <!-- dolphinscheduler -->

--- a/dolphinscheduler-datasource-plugin/pom.xml
+++ b/dolphinscheduler-datasource-plugin/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dolphinscheduler-datasource-plugin</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-datasource-plugin</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dolphinscheduler-dist</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-dist</name>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/dolphinscheduler-microbench/pom.xml
+++ b/dolphinscheduler-microbench/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>dolphinscheduler-microbench</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-microbench</name>
 
     <properties>
         <jmh.version>1.21</jmh.version>

--- a/dolphinscheduler-python/pom.xml
+++ b/dolphinscheduler-python/pom.xml
@@ -24,7 +24,7 @@
         <version>3.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-python</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-python</name>
     <packaging>jar</packaging>
 
     <profiles>

--- a/dolphinscheduler-spi/pom.xml
+++ b/dolphinscheduler-spi/pom.xml
@@ -23,7 +23,7 @@
         <version>3.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>dolphinscheduler-spi</artifactId>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler-spi</name>
 
     <dependencies>
         <!-- the SPI should have only minimal dependencies -->

--- a/dolphinscheduler-ui/pom.xml
+++ b/dolphinscheduler-ui/pom.xml
@@ -26,7 +26,7 @@
 
   <artifactId>dolphinscheduler-ui</artifactId>
 
-  <name>${project.artifactId}</name>
+  <name>dolphinscheduler-ui</name>
 
   <properties>
     <node.version>v16.13.1</node.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>dolphinscheduler</artifactId>
     <version>3.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>${project.artifactId}</name>
+    <name>dolphinscheduler</name>
     <url>https://dolphinscheduler.apache.org</url>
     <description>Dolphin Scheduler is a distributed and easy-to-expand visual DAG workflow scheduling system, dedicated
         to solving the complex dependencies in data processing, making the scheduling system out of the box for data


### PR DESCRIPTION
This is my first PR, to improve the name information of each module in the pom. xml for the specific module corresponding name to facilitate the source maven structure view. Try committing a minor feature fix first, and get a feel for the workflow of contributing code. The next step is to fix the jar file upload bug in the resource center.

完善各模块的pom.xml中的name信息为具体的模块对应名称便于源码maven结构查看
