### PR TITLE
[DISCUSS]ci: Mergeable must have ready-to-merge and not require version

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -58,5 +58,5 @@ mergeable:
               regex: 'feature|bug|improvement|document|chore'
               message: 'Label must include one of the following: `feature`, `bug`, `improvement`, `document`, `chore`'
           - must_include:
-              regex: '\d+\.\d+\.\w+'
-              message: 'Label must include one or more version numbers.'
+              regex: 'ready-to-merge'
+              message: 'Please check if there are PRs that already have a `ready-to-merge` label and can be merged, if exists please merge them first.'


### PR DESCRIPTION
you can see our init discuss in https://lists.apache.org/thread/xgcd3wndfst88ornvdknd64nol76k89n

If your guys think using `read-to-merge` label is a good idea, I will add a new rule to our [mergeable bot](https://github.com/apache/dolphinscheduler/blob/dev/.github/mergeable.yml),  And BTW, I think we can remove some existing merging rules in mergeable too, such as we [do not need versions](https://github.com/apache/dolphinscheduler/blob/8505f1878d4b3cfc12e9ede8ea394a31c9a0d6fb/.github/mergeable.yml#L60-L62) anymore because we will not release more than one version so frequently in these cases I think using milestone rule(already exists) is enough. and it can reduce one label check for committer