### PR TITLE
[Bug] [Mater] The process always runs when the process contains subprocess and params deliver

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/TaskStateEventHandler.java
@@ -90,6 +90,7 @@ public class TaskStateEventHandler implements StateEventHandler {
             if (iTaskProcessor.taskInstance().getState().isFinished()) {
                 if (iTaskProcessor.taskInstance().getState() != task.getState()) {
                     task.setState(iTaskProcessor.taskInstance().getState());
+                    task.setEndTime(iTaskProcessor.taskInstance().getEndTime());
                 }
                 workflowExecuteRunnable.taskFinished(task);
             }


### PR DESCRIPTION
- close #14855