### PR TITLE
chore: roadmap should not label stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,7 +33,7 @@ jobs:
           days-before-issue-stale: 30
           days-before-issue-close: 7
           # We do not stale Issues with label `Waiting for reply`, `feature` and `DSIP`
-          exempt-issue-labels: 'Waiting for reply,feature,DSIP,security'
+          exempt-issue-labels: 'Waiting for reply,feature,DSIP,security,roadmap'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had recent activity
             for 30 days. It will be closed in next 7 days if no further activity occurs.


### PR DESCRIPTION
The issue with roadmap label should not be set stale. https://github.com/apache/dolphinscheduler/issues/13459#issuecomment-1521096965