### PR TITLE
Fix NullPointerException after upgrade from 1.3.6 to 3.1.9

### DIFF
--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/JsonSplitDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/JsonSplitDao.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.tools.datasource.dao;
 
+import org.apache.dolphinscheduler.common.enums.TimeoutFlag;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.ProcessTaskRelationLog;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/JsonSplitDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/JsonSplitDao.java
@@ -191,7 +191,7 @@ public class JsonSplitDao {
                 insert.setLong(12, taskDefinitionLog.getEnvironmentCode());
                 insert.setInt(13, taskDefinitionLog.getFailRetryTimes());
                 insert.setInt(14, taskDefinitionLog.getFailRetryInterval());
-                insert.setInt(15, taskDefinitionLog.getTimeoutFlag().getCode());
+                insert.setInt(15, taskDefinitionLog.getTimeoutFlag() == null ? TimeoutFlag.CLOSE.getCode() : taskDefinitionLog.getTimeoutFlag().getCode());
                 insert.setInt(16, taskDefinitionLog.getTimeoutNotifyStrategy() == null ? 0
                         : taskDefinitionLog.getTimeoutNotifyStrategy().getCode());
                 insert.setInt(17, taskDefinitionLog.getTimeout());


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
fix NullPointerException

## Brief change log

org.apache.dolphinscheduler.tools.datasource.dao.JsonSplitDao#executeJsonSplitTaskDefinition


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
