### PR TITLE
[Bug] Fix TaskGroupCoordinator might cause OOM when there is a lot of waiting TaskGroupQueue

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.java
@@ -122,4 +122,18 @@ public interface TaskGroupQueueMapper extends BaseMapper<TaskGroupQueue> {
                                                            @Param("status") int status,
                                                            @Param("inQueue") int inQueue,
                                                            @Param("forceStart") int forceStart);
+
+    int countUsingTaskGroupQueueByGroupId(@Param("taskGroupId") Integer taskGroupId,
+                                          @Param("status") int status,
+                                          @Param("inQueue") int inQueue,
+                                          @Param("forceStart") int forceStart);
+
+    List<TaskGroupQueue> queryInQueueTaskGroupQueue(@Param("inQueue") int inQueue,
+                                                    @Param("minTaskGroupQueueId") int minTaskGroupQueueId,
+                                                    @Param("limit") int limit);
+
+    List<TaskGroupQueue> queryWaitNotifyForceStartTaskGroupQueue(@Param("inQueue") int inQueue,
+                                                                 @Param("forceStart") int forceStart,
+                                                                 @Param("minTaskGroupQueueId") int minTaskGroupQueueId,
+                                                                 @Param("limit") int limit);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TaskGroupQueueDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TaskGroupQueueDao.java
@@ -39,6 +39,17 @@ public interface TaskGroupQueueDao extends IDao<TaskGroupQueue> {
     List<TaskGroupQueue> queryAllInQueueTaskGroupQueue();
 
     /**
+     * Query all {@link TaskGroupQueue} which
+     * in_queue is {@link org.apache.dolphinscheduler.common.enums.Flag#YES}
+     * and id > minTaskGroupQueueId
+     * ordered by id asc
+     * limit #{limit}
+     *
+     * @return TaskGroupQueue ordered by id asc
+     */
+    List<TaskGroupQueue> queryInQueueTaskGroupQueue(int minTaskGroupQueueId, int limit);
+
+    /**
      * Query all {@link TaskGroupQueue} which in_queue is {@link org.apache.dolphinscheduler.common.enums.Flag#YES} and taskGroupId is taskGroupId
      *
      * @param taskGroupId taskGroupId
@@ -61,4 +72,24 @@ public interface TaskGroupQueueDao extends IDao<TaskGroupQueue> {
      * @return TaskGroupQueue
      */
     List<TaskGroupQueue> queryAcquiredTaskGroupQueueByGroupId(Integer taskGroupId);
+
+    /**
+     * Count all {@link TaskGroupQueue} which status is TaskGroupQueueStatus.ACQUIRE_SUCCESS and forceStart is {@link org.apache.dolphinscheduler.common.enums.Flag#NO}.
+     *
+     * @param taskGroupId taskGroupId
+     * @return TaskGroupQueue
+     */
+    int countUsingTaskGroupQueueByGroupId(Integer taskGroupId);
+
+    /**
+     * Query all {@link TaskGroupQueue} which
+     * in_queue is {@link org.apache.dolphinscheduler.common.enums.Flag#YES}
+     * and forceStart is {@link org.apache.dolphinscheduler.common.enums.Flag#YES}
+     * and id > minTaskGroupQueueId
+     * order by id asc
+     * limit #{limit}
+     *
+     * @return TaskGroupQueue ordered by priority desc
+     */
+    List<TaskGroupQueue> queryWaitNotifyForceStartTaskGroupQueue(int minTaskGroupQueueId, int limit);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TaskGroupQueueDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TaskGroupQueueDaoImpl.java
@@ -53,6 +53,11 @@ public class TaskGroupQueueDaoImpl extends BaseDao<TaskGroupQueue, TaskGroupQueu
     }
 
     @Override
+    public List<TaskGroupQueue> queryInQueueTaskGroupQueue(int minTaskGroupQueueId, int limit) {
+        return mybatisMapper.queryInQueueTaskGroupQueue(Flag.YES.getCode(), minTaskGroupQueueId, limit);
+    }
+
+    @Override
     public List<TaskGroupQueue> queryAllInQueueTaskGroupQueueByGroupId(Integer taskGroupId) {
         return mybatisMapper.queryAllInQueueTaskGroupQueueByGroupId(taskGroupId, Flag.YES.getCode());
     }
@@ -69,5 +74,22 @@ public class TaskGroupQueueDaoImpl extends BaseDao<TaskGroupQueue, TaskGroupQueu
                 TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode(),
                 Flag.YES.getCode(),
                 Flag.NO.getCode());
+    }
+
+    @Override
+    public int countUsingTaskGroupQueueByGroupId(Integer taskGroupId) {
+        return mybatisMapper.countUsingTaskGroupQueueByGroupId(taskGroupId,
+                TaskGroupQueueStatus.ACQUIRE_SUCCESS.getCode(),
+                Flag.YES.ordinal(),
+                Flag.NO.getCode());
+    }
+
+    @Override
+    public List<TaskGroupQueue> queryWaitNotifyForceStartTaskGroupQueue(int minTaskGroupQueueId, int limit) {
+        return mybatisMapper.queryWaitNotifyForceStartTaskGroupQueue(
+                Flag.YES.getCode(),
+                Flag.YES.getCode(),
+                minTaskGroupQueueId,
+                limit);
     }
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskGroupQueueMapper.xml
@@ -219,6 +219,16 @@
         where in_queue = #{inQueue} order by priority desc
     </select>
 
+    <select id="queryInQueueTaskGroupQueue" resultType="org.apache.dolphinscheduler.dao.entity.TaskGroupQueue">
+        select
+        <include refid="baseSql"/>
+        from t_ds_task_group_queue
+        where in_queue = #{inQueue}
+        and id &gt; #{minTaskGroupQueueId}
+        order by id asc
+        limit #{limit}
+    </select>
+
     <select id="queryByTaskInstanceId" resultType="org.apache.dolphinscheduler.dao.entity.TaskGroupQueue">
         select
         <include refid="baseSql" />
@@ -231,6 +241,23 @@
         <include refid="baseSql" />
         from t_ds_task_group_queue
         where group_id = #{taskGroupId} and status = #{status} and force_start = #{forceStart} and in_queue = #{inQueue}
+    </select>
+
+    <select id="countUsingTaskGroupQueueByGroupId" resultType="java.lang.Integer">
+        select count(1)
+        from t_ds_task_group_queue
+        where group_id = #{taskGroupId} and status = #{status} and force_start = #{forceStart} and in_queue = #{inQueue}
+    </select>
+
+    <select id="queryWaitNotifyForceStartTaskGroupQueue" resultType="org.apache.dolphinscheduler.dao.entity.TaskGroupQueue">
+        select
+        <include refid="baseSql"/>
+        from t_ds_task_group_queue
+        where in_queue = #{inQueue}
+        and force_start = #{forceStart}
+        and id &gt; #{minTaskGroupQueueId}
+        order by id asc
+        limit #{limit}
     </select>
 
 </mapper>


### PR DESCRIPTION
## Purpose of the pull request

We shouldn't query all taskGroupQueue in TaskGroupCoordinator at once, this might cause master OOM.
Furthermore, this might cause the master cannot start up due to OOM.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
