### PR TITLE
[Improvement][security] get-user-info API endpoint should not return the user's password in MD5 format

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -1086,6 +1086,9 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             user.setTimeZone(TimeZone.getDefault().toZoneId().getId());
         }
 
+        // remove password
+        user.setUserPassword(null);
+
         result.put(Constants.DATA_LIST, user);
 
         putMsg(result, Status.SUCCESS);

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/UserMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/UserMapper.xml
@@ -48,7 +48,7 @@
         where user_name=#{userName} and user_password = #{password}
     </select>
     <select id="queryUserPaging" resultType="org.apache.dolphinscheduler.dao.entity.User">
-        select u.id,u.user_name,u.user_password,u.user_type,u.email,u.phone,u.tenant_id,u.create_time,
+        select u.id,u.user_name,u.user_type,u.email,u.phone,u.tenant_id,u.create_time,
         u.update_time,t.tenant_code,u.state,
         case when u.queue  <![CDATA[ <> ]]> '' then u.queue else q.queue_name end as queue, q.queue_name
         from t_ds_user u


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

- close #14679 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
