### PR TITLE
Remove StateCheck for SubProcess/DependTask

### DIFF
--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -270,7 +270,7 @@ Location: `master-server/conf/application.yaml`
 |master.heartbeat-interval|10|master heartbeat interval, the unit is second|
 |master.task-commit-retry-times|5|master commit task retry times|
 |master.task-commit-interval|1000|master commit task interval, the unit is millisecond|
-|master.state-wheel-interval|5|time to check status|
+|master.state-wheel-interval|500|time to check status, the unit is millisecond|
 |master.max-cpu-load-avg|-1|master max CPU load avg, only higher than the system CPU load average, master server can schedule. default value -1: the number of CPU cores * 2|
 |master.reserved-memory|0.3|master reserved memory, only lower than system available memory, master server can schedule. default value 0.3, the unit is G|
 |master.failover-interval|10|failover interval, the unit is minute|

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -265,7 +265,7 @@ common.properties配置文件目前主要是配置hadoop/s3/yarn相关的配置�
 |master.heartbeat-interval|10|master心跳间隔,单位为秒|
 |master.task-commit-retry-times|5|任务重试次数|
 |master.task-commit-interval|1000|任务提交间隔,单位为毫秒|
-|master.state-wheel-interval|5|轮询检查状态时间|
+|master.state-wheel-interval|500|轮询检查状态时间,单位为毫秒|
 |master.max-cpu-load-avg|-1|master最大cpuload均值,只有高于系统cpuload均值时,master服务才能调度任务. 默认值为-1: cpu cores * 2|
 |master.reserved-memory|0.3|master预留内存,只有低于系统可用内存时,master服务才能调度任务,单位为G|
 |master.failover-interval|10|failover间隔，单位为分钟|

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/config/MasterConfig.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/config/MasterConfig.java
@@ -84,7 +84,7 @@ public class MasterConfig implements Validator {
     /**
      * state wheel check interval, if this value is bigger, may increase the delay of task/processInstance.
      */
-    private Duration stateWheelInterval = Duration.ofMillis(5);
+    private Duration stateWheelInterval = Duration.ofMillis(500);
     private double maxCpuLoadAvg = -1;
     private double reservedMemory = 0.3;
     private Duration failoverInterval = Duration.ofMinutes(10);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/StateWheelExecuteThread.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/StateWheelExecuteThread.java
@@ -401,7 +401,7 @@ public class StateWheelExecuteThread extends BaseDaemonThread {
                 .type(StateEventType.TASK_STATE_CHANGE)
                 .status(TaskExecutionStatus.RUNNING_EXECUTION)
                 .build();
-        workflowExecuteThreadPool.submitStateEvent(stateEvent);
+        workflowExecuteThreadPool.submitStateEvent(stateEvent, false);
     }
 
     private void addProcessStopEvent(ProcessInstance processInstance) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/StateWheelExecuteThread.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/StateWheelExecuteThread.java
@@ -72,6 +72,11 @@ public class StateWheelExecuteThread extends BaseDaemonThread {
      */
     private final ConcurrentLinkedQueue<TaskInstanceKey> taskInstanceRetryCheckList = new ConcurrentLinkedQueue<>();
 
+    /**
+     * task state check list
+     */
+    private final ConcurrentLinkedQueue<TaskInstanceKey> taskInstanceStateCheckList = new ConcurrentLinkedQueue<>();
+
     @Autowired
     private MasterConfig masterConfig;
 
@@ -98,6 +103,7 @@ public class StateWheelExecuteThread extends BaseDaemonThread {
             try {
                 checkTask4Timeout();
                 checkTask4Retry();
+                checkTask4State();
                 checkProcess4Timeout();
             } catch (Exception e) {
                 logger.error("state wheel thread check error:", e);
@@ -209,10 +215,30 @@ public class StateWheelExecuteThread extends BaseDaemonThread {
         logger.info("remove task instance from retry check list");
     }
 
+    public void addTask4StateCheck(@NonNull ProcessInstance processInstance, @NonNull TaskInstance taskInstance) {
+        logger.info("Adding task instance into state check list");
+        TaskInstanceKey taskInstanceKey = TaskInstanceKey.getTaskInstanceKey(processInstance, taskInstance);
+        if (taskInstanceStateCheckList.contains(taskInstanceKey)) {
+            logger.warn("Task instance is already in state check list");
+            return;
+        }
+        if (taskInstance.isDependTask() || taskInstance.isSubProcess()) {
+            taskInstanceStateCheckList.add(taskInstanceKey);
+            logger.info("Added task instance into state check list");
+        }
+    }
+
+    public void removeTask4StateCheck(@NonNull ProcessInstance processInstance, @NonNull TaskInstance taskInstance) {
+        TaskInstanceKey taskInstanceKey = TaskInstanceKey.getTaskInstanceKey(processInstance, taskInstance);
+        taskInstanceStateCheckList.remove(taskInstanceKey);
+        logger.info("Removed task instance from state check list");
+    }
+
     public void clearAllTasks() {
         processInstanceTimeoutCheckList.clear();
         taskInstanceTimeoutCheckList.clear();
         taskInstanceRetryCheckList.clear();
+        taskInstanceStateCheckList.clear();
     }
 
     private void checkTask4Timeout() {
@@ -326,6 +352,56 @@ public class StateWheelExecuteThread extends BaseDaemonThread {
                 LoggerUtils.removeWorkflowInstanceIdMDC();
             }
         }
+    }
+
+    private void checkTask4State() {
+        if (taskInstanceStateCheckList.isEmpty()) {
+            return;
+        }
+        for (TaskInstanceKey taskInstanceKey : taskInstanceStateCheckList) {
+            int processInstanceId = taskInstanceKey.getProcessInstanceId();
+            long taskCode = taskInstanceKey.getTaskCode();
+
+            try {
+                LoggerUtils.setTaskInstanceIdMDC(processInstanceId);
+                WorkflowExecuteRunnable workflowExecuteThread =
+                        processInstanceExecCacheManager.getByProcessInstanceId(processInstanceId);
+                if (workflowExecuteThread == null) {
+                    logger.warn(
+                            "Task instance state check failed, can not find workflowExecuteThread from cache manager, will remove this check task");
+                    taskInstanceStateCheckList.remove(taskInstanceKey);
+                    continue;
+                }
+                Optional<TaskInstance> taskInstanceOptional =
+                        workflowExecuteThread.getActiveTaskInstanceByTaskCode(taskCode);
+                if (!taskInstanceOptional.isPresent()) {
+                    logger.warn(
+                            "Task instance state check failed, can not find taskInstance from workflowExecuteThread, will remove this check event");
+                    taskInstanceStateCheckList.remove(taskInstanceKey);
+                    continue;
+                }
+                TaskInstance taskInstance = taskInstanceOptional.get();
+                if (taskInstance.getState().isFinished()) {
+                    continue;
+                }
+                addTaskStateChangeEvent(taskInstance);
+            } catch (Exception ex) {
+                logger.error("Task state check error, taskInstanceKey: {}", taskInstanceKey, ex);
+            } finally {
+                LoggerUtils.removeWorkflowInstanceIdMDC();
+            }
+        }
+    }
+
+    private void addTaskStateChangeEvent(TaskInstance taskInstance) {
+        TaskStateEvent stateEvent = TaskStateEvent.builder()
+                .processInstanceId(taskInstance.getProcessInstanceId())
+                .taskInstanceId(taskInstance.getId())
+                .taskCode(taskInstance.getTaskCode())
+                .type(StateEventType.TASK_STATE_CHANGE)
+                .status(TaskExecutionStatus.RUNNING_EXECUTION)
+                .build();
+        workflowExecuteThreadPool.submitStateEvent(stateEvent);
     }
 
     private void addProcessStopEvent(ProcessInstance processInstance) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -388,7 +388,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
             activeTaskProcessorMaps.remove(taskInstance.getTaskCode());
             stateWheelExecuteThread.removeTask4TimeoutCheck(processInstance, taskInstance);
             stateWheelExecuteThread.removeTask4RetryCheck(processInstance, taskInstance);
-            stateWheelExecuteThread.removeTask4StateCheck(processInstance, taskInstance);
 
             if (taskInstance.getState().isSuccess()) {
                 completeTaskMap.put(taskInstance.getTaskCode(), taskInstance.getId());
@@ -990,7 +989,6 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
             taskProcessor.action(TaskAction.RUN);
 
             stateWheelExecuteThread.addTask4TimeoutCheck(processInstance, taskInstance);
-            stateWheelExecuteThread.addTask4StateCheck(processInstance, taskInstance);
 
             if (taskProcessor.taskInstance().getState().isFinished()) {
                 if (processInstance.isBlocked()) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -331,6 +331,17 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
         return true;
     }
 
+    public boolean addUniqueStateEvent(StateEvent stateEvent) {
+        if (processInstance.getId() != stateEvent.getProcessInstanceId()) {
+            logger.info("state event would be abounded :{}", stateEvent);
+            return false;
+        }
+        if (!stateEvents.contains(stateEvent)) {
+            this.stateEvents.add(stateEvent);
+        }
+        return true;
+    }
+
     public int eventSize() {
         return this.stateEvents.size();
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -388,6 +388,7 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
             activeTaskProcessorMaps.remove(taskInstance.getTaskCode());
             stateWheelExecuteThread.removeTask4TimeoutCheck(processInstance, taskInstance);
             stateWheelExecuteThread.removeTask4RetryCheck(processInstance, taskInstance);
+            stateWheelExecuteThread.removeTask4StateCheck(processInstance, taskInstance);
 
             if (taskInstance.getState().isSuccess()) {
                 completeTaskMap.put(taskInstance.getTaskCode(), taskInstance.getId());
@@ -989,6 +990,7 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatue> {
             taskProcessor.action(TaskAction.RUN);
 
             stateWheelExecuteThread.addTask4TimeoutCheck(processInstance, taskInstance);
+            stateWheelExecuteThread.addTask4StateCheck(processInstance, taskInstance);
 
             if (taskProcessor.taskInstance().getState().isFinished()) {
                 if (processInstance.isBlocked()) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
@@ -97,12 +97,15 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
                     stateEvent);
             return;
         }
+        boolean submitRes;
         if (redundancyAllowed) {
-            workflowExecuteThread.addStateEvent(stateEvent);
+            submitRes = workflowExecuteThread.addStateEvent(stateEvent);
         } else {
-            workflowExecuteThread.addUniqueStateEvent(stateEvent);
+            submitRes = workflowExecuteThread.addUniqueStateEvent(stateEvent);
         }
-        logger.info("Submit state event success, stateEvent: {}", stateEvent);
+        if (submitRes) {
+            logger.info("Submit state event success, stateEvent: {}", stateEvent);
+        }
     }
 
     /**

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteThreadPool.java
@@ -86,6 +86,10 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
      * submit state event
      */
     public void submitStateEvent(StateEvent stateEvent) {
+        submitStateEvent(stateEvent, true);
+    }
+
+    public void submitStateEvent(StateEvent stateEvent, boolean redundancyAllowed) {
         WorkflowExecuteRunnable workflowExecuteThread =
                 processInstanceExecCacheManager.getByProcessInstanceId(stateEvent.getProcessInstanceId());
         if (workflowExecuteThread == null) {
@@ -93,7 +97,11 @@ public class WorkflowExecuteThreadPool extends ThreadPoolTaskExecutor {
                     stateEvent);
             return;
         }
-        workflowExecuteThread.addStateEvent(stateEvent);
+        if (redundancyAllowed) {
+            workflowExecuteThread.addStateEvent(stateEvent);
+        } else {
+            workflowExecuteThread.addUniqueStateEvent(stateEvent);
+        }
         logger.info("Submit state event success, stateEvent: {}", stateEvent);
     }
 


### PR DESCRIPTION
Remove StateCheck for SubProcess/DependTask which will cause task submission madness in the default state-wheel-interval configuration

Close https://github.com/apache/dolphinscheduler/issues/14262

In dev I found pr https://github.com/apache/dolphinscheduler/pull/14242 has already fix this. 
However, the description of PR14242 misses an important part: the statecheck can actually result in a large number of SubProcess/DependTask scenarios where the workflow cannot run successfully due to excessive task submission. This issue should be fixed in version 3.1.8, otherwise 3.1.x is not available with default parameters in such a scenario, `state-wheel-interval` is default 5 which will cause 200 statecheck task submitted in a second.

What's worse is that once the task is success, the previous state events are all in exception, cause slower event handling.
![image](https://github.com/apache/dolphinscheduler/assets/30034544/6702f8a0-6704-4d7c-9635-7d51e7db3ef9)

From my pratice, it can be stuck for 10+ hours.

cc @ruanwenjun @zhuangchong 

## Purpose of the pull request
Fix task submission madness in 3.1.x

## Brief change log
Remove StateCheck for SubProcess/DependTask

## Verify this pull request

This pull request is code cleanup without any test coverage.


