### PR TITLE
Fix the ephemeralId will not be deleted before jdbc-registry closed.

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/task/EphemeralDateManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/task/EphemeralDateManager.java
@@ -83,12 +83,12 @@ public class EphemeralDateManager implements AutoCloseable {
 
     @Override
     public void close() throws SQLException {
-        ephemeralDateIds.clear();
-        connectionListeners.clear();
-        scheduledExecutorService.shutdownNow();
         for (Long ephemeralDateId : ephemeralDateIds) {
             jdbcOperator.deleteDataById(ephemeralDateId);
         }
+        ephemeralDateIds.clear();
+        connectionListeners.clear();
+        scheduledExecutorService.shutdownNow();
     }
 
     // Use this task to refresh ephemeral term and check the connect state.


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
