### PR TITLE
[Bug] [Seatunnel] Run Mode defaults to run, and you cannot select a n…

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkParameters.java
@@ -34,7 +34,7 @@ public class SeatunnelFlinkParameters extends SeatunnelParameters {
 
     @Getter
     public enum RunModeEnum {
-
+        NONE("none"),
         RUN("--run-mode run"),
         RUN_APPLICATION("--run-mode run-application");
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkTask.java
@@ -44,9 +44,11 @@ public class SeatunnelFlinkTask extends SeatunnelTask {
     @Override
     public List<String> buildOptions() throws Exception {
         List<String> args = super.buildOptions();
-        args.add(
-                Objects.isNull(seatunnelParameters.getRunMode()) ? SeatunnelFlinkParameters.RunModeEnum.RUN.getCommand()
-                        : seatunnelParameters.getRunMode().getCommand());
+
+        if(!(Objects.nonNull(seatunnelParameters.getRunMode())&& SeatunnelFlinkParameters.RunModeEnum.NONE.equals(seatunnelParameters.getRunMode()))){
+            args.add(Objects.isNull(seatunnelParameters.getRunMode()) ? SeatunnelFlinkParameters.RunModeEnum.RUN.getCommand() : seatunnelParameters.getRunMode().getCommand());
+        }
+
         if (StringUtils.isNotBlank(seatunnelParameters.getOthers())) {
             args.add(seatunnelParameters.getOthers());
         }

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-sea-tunnel.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-sea-tunnel.ts
@@ -197,6 +197,10 @@ export const STARTUP_SCRIPT = [
 
 export const FLINK_RUN_MODE = [
   {
+    label: 'none',
+    value: 'NONE'
+  },
+  {
     label: 'run',
     value: 'RUN'
   },


### PR DESCRIPTION
…ull value
https://github.com/apache/dolphinscheduler/issues/14250

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
When Dolphinscheduler creates a seattunnel task, if the Flink startup script is used, the Run Mode defaults to run, and a null value cannot be selected. As a result of this operation, when seatunnel invokes the Flink service to perform tasks, --run-mode run will be spliced by default in the execution command, but the run-mode parameter is not supported in multiple flink versions (tested 1.13 1.14 1.15 1.16 1.17), and finally Task execution failed.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request


<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
