### PR TITLE
[Fix-15698][UI] close the definition when opened in the new tab

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/dag-toolbar.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/dag-toolbar.tsx
@@ -148,17 +148,18 @@ export default defineComponent({
      * Back to the entrance
      */
     const onClose = () => {
-      if (history.state.back !== '/login') {
+      const { back, current } = history.state
+      if (back && back !== '/login') {
         router.go(-1)
         return
       }
-      if (history.state.current.includes('workflow/definitions')) {
+      if (!back || current.includes('workflow/definitions')) {
         router.push({
           path: `/projects/${route.params.projectCode}/workflow-definition`
         })
         return
       }
-      if (history.state.current.includes('workflow/instances')) {
+      if (current.includes('workflow/instances')) {
         router.push({
           path: `/projects/${route.params.projectCode}/workflow/instances`
         })


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #15698

![workflow](https://github.com/apache/dolphinscheduler/assets/9403654/0b1e4a19-7f11-41a2-ae98-8ff46b8fd2fa)


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

edit router check when close the workflow definition opened in the new tab

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
