### PR TITLE
fix: default datax plugin

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxUtils.java
@@ -68,11 +68,9 @@ public class DataxUtils {
             case CLICKHOUSE:
                 return DATAX_READER_PLUGIN_CLICKHOUSE;
             case HIVE:
-                return DATAX_READER_PLUGIN_RDBMS;
             case PRESTO:
-                return DATAX_READER_PLUGIN_RDBMS;
             default:
-                return null;
+                return DATAX_READER_PLUGIN_RDBMS;
         }
     }
 
@@ -91,11 +89,9 @@ public class DataxUtils {
             case DATABEND:
                 return DATAX_WRITER_PLUGIN_DATABEND;
             case HIVE:
-                return DATAX_WRITER_PLUGIN_RDBMS;
             case PRESTO:
-                return DATAX_WRITER_PLUGIN_RDBMS;
             default:
-                return null;
+                return DATAX_WRITER_PLUGIN_RDBMS;
         }
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
This pr fix default datax plugin, using RDBMS as default.
Fix https://github.com/apache/dolphinscheduler/issues/14180

