### PR TITLE
chore: Remove EOL issue version and add prepare one

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -100,8 +100,7 @@ body:
       options:
         - dev
         - 3.1.x
-        - 3.0.x
-        - 2.0.x
+        - 3.2.0-prepare
     validations:
       required: true
 


### PR DESCRIPTION
* due to we release the last version of 2.0.x and 3.0.x, we do not accept bug report for them now.
* Add new version 3.2.0-prepare for testing the incoming verison 3.2.0-prepare
