### PR TITLE
[Fix-13615]Built-in parameters in sql cannot be executed

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -482,7 +482,7 @@ public class SqlTask extends AbstractTask {
         sql = ParameterUtils.replaceScheduleTime(sql,
                 DateUtils.timeStampToDate(taskExecutionContext.getScheduleTime()));
         // combining local and global parameters
-        Map<String, Property> paramsMap = taskExecutionContext.getPrepareParamsMap();
+        Map<String, Property> paramsMap = ParamUtils.convert(taskExecutionContext, getParameters());
 
         // spell SQL according to the final user-defined variable
         if (paramsMap == null) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler. Please review https://dolphinscheduler.apache.org/en-us/community/development/pull-request.html before opening a pull request.-->

## Purpose of the pull request
This pull request closes #13615 

## Brief change log
Replace params get method of ds 2.x version `ParamUtils.convert(taskExecutionContext, getParameters())` with `taskExecutionContext.getPrepareParamsMap()` in `SqlTask`

## Verify this pull request
UT
