### PR TITLE
Fix task log appender will not be closed immediate after throwing exception

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/execute/MasterTaskExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/execute/MasterTaskExecuteRunnable.java
@@ -55,9 +55,10 @@ public abstract class MasterTaskExecuteRunnable implements Runnable {
     protected abstract void afterExecute() throws MasterTaskExecuteException;
 
     protected void afterThrowing(Throwable throwable) {
+        TaskInstanceLogHeader.printFinalizeTaskHeader();
         try {
+            log.error("Get a exception when execute the task, will try to cancel the task", throwable);
             cancelTask();
-            log.error("Get a exception when execute the task, canceled the task", throwable);
         } catch (Exception e) {
             log.error("Cancel task failed,", e);
         }
@@ -69,6 +70,7 @@ public abstract class MasterTaskExecuteRunnable implements Runnable {
         MasterTaskExecutionContextHolder.removeTaskExecutionContext(taskExecutionContext.getTaskInstanceId());
         MasterTaskExecuteRunnableHolder.removeMasterTaskExecuteRunnable(taskExecutionContext.getTaskInstanceId());
         log.info("Get a exception when execute the task, removed the TaskExecutionContext");
+        closeLogAppender();
     }
 
     public void cancelTask() throws MasterTaskExecuteException {
@@ -111,7 +113,6 @@ public abstract class MasterTaskExecuteRunnable implements Runnable {
         } catch (Throwable ex) {
             log.error("Task execute failed, due to meet an exception", ex);
             afterThrowing(ex);
-            closeLogAppender();
         } finally {
             LogUtils.removeWorkflowAndTaskInstanceIdMDC();
             LogUtils.removeTaskInstanceLogFullPathMDC();


### PR DESCRIPTION
## Purpose of the pull request

When logic task execute failed with exception, the log appender will not be closed immediate, it will be drop after 30 minutes, this is too long, we should close it immediate.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
