### PR TITLE
[Improvement-14080][script] cleanup dist directory at the beginning of check-LICENSE.sh

### DIFF
--- a/tools/dependencies/check-LICENSE.sh
+++ b/tools/dependencies/check-LICENSE.sh
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+if [ -d "dist" ];then
+rm -rf dist
+fi
 mkdir dist || true
 
 tar -zxf dolphinscheduler-dist/target/apache-dolphinscheduler*-bin.tar.gz --strip=1 -C dist


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request

* close: #14080 

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

* cleanup dist directory at the beginning of check-LICENSE.sh
* Avoid the interference of the pre-existing `dist` directory on the LICENSE check results

## Verify this pull request


<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

