### PR TITLE
[Doc] Fix upgrade-schema.sh cannot load driver class

### DIFF
--- a/docs/docs/en/guide/howto/datasource-setting.md
+++ b/docs/docs/en/guide/howto/datasource-setting.md
@@ -25,7 +25,7 @@ export SPRING_DATASOURCE_PASSWORD={password}
 
 DolphinScheduler stores metadata in `relational database`. Currently, we support `PostgreSQL` and `MySQL`. Let's walk through how to initialize the database in `MySQL` and `PostgreSQL` :
 
-> If you use MySQL, you need to manually download [mysql-connector-java driver][mysql] (8.0.16) and move it to the libs directory of DolphinScheduler which is `api-server/libs` and `alert-server/libs` and `master-server/libs` and `worker-server/libs`.
+> If you use MySQL, you need to manually download [mysql-connector-java driver][mysql] (8.0.16) and move it to the libs directory of DolphinScheduler which is `api-server/libs` and `alert-server/libs` and `master-server/libs` and `worker-server/libs` and `tools/libs`.
 
 For mysql 5.6 / 5.7
 

--- a/docs/docs/zh/guide/howto/datasource-setting.md
+++ b/docs/docs/zh/guide/howto/datasource-setting.md
@@ -24,7 +24,7 @@ export SPRING_DATASOURCE_PASSWORD={password}
 
 DolphinScheduler 元数据存储在关系型数据库中，目前支持 PostgreSQL 和 MySQL。下面分别介绍如何使用 MySQL 和 PostgresQL 初始化数据库。
 
-> 如果使用 MySQL 需要手动下载 [mysql-connector-java 驱动][mysql] (8.0.16) 并移动到 DolphinScheduler 的每个模块的 libs 目录下，其中包括 `api-server/libs` 和 `alert-server/libs` 和 `master-server/libs` 和 `worker-server/libs` 和 `worker-server/libs` 和 `tools/libs`。
+> 如果使用 MySQL 需要手动下载 [mysql-connector-java 驱动][mysql] (8.0.16) 并移动到 DolphinScheduler 的每个模块的 libs 目录下，其中包括 `api-server/libs` 和 `alert-server/libs` 和 `master-server/libs` 和 `worker-server/libs` 和 `tools/libs`。
 
 对于mysql 5.6 / 5.7：
 

--- a/docs/docs/zh/guide/howto/datasource-setting.md
+++ b/docs/docs/zh/guide/howto/datasource-setting.md
@@ -24,7 +24,7 @@ export SPRING_DATASOURCE_PASSWORD={password}
 
 DolphinScheduler 元数据存储在关系型数据库中，目前支持 PostgreSQL 和 MySQL。下面分别介绍如何使用 MySQL 和 PostgresQL 初始化数据库。
 
-> 如果使用 MySQL 需要手动下载 [mysql-connector-java 驱动][mysql] (8.0.16) 并移动到 DolphinScheduler 的每个模块的 libs 目录下，其中包括 `api-server/libs` 和 `alert-server/libs` 和 `master-server/libs` 和 `worker-server/libs`。
+> 如果使用 MySQL 需要手动下载 [mysql-connector-java 驱动][mysql] (8.0.16) 并移动到 DolphinScheduler 的每个模块的 libs 目录下，其中包括 `api-server/libs` 和 `alert-server/libs` 和 `master-server/libs` 和 `worker-server/libs` 和 `worker-server/libs` 和 `tools/libs`。
 
 对于mysql 5.6 / 5.7：
 


### PR DESCRIPTION
When initializing and creating related tables for the first time, the support of related jdbc drivers is required. This article omits placing jdbc drivers in the tools directory.

**command**: `bash tools/bin/upgrade-schema.sh`

**problem**: `Cannot load driver class: com.mysql.cj.jdbc.Driver`

