### PR TITLE
[fix-#14858][datasource] can not correctly parse the 'other' parameter

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/DecoratorDataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/datasource/DecoratorDataSourceProcessor.java
@@ -1,0 +1,103 @@
+package org.apache.dolphinscheduler.plugin.datasource.api.datasource;
+
+import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EQUAL_SIGN;
+
+import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
+import org.apache.dolphinscheduler.spi.enums.DbType;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class DecoratorDataSourceProcessor extends AbstractDataSourceProcessor {
+
+    private final DataSourceProcessor dataSourceProcessor;
+
+    /**
+     * Mysql other param
+     */
+    private static final String OTHER_PARAMS_REGEX = "([a-zA-Z0-9]+=\\S+)(?:&[a-zA-Z0-9]+=\\S+)*";
+
+    public DecoratorDataSourceProcessor(DataSourceProcessor dataSourceProcessor) {
+        this.dataSourceProcessor = dataSourceProcessor;
+    }
+
+    @Override
+    public BaseDataSourceParamDTO castDatasourceParamDTO(String paramJson) {
+        return dataSourceProcessor.castDatasourceParamDTO(fixOtherParam(paramJson));
+    }
+
+    @Override
+    public BaseDataSourceParamDTO createDatasourceParamDTO(String connectionJson) {
+        return dataSourceProcessor.createDatasourceParamDTO(fixOtherParam(connectionJson));
+    }
+
+    @Override
+    public ConnectionParam createConnectionParams(BaseDataSourceParamDTO datasourceParam) {
+        return dataSourceProcessor.createConnectionParams(datasourceParam);
+    }
+
+    @Override
+    public ConnectionParam createConnectionParams(String connectionJson) {
+        return dataSourceProcessor.createConnectionParams(fixOtherParam(connectionJson));
+    }
+
+    @Override
+    public String getDatasourceDriver() {
+        return dataSourceProcessor.getDatasourceDriver();
+    }
+
+    @Override
+    public String getValidationQuery() {
+        return dataSourceProcessor.getValidationQuery();
+    }
+
+    @Override
+    public String getJdbcUrl(ConnectionParam connectionParam) {
+        return dataSourceProcessor.getJdbcUrl(connectionParam);
+    }
+
+    @Override
+    public Connection getConnection(ConnectionParam connectionParam) throws ClassNotFoundException, SQLException, IOException {
+        return dataSourceProcessor.getConnection(connectionParam);
+    }
+
+    @Override
+    public DbType getDbType() {
+        return dataSourceProcessor.getDbType();
+    }
+
+    @Override
+    public DataSourceProcessor create() {
+        return dataSourceProcessor;
+    }
+
+    public static DataSourceProcessor wrap(DataSourceProcessor dataSourceProcessor) {
+        return new DecoratorDataSourceProcessor(dataSourceProcessor);
+    }
+
+    private String fixOtherParam(String connectionJson) {
+        String other = JSONUtils.getNodeString(connectionJson, Constants.OTHER);
+        if (Pattern.compile(OTHER_PARAMS_REGEX)
+                .matcher(other)
+                .matches()) {
+            ObjectNode jn = JSONUtils.parseObject(connectionJson);
+            HashMap<String, Object> otherMap = Arrays.stream(other.split("&"))
+                    .filter(kvStr -> StringUtils.isNotEmpty(kvStr) && kvStr.contains(EQUAL_SIGN))
+                    .map(kvStr -> kvStr.split(EQUAL_SIGN))
+                    .collect(HashMap::new, (map, kv) -> map.put(kv[0], kv[1]), HashMap::putAll);
+            jn.set(Constants.OTHER, JSONUtils.toJsonNode(otherMap));
+            return JSONUtils.toJsonString(jn);
+        }
+        return connectionJson;
+    }
+}

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/plugin/DataSourceProcessorManager.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/plugin/DataSourceProcessorManager.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.plugin.datasource.api.plugin;
 import static java.lang.String.format;
 
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.DataSourceProcessor;
+import org.apache.dolphinscheduler.plugin.datasource.api.datasource.DecoratorDataSourceProcessor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -55,6 +56,6 @@ public class DataSourceProcessorManager {
 
     private void loadDatasourceClient(DataSourceProcessor processor) {
         DataSourceProcessor instance = processor.create();
-        dataSourceProcessorMap.put(processor.getDbType().name(), instance);
+        dataSourceProcessorMap.put(processor.getDbType().name(), DecoratorDataSourceProcessor.wrap(instance));
     }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/param/MySQLDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-mysql/src/test/java/org/apache/dolphinscheduler/plugin/datasource/mysql/param/MySQLDataSourceProcessorTest.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.plugin.datasource.mysql.param;
 
 import org.apache.dolphinscheduler.common.constants.DataSourceConstants;
+import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 
@@ -65,6 +66,17 @@ public class MySQLDataSourceProcessorTest {
                 + ",\"database\":\"default\",\"jdbcUrl\":\"jdbc:mysql://localhost:3306/default\"}";
         MySQLConnectionParam connectionParams = (MySQLConnectionParam) mysqlDatasourceProcessor
                 .createConnectionParams(connectionJson);
+        Assertions.assertNotNull(connectionJson);
+        Assertions.assertEquals("root", connectionParams.getUser());
+    }
+
+    @Test
+    public void testCreateConnectionParams3() {
+        String connectionJson =
+                "{\"user\":\"root\",\"password\":\"123\",\"address\":\"jdbc:mysql://127.0.0.1:3307\",\"database\":\"test\",\"jdbcUrl\":\"jdbc:mysql://127.0.0.1:3307/test\",\"driverClassName\":\"com.mysql.cj.jdbc.Driver\",\"validationQuery\":\"select 1\",\"other\":\"tinyInt1isBit=false&zeroDateTimeBehavior=convertToNull&\",\"props\":{\"zeroDateTimeBehavior\":\"convertToNull\",\"tinyInt1isBit\":\"false\"}}";
+        MySQLConnectionParam connectionParams =
+                (MySQLConnectionParam) DataSourceUtils.getDatasourceProcessor(DbType.MYSQL)
+                        .createConnectionParams(connectionJson);
         Assertions.assertNotNull(connectionJson);
         Assertions.assertEquals("root", connectionParams.getUser());
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix this bug #14858 

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
