### PR TITLE
[Improvement][Task Plugin] Improve to access https without ssl certificate for HttpTask

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HttpUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HttpUtils.java
@@ -83,7 +83,7 @@ public class HttpUtils {
 
     private static Registry<ConnectionSocketFactory> socketFactoryRegistry;
 
-    public static X509TrustManager xtm = new X509TrustManager() {
+    public final static X509TrustManager xtm = new X509TrustManager() {
 
         @Override
         public void checkClientTrusted(X509Certificate[] chain, String authType) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HttpUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HttpUtils.java
@@ -75,7 +75,7 @@ public class HttpUtils {
 
     private static PoolingHttpClientConnectionManager cm;
 
-    private static SSLContext ctx = null;
+    public static SSLContext ctx = null;
 
     private static SSLConnectionSocketFactory socketFactory;
 
@@ -83,7 +83,7 @@ public class HttpUtils {
 
     private static Registry<ConnectionSocketFactory> socketFactoryRegistry;
 
-    public final static X509TrustManager xtm = new X509TrustManager() {
+    private static X509TrustManager xtm = new X509TrustManager() {
 
         @Override
         public void checkClientTrusted(X509Certificate[] chain, String authType) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HttpUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HttpUtils.java
@@ -83,7 +83,7 @@ public class HttpUtils {
 
     private static Registry<ConnectionSocketFactory> socketFactoryRegistry;
 
-    private static X509TrustManager xtm = new X509TrustManager() {
+    public static X509TrustManager xtm = new X509TrustManager() {
 
         @Override
         public void checkClientTrusted(X509Certificate[] chain, String authType) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpParameters.java
@@ -70,8 +70,6 @@ public class HttpParameters extends AbstractParameters {
      */
     private int socketTimeout;
 
-    private Boolean enableSSL = false;
-
     @Override
     public boolean checkParameters() {
         return StringUtils.isNotEmpty(url);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpParameters.java
@@ -25,9 +25,12 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Data;
+
 /**
  * http parameter
  */
+@Data
 public class HttpParameters extends AbstractParameters {
 
     /**
@@ -67,6 +70,8 @@ public class HttpParameters extends AbstractParameters {
      */
     private int socketTimeout;
 
+    private Boolean enableSSL = false;
+
     @Override
     public boolean checkParameters() {
         return StringUtils.isNotEmpty(url);
@@ -75,61 +80,5 @@ public class HttpParameters extends AbstractParameters {
     @Override
     public List<ResourceInfo> getResourceFilesList() {
         return new ArrayList<>();
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public HttpMethod getHttpMethod() {
-        return httpMethod;
-    }
-
-    public void setHttpMethod(HttpMethod httpMethod) {
-        this.httpMethod = httpMethod;
-    }
-
-    public List<HttpProperty> getHttpParams() {
-        return httpParams;
-    }
-
-    public void setHttpParams(List<HttpProperty> httpParams) {
-        this.httpParams = httpParams;
-    }
-
-    public HttpCheckCondition getHttpCheckCondition() {
-        return httpCheckCondition;
-    }
-
-    public void setHttpCheckCondition(HttpCheckCondition httpCheckCondition) {
-        this.httpCheckCondition = httpCheckCondition;
-    }
-
-    public String getCondition() {
-        return condition;
-    }
-
-    public void setCondition(String condition) {
-        this.condition = condition;
-    }
-
-    public int getConnectTimeout() {
-        return connectTimeout;
-    }
-
-    public void setConnectTimeout(int connectTimeout) {
-        this.connectTimeout = connectTimeout;
-    }
-
-    public int getSocketTimeout() {
-        return socketTimeout;
-    }
-
-    public void setSocketTimeout(int socketTimeout) {
-        this.socketTimeout = socketTimeout;
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -40,6 +40,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -316,7 +317,7 @@ public class HttpTask extends AbstractTask {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, trustAllCerts, new SecureRandom());
             httpClientBuilder.setSSLContext(sslContext);
-            httpClientBuilder.setSSLHostnameVerifier((s, sslSession) -> true);
+            httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
         }
         httpClientBuilder.setDefaultRequestConfig(requestConfig);
         return httpClientBuilder.build();

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -289,7 +289,7 @@ public class HttpTask extends AbstractTask {
      *
      * @return CloseableHttpClient
      */
-    protected CloseableHttpClient createHttpClient() throws Exception {
+    protected CloseableHttpClient createHttpClient() {
         final RequestConfig requestConfig = requestConfig();
         HttpClientBuilder httpClientBuilder;
         httpClientBuilder = HttpClients.custom().setDefaultRequestConfig(requestConfig);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -297,7 +297,7 @@ public class HttpTask extends AbstractTask {
         final RequestConfig requestConfig = requestConfig();
         HttpClientBuilder httpClientBuilder;
         httpClientBuilder = HttpClients.custom().setDefaultRequestConfig(requestConfig);
-        if (httpParameters.getEnableSSL()) {
+        if (httpParameters.getUrl().startsWith("https://")) {
             TrustManager[] trustAllCerts = new TrustManager[]{HttpUtils.xtm};
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, trustAllCerts, new SecureRandom());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -51,14 +51,12 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -49,6 +49,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -299,14 +300,17 @@ public class HttpTask extends AbstractTask {
         if (httpParameters.getEnableSSL()) {
             TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
 
-                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
                     return null;
                 }
 
-                public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+                @Override
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
                 }
 
-                public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+                @Override
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
                 }
             }};
             SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.plugin.task.http;
 import static org.apache.dolphinscheduler.plugin.task.http.HttpTaskConstants.APPLICATION_JSON;
 
 import org.apache.dolphinscheduler.common.utils.DateUtils;
+import org.apache.dolphinscheduler.common.utils.HttpUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTask;
 import org.apache.dolphinscheduler.plugin.task.api.TaskCallBack;
@@ -299,21 +300,7 @@ public class HttpTask extends AbstractTask {
         HttpClientBuilder httpClientBuilder;
         httpClientBuilder = HttpClients.custom().setDefaultRequestConfig(requestConfig);
         if (httpParameters.getEnableSSL()) {
-            TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
-
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
-
-                @Override
-                public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                }
-
-                @Override
-                public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                }
-            }};
+            TrustManager[] trustAllCerts = new TrustManager[]{HttpUtils.xtm};
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, trustAllCerts, new SecureRandom());
             httpClientBuilder.setSSLContext(sslContext);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-http/src/main/java/org/apache/dolphinscheduler/plugin/task/http/HttpTask.java
@@ -50,13 +50,9 @@ import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -298,10 +294,7 @@ public class HttpTask extends AbstractTask {
         HttpClientBuilder httpClientBuilder;
         httpClientBuilder = HttpClients.custom().setDefaultRequestConfig(requestConfig);
         if (httpParameters.getUrl().startsWith("https://")) {
-            TrustManager[] trustAllCerts = new TrustManager[]{HttpUtils.xtm};
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, trustAllCerts, new SecureRandom());
-            httpClientBuilder.setSSLContext(sslContext);
+            httpClientBuilder.setSSLContext(HttpUtils.ctx);
             httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
         }
         httpClientBuilder.setDefaultRequestConfig(requestConfig);


### PR DESCRIPTION
`HttpTask`目前不支持添加证书访问https。由于需要去第三方机构花钱才能申请合法的证书，我们是否可以先实现一种不添加证书但是依然可以访问https的方法?  

`HttpTask` does not support to add ssl certificate to access https currently, we need to spend money to apply for a legitimate certificate from a third-party organization, could we first have an implementation that able to access https without ssl certificate?