### PR TITLE
fix: Resource relate path invalid when tenant change

### DIFF
--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/StorageOperate.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/StorageOperate.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.plugin.storage.api;
 
+import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_TYPE_FILE;
+
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.ResUploadType;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
@@ -72,7 +74,16 @@ public interface StorageOperate {
      */
     default String getResourceFileName(String tenantCode, String fullName) {
         String resDir = getResDir(tenantCode);
-        return fullName.replaceFirst(resDir, "");
+        String filenameReplaceResDir = fullName.replaceFirst(resDir, "");
+        if (!filenameReplaceResDir.equals(fullName)) {
+            return filenameReplaceResDir;
+        }
+
+        // Replace resource dir not effective in case of run workflow with different tenant from resource file's.
+        // this is backup solution to get related path, by split with RESOURCE_TYPE_FILE
+        return filenameReplaceResDir.contains(RESOURCE_TYPE_FILE)
+                ? filenameReplaceResDir.split(String.format("%s/", RESOURCE_TYPE_FILE))[1]
+                : filenameReplaceResDir;
     }
 
     /**

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/HdfsStorageOperator.java
@@ -71,7 +71,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @Slf4j
 public class HdfsStorageOperator implements Closeable, StorageOperate {
 
-    private static HdfsStorageProperties hdfsProperties = new HdfsStorageProperties();
+    protected static HdfsStorageProperties hdfsProperties = new HdfsStorageProperties();
     private static final String HADOOP_UTILS_KEY = "HADOOP_UTILS_KEY";
 
     private volatile boolean yarnEnabled = false;

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/LocalStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-hdfs/src/main/java/org/apache/dolphinscheduler/plugin/storage/hdfs/LocalStorageOperator.java
@@ -17,26 +17,23 @@
 
 package org.apache.dolphinscheduler.plugin.storage.hdfs;
 
-import org.apache.dolphinscheduler.plugin.storage.api.StorageOperate;
-import org.apache.dolphinscheduler.plugin.storage.api.StorageOperateFactory;
-import org.apache.dolphinscheduler.plugin.storage.api.StorageType;
+import lombok.extern.slf4j.Slf4j;
 
-import com.google.auto.service.AutoService;
+@Slf4j
+public class LocalStorageOperator extends HdfsStorageOperator {
 
-@AutoService(StorageOperateFactory.class)
-public class LocalStorageOperatorFactory implements StorageOperateFactory {
+    public LocalStorageOperator() {
+        super(new HdfsStorageProperties());
+    }
 
-    private static final String LOCAL_DEFAULT_FS = "file:/";
-
-    @Override
-    public StorageOperate createStorageOperate() {
-        HdfsStorageProperties hdfsStorageProperties = new HdfsStorageProperties();
-        hdfsStorageProperties.setDefaultFS(LOCAL_DEFAULT_FS);
-        return new LocalStorageOperator(hdfsStorageProperties);
+    public LocalStorageOperator(HdfsStorageProperties hdfsStorageProperties) {
+        super(hdfsStorageProperties);
     }
 
     @Override
-    public StorageType getStorageOperate() {
-        return StorageType.LOCAL;
+    public String getResourceFileName(String tenantCode, String fullName) {
+        // prefix schema `file:/` should be remove in local file mode
+        String fullNameRemoveSchema = fullName.replaceFirst(hdfsProperties.getDefaultFS(), "");
+        return super.getResourceFileName(tenantCode, fullNameRemoveSchema);
     }
 }


### PR DESCRIPTION
* fix can not get correct resource related path when user run workflow with differnet tenant of resource created
* also fix can not get correct related path when we use `resource.storage.type=LOCAL`

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
