### PR TITLE
[Improvement-14464][Task] Remove the useless taskResultString

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -93,11 +93,6 @@ public abstract class AbstractCommandExecutor {
 
     protected boolean podLogOutputIsFinished = false;
 
-    /*
-     * SHELL result string
-     */
-    protected String taskResultString;
-
     /**
      * taskRequest
      */
@@ -370,7 +365,6 @@ public abstract class AbstractCommandExecutor {
                         varPool.append("$VarPool$");
                     } else {
                         logBuffer.add(line);
-                        taskResultString = line;
                     }
                 }
                 processLogOutputIsSuccess = true;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

* close: #14464 

## Brief change log

Remove the useless taskResultString

## Verify this pull request

