### PR TITLE
[Fix-14503][Worker] Fix the problem of subprocess cannot be killed

### DIFF
--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/WorkerTaskKillProcessor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/processor/WorkerTaskKillProcessor.java
@@ -85,6 +85,7 @@ public class WorkerTaskKillProcessor implements WorkerRpcProcessor {
                 return;
             }
 
+            boolean result = doKill(taskExecutionContext);
             this.cancelApplication(taskInstanceId);
 
             int processId = taskExecutionContext.getProcessId();
@@ -96,8 +97,6 @@ public class WorkerTaskKillProcessor implements WorkerRpcProcessor {
                 log.info("the task has not been executed and has been cancelled, task id:{}", taskInstanceId);
                 return;
             }
-
-            boolean result = doKill(taskExecutionContext);
 
             taskExecutionContext.setCurrentExecutionStatus(
                     result ? TaskExecutionStatus.SUCCESS : TaskExecutionStatus.FAILURE);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

* close: #14503 

## Brief change log

* `doKill()` must be running before `cancelApplication()` so that `pstree` could get all the sub process id and kill them

## Verify this pull request

<img width="511" alt="截屏2023-07-11 14 46 38" src="https://github.com/apache/dolphinscheduler/assets/38122586/aff6f7a5-eec3-4d09-822a-eabf9bf46773">
