### PR TITLE
[Fix-14334][master] Fix the complement function does not generate the next running instances in parallel mode

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -732,8 +732,9 @@ public class WorkflowExecuteRunnable implements Callable<WorkflowSubmitStatus> {
         command.setProcessInstanceId(0);
         command.setProcessDefinitionVersion(processInstance.getProcessDefinitionVersion());
         command.setTestFlag(processInstance.getTestFlag());
+        int create = commandService.createCommand(command);
         processService.saveCommandTrigger(command.getId(), processInstance.getId());
-        return commandService.createCommand(command);
+        return create;
     }
 
     private boolean needComplementProcess() {


### PR DESCRIPTION
…ces in parallel mode

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #14334 

![iShot_2023-06-12_17 46 33](https://github.com/apache/dolphinscheduler/assets/37063904/3ed17262-6724-426c-9bae-98631cb67633)


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
