### PR TITLE
[Bug] [Master] kill task when TaskInstance set TimeoutFailed

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/operator/BaseTaskExecuteRunnableTimeoutOperator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/operator/BaseTaskExecuteRunnableTimeoutOperator.java
@@ -38,18 +38,8 @@ public abstract class BaseTaskExecuteRunnableTimeoutOperator implements TaskExec
 
     @Override
     public void operate(DefaultTaskExecuteRunnable taskExecuteRunnable) {
-        // Right now, if the task is running in worker, the timeout strategy will be handled at worker side.
-        // if the task is in master, the timeout strategy will be handled at master side.
-        // todo: we should unify this, the master only need to handle the timeout strategy. and send request to worker
-        // to kill the task, if the strategy is timeout_failed.
         TaskInstance taskInstance = taskExecuteRunnable.getTaskInstance();
         TaskTimeoutStrategy taskTimeoutStrategy = taskInstance.getTaskDefine().getTimeoutNotifyStrategy();
-        if (TaskTimeoutStrategy.FAILED != taskTimeoutStrategy
-                && TaskTimeoutStrategy.WARNFAILED != taskTimeoutStrategy) {
-            log.warn("TaskInstance: {} timeout, the current timeout strategy is {}, will continue running",
-                    taskInstance.getName(), taskTimeoutStrategy.name());
-            return;
-        }
         try {
             timeoutTaskInstanceInDB(taskInstance);
             killRemoteTaskInstanceInThreadPool(taskInstance);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

resolve https://github.com/apache/dolphinscheduler/issues/15545

## Brief change log

directly kill task if the strategy is timeout_failed.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
