### PR TITLE
ci: Require up to date before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,8 @@ github:
   protected_branches:
     dev:
       required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
         contexts:
           - Build
           - Unit Test


### PR DESCRIPTION
closed #14412

We can do that by turn on update to date for each PR ref https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch but it will take our maintainer much time and ci workflow more crowded