### PR TITLE
Conflict when input and output variables have the same name

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImpl.java
@@ -190,10 +190,6 @@ public class CuringParamsServiceImpl implements CuringParamsService {
             prepareParamsMap.putAll(globalParams);
         }
 
-        if (MapUtils.isNotEmpty(varParams)) {
-            prepareParamsMap.putAll(varParams);
-        }
-
         if (MapUtils.isNotEmpty(localParams)) {
             prepareParamsMap.putAll(localParams);
         }
@@ -202,6 +198,10 @@ public class CuringParamsServiceImpl implements CuringParamsService {
             prepareParamsMap.putAll(ParameterUtils.getUserDefParamsMap(cmdParam));
         }
 
+        if (MapUtils.isNotEmpty(varParams)) {
+            prepareParamsMap.putAll(varParams);
+        }
+        
         Iterator<Map.Entry<String, Property>> iter = prepareParamsMap.entrySet().iterator();
         while (iter.hasNext()) {
             Map.Entry<String, Property> en = iter.next();


### PR DESCRIPTION
If the input and output parameter variables have the same name, the current input variable will overwrite the output variable value of the previous task

## Purpose of the pull request
modify globalParams put order

## Brief change log
when the output parameter store in valpool . if the input and output parameter variables have the same name, the current inputvariable will overwrite the output variable value of the previous task

## Verify this pull request
This pull request is code cleanup without any test coverage.
