### PR TITLE
[fix-14944][SQL] add missing postgrepsql's ddl in 3.1.x

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.6_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.1.6_schema/postgresql/dolphinscheduler_ddl.sql
@@ -14,3 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
+ALTER TABLE t_ds_process_definition ADD COLUMN IF NOT EXISTS execution_type int NULL DEFAULT '0';
+
+ALTER TABLE t_ds_process_definition_log ADD COLUMN IF NOT EXISTS execution_type int NULL DEFAULT '0';
+
+ALTER TABLE t_ds_process_instance ADD COLUMN IF NOT EXISTS next_process_instance_id int NULL DEFAULT '0';


### PR DESCRIPTION

## Purpose of the pull request

- plz close this issue : #14944 

## Brief change log

add missing postgrepsql's ddl in 3.1.x

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.


