### PR TITLE
[fix-#14169]The subprocess type node is always in the ```ready pause``` or ``` ready stop ``` state

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/SubTaskProcessor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/SubTaskProcessor.java
@@ -178,7 +178,8 @@ public class SubTaskProcessor extends BaseTaskProcessor {
     private boolean pauseSubWorkFlow() {
         ProcessInstance subProcessInstance =
                 processService.findSubProcessInstance(processInstance.getId(), taskInstance.getId());
-        if (subProcessInstance == null || taskInstance.getState().isFinished()) {
+        if (subProcessInstance == null || taskInstance.getState().isFinished()
+                || subProcessInstance.getState().isFinished()) {
             return false;
         }
         subProcessInstance.setStateWithDesc(WorkflowExecutionStatus.READY_PAUSE, "ready pause sub workflow");
@@ -214,7 +215,8 @@ public class SubTaskProcessor extends BaseTaskProcessor {
     protected boolean killTask() {
         ProcessInstance subProcessInstance =
                 processService.findSubProcessInstance(processInstance.getId(), taskInstance.getId());
-        if (subProcessInstance == null || taskInstance.getState().isFinished()) {
+        if (subProcessInstance == null || taskInstance.getState().isFinished()
+                || subProcessInstance.getState().isFinished()) {
             return false;
         }
         subProcessInstance.setStateWithDesc(WorkflowExecutionStatus.READY_STOP, "ready stop by kill task");


### PR DESCRIPTION


## Purpose of the pull request

this close : #14169
- #14169 

## Brief change log



## Verify this pull request



This pull request is code cleanup without any test coverage.

