### PR TITLE
[Fix-14819][Master] Fix the full log path of logical task is not be set when task is dispatched.

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/LogicITaskInstanceDispatchOperationFunction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/LogicITaskInstanceDispatchOperationFunction.java
@@ -56,6 +56,8 @@ public class LogicITaskInstanceDispatchOperationFunction
             final int workflowInstanceId = taskExecutionContext.getProcessInstanceId();
             final String taskInstanceName = taskExecutionContext.getTaskName();
 
+            taskExecutionContext.setLogPath(LogUtils.getTaskInstanceLogFullPath(taskExecutionContext));
+
             LogUtils.setWorkflowAndTaskInstanceIDMDC(workflowInstanceId, taskInstanceId);
             LogUtils.setTaskInstanceLogFullPathMDC(taskExecutionContext.getLogPath());
 


### PR DESCRIPTION
ref #14819

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
Fix the full log path of logical task is not be set when task is dispatched.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
set the full log path when logical task is dispatched.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->
*Manually verified the change by testing locally.*