### PR TITLE
Exit JVM when OOM

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/bin/jvm_args_env.sh
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/bin/jvm_args_env.sh
@@ -24,6 +24,7 @@
 -XX:+PrintGCDetails
 -Xloggc:gc.log
 
+-XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:HeapDumpPath=dump.hprof
 

--- a/dolphinscheduler-api/src/main/bin/jvm_args_env.sh
+++ b/dolphinscheduler-api/src/main/bin/jvm_args_env.sh
@@ -24,6 +24,7 @@
 -XX:+PrintGCDetails
 -Xloggc:gc.log
 
+-XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:HeapDumpPath=dump.hprof
 

--- a/dolphinscheduler-master/src/main/bin/jvm_args_env.sh
+++ b/dolphinscheduler-master/src/main/bin/jvm_args_env.sh
@@ -24,6 +24,7 @@
 -XX:+PrintGCDetails
 -Xloggc:gc.log
 
+-XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:HeapDumpPath=dump.hprof
 

--- a/dolphinscheduler-standalone-server/src/main/bin/jvm_args_env.sh
+++ b/dolphinscheduler-standalone-server/src/main/bin/jvm_args_env.sh
@@ -24,6 +24,7 @@
 -XX:+PrintGCDetails
 -Xloggc:gc.log
 
+-XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:HeapDumpPath=dump.hprof
 

--- a/dolphinscheduler-worker/src/main/bin/jvm_args_env.sh
+++ b/dolphinscheduler-worker/src/main/bin/jvm_args_env.sh
@@ -24,6 +24,7 @@
 -XX:+PrintGCDetails
 -Xloggc:gc.log
 
+-XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:HeapDumpPath=dump.hprof
 


### PR DESCRIPTION
## Purpose of the pull request

Avoid JVM doesn't exit when OOM occur. This may cause some problem, e.g. the Server cannot work but still in registry and the server crash alert doesn't send.

## Brief change log

Add `-XX:+ExitOnOutOfMemoryError` in jvm_args_env.sh, this should work on jvm version > 8.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
