### PR TITLE
[Improvement] Directly Throw exception when taskInstancy log path is empty which log need to be queried

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -131,7 +131,7 @@ public enum Status {
     VERIFY_USERNAME_ERROR(10100, "verify username error", "用户名验证错误"),
     UNAUTHORIZED_USER_ERROR(10101, "unauthorized user error", "查询未授权用户错误"),
     AUTHORIZED_USER_ERROR(10102, "authorized user error", "查询授权用户错误"),
-    QUERY_TASK_INSTANCE_LOG_ERROR(10103, "view task instance log error", "查询任务实例日志错误"),
+    QUERY_TASK_INSTANCE_LOG_ERROR(10103, "view task instance log error: {0}", "查询任务实例日志错误: {0}"),
     DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR(10104, "download task instance log file error", "下载任务日志文件错误"),
     CREATE_PROCESS_DEFINITION_ERROR(10105, "create process definition error", "创建工作流错误"),
     VERIFY_PROCESS_DEFINITION_NAME_UNIQUE_ERROR(10106, "verify process definition name unique error", "工作流定义名称验证错误"),

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -188,6 +188,11 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
         final String logPath = taskInstance.getLogPath();
         log.info("Query task instance log, taskInstanceId:{}, taskInstanceName:{}, host: {}, logPath:{}",
                 taskInstance.getId(), taskInstance.getName(), taskInstance.getHost(), logPath);
+        if (StringUtils.isBlank(logPath)) {
+            throw new ServiceException(Status.QUERY_TASK_INSTANCE_LOG_ERROR,
+                    "TaskInstanceLogPath is empty, maybe the taskInstance doesn't be dispatched");
+        }
+
         StringBuilder sb = new StringBuilder();
         if (skipLineNum == 0) {
             String head = String.format(LOG_HEAD_FORMAT,
@@ -213,7 +218,7 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
             }
             return sb.toString();
         } catch (Throwable ex) {
-            throw new ServiceException(Status.QUERY_TASK_INSTANCE_LOG_ERROR, ex);
+            throw new ServiceException(Status.QUERY_TASK_INSTANCE_LOG_ERROR, ex.getMessage(), ex);
         }
     }
 


### PR DESCRIPTION
## Purpose of the pull request

Avoid send RPC to worker, cause worker NPE

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
