### PR TITLE
[Doc][remote shell] missing remote shell doc for version 3.2.1

### DIFF
--- a/docs/configs/docsdev.js
+++ b/docs/configs/docsdev.js
@@ -270,6 +270,10 @@ export default {
                                 title: 'Vertica',
                                 link: '/en-us/docs/dev/user_doc/guide/datasource/vertica.html',
                             },
+                            {
+                                title: 'Remote Shell',
+                                link: '/en-us/docs/dev/user_doc/guide/task/remoteshell.html',
+                            },
                         ],
                     },
                     {
@@ -968,6 +972,10 @@ export default {
                             {
                                 title: 'Vertica',
                                 link: '/zh-cn/docs/dev/user_doc/guide/datasource/vertica.html',
+                            },
+                            {
+                                title: 'Remote Shell',
+                                link: '/zh-cn/docs/dev/user_doc/guide/task/remoteshell.html',
                             },
                         ],
                     },


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix: https://github.com/apache/dolphinscheduler/issues/15649

## Brief change log

remoteshell.md has been in task/, see [link](https://github.com/apache/dolphinscheduler/blob/88a8f06b1d42da00faf992b3542624f4c3590563/docs/docs/zh/guide/task/remoteshell.md#L4), we should add it into doc index.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
