### PR TITLE
fixed the bug, "Failed to load driver class oracle.jdbc.OracleDriver in either of HikariConfig class loader or Thread context classloader. " occurred when create datasource in datasource manager menu.

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -382,14 +382,12 @@
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql-connector.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${oracle-jdbc.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
this push fixed the bug,  "Failed to load driver class oracle.jdbc.OracleDriver in either of HikariConfig class loader or Thread context classloader. " occurred when create datasource in datasource manager menu. 
## Brief change log

remove the scope tag of oracle and mysql driver in the pom.xml

## Verify this pull request

This pull request is code cleanup without any test coverage.
