### PR TITLE
[Improvement][Api]Change default zookeeper timeout setting

### DIFF
--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -114,7 +114,7 @@ registry:
       max-sleep: 300ms
       max-retries: 5
     session-timeout: 30s
-    connection-timeout: 30s
+    connection-timeout: 35s
     block-until-connected: 30s
     digest: ~
 

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -114,8 +114,8 @@ registry:
       max-sleep: 300ms
       max-retries: 5
     session-timeout: 30s
-    connection-timeout: 9s
-    block-until-connected: 600ms
+    connection-timeout: 30s
+    block-until-connected: 30s
     digest: ~
 
 api:

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -113,9 +113,9 @@ registry:
       base-sleep-time: 60ms
       max-sleep: 300ms
       max-retries: 5
-    session-timeout: 35s
-    connection-timeout: 35s
-    block-until-connected: 30s
+    session-timeout: 60s
+    connection-timeout: 15s
+    block-until-connected: 15s
     digest: ~
 
 api:

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -113,7 +113,7 @@ registry:
       base-sleep-time: 60ms
       max-sleep: 300ms
       max-retries: 5
-    session-timeout: 30s
+    session-timeout: 35s
     connection-timeout: 35s
     block-until-connected: 30s
     digest: ~


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
 solve to Local running api project connection remote zookeeper always reported connection timeout。

This problem, for the new people just started, build the project, may take a lot of time to understand, debugging, and then the normal operation




<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
Corresponding to a single connection timeout profile

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request
<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
