### PR TITLE
Fix check value rather than key in AbstractDataSourceProcessor#checkOther

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-task-api</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/AbstractDataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/AbstractDataSourceProcessor.java
@@ -92,12 +92,15 @@ public abstract class AbstractDataSourceProcessor implements DataSourceProcessor
         if (MapUtils.isEmpty(other)) {
             return;
         }
+
         if (!Sets.intersection(other.keySet(), POSSIBLE_MALICIOUS_KEYS).isEmpty()) {
             throw new IllegalArgumentException("Other params include possible malicious keys.");
         }
-        boolean paramsCheck = other.entrySet().stream().allMatch(p -> PARAMS_PATTER.matcher(p.getValue()).matches());
-        if (!paramsCheck) {
-            throw new IllegalArgumentException("datasource other params illegal");
+
+        for (Map.Entry<String, String> entry : other.entrySet()) {
+            if (!PARAMS_PATTER.matcher(entry.getKey()).matches()) {
+                throw new IllegalArgumentException("datasource other params: " + entry.getKey() + " illegal");
+            }
         }
     }
 

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-trino/src/test/java/org/apache/dolphinscheduler/plugin/datasource/trino/param/TrinoDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-trino/src/test/java/org/apache/dolphinscheduler/plugin/datasource/trino/param/TrinoDataSourceProcessorTest.java
@@ -34,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class TrinoDataSourceProcessorTest {
 
-    private TrinoDataSourceProcessor TrinoDatasourceProcessor = new TrinoDataSourceProcessor();
+    private final TrinoDataSourceProcessor TrinoDatasourceProcessor = new TrinoDataSourceProcessor();
 
     @Test
     public void testCreateConnectionParams() {
@@ -91,5 +91,18 @@ public class TrinoDataSourceProcessorTest {
     public void testGetValidationQuery() {
         Assertions.assertEquals(DataSourceConstants.TRINO_VALIDATION_QUERY,
                 TrinoDatasourceProcessor.getValidationQuery());
+    }
+
+    @Test
+    public void testCheckDatasourceParam() {
+        Map<String, String> others = new HashMap<>();
+        others.put("SSL", "true");
+        others.put("SSLKeyStorePassword", "******");
+        others.put("SSLKeyStorePath", "/home/dolphinscheduler/trino.jks");
+        TrinoDataSourceParamDTO trinoDataSourceParamDTO = new TrinoDataSourceParamDTO();
+        trinoDataSourceParamDTO.setDatabase("dwh");
+        trinoDataSourceParamDTO.setHost("10.11.12.13");
+        trinoDataSourceParamDTO.setOther(others);
+        Assertions.assertDoesNotThrow(() -> TrinoDatasourceProcessor.checkDatasourceParam(trinoDataSourceParamDTO));
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

close #15347.

We need to check key rather than value.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
