### PR TITLE
[Fix][SeaTunnel] Fix wrong judgment condition when building parameters of seatunnel task node.

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkTask.java
@@ -44,13 +44,12 @@ public class SeatunnelFlinkTask extends SeatunnelTask {
     @Override
     public List<String> buildOptions() throws Exception {
         List<String> args = super.buildOptions();
-        if (!(Objects.isNull(seatunnelParameters.getRunMode())
-                && SeatunnelFlinkParameters.RunModeEnum.NONE.equals(seatunnelParameters.getRunMode()))) {
-            args.add(
-                    Objects.isNull(seatunnelParameters.getRunMode())
-                            ? SeatunnelFlinkParameters.RunModeEnum.RUN.getCommand()
-                            : seatunnelParameters.getRunMode().getCommand());
+
+        if (Objects.nonNull(seatunnelParameters.getRunMode())
+                && !SeatunnelFlinkParameters.RunModeEnum.NONE.equals(seatunnelParameters.getRunMode())) {
+            args.add(seatunnelParameters.getRunMode().getCommand());
         }
+
         if (StringUtils.isNotBlank(seatunnelParameters.getOthers())) {
             args.add(seatunnelParameters.getOthers());
         }


### PR DESCRIPTION
…sk node.

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

the related: #14267 

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
