### PR TITLE
[Improvement-14282][Task] Add app_link on the ui of task instance

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -260,6 +260,7 @@ export default {
     retry_count: 'Retry Count',
     dry_run_flag: 'Dry Run Flag',
     host: 'Host',
+    app_link: 'External Application Link',
     operation: 'Operation',
     edit: 'Edit',
     delete: 'Delete',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -259,6 +259,7 @@ export default {
     duration: '运行时间',
     retry_count: '重试次数',
     dry_run_flag: '空跑标识',
+    app_link: '外部应用链接',
     host: '主机',
     operation: '操作',
     edit: '编辑',

--- a/dolphinscheduler-ui/src/views/projects/task/instance/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/instance/types.ts
@@ -32,6 +32,7 @@ interface IRecord {
   retryTimes: number
   dryRun: number
   host: string
+  appLink: string
   testFlag?: number
 }
 

--- a/dolphinscheduler-ui/src/views/projects/task/instance/use-table.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/instance/use-table.ts
@@ -188,6 +188,12 @@ export function useTable() {
         render: (row: IRecord) => row.host || '-'
       },
       {
+        title: t('project.task.app_link'),
+        key: 'appLink',
+        ...COLUMN_WIDTH_CONFIG['name'],
+        render: (row: IRecord) => row.appLink || '-'
+      },
+      {
         title: t('project.task.operation'),
         key: 'operation',
         ...COLUMN_WIDTH_CONFIG['operation'](3),


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

* close: #14282 
* It allows users to intuitively see the external application link (E.g., Yarn App ID) corresponding to the task instance

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<img width="1503" alt="截屏2023-06-06 15 04 17" src="https://github.com/apache/dolphinscheduler/assets/38122586/d8865d52-83a6-4f6f-aed2-cfe275c3497b">


<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
