### PR TITLE
fix: null app-info-path cause NPE

### DIFF
--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/GetAppIdRequest.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/log/GetAppIdRequest.java
@@ -29,9 +29,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GetAppIdRequest implements RequestMessageBuilder {
 
-    private String logPath;
+    private int taskInstanceId;
 
-    private String appInfoPath;
+    private String logPath;
 
     @Override
     public MessageType getCommandType() {

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/processor/GetAppIdProcessor.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/processor/GetAppIdProcessor.java
@@ -22,6 +22,8 @@ import static org.apache.dolphinscheduler.common.constants.Constants.DEFAULT_COL
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContextCacheManager;
 import org.apache.dolphinscheduler.plugin.task.api.utils.LogUtils;
 import org.apache.dolphinscheduler.remote.command.Message;
 import org.apache.dolphinscheduler.remote.command.MessageType;
@@ -44,7 +46,9 @@ public class GetAppIdProcessor extends BaseLogProcessor implements NettyRequestP
     public void process(Channel channel, Message message) {
         GetAppIdRequest getAppIdRequest =
                 JSONUtils.parseObject(message.getBody(), GetAppIdRequest.class);
-        String appInfoPath = getAppIdRequest.getAppInfoPath();
+        TaskExecutionContext taskExecutionContext =
+                TaskExecutionContextCacheManager.getByTaskInstanceId(getAppIdRequest.getTaskInstanceId());
+        String appInfoPath = taskExecutionContext.getAppInfoPath();
         String logPath = getAppIdRequest.getLogPath();
         List<String> appIds = LogUtils.getAppIds(logPath, appInfoPath,
                 PropertyUtils.getString(APPID_COLLECT, DEFAULT_COLLECT_WAY));

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/log/LogClient.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/log/LogClient.java
@@ -210,8 +210,9 @@ public class LogClient implements AutoCloseable {
         }
     }
 
-    public @Nullable List<String> getAppIds(@NonNull String host, int port, @NonNull String taskLogFilePath,
-                                            @NonNull String taskAppInfoPath) throws RemotingException, InterruptedException {
+    public @Nullable List<String> getAppIds(@NonNull String host, int port, String taskLogFilePath,
+                                            String taskAppInfoPath,
+                                            int taskInstanceId) throws RemotingException, InterruptedException {
         log.info("Begin to get appIds from worker: {}:{} taskLogPath: {}, taskAppInfoPath: {}", host, port,
                 taskLogFilePath, taskAppInfoPath);
         final Host workerAddress = new Host(host, port);
@@ -220,7 +221,7 @@ public class LogClient implements AutoCloseable {
             appIds = LogUtils.getAppIds(taskLogFilePath, taskAppInfoPath,
                     PropertyUtils.getString(APPID_COLLECT, DEFAULT_COLLECT_WAY));
         } else {
-            final Message message = new GetAppIdRequest(taskLogFilePath, taskAppInfoPath).convert2Command();
+            final Message message = new GetAppIdRequest(taskInstanceId, taskLogFilePath).convert2Command();
             Message response = this.client.sendSync(workerAddress, message, LOG_REQUEST_TIMEOUT);
             if (response != null) {
                 GetAppIdResponse responseCommand =

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ProcessUtils.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ProcessUtils.java
@@ -171,7 +171,7 @@ public class ProcessUtils {
             Thread.sleep(Constants.SLEEP_TIME_MILLIS);
             Host host = Host.of(taskExecutionContext.getHost());
             List<String> appIds = logClient.getAppIds(host.getIp(), host.getPort(), taskExecutionContext.getLogPath(),
-                    taskExecutionContext.getAppInfoPath());
+                    taskExecutionContext.getAppInfoPath(), taskExecutionContext.getTaskInstanceId());
             if (CollectionUtils.isNotEmpty(appIds)) {
                 taskExecutionContext.setAppIds(String.join(TaskConstants.COMMA, appIds));
                 if (StringUtils.isEmpty(taskExecutionContext.getExecutePath())) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
@@ -71,7 +71,7 @@ public class LogUtils {
      * @param fetchWay    fetch way
      * @return application id list.
      */
-    public List<String> getAppIds(@NonNull String logPath, @NonNull String appInfoPath, String fetchWay) {
+    public List<String> getAppIds(String logPath, String appInfoPath, String fetchWay) {
         if (!StringUtils.isEmpty(fetchWay) && fetchWay.equals("aop")) {
             log.info("Start finding appId in {}, fetch way: {} ", appInfoPath, fetchWay);
             return getAppIdsFromAppInfoFile(appInfoPath);
@@ -142,7 +142,11 @@ public class LogUtils {
                 .orElse(null);
     }
 
-    public List<String> getAppIdsFromAppInfoFile(@NonNull String appInfoPath) {
+    public List<String> getAppIdsFromAppInfoFile(String appInfoPath) {
+        if (StringUtils.isEmpty(appInfoPath)) {
+            log.warn("appInfoPath is empty");
+            return Collections.emptyList();
+        }
         File appInfoFile = new File(appInfoPath);
         if (!appInfoFile.exists() || !appInfoFile.isFile()) {
             return Collections.emptyList();


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
- I find this NPE in error logs provided in https://github.com/apache/dolphinscheduler/issues/14723, not the bug which issue mentions about, but still have to fix.
<!--(For example: This pull request adds checkstyle plugin).-->
```
[ERROR] 2023-08-15 16:10:28.329 +0800 org.apache.dolphinscheduler.service.utils.ProcessUtils:[195] - [WorkflowInstance-5][TaskInstance-7] - Kill yarn job failure, taskInstanceId: 7
java.lang.NullPointerException: taskAppInfoPath is marked non-null but is null
	at org.apache.dolphinscheduler.service.log.LogClient.getAppIds(LogClient.java:214)
	at org.apache.dolphinscheduler.service.utils.ProcessUtils.killApplication(ProcessUtils.java:173)
	at org.apache.dolphinscheduler.server.master.service.WorkerFailoverService.failoverTaskInstance(WorkerFailoverService.java:184)
	at org.apache.dolphinscheduler.server.master.service.WorkerFailoverService.failoverWorker(WorkerFailoverService.java:144)
	at org.apache.dolphinscheduler.server.master.service.FailoverService.failoverServerWhenDown(FailoverService.java:55)
	at org.apache.dolphinscheduler.server.master.registry.MasterRegistryClient.removeWorkerNodePath(MasterRegistryClient.java:142)
	at org.apache.dolphinscheduler.server.master.registry.MasterRegistryDataListener.handleWorkerEvent(MasterRegistryDataListener.java:77)
	at org.apache.dolphinscheduler.server.master.registry.MasterRegistryDataListener.notify(MasterRegistryDataListener.java:50)
	at org.apache.dolphinscheduler.plugin.registry.zookeeper.ZookeeperRegistry.lambda$subscribe$1(ZookeeperRegistry.java:147)
	at org.apache.curator.framework.recipes.cache.TreeCache.lambda$callListeners$1(TreeCache.java:811)
	at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92)
	at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89)
	at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89)
	at org.apache.curator.framework.recipes.cache.TreeCache.callListeners(TreeCache.java:807)
	at org.apache.curator.framework.recipes.cache.TreeCache.access$1900(TreeCache.java:79)
	at org.apache.curator.framework.recipes.cache.TreeCache$2.run(TreeCache.java:909)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```
## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
