### PR TITLE
[fix-14073][pom] fix project root pom's alert-plugin and registry-plugin dependency not exist problem.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,13 +115,15 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
-                <artifactId>dolphinscheduler-alert-plugin</artifactId>
+                <artifactId>dolphinscheduler-alert-plugins</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>
-                <artifactId>dolphinscheduler-registry-plugin</artifactId>
+                <artifactId>dolphinscheduler-registry-plugins</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dolphinscheduler</groupId>


### PR DESCRIPTION
bug fix pom dependency not exist problems
https://github.com/apache/dolphinscheduler/issues/14073