### PR TITLE
[Improvement-15694][UI] After saving the task form the task node uses the wrong background color. 

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/use-task-edit.ts
@@ -163,15 +163,17 @@ export function useTaskEdit(options: Options) {
    */
   function taskConfirm({ data }: any) {
     const taskDef = formatParams(data).taskDefinitionJsonObj as NodeData
+
     // override target config
     processDefinition.value.taskDefinitionList =
       processDefinition.value.taskDefinitionList.map((task) => {
         if (task.code === currTask.value?.code) {
           setNodeName(task.code + '', taskDef.name)
           let fillColor = '#ffffff'
-          if (task.flag === 'YES') {
+          if (taskDef.flag === 'NO') {
             fillColor = 'var(--custom-disable-bg)'
           }
+
           setNodeFillColor(task.code + '', fillColor)
 
           setNodeEdge(String(task.code), data.preTasks)


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

This PR will close #15694 .

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request
This change added tests and can be verified as follows:
- *Manually verified the change by testing locally.* 

The test results are as follows:
![image](https://github.com/apache/dolphinscheduler/assets/4928204/a7fe1377-f66e-4fdf-89e3-cced2686ba50)
![image](https://github.com/apache/dolphinscheduler/assets/4928204/9494cf42-38bb-40b1-9890-d5551a994da1)



