### PR TITLE
Fix session/thread leak at ssh datasource

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/AbstractDataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/AbstractDataSourceProcessor.java
@@ -26,15 +26,19 @@ import org.apache.dolphinscheduler.spi.enums.DbType;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.sql.Connection;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Sets;
 
+@Slf4j
 public abstract class AbstractDataSourceProcessor implements DataSourceProcessor {
 
     private static final Pattern IPV4_PATTERN = Pattern.compile("^[a-zA-Z0-9\\_\\-\\.\\,]+$");
@@ -110,5 +114,15 @@ public abstract class AbstractDataSourceProcessor implements DataSourceProcessor
         BaseConnectionParam baseConnectionParam = (BaseConnectionParam) connectionParam;
         return MessageFormat.format("{0}@{1}@{2}@{3}", dbType.getDescp(), baseConnectionParam.getUser(),
                 PasswordUtils.encodePassword(baseConnectionParam.getPassword()), baseConnectionParam.getJdbcUrl());
+    }
+
+    @Override
+    public boolean checkDataSourceConnectivity(ConnectionParam connectionParam) {
+        try (Connection connection = getConnection(connectionParam)) {
+            return true;
+        } catch (Exception e) {
+            log.error("Check datasource connectivity for: {} error", getDbType().name(), e);
+            return false;
+        }
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/DataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/DataSourceProcessor.java
@@ -93,17 +93,16 @@ public interface DataSourceProcessor {
      * @param connectionParam connectionParam
      * @return {@link Connection}
      */
+    // todo: Change to return a ConnectionWrapper
     Connection getConnection(ConnectionParam connectionParam) throws ClassNotFoundException, SQLException, IOException;
 
     /**
-     * test connection, use for not jdbc datasource
+     * test connection
      *
      * @param connectionParam connectionParam
      * @return true if connection is valid
      */
-    default boolean testConnection(ConnectionParam connectionParam) {
-        return false;
-    }
+    boolean checkDataSourceConnectivity(ConnectionParam connectionParam);
 
     /**
      * @return {@link DbType}

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-ssh/src/main/java/org/apache/dolphinscheduler/plugin/datasource/ssh/SshClientWrapper.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-ssh/src/main/java/org/apache/dolphinscheduler/plugin/datasource/ssh/SshClientWrapper.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.datasource.ssh;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.config.keys.loader.KeyPairResourceLoader;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.time.Duration;
+import java.util.Collection;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SshClientWrapper implements AutoCloseable {
+
+    private SshClient sshClient;
+
+    private final ClientSession clientSession;
+
+    public SshClientWrapper(
+                            String ip, Integer port, String userName, String password, String privateKey)
+                                                                                                          throws IOException,
+                                                                                                          GeneralSecurityException {
+        checkNotNull(ip);
+        checkNotNull(port);
+        checkNotNull(userName);
+        clientSession = createSession(ip, port, userName);
+        if (StringUtils.isNotEmpty(password)) {
+            clientSession.addPasswordIdentity(password);
+        }
+        if (StringUtils.isNotEmpty(privateKey)) {
+            KeyPairResourceLoader loader = SecurityUtils.getKeyPairResourceParser();
+            Collection<KeyPair> keyPairCollection = loader.loadKeyPairs(null, null, null, privateKey);
+            for (KeyPair keyPair : keyPairCollection) {
+                clientSession.addPublicKeyIdentity(keyPair);
+            }
+        }
+    }
+
+    public boolean isAuth() throws IOException {
+        return clientSession.auth().verify(Duration.ofSeconds(10)).isSuccess();
+    }
+
+    private ClientSession createSession(String ip, Integer port, String userName) throws IOException {
+        sshClient = SshClient.setUpDefaultClient();
+        sshClient.start();
+        return sshClient.connect(userName, ip, port).verify(Duration.ofSeconds(10)).getSession();
+    }
+
+    @Override
+    public void close() throws Exception {
+        try (
+                ClientSession clientSession1 = clientSession;
+                SshClient sshClient1 = sshClient) {
+            // closed the resources
+        }
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

In the current code, when we test an ssh datasource connective, we create a sshclient and sshsession, but doen's close it, this will cause resources leak.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
