### PR TITLE
[fix-14515][Bug][api] Get dqRules entry failed in postgres database

### DIFF
--- a/dolphinscheduler-api/src/test/resources/application.yaml
+++ b/dolphinscheduler-api/src/test/resources/application.yaml
@@ -20,7 +20,7 @@ spring:
     banner-mode: off
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;INIT=runscript from 'classpath:sql/dolphinscheduler_h2.sql'
+    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;INIT=runscript from 'classpath:sql/dolphinscheduler_h2.sql';NON_KEYWORDS=value
     username: sa
     password: ""
 

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/DqRuleInputEntryMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/DqRuleInputEntryMapper.xml
@@ -24,7 +24,7 @@
                a.field,
                a.type,
                a.title,
-               a.`value`,
+               a.value,
                a.options,
                a.placeholder,
                a.option_source_type,

--- a/dolphinscheduler-dao/src/test/resources/application.yaml
+++ b/dolphinscheduler-dao/src/test/resources/application.yaml
@@ -18,6 +18,6 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;INIT=runscript from 'classpath:sql/dolphinscheduler_h2.sql'
+    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;INIT=runscript from 'classpath:sql/dolphinscheduler_h2.sql';NON_KEYWORDS=value
     username: sa
     password: ""

--- a/dolphinscheduler-data-quality/src/test/java/org/apache/dolphinscheduler/data/quality/flow/FlowTestBase.java
+++ b/dolphinscheduler-data-quality/src/test/java/org/apache/dolphinscheduler/data/quality/flow/FlowTestBase.java
@@ -28,7 +28,7 @@ import java.util.Properties;
  */
 public class FlowTestBase extends SparkApplicationTestBase {
 
-    protected String url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true";
+    protected String url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;NON_KEYWORDS=value";
 
     protected String driver = "org.h2.Driver";
 

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -37,7 +37,7 @@ spring:
       schema-locations: classpath:sql/dolphinscheduler_h2.sql
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true
+    url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;NON_KEYWORDS=value
     username: sa
     password: ""
   quartz:


### PR DESCRIPTION
## Purpose of the pull request

This pull request fix https://github.com/apache/dolphinscheduler/issues/14515

Related link: https://github.com/apache/dolphinscheduler/pull/12108
@boy-xiaozhang 

## Brief change log

old code in DqRuleInputEntryMapper.xml:
```sql
 SELECT a.id,
               a.field,
               a.type,
               a.title,
               a.`value`,
               a.options,
               a.placeholder,
               a.option_source_type,
               a.value_type,
               a.input_type,
               a.is_show,
               a.can_edit,
               a.is_emit,
               a.is_validate,
               b.values_map,
               b.index
        FROM t_ds_dq_rule_input_entry a join ( SELECT *
        FROM t_ds_relation_rule_input_entry where rule_id = #{ruleId} )  b
        on a.id = b.rule_input_entry_id order by b.index
```
new code :
```sql
SELECT a.id,
               a.field,
               a.type,
               a.title,
               a.value,
               a.options,
               a.placeholder,
               a.option_source_type,
               a.value_type,
               a.input_type,
               a.is_show,
               a.can_edit,
               a.is_emit,
               a.is_validate,
               b.values_map,
               b.index
        FROM t_ds_dq_rule_input_entry a join ( SELECT *
        FROM t_ds_relation_rule_input_entry where rule_id = #{ruleId} )  b
        on a.id = b.rule_input_entry_id order by b.index
```

Delete "`" and check , the new code query execution encounters an unfortunate failure when executed in the H2 database. In an effort to address this compatibility issue, I made an attempt to resolve it by appending ";NON_KEYWORDS=value" to the H2 URL. 

old:
```shell
 url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true
```

new:
```shell
url: jdbc:h2:mem:dolphinscheduler;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true;NON_KEYWORDS=value
```

## Verify this pull request

This change can be verified as follows:

Manually verified the change by testing locally.