### PR TITLE
Fix the NullPointerException when "start param to overwrite global param"

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -601,9 +601,12 @@ public class ProcessServiceImpl implements ProcessService {
         if (MapUtils.isNotEmpty(startParamMap) && globalMap != null) {
             // start param to overwrite global param
             for (Map.Entry<String, String> param : globalMap.entrySet()) {
-                String val = startParamMap.get(param.getKey()).getValue();
-                if (val != null) {
-                    param.setValue(val);
+                String globalKey = param.getKey();
+                if (startParamMap.containsKey(globalKey)) {
+                    String val = startParamMap.get(globalKey).getValue();
+                    if (val != null) {
+                        param.setValue(val);
+                    }
                 }
             }
             // start param to create new global param if global not exist


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

This pull request to fix #15676 , fix the NullPointerException by checking whether the key exists when "start param to overwrite global param"

## Brief change log

Add a "containsKey" judgement when "start param to overwrite global param"

## Verify this pull request

This pull request is code cleanup without any test coverage.
