### PR TITLE
[Bug] use hashId instead of command id for distribute commands evenly

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/CommandMapper.xml
@@ -43,7 +43,7 @@
     <select id="queryCommandPageBySlot" resultType="org.apache.dolphinscheduler.dao.entity.Command">
         select *
         from t_ds_command
-        where id % #{masterCount} = #{thisMasterSlot}
+        where conv(left(md5(id), 4), 16, 10) % #{masterCount} = #{thisMasterSlot}
         order by process_instance_priority, id asc
             limit #{limit}
     </select>

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteContextFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteContextFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.runner;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.dolphinscheduler.common.enums.SlotCheckState;
 import org.apache.dolphinscheduler.dao.entity.Command;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
@@ -90,12 +91,17 @@ public class WorkflowExecuteContextFactory {
         SlotCheckState state;
         if (masterSize <= 0) {
             state = SlotCheckState.CHANGE;
-        } else if (command.getId() % masterSize == slot) {
+        } else if (hashCommandId(command.getId()) % masterSize == slot) {
             state = SlotCheckState.PASS;
         } else {
             state = SlotCheckState.INJECT;
         }
         return state;
+    }
+
+    private int hashCommandId(Integer commandId) {
+        String md5 = DigestUtils.md5Hex(String.valueOf(commandId));
+        return Integer.valueOf(md5.substring(0, 4), 16);
     }
 
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
Now we will assign the commands to our masters through the command id, but the command id generator is depends on the mysql increment step, if the increment step equals the master size, it will always assign the commands to the first master.

So we use the timestamp to assign the commands, i write some code to check the distribution, it looks not bad
```java
import org.apache.commons.codec.digest.DigestUtils;

public class HashTest {

    public static void main(String[] args) {
        int k = 7; // number of masters
        int limit = 900000000;
        int[] res = new int[k];
        for (int id = 100000000; id <= 900000000; id += k) {
            long hashId = hashCommandId(id);
            long r = hashId % k;
            res[(int) r] += 1;
        }
        for (int i = 0; i < k; i++) {
            System.out.println(i + ": " + res[i]);
        }
    }


    private static long hashCommandId(Integer commandId) {
        String md5 = DigestUtils.md5Hex(String.valueOf(commandId));
        return Integer.valueOf(md5.substring(0, 4), 16);
    }
}
``` 
```
0: 16330315
1: 16331143
2: 16318265
3: 16329685
4: 16324449
5: 16325290
6: 16326568
``` 
