### PR TITLE
Fix serial mode will cause NPE in Workflow bootstrap

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerBootstrap.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerBootstrap.java
@@ -40,6 +40,7 @@ import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -132,8 +133,14 @@ public class MasterSchedulerBootstrap extends BaseDaemonThread implements AutoCl
                 commands.parallelStream()
                         .forEach(command -> {
                             try {
-                                WorkflowExecuteRunnable workflowExecuteRunnable =
+                                Optional<WorkflowExecuteRunnable> workflowExecuteRunnableOptional =
                                         workflowExecuteRunnableFactory.createWorkflowExecuteRunnable(command);
+                                if (!workflowExecuteRunnableOptional.isPresent()) {
+                                    log.warn(
+                                            "The command execute success, will not trigger a WorkflowExecuteRunnable, this workflowInstance might be in serial mode");
+                                    return;
+                                }
+                                WorkflowExecuteRunnable workflowExecuteRunnable = workflowExecuteRunnableOptional.get();
                                 ProcessInstance processInstance = workflowExecuteRunnable
                                         .getWorkflowExecuteContext().getWorkflowInstance();
                                 if (processInstanceExecCacheManager.contains(processInstance.getId())) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnableFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnableFactory.java
@@ -19,7 +19,6 @@ package org.apache.dolphinscheduler.server.master.runner;
 
 import org.apache.dolphinscheduler.dao.entity.Command;
 import org.apache.dolphinscheduler.dao.repository.ProcessInstanceDao;
-import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.exception.WorkflowCreateException;
@@ -29,6 +28,8 @@ import org.apache.dolphinscheduler.service.alert.ProcessAlertManager;
 import org.apache.dolphinscheduler.service.command.CommandService;
 import org.apache.dolphinscheduler.service.expand.CuringParamsService;
 import org.apache.dolphinscheduler.service.process.ProcessService;
+
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -67,20 +68,17 @@ public class WorkflowExecuteRunnableFactory {
     private MasterConfig masterConfig;
 
     @Autowired
-    private TaskDefinitionLogDao taskDefinitionLogDao;
-
-    @Autowired
     private DefaultTaskExecuteRunnableFactory defaultTaskExecuteRunnableFactory;
 
     @Autowired
     private WorkflowExecuteContextFactory workflowExecuteContextFactory;
 
-    public WorkflowExecuteRunnable createWorkflowExecuteRunnable(Command command) throws WorkflowCreateException {
+    public Optional<WorkflowExecuteRunnable> createWorkflowExecuteRunnable(Command command) throws WorkflowCreateException {
         try {
-            IWorkflowExecuteContext workflowExecuteRunnableContext =
+            Optional<IWorkflowExecuteContext> workflowExecuteRunnableContextOptional =
                     workflowExecuteContextFactory.createWorkflowExecuteRunnableContext(command);
-            return new WorkflowExecuteRunnable(
-                    workflowExecuteRunnableContext,
+            return workflowExecuteRunnableContextOptional.map(iWorkflowExecuteContext -> new WorkflowExecuteRunnable(
+                    iWorkflowExecuteContext,
                     commandService,
                     processService,
                     processInstanceDao,
@@ -90,7 +88,7 @@ public class WorkflowExecuteRunnableFactory {
                     stateWheelExecuteThread,
                     curingGlobalParamsService,
                     taskInstanceDao,
-                    defaultTaskExecuteRunnableFactory);
+                    defaultTaskExecuteRunnableFactory));
         } catch (Exception ex) {
             throw new WorkflowCreateException("Create workflow execute runnable failed", ex);
         }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessService.java
@@ -56,11 +56,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import org.springframework.transaction.annotation.Transactional;
 
 public interface ProcessService {
 
     @Transactional
+    @Nullable
     ProcessInstance handleCommand(String host,
                                   Command command) throws CronParseException, CodeGenerateUtils.CodeGenerateException;
 

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -303,6 +303,7 @@ public class ProcessServiceImpl implements ProcessService {
     @Autowired
     private TriggerRelationService triggerRelationService;
     /**
+     * todo: split this method
      * handle Command (construct ProcessInstance from Command) , wrapped in transaction
      *
      * @param host    host
@@ -311,8 +312,8 @@ public class ProcessServiceImpl implements ProcessService {
      */
     @Override
     @Transactional
-    public ProcessInstance handleCommand(String host,
-                                         Command command) throws CronParseException, CodeGenerateException {
+    public @Nullable ProcessInstance handleCommand(String host,
+                                                   Command command) throws CronParseException, CodeGenerateException {
         ProcessInstance processInstance = constructProcessInstance(command, host);
         // cannot construct process instance, return null
         if (processInstance == null) {
@@ -332,6 +333,7 @@ public class ProcessServiceImpl implements ProcessService {
                 setSubProcessParam(processInstance);
                 triggerRelationService.saveProcessInstanceTrigger(command.getId(), processInstance.getId());
                 deleteCommandWithCheck(command.getId());
+                // todo: this is a bad design to return null here, whether trigger the task
                 return null;
             }
         } else {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #14698

## Brief change log

When the workflow is in serial mode, will return  null in handleCommand, will cause NPE, this PR will fix this.

Add todo to split the handleCommand

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
