### PR TITLE
[Fix] add resource full name check

### DIFF
--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -190,7 +190,7 @@ public class ResourcesServiceTest {
         mockMultipartFile = new MockMultipartFile(tooLongFileName, tooLongFileName, "pdf", "test".getBytes());
         when(Files.getFileExtension(tooLongFileName)).thenReturn("pdf");
         // '/databasePath/tenantCode/RESOURCE/'
-        when(storageOperate.getResDir("123")).thenReturn("/dolphinscheduler/123/resources/");
+        when(storageOperate.getResDir(tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
         result = resourcesService.uploadResource(user, tooLongFileName, ResourceType.FILE, mockMultipartFile, "/");
         logger.info(result.toString());
         assertEquals(Status.RESOURCE_FULL_NAME_TOO_LONG_ERROR.getMsg(), result.getMsg());
@@ -207,7 +207,7 @@ public class ResourcesServiceTest {
         user.setTenantId(1);
         when(tenantMapper.queryById(1)).thenReturn(getTenant());
         when(userMapper.selectById(user.getId())).thenReturn(getUser());
-        when(storageOperate.getResDir("123")).thenReturn("/dolphinscheduler/123/resources/");
+        when(storageOperate.getResDir(tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
         try {
             when(storageOperate.exists("/dolphinscheduler/123/resources/directoryTest")).thenReturn(true);
         } catch (IOException e) {
@@ -227,7 +227,7 @@ public class ResourcesServiceTest {
 
         when(userMapper.selectById(user.getId())).thenReturn(getUser());
         when(tenantMapper.queryById(1)).thenReturn(getTenant());
-        when(storageOperate.getResDir("123")).thenReturn("/dolphinscheduler/123/resources/");
+        when(storageOperate.getResDir(tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
 
         // USER_NO_OPERATION_PERM
         user.setUserType(UserType.GENERAL_USER);
@@ -236,7 +236,7 @@ public class ResourcesServiceTest {
         tenantWNoPermission.setTenantCode("321");
         when(tenantMapper.queryById(1)).thenReturn(tenantWNoPermission);
         Result result = resourcesService.updateResource(user, "/dolphinscheduler/123/resources/ResourcesServiceTest",
-                "123", "ResourcesServiceTest", ResourceType.FILE, null);
+                tenantCode, "ResourcesServiceTest", ResourceType.FILE, null);
         logger.info(result.toString());
         assertEquals(Status.NO_CURRENT_OPERATING_PERMISSION.getMsg(), result.getMsg());
 
@@ -250,10 +250,10 @@ public class ResourcesServiceTest {
 
         try {
             when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest",
-                    "/dolphinscheduler/123/resources/", "123", ResourceType.FILE))
+                    "/dolphinscheduler/123/resources/", tenantCode, ResourceType.FILE))
                             .thenReturn(getStorageEntityResource());
             result = resourcesService.updateResource(user, "/dolphinscheduler/123/resources/ResourcesServiceTest",
-                    "123", "ResourcesServiceTest", ResourceType.FILE, null);
+                    tenantCode, "ResourcesServiceTest", ResourceType.FILE, null);
             logger.info(result.toString());
             assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
         } catch (Exception e) {
@@ -272,14 +272,14 @@ public class ResourcesServiceTest {
 
         try {
             when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest1.jar",
-                    "/dolphinscheduler/123/resources/", "123", ResourceType.UDF))
+                    "/dolphinscheduler/123/resources/", tenantCode, ResourceType.UDF))
                             .thenReturn(getStorageEntityUdfResource());
         } catch (Exception e) {
             logger.error(e.getMessage() + " Resource path: {}",
                     "/dolphinscheduler/123/resources/ResourcesServiceTest1.jar", e);
         }
         result = resourcesService.updateResource(user, "/dolphinscheduler/123/resources/ResourcesServiceTest1.jar",
-                "123", "ResourcesServiceTest2.jar", ResourceType.UDF, null);
+                tenantCode, "ResourcesServiceTest2.jar", ResourceType.UDF, null);
         logger.info(result.toString());
         assertEquals(Status.RESOURCE_EXIST.getMsg(), result.getMsg());
 
@@ -292,7 +292,7 @@ public class ResourcesServiceTest {
         when(tenantMapper.queryById(1)).thenReturn(getTenant());
 
         result = resourcesService.updateResource(user, "/dolphinscheduler/123/resources/ResourcesServiceTest1.jar",
-                "123", "ResourcesServiceTest1.jar", ResourceType.UDF, null);
+                tenantCode, "ResourcesServiceTest1.jar", ResourceType.UDF, null);
         logger.info(result.toString());
         assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
     }
@@ -311,11 +311,11 @@ public class ResourcesServiceTest {
         when(userMapper.selectList(null)).thenReturn(mockUserList);
         when(userMapper.selectById(getUser().getId())).thenReturn(getUser());
         when(tenantMapper.queryById(getUser().getTenantId())).thenReturn(getTenant());
-        when(storageOperate.getResDir("123")).thenReturn("/dolphinscheduler/123/resources/");
+        when(storageOperate.getResDir(tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
 
         try {
             when(storageOperate.listFilesStatus("/dolphinscheduler/123/resources/", "/dolphinscheduler/123/resources/",
-                    "123", ResourceType.FILE)).thenReturn(mockResList);
+                    tenantCode, ResourceType.FILE)).thenReturn(mockResList);
         } catch (Exception e) {
             logger.error("QueryResourceListPaging Error");
         }
@@ -334,10 +334,11 @@ public class ResourcesServiceTest {
         when(userMapper.selectList(null)).thenReturn(Collections.singletonList(loginUser));
         when(userMapper.selectById(loginUser.getId())).thenReturn(loginUser);
         when(tenantMapper.queryById(Mockito.anyInt())).thenReturn(getTenant());
+        when(storageOperate.getDir(ResourceType.ALL, tenantCode)).thenReturn("/dolphinscheduler");
         when(storageOperate.getDir(ResourceType.FILE, tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
-        when(storageOperate.getResDir("123")).thenReturn("/dolphinscheduler/123/resources/");
+        when(storageOperate.getResDir(tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
         when(storageOperate.listFilesStatusRecursively("/dolphinscheduler/123/resources/",
-                "/dolphinscheduler/123/resources/", "123", ResourceType.FILE))
+                "/dolphinscheduler/123/resources/", tenantCode, ResourceType.FILE))
                         .thenReturn(Collections.singletonList(getStorageEntityResource()));
         Map<String, Object> result =
                 resourcesService.queryResourceList(loginUser, ResourceType.FILE, "/dolphinscheduler/123/resources/");
@@ -347,9 +348,9 @@ public class ResourcesServiceTest {
 
         // test udf
         when(storageOperate.getDir(ResourceType.UDF, tenantCode)).thenReturn("/dolphinscheduler/123/udfs/");
-        when(storageOperate.getUdfDir("123")).thenReturn("/dolphinscheduler/123/udfs/");
+        when(storageOperate.getUdfDir(tenantCode)).thenReturn("/dolphinscheduler/123/udfs/");
         when(storageOperate.listFilesStatusRecursively("/dolphinscheduler/123/udfs/", "/dolphinscheduler/123/udfs/",
-                "123", ResourceType.UDF)).thenReturn(Arrays.asList(getStorageEntityUdfResource()));
+                tenantCode, ResourceType.UDF)).thenReturn(Arrays.asList(getStorageEntityUdfResource()));
         loginUser.setUserType(UserType.GENERAL_USER);
         result = resourcesService.queryResourceList(loginUser, ResourceType.UDF, "/dolphinscheduler/123/udfs/");
         assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
@@ -372,16 +373,17 @@ public class ResourcesServiceTest {
 
         // RESOURCE_NOT_EXIST
         when(tenantMapper.queryById(Mockito.anyInt())).thenReturn(getTenant());
+        when(storageOperate.getDir(ResourceType.ALL, tenantCode)).thenReturn("/dolphinscheduler");
         when(storageOperate.getResDir(getTenant().getTenantCode())).thenReturn("/dolphinscheduler/123/resources/");
         when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest",
-                "/dolphinscheduler/123/resources/", "123", null))
+                "/dolphinscheduler/123/resources/", tenantCode, null))
                         .thenReturn(getStorageEntityResource());
-        Result result = resourcesService.delete(loginUser, "/dolphinscheduler/123/resources/ResNotExist", "123");
+        Result result = resourcesService.delete(loginUser, "/dolphinscheduler/123/resources/ResNotExist", tenantCode);
         assertEquals(Status.RESOURCE_NOT_EXIST.getMsg(), result.getMsg());
 
         // SUCCESS
         loginUser.setTenantId(1);
-        result = resourcesService.delete(loginUser, "/dolphinscheduler/123/resources/ResourcesServiceTest", "123");
+        result = resourcesService.delete(loginUser, "/dolphinscheduler/123/resources/ResourcesServiceTest", tenantCode);
         assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
     }
 
@@ -439,13 +441,15 @@ public class ResourcesServiceTest {
 
         // SUCCESS
         when(FileUtils.getResourceViewSuffixes()).thenReturn("jar,sh");
+        when(storageOperate.getDir(ResourceType.ALL, tenantCode)).thenReturn("/dolphinscheduler");
         when(storageOperate.getResDir(getTenant().getTenantCode())).thenReturn("/dolphinscheduler/123/resources/");
         when(userMapper.selectById(getUser().getId())).thenReturn(getUser());
         when(tenantMapper.queryById(getUser().getTenantId())).thenReturn(getTenant());
         when(storageOperate.exists(Mockito.any())).thenReturn(true);
         when(storageOperate.vimFile(Mockito.any(), Mockito.any(), eq(1), eq(10))).thenReturn(getContent());
         when(Files.getFileExtension("/dolphinscheduler/123/resources/test.jar")).thenReturn("jar");
-        result = resourcesService.readResource(getUser(), "/dolphinscheduler/123/resources/test.jar", "123", 1, 10);
+        result = resourcesService.readResource(getUser(), "/dolphinscheduler/123/resources/test.jar", tenantCode, 1,
+                10);
         assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
     }
 
@@ -480,29 +484,32 @@ public class ResourcesServiceTest {
         when(storageOperate.getResDir(Mockito.anyString())).thenReturn("/tmp");
         ServiceException serviceException =
                 Assertions.assertThrows(ServiceException.class, () -> resourcesService.updateResourceContent(getUser(),
-                        "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "123", "content"));
+                        "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", tenantCode, "content"));
         assertTrue(serviceException.getMessage()
                 .contains("Resource file: /dolphinscheduler/123/resources/ResourcesServiceTest.jar is illegal"));
 
         // RESOURCE_NOT_EXIST
+        when(storageOperate.getDir(ResourceType.ALL, tenantCode)).thenReturn("/dolphinscheduler");
         when(storageOperate.getResDir(Mockito.anyString())).thenReturn("/dolphinscheduler/123/resources");
-        when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "", "123",
+        when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "", tenantCode,
                 ResourceType.FILE)).thenReturn(null);
         Result result = resourcesService.updateResourceContent(getUser(),
-                "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "123", "content");
+                "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", tenantCode, "content");
         assertEquals(Status.RESOURCE_NOT_EXIST.getMsg(), result.getMsg());
 
         // RESOURCE_SUFFIX_NOT_SUPPORT_VIEW
         when(FileUtils.getResourceViewSuffixes()).thenReturn("class");
-        when(storageOperate.getFileStatus("/dolphinscheduler/123/resources", "", "123", ResourceType.FILE))
+        when(storageOperate.getFileStatus("/dolphinscheduler/123/resources", "", tenantCode, ResourceType.FILE))
                 .thenReturn(getStorageEntityResource());
 
-        result = resourcesService.updateResourceContent(getUser(), "/dolphinscheduler/123/resources", "123", "content");
+        result = resourcesService.updateResourceContent(getUser(), "/dolphinscheduler/123/resources", tenantCode,
+                "content");
         assertEquals(Status.RESOURCE_SUFFIX_NOT_SUPPORT_VIEW.getMsg(), result.getMsg());
 
         // USER_NOT_EXIST
         when(userMapper.selectById(getUser().getId())).thenReturn(null);
-        result = resourcesService.updateResourceContent(getUser(), "/dolphinscheduler/123/resources/123.class", "123",
+        result = resourcesService.updateResourceContent(getUser(), "/dolphinscheduler/123/resources/123.class",
+                tenantCode,
                 "content");
         Assertions.assertTrue(Status.USER_NOT_EXIST.getCode() == result.getCode());
 
@@ -510,10 +517,10 @@ public class ResourcesServiceTest {
         when(userMapper.selectById(getUser().getId())).thenReturn(getUser());
         when(tenantMapper.queryById(1)).thenReturn(null);
         Assertions.assertThrows(ServiceException.class, () -> resourcesService.updateResourceContent(getUser(),
-                "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "123", "content"));
+                "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", tenantCode, "content"));
 
         // SUCCESS
-        when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "", "123",
+        when(storageOperate.getFileStatus("/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "", tenantCode,
                 ResourceType.FILE)).thenReturn(getStorageEntityResource());
 
         when(Files.getFileExtension(Mockito.anyString())).thenReturn("jar");
@@ -523,7 +530,7 @@ public class ResourcesServiceTest {
         when(FileUtils.getUploadFilename(Mockito.anyString(), Mockito.anyString())).thenReturn("test");
         when(FileUtils.writeContent2File(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
         result = resourcesService.updateResourceContent(getUser(),
-                "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", "123", "content");
+                "/dolphinscheduler/123/resources/ResourcesServiceTest.jar", tenantCode, "content");
         logger.info(result.toString());
         assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
     }
@@ -614,7 +621,7 @@ public class ResourcesServiceTest {
         User user = getUser();
         when(userMapper.selectById(user.getId())).thenReturn(getUser());
         when(tenantMapper.queryById(user.getTenantId())).thenReturn(getTenant());
-        when(storageOperate.getDir(ResourceType.FILE, "123")).thenReturn("/dolphinscheduler/123/resources/");
+        when(storageOperate.getDir(ResourceType.FILE, tenantCode)).thenReturn("/dolphinscheduler/123/resources/");
         try {
             when(storageOperate.getFileStatus(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
                     Mockito.any())).thenReturn(getStorageEntityResource());
@@ -646,7 +653,7 @@ public class ResourcesServiceTest {
         entity.setAlias("ResourcesServiceTest");
         entity.setFileName("ResourcesServiceTest");
         entity.setDirectory(false);
-        entity.setUserName("123");
+        entity.setUserName(tenantCode);
         entity.setType(ResourceType.FILE);
         entity.setFullName("/dolphinscheduler/123/resources/ResourcesServiceTest");
         return entity;
@@ -657,7 +664,7 @@ public class ResourcesServiceTest {
         entity.setAlias("ResourcesServiceTest1.jar");
         entity.setFileName("ResourcesServiceTest1.jar");
         entity.setDirectory(false);
-        entity.setUserName("123");
+        entity.setUserName(tenantCode);
         entity.setType(ResourceType.UDF);
         entity.setFullName("/dolphinscheduler/123/resources/ResourcesServiceTest1.jar");
 

--- a/dolphinscheduler-ui/src/views/resource/components/resource/table/use-table.ts
+++ b/dolphinscheduler-ui/src/views/resource/components/resource/table/use-table.ts
@@ -284,8 +284,8 @@ export const useDetailPageStore = defineStore('detailPage', {
     setFullName(fullName: string) {
       this.fullName = fullName
     },
-    setTenantCode(fullName: string) {
-      this.fullName = fullName
+    setTenantCode(tenantCode: string) {
+      this.tenantCode = tenantCode
     },
     setSearchValue(searchValue: string) {
       this.searchValue = searchValue


### PR DESCRIPTION
## Purpose of the pull request

Add the resource full name check during resource operations to avoid illegal paths.

## Brief change log

`dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java`

```
private void checkFullName(String baseDir, String fullName) {
        if (StringUtils.isNotBlank(fullName) && !StringUtils.startsWith(fullName, baseDir)) {
            throw new ServiceException("Resource file: " + fullName + " is illegal");
        }
    }
```


## Verify this pull request

- *Manually verified the change by testing locally.* 
