### PR TITLE
[bug][plugin]Fix: Correct the way to determine the yarn queue in Flink CommandLine and SQL mode

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -302,7 +302,7 @@ public class FlinkArgsUtils {
     }
 
     private static void determinedYarnQueue(List<String> args, FlinkParameters flinkParameters,
-                                     FlinkDeployMode deployMode, String flinkVersion) {
+                                            FlinkDeployMode deployMode, String flinkVersion) {
         switch (deployMode) {
             case CLUSTER:
                 if (FLINK_VERSION_AFTER_OR_EQUALS_1_12.equals(flinkVersion)

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -165,7 +165,7 @@ public class FlinkArgsUtils {
 
             // yarn.application.queue
             String others = flinkParameters.getOthers();
-            if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE)) {
+            if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_MODE)) {
                 String queue = flinkParameters.getQueue();
                 if (StringUtils.isNotEmpty(queue)) {
                     initOptions.add(String.format(FlinkConstants.FLINK_FORMAT_YARN_APPLICATION_QUEUE, queue));
@@ -186,6 +186,8 @@ public class FlinkArgsUtils {
                                                              FlinkParameters flinkParameters) {
         List<String> args = new ArrayList<>();
 
+        String others = flinkParameters.getOthers();
+
         args.add(FlinkConstants.FLINK_COMMAND);
         FlinkDeployMode deployMode = Optional.ofNullable(flinkParameters.getDeployMode()).orElse(DEFAULT_DEPLOY_MODE);
         String flinkVersion = flinkParameters.getFlinkVersion();
@@ -197,16 +199,41 @@ public class FlinkArgsUtils {
                     args.add(FlinkConstants.FLINK_RUN); // run
                     args.add(FlinkConstants.FLINK_EXECUTION_TARGET); // -t
                     args.add(FlinkConstants.FLINK_YARN_PER_JOB); // yarn-per-job
+
+                    if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_TARGETS)) {
+                        String queue = flinkParameters.getQueue();
+                        if (StringUtils.isNotEmpty(queue)) { // -Dyarn.application.queue=%s
+                            args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS, queue));
+                        }
+                    }
+
                 } else {
                     args.add(FlinkConstants.FLINK_RUN); // run
                     args.add(FlinkConstants.FLINK_RUN_MODE); // -m
                     args.add(FlinkConstants.FLINK_YARN_CLUSTER); // yarn-cluster
+
+                    if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_MODE)) {
+                        String queue = flinkParameters.getQueue();
+                        if (StringUtils.isNotEmpty(queue)) { // -yqu
+                            args.add(FlinkConstants.FLINK_QUEUE_FOR_MODE);
+                            args.add(queue);
+                        }
+                    }
+
                 }
                 break;
             case APPLICATION:
                 args.add(FlinkConstants.FLINK_RUN_APPLICATION); // run-application
                 args.add(FlinkConstants.FLINK_EXECUTION_TARGET); // -t
                 args.add(FlinkConstants.FLINK_YARN_APPLICATION); // yarn-application
+
+                if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_TARGETS)) {
+                    String queue = flinkParameters.getQueue();
+                    if (StringUtils.isNotEmpty(queue)) { // -Dyarn.application.queue=%s
+                        args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS, queue));
+                    }
+                }
+
                 break;
             case LOCAL:
                 args.add(FlinkConstants.FLINK_RUN); // run
@@ -215,8 +242,6 @@ public class FlinkArgsUtils {
                 args.add(FlinkConstants.FLINK_RUN); // run
                 break;
         }
-
-        String others = flinkParameters.getOthers();
 
         // build args
         switch (deployMode) {
@@ -254,13 +279,6 @@ public class FlinkArgsUtils {
                     args.add(taskManagerMemory);
                 }
 
-                if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE)) {
-                    String queue = flinkParameters.getQueue();
-                    if (StringUtils.isNotEmpty(queue)) { // -yqu
-                        args.add(FlinkConstants.FLINK_QUEUE);
-                        args.add(queue);
-                    }
-                }
                 break;
             case LOCAL:
                 break;

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -303,7 +303,6 @@ public class FlinkArgsUtils {
 
     private static void determinedYarnQueue(List<String> args, FlinkParameters flinkParameters,
                                      FlinkDeployMode deployMode, String flinkVersion) {
-        String others = flinkParameters.getOthers();
         switch (deployMode) {
             case CLUSTER:
                 if (FLINK_VERSION_AFTER_OR_EQUALS_1_12.equals(flinkVersion)

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -321,7 +321,7 @@ public class FlinkArgsUtils {
         String others = flinkParameters.getOthers();
         if (StringUtils.isEmpty(others) || !others.contains(option)) {
             String queue = flinkParameters.getQueue();
-            if (StringUtils.isNotEmpty(queue)) { // -Dyarn.application.queue=%s
+            if (StringUtils.isNotEmpty(queue)) {
                 switch (option) {
                     case FlinkConstants.FLINK_QUEUE_FOR_TARGETS:
                         args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS, queue));

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -183,8 +183,6 @@ public class FlinkArgsUtils {
                                                              FlinkParameters flinkParameters) {
         List<String> args = new ArrayList<>();
 
-        String others = flinkParameters.getOthers();
-
         args.add(FlinkConstants.FLINK_COMMAND);
         FlinkDeployMode deployMode = Optional.ofNullable(flinkParameters.getDeployMode()).orElse(DEFAULT_DEPLOY_MODE);
         String flinkVersion = flinkParameters.getFlinkVersion();
@@ -196,19 +194,16 @@ public class FlinkArgsUtils {
                     args.add(FlinkConstants.FLINK_RUN); // run
                     args.add(FlinkConstants.FLINK_EXECUTION_TARGET); // -t
                     args.add(FlinkConstants.FLINK_YARN_PER_JOB); // yarn-per-job
-
                 } else {
                     args.add(FlinkConstants.FLINK_RUN); // run
                     args.add(FlinkConstants.FLINK_RUN_MODE); // -m
                     args.add(FlinkConstants.FLINK_YARN_CLUSTER); // yarn-cluster
-
                 }
                 break;
             case APPLICATION:
                 args.add(FlinkConstants.FLINK_RUN_APPLICATION); // run-application
                 args.add(FlinkConstants.FLINK_EXECUTION_TARGET); // -t
                 args.add(FlinkConstants.FLINK_YARN_APPLICATION); // yarn-application
-
                 break;
             case LOCAL:
                 args.add(FlinkConstants.FLINK_RUN); // run
@@ -217,6 +212,8 @@ public class FlinkArgsUtils {
                 args.add(FlinkConstants.FLINK_RUN); // run
                 break;
         }
+
+        String others = flinkParameters.getOthers();
 
         // build args
         switch (deployMode) {
@@ -311,28 +308,28 @@ public class FlinkArgsUtils {
             case CLUSTER:
                 if (FLINK_VERSION_AFTER_OR_EQUALS_1_12.equals(flinkVersion)
                         || FLINK_VERSION_AFTER_OR_EQUALS_1_13.equals(flinkVersion)) {
-                    if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_TARGETS)) {
-                        String queue = flinkParameters.getQueue();
-                        if (StringUtils.isNotEmpty(queue)) { // -Dyarn.application.queue=%s
-                            args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS, queue));
-                        }
-                    }
+                    doAddQueue(args, flinkParameters, FlinkConstants.FLINK_QUEUE_FOR_TARGETS);
                 } else {
-                    if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_MODE)) {
-                        String queue = flinkParameters.getQueue();
-                        if (StringUtils.isNotEmpty(queue)) { // -yqu
-                            args.add(FlinkConstants.FLINK_QUEUE_FOR_MODE);
-                            args.add(queue);
-                        }
-                    }
+                    doAddQueue(args, flinkParameters, FlinkConstants.FLINK_QUEUE_FOR_MODE);
                 }
             case APPLICATION:
-                if (StringUtils.isEmpty(others) || !others.contains(FlinkConstants.FLINK_QUEUE_FOR_TARGETS)) {
-                    String queue = flinkParameters.getQueue();
-                    if (StringUtils.isNotEmpty(queue)) { // -Dyarn.application.queue=%s
+                doAddQueue(args, flinkParameters, FlinkConstants.FLINK_QUEUE_FOR_TARGETS);
+        }
+    }
+
+    private static void doAddQueue(List<String> args, FlinkParameters flinkParameters, String option) {
+        String others = flinkParameters.getOthers();
+        if (StringUtils.isEmpty(others) || !others.contains(option)) {
+            String queue = flinkParameters.getQueue();
+            if (StringUtils.isNotEmpty(queue)) { // -Dyarn.application.queue=%s
+                switch (option) {
+                    case FlinkConstants.FLINK_QUEUE_FOR_TARGETS:
                         args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS, queue));
-                    }
+                    case FlinkConstants.FLINK_QUEUE_FOR_MODE:
+                        args.add(FlinkConstants.FLINK_QUEUE_FOR_MODE);
+                        args.add(queue);
                 }
+            }
         }
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkArgsUtils.java
@@ -324,7 +324,7 @@ public class FlinkArgsUtils {
             if (StringUtils.isNotEmpty(queue)) {
                 switch (option) {
                     case FlinkConstants.FLINK_QUEUE_FOR_TARGETS:
-                        args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS, queue));
+                        args.add(String.format(FlinkConstants.FLINK_QUEUE_FOR_TARGETS + "=%s", queue));
                     case FlinkConstants.FLINK_QUEUE_FOR_MODE:
                         args.add(FlinkConstants.FLINK_QUEUE_FOR_MODE);
                         args.add(queue);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkConstants.java
@@ -49,7 +49,7 @@ public class FlinkConstants {
     public static final String FLINK_YARN_SLOT = "-ys";
     public static final String FLINK_APP_NAME = "-ynm";
     public static final String FLINK_QUEUE_FOR_MODE = "-yqu";
-    public static final String FLINK_QUEUE_FOR_TARGETS = "-Dyarn.application.queue=%s";
+    public static final String FLINK_QUEUE_FOR_TARGETS = "-Dyarn.application.queue";
     public static final String FLINK_TASK_MANAGE = "-yn";
     public static final String FLINK_JOB_MANAGE_MEM = "-yjm";
     public static final String FLINK_TASK_MANAGE_MEM = "-ytm";

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkConstants.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkConstants.java
@@ -48,7 +48,8 @@ public class FlinkConstants {
     public static final String FLINK_EXECUTION_TARGET = "-t";
     public static final String FLINK_YARN_SLOT = "-ys";
     public static final String FLINK_APP_NAME = "-ynm";
-    public static final String FLINK_QUEUE = "-yqu";
+    public static final String FLINK_QUEUE_FOR_MODE = "-yqu";
+    public static final String FLINK_QUEUE_FOR_TARGETS = "-Dyarn.application.queue=%s";
     public static final String FLINK_TASK_MANAGE = "-yn";
     public static final String FLINK_JOB_MANAGE_MEM = "-yjm";
     public static final String FLINK_TASK_MANAGE_MEM = "-ytm";


### PR DESCRIPTION
## Purpose of the pull request
Correct the way to determine the yarn queue in Flink CommandLine.

closed #14236

## Brief change log

In Flink command line with -t option, Yarn queue should be determined by -Dyarn.application.name=%s rather than -yqu.

## Verify this pull request

This pull request is code cleanup without any test coverage. I test it manually.
![image](https://github.com/apache/dolphinscheduler/assets/30034544/3341ed90-b96a-4daa-926f-958b6dfe4179)

