### PR TITLE
[Fix-14721] [K8S Task] Handle job delete event when user manually delete the job in k8s cluster

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/impl/K8sTaskExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/impl/K8sTaskExecutor.java
@@ -198,7 +198,11 @@ public class K8sTaskExecutor extends AbstractK8sTaskExecutor {
                         final LogUtils.MDCAutoClosableContext mdcAutoClosableContext =
                                 LogUtils.setTaskInstanceLogFullPathMDC(taskRequest.getLogPath())) {
                     log.info("event received : job:{} action:{}", job.getMetadata().getName(), action);
-                    if (action != Action.ADDED) {
+                    if (action == Action.DELETED) {
+                        log.error("[K8sJobExecutor-{}] fail in k8s", job.getMetadata().getName());
+                        taskResponse.setExitStatusCode(EXIT_CODE_FAILURE);
+                        countDownLatch.countDown();
+                    } else if (action != Action.ADDED) {
                         int jobStatus = getK8sJobStatus(job);
                         log.info("job {} status {}", job.getMetadata().getName(), jobStatus);
                         if (jobStatus == TaskConstants.RUNNING_CODE) {


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
- close https://github.com/apache/dolphinscheduler/issues/14721
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- Handle `Delete` action, and fail the k8s task.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
