### PR TITLE
[Fix-14627][dolphinscheduler-ui] Fix there are too many child node in sub_process, it cannot to filter by keywords

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-child-node.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-child-node.ts
@@ -72,7 +72,8 @@ export function useChildNode({
     span: 24,
     name: t('project.node.child_node'),
     props: {
-      loading: loading
+      loading: loading,
+      filterable: true
     },
     options: options,
     class: 'select-child-node',


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Fix https://github.com/apache/dolphinscheduler/issues/14627

## Brief change log

I fix this problem.

