### PR TITLE
[Fix-14811][api] Fix when using Casdoor SSO, ldap, OAuth2 to login, the tenant problem of not specifying the currently logged in user

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoginController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoginController.java
@@ -31,6 +31,7 @@ import org.apache.dolphinscheduler.api.service.SessionService;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.OkHttpUtils;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -241,7 +242,7 @@ public class LoginController extends BaseController {
             String username = JSONUtils.getNodeString(userInfoJsonStr, "login");
             User user = usersService.getUserByUserName(username);
             if (user == null) {
-                user = usersService.createUser(username, null, null, 0, null, null, 1);
+                user = usersService.createUser(UserType.GENERAL_USER, username, null);
             }
             String sessionId = sessionService.createSession(user, null);
             if (sessionId == null) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -224,7 +224,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     }
 
     /***
-     * create User for ldap and sso login
+     * create User for ldap、Casdoor SSO and OAuth2.0 login
      */
     @Override
     @Transactional
@@ -238,6 +238,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         user.setUserType(userType);
         user.setCreateTime(now);
         user.setUpdateTime(now);
+        user.setTenantId(-1);
         user.setQueue("");
         user.setState(Flag.YES.getCode());
 


### PR DESCRIPTION


    Fix when using Casdoor SSO, ldap, OAuth2 to log in, the tenant problem of not specifying the currently logged in user

This closes #14811

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
