### PR TITLE
[Fix-14696] [Startup scripts] /bin/java command Argument list too long

### DIFF
--- a/dolphinscheduler-standalone-server/src/main/bin/start.sh
+++ b/dolphinscheduler-standalone-server/src/main/bin/start.sh
@@ -42,11 +42,9 @@ fi
 
 CP=""
 for d in $DOLPHINSCHEDULER_HOME/libs/*; do
-  for f in $d/*.jar; do
-    CP=$CP:$f
-  done
+  CP=$CP:"$d/*"
 done
 
 $JAVA_HOME/bin/java $JAVA_OPTS \
-  -cp "$DOLPHINSCHEDULER_HOME/conf":"$CP" \
+  -cp "$DOLPHINSCHEDULER_HOME/conf""$CP" \
   org.apache.dolphinscheduler.StandaloneServer


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #14696

use wildcard import according to `https://docs.oracle.com/javase/6/docs/technotes/tools/windows/classpath.html`