### PR TITLE
[Fix-14963] Fix the error of using shell task to obtain Home variable in Ubuntu system

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/shell/BaseLinuxShellInterceptorBuilder.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/shell/BaseLinuxShellInterceptorBuilder.java
@@ -129,7 +129,7 @@ public abstract class BaseLinuxShellInterceptorBuilder<T extends BaseLinuxShellI
             bootstrapCommand.add("-u");
             bootstrapCommand.add(runUser);
         }
-        bootstrapCommand.add("-E");
+        bootstrapCommand.add("-i");
         bootstrapCommand.add(shellAbsolutePath().toString());
         return bootstrapCommand;
     }


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
close #14963

sudo -E:

The -E option retains the current user's environment variables. This means that when using sudo -E, the new child process will inherit the environment variables of the current user, rather than using the environment variables of the target user. This includes variables like PATH and others.
sudo -E is typically used to ensure that when using sudo to execute commands, some important environment variables remain unchanged to avoid affecting the command's execution.

sudo -i:

The -i option signifies logging in as the target user (usually the root user) and creating a new login shell. This switches to the environment of the target user, including the working directory, user variables, and so on, just as if you had logged in as the target user.

sudo -i is usually used when you need to perform tasks that require root privileges or when you need to execute commands within the environment of the target user.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
