### PR TITLE
[Bug] Workflow instance can't stop due to doesn't refresh status in master

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/WorkflowStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/WorkflowStateEventHandler.java
@@ -63,10 +63,13 @@ public class WorkflowStateEventHandler implements StateEventHandler {
             }
             workflowExecuteRunnable.endProcess();
         }
-        if (processInstance.getState().isReadyStop()) {
-            workflowExecuteRunnable.killAllTasks();
-        }
 
+        if (workflowStateEvent.getStatus().isReadyStop()) {
+            workflowExecuteRunnable.refreshProcessInstance(processInstance.getId());
+            if (processInstance.getState().isReadyStop()) {
+                workflowExecuteRunnable.killAllTasks();
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

we can't stop the process instance, because master not refresh the process status from DB

