### PR TITLE
Fix a typo in English development-environment-setup.md

### DIFF
--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -70,7 +70,7 @@ cd dolphinscheduler
        -Pdocker,release
 ```
 
-When the command is finished you could find them by command `docker imaegs`.
+When the command is finished you could find them by command `docker images`.
 
 - If you want to modify DolphinScheduler source code, build and push Docker images to your registry <HUB_URL>，you can run when finished the modification
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
There is a typo in English development-environment-setup.md.
![20230818112304](https://github.com/apache/dolphinscheduler/assets/23622441/9c69247e-7a2f-460e-bfb5-bd3635ba00ee)


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
I fix a typo in English development-environment-setup.md
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

