### PR TITLE
fix: execute sql error: datasource plugin 'doris' is not found。

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-doris/src/main/java/org/apache/dolphinscheduler/plugin/doris/DorisDataSourceChannelFactory.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-doris/src/main/java/org/apache/dolphinscheduler/plugin/doris/DorisDataSourceChannelFactory.java
@@ -18,7 +18,11 @@ package org.apache.dolphinscheduler.plugin.doris;
 
 import org.apache.dolphinscheduler.spi.datasource.DataSourceChannel;
 import org.apache.dolphinscheduler.spi.datasource.DataSourceChannelFactory;
+import org.apache.dolphinscheduler.spi.enums.DbType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(DataSourceChannelFactory.class)
 public class DorisDataSourceChannelFactory implements DataSourceChannelFactory {
 
     @Override
@@ -28,6 +32,6 @@ public class DorisDataSourceChannelFactory implements DataSourceChannelFactory {
 
     @Override
     public String getName() {
-        return "doris";
+        return DbType.DORIS.getDescp();
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix doris datasource bug
https://github.com/apache/dolphinscheduler/issues/15075

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

![](https://github.com/apache/dolphinscheduler/assets/49302071/fda8708f-8751-451c-9bcf-af116f5b95d4)