### PR TITLE
[Improvement][Resource Center] Display brief file name in file-details page

### DIFF
--- a/dolphinscheduler-ui/src/views/resource/components/resource/edit/index.tsx
+++ b/dolphinscheduler-ui/src/views/resource/components/resource/edit/index.tsx
@@ -37,6 +37,7 @@ export default defineComponent({
     // fullname is now the id of resources
     const fullName = String(router.currentRoute.value.query.prefix || '')
     const tenantCode = String(router.currentRoute.value.query.tenantCode || '')
+    const alias = String(router.currentRoute.value.query.alias || '')
 
     const { state } = useForm()
     const { getResourceView, handleUpdateContent } = useEdit(state)
@@ -61,6 +62,7 @@ export default defineComponent({
     return {
       componentName,
       resourceViewRef,
+      alias,
       handleReturn,
       handleFileContent,
       ...toRefs(state)
@@ -73,7 +75,7 @@ export default defineComponent({
         {this.resourceViewRef.isReady.value ? (
           <div class={styles['file-edit-content']}>
             <h2>
-              <span>{this.resourceViewRef.state.value.alias}</span>
+              <span>{this.alias}</span>
             </h2>
             <NForm
               rules={this.rules}

--- a/dolphinscheduler-ui/src/views/resource/components/resource/table/table-action.tsx
+++ b/dolphinscheduler-ui/src/views/resource/components/resource/table/table-action.tsx
@@ -67,10 +67,18 @@ export default defineComponent({
       return !(flag && size < 1000000)
     }
 
-    const handleEditFile = (item: { fullName: string; user_name: string }) => {
+    const handleEditFile = (item: {
+      fullName: string
+      user_name: string
+      alias: string
+    }) => {
       router.push({
         name: 'resource-file-edit',
-        query: { prefix: item.fullName, tenantCode: item.user_name }
+        query: {
+          prefix: item.fullName,
+          tenantCode: item.user_name,
+          alias: item.alias
+        }
       })
     }
 
@@ -126,7 +134,8 @@ export default defineComponent({
                   onClick={() => {
                     this.handleEditFile({
                       fullName: this.row.fullName,
-                      user_name: this.row.user_name
+                      user_name: this.row.user_name,
+                      alias: this.row.alias
                     })
                   }}
                   style={{ marginRight: '-5px' }}

--- a/dolphinscheduler-ui/src/views/resource/components/resource/types.ts
+++ b/dolphinscheduler-ui/src/views/resource/components/resource/types.ts
@@ -23,6 +23,7 @@ export interface ResourceFileTableData {
   user_name: string
   directory: string
   file_name: string
+  alias: string
   description: string
   size: number
   type: ResourceType


### PR DESCRIPTION
close #15137 
change the file name in resource center file detail page to brief name.

![20231116181956](https://github.com/apache/dolphinscheduler/assets/9403654/9d5b9771-1e30-4d1d-9bfc-894311827a0f)
![20231116182040](https://github.com/apache/dolphinscheduler/assets/9403654/deaea82e-78b0-4a5e-a1c2-ef528eee18b5)
