### PR TITLE
Bind processId to construct CodeGenerator

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -184,7 +184,7 @@ public class PythonGateway {
         Map<String, Long> result = new HashMap<>();
         // project do not exists, mean task not exists too, so we should directly return init value
         if (project == null) {
-            result.put("code", CodeGenerateUtils.getInstance().genCode());
+            result.put("code", CodeGenerateUtils.genCode());
             result.put("version", 0L);
             return result;
         }
@@ -194,7 +194,7 @@ public class PythonGateway {
         // In the case project exists, but current workflow still not created, we should also return the init
         // version of it
         if (processDefinition == null) {
-            result.put("code", CodeGenerateUtils.getInstance().genCode());
+            result.put("code", CodeGenerateUtils.genCode());
             result.put("version", 0L);
             return result;
         }
@@ -202,7 +202,7 @@ public class PythonGateway {
         TaskDefinition taskDefinition =
                 taskDefinitionMapper.queryByName(project.getCode(), processDefinition.getCode(), taskName);
         if (taskDefinition == null) {
-            result.put("code", CodeGenerateUtils.getInstance().genCode());
+            result.put("code", CodeGenerateUtils.genCode());
             result.put("version", 0L);
         } else {
             result.put("code", taskDefinition.getCode());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceImpl.java
@@ -96,7 +96,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
         cluster.setOperator(loginUser.getId());
         cluster.setCreateTime(new Date());
         cluster.setUpdateTime(new Date());
-        cluster.setCode(CodeGenerateUtils.getInstance().genCode());
+        cluster.setCode(CodeGenerateUtils.genCode());
 
         if (clusterMapper.insert(cluster) > 0) {
             return cluster.getCode();

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/EnvironmentServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/EnvironmentServiceImpl.java
@@ -123,7 +123,7 @@ public class EnvironmentServiceImpl extends BaseServiceImpl implements Environme
         env.setUpdateTime(new Date());
         long code = 0L;
         try {
-            code = CodeGenerateUtils.getInstance().genCode();
+            code = CodeGenerateUtils.genCode();
             env.setCode(code);
         } catch (CodeGenerateException e) {
             log.error("Generate environment code error.", e);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -258,7 +258,7 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
         checkScheduleTimeNumExceed(commandType, cronTime);
         checkMasterExists();
 
-        long triggerCode = CodeGenerateUtils.getInstance().genCode();
+        long triggerCode = CodeGenerateUtils.genCode();
 
         /**
          * create command

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/K8SNamespaceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/K8SNamespaceServiceImpl.java
@@ -141,7 +141,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
 
         long code = 0L;
         try {
-            code = CodeGenerateUtils.getInstance().genCode();
+            code = CodeGenerateUtils.genCode();
             cluster.setCode(code);
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("Generate cluster code error.", e);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -299,7 +299,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         List<TaskDefinitionLog> taskDefinitionLogs = generateTaskDefinitionList(taskDefinitionJson);
         List<ProcessTaskRelationLog> taskRelationList = generateTaskRelationList(taskRelationJson, taskDefinitionLogs);
 
-        long processDefinitionCode = CodeGenerateUtils.getInstance().genCode();
+        long processDefinitionCode = CodeGenerateUtils.genCode();
         ProcessDefinition processDefinition =
                 new ProcessDefinition(projectCode, name, processDefinitionCode, description,
                         globalParams, locations, timeout, loginUser.getId());
@@ -360,7 +360,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
 
         long processDefinitionCode;
         try {
-            processDefinitionCode = CodeGenerateUtils.getInstance().genCode();
+            processDefinitionCode = CodeGenerateUtils.genCode();
         } catch (CodeGenerateException e) {
             throw new ServiceException(Status.INTERNAL_SERVER_ERROR_ARGS);
         }
@@ -1233,7 +1233,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
             // build process definition
             processDefinition = new ProcessDefinition(projectCode,
                     processDefinitionName,
-                    CodeGenerateUtils.getInstance().genCode(),
+                    CodeGenerateUtils.genCode(),
                     "",
                     "[]", null,
                     0, loginUser.getId());
@@ -1388,7 +1388,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         sqlParameters.setSqlType(SqlType.NON_QUERY.ordinal());
         sqlParameters.setLocalParams(Collections.emptyList());
         taskDefinition.setTaskParams(JSONUtils.toJsonString(sqlParameters));
-        taskDefinition.setCode(CodeGenerateUtils.getInstance().genCode());
+        taskDefinition.setCode(CodeGenerateUtils.genCode());
         taskDefinition.setTaskType(TASK_TYPE_SQL);
         taskDefinition.setFailRetryTimes(0);
         taskDefinition.setFailRetryInterval(0);
@@ -1433,7 +1433,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
         processDefinition.setProjectCode(projectCode);
         processDefinition.setUserId(loginUser.getId());
         try {
-            processDefinition.setCode(CodeGenerateUtils.getInstance().genCode());
+            processDefinition.setCode(CodeGenerateUtils.genCode());
         } catch (CodeGenerateException e) {
             log.error(
                     "Save process definition error because generate process definition code error, projectCode:{}.",
@@ -1456,7 +1456,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
             taskDefinitionLog.setOperator(loginUser.getId());
             taskDefinitionLog.setOperateTime(now);
             try {
-                long code = CodeGenerateUtils.getInstance().genCode();
+                long code = CodeGenerateUtils.genCode();
                 taskCodeMap.put(taskDefinitionLog.getCode(), code);
                 taskDefinitionLog.setCode(code);
             } catch (CodeGenerateException e) {
@@ -2074,7 +2074,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 Map<Long, Long> taskCodeMap = new HashMap<>();
                 for (TaskDefinitionLog taskDefinitionLog : taskDefinitionLogs) {
                     try {
-                        long taskCode = CodeGenerateUtils.getInstance().genCode();
+                        long taskCode = CodeGenerateUtils.genCode();
                         taskCodeMap.put(taskDefinitionLog.getCode(), taskCode);
                         taskDefinitionLog.setCode(taskCode);
                     } catch (CodeGenerateException e) {
@@ -2097,7 +2097,7 @@ public class ProcessDefinitionServiceImpl extends BaseServiceImpl implements Pro
                 }
                 final long oldProcessDefinitionCode = processDefinition.getCode();
                 try {
-                    processDefinition.setCode(CodeGenerateUtils.getInstance().genCode());
+                    processDefinition.setCode(CodeGenerateUtils.genCode());
                 } catch (CodeGenerateException e) {
                     log.error("Generate process definition code error, projectCode:{}.", targetProjectCode, e);
                     putMsg(result, Status.INTERNAL_SERVER_ERROR_ARGS);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectParameterServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectParameterServiceImpl.java
@@ -97,7 +97,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
                     .builder()
                     .paramName(projectParameterName)
                     .paramValue(projectParameterValue)
-                    .code(CodeGenerateUtils.getInstance().genCode())
+                    .code(CodeGenerateUtils.genCode())
                     .projectCode(projectCode)
                     .userId(loginUser.getId())
                     .createTime(now)

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectPreferenceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectPreferenceServiceImpl.java
@@ -76,7 +76,7 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
             projectPreference.setProjectCode(projectCode);
             projectPreference.setPreferences(preferences);
             projectPreference.setUserId(loginUser.getId());
-            projectPreference.setCode(CodeGenerateUtils.getInstance().genCode());
+            projectPreference.setCode(CodeGenerateUtils.genCode());
             projectPreference.setState(1);
             projectPreference.setCreateTime(now);
             projectPreference.setUpdateTime(now);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -126,7 +126,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             project = Project
                     .builder()
                     .name(name)
-                    .code(CodeGenerateUtils.getInstance().genCode())
+                    .code(CodeGenerateUtils.genCode())
                     .description(desc)
                     .userId(loginUser.getId())
                     .userName(loginUser.getUserName())

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -265,7 +265,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
 
         long taskDefinitionCode;
         try {
-            taskDefinitionCode = CodeGenerateUtils.getInstance().genCode();
+            taskDefinitionCode = CodeGenerateUtils.genCode();
         } catch (CodeGenerateException e) {
             throw new ServiceException(Status.INTERNAL_SERVER_ERROR_ARGS);
         }
@@ -338,7 +338,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         }
         long taskCode = taskDefinition.getCode();
         if (taskCode == 0) {
-            taskDefinition.setCode(CodeGenerateUtils.getInstance().genCode());
+            taskDefinition.setCode(CodeGenerateUtils.genCode());
         }
         List<ProcessTaskRelationLog> processTaskRelationLogList =
                 processTaskRelationMapper.queryByProcessCode(processDefinitionCode)
@@ -1264,7 +1264,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < genNum; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateException e) {
             log.error("Generate task definition code error.", e);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/EnvironmentServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/EnvironmentServiceTest.java
@@ -96,9 +96,6 @@ public class EnvironmentServiceTest {
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
 
-    @Mock
-    private CodeGenerateUtils codeGenerateUtils;
-
     public static final String testUserName = "environmentServerTest";
 
     public static final String environmentName = "Env1";
@@ -141,8 +138,7 @@ public class EnvironmentServiceTest {
                 () -> environmentService.createEnvironment(adminUser, "testName", "test", "test", workerGroups));
 
         try (MockedStatic<CodeGenerateUtils> ignored = Mockito.mockStatic(CodeGenerateUtils.class)) {
-            when(CodeGenerateUtils.getInstance()).thenReturn(codeGenerateUtils);
-            when(codeGenerateUtils.genCode()).thenThrow(CodeGenerateUtils.CodeGenerateException.class);
+            when(CodeGenerateUtils.genCode()).thenThrow(CodeGenerateUtils.CodeGenerateException.class);
 
             assertThrowsServiceException(Status.INTERNAL_SERVER_ERROR_ARGS,
                     () -> environmentService.createEnvironment(adminUser, "testName", "test", "test", workerGroups));

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/CodeGenerateUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/CodeGenerateUtils.java
@@ -1,4 +1,6 @@
-/** Copyright 2010-2012 Twitter, Inc.*/
+/**
+ * Copyright 2010-2012 Twitter, Inc.
+ */
 
 package org.apache.dolphinscheduler.common.utils;
 
@@ -6,66 +8,71 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
- *  Rewriting based on Twitter snowflake algorithm
+ * Rewriting based on Twitter snowflake algorithm
  */
+@Slf4j
 public class CodeGenerateUtils {
 
-    // start timestamp
-    private static final long START_TIMESTAMP = 1609430400000L; // 2021-01-01 00:00:00
-    // Each machine generates 32 in the same millisecond
-    private static final long LOW_DIGIT_BIT = 5L;
-    private static final long MIDDLE_BIT = 2L;
-    private static final long MAX_LOW_DIGIT = ~(-1L << LOW_DIGIT_BIT);
-    // The displacement to the left
-    private static final long MIDDLE_LEFT = LOW_DIGIT_BIT;
-    private static final long HIGH_DIGIT_LEFT = LOW_DIGIT_BIT + MIDDLE_BIT;
-    private final long machineHash;
-    private long lowDigit = 0L;
-    private long recordMillisecond = -1L;
+    private static final CodeGenerator codeGenerator;
 
-    private static final long SYSTEM_TIMESTAMP = System.currentTimeMillis();
-    private static final long SYSTEM_NANOTIME = System.nanoTime();
-
-    private CodeGenerateUtils() throws CodeGenerateException {
+    static {
         try {
-            this.machineHash =
-                    Math.abs(Objects.hash(InetAddress.getLocalHost().getHostName())) % (2 << (MIDDLE_BIT - 1));
+            codeGenerator = new CodeGenerator(InetAddress.getLocalHost().getHostName() + "-" + OSUtils.getProcessID());
         } catch (UnknownHostException e) {
             throw new CodeGenerateException(e.getMessage());
         }
     }
 
-    private static CodeGenerateUtils instance = null;
-
-    public static synchronized CodeGenerateUtils getInstance() throws CodeGenerateException {
-        if (instance == null) {
-            instance = new CodeGenerateUtils();
-        }
-        return instance;
+    public static long genCode() throws CodeGenerateException {
+        return codeGenerator.genCode();
     }
 
-    public synchronized long genCode() throws CodeGenerateException {
-        long nowtMillisecond = systemMillisecond();
-        if (nowtMillisecond < recordMillisecond) {
-            throw new CodeGenerateException("New code exception because time is set back.");
+    public static class CodeGenerator {
+
+        // start timestamp
+        private static final long START_TIMESTAMP = 1609430400000L; // 2021-01-01 00:00:00
+        // Each machine generates 32 in the same millisecond
+        private static final long LOW_DIGIT_BIT = 5L;
+        private static final long MACHINE_BIT = 5L;
+        private static final long MAX_LOW_DIGIT = ~(-1L << LOW_DIGIT_BIT);
+        // The displacement to the left
+        private static final long HIGH_DIGIT_LEFT = LOW_DIGIT_BIT + MACHINE_BIT;
+        public final long machineHash;
+        private long lowDigit = 0L;
+        private long recordMillisecond = -1L;
+
+        private static final long SYSTEM_TIMESTAMP = System.currentTimeMillis();
+        private static final long SYSTEM_NANOTIME = System.nanoTime();
+
+        public CodeGenerator(String appName) {
+            this.machineHash = Math.abs(Objects.hash(appName)) % (1 << MACHINE_BIT);
         }
-        if (nowtMillisecond == recordMillisecond) {
-            lowDigit = (lowDigit + 1) & MAX_LOW_DIGIT;
-            if (lowDigit == 0L) {
-                while (nowtMillisecond <= recordMillisecond) {
-                    nowtMillisecond = systemMillisecond();
-                }
+
+        public synchronized long genCode() throws CodeGenerateException {
+            long nowtMillisecond = systemMillisecond();
+            if (nowtMillisecond < recordMillisecond) {
+                throw new CodeGenerateException("New code exception because time is set back.");
             }
-        } else {
-            lowDigit = 0L;
+            if (nowtMillisecond == recordMillisecond) {
+                lowDigit = (lowDigit + 1) & MAX_LOW_DIGIT;
+                if (lowDigit == 0L) {
+                    while (nowtMillisecond <= recordMillisecond) {
+                        nowtMillisecond = systemMillisecond();
+                    }
+                }
+            } else {
+                lowDigit = 0L;
+            }
+            recordMillisecond = nowtMillisecond;
+            return (nowtMillisecond - START_TIMESTAMP) << HIGH_DIGIT_LEFT | machineHash << LOW_DIGIT_BIT | lowDigit;
         }
-        recordMillisecond = nowtMillisecond;
-        return (nowtMillisecond - START_TIMESTAMP) << HIGH_DIGIT_LEFT | machineHash << MIDDLE_LEFT | lowDigit;
-    }
 
-    private long systemMillisecond() {
-        return SYSTEM_TIMESTAMP + (System.nanoTime() - SYSTEM_NANOTIME) / 1000000;
+        private long systemMillisecond() {
+            return SYSTEM_TIMESTAMP + (System.nanoTime() - SYSTEM_NANOTIME) / 1000000;
+        }
     }
 
     public static class CodeGenerateException extends RuntimeException {

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -1679,7 +1679,7 @@ public class ProcessServiceImpl implements ProcessService {
             taskDefinitionLog.setOperateTime(now);
             taskDefinitionLog.setOperator(operator.getId());
             if (taskDefinitionLog.getCode() == 0) {
-                taskDefinitionLog.setCode(CodeGenerateUtils.getInstance().genCode());
+                taskDefinitionLog.setCode(CodeGenerateUtils.genCode());
             }
             if (taskDefinitionLog.getVersion() == 0) {
                 // init first version

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ProcessDefinitionDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ProcessDefinitionDao.java
@@ -100,7 +100,7 @@ public class ProcessDefinitionDao {
                 processDefinition.setId(rs.getInt(1));
                 long code = rs.getLong(2);
                 if (code == 0L) {
-                    code = CodeGenerateUtils.getInstance().genCode();
+                    code = CodeGenerateUtils.genCode();
                 }
                 processDefinition.setCode(code);
                 processDefinition.setVersion(Constants.VERSION_FIRST);

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ProjectDao.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/dao/ProjectDao.java
@@ -47,7 +47,7 @@ public class ProjectDao {
                 Integer id = rs.getInt(1);
                 long code = rs.getLong(2);
                 if (code == 0L) {
-                    code = CodeGenerateUtils.getInstance().genCode();
+                    code = CodeGenerateUtils.genCode();
                 }
                 projectMap.put(id, code);
             }

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/upgrader/v200/V200DolphinSchedulerUpgrader.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/datasource/upgrader/v200/V200DolphinSchedulerUpgrader.java
@@ -206,7 +206,7 @@ public class V200DolphinSchedulerUpgrader implements DolphinSchedulerUpgrader {
                 taskDefinitionLog.setName(name);
                 taskDefinitionLog
                         .setWorkerGroup(task.get("workerGroup") == null ? "default" : task.get("workerGroup").asText());
-                long taskCode = CodeGenerateUtils.getInstance().genCode();
+                long taskCode = CodeGenerateUtils.genCode();
                 taskDefinitionLog.setCode(taskCode);
                 taskDefinitionLog.setVersion(Constants.VERSION_FIRST);
                 taskDefinitionLog.setProjectCode(processDefinition.getProjectCode());

--- a/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/demo/ProcessDefinitionDemo.java
+++ b/dolphinscheduler-tools/src/main/java/org/apache/dolphinscheduler/tools/demo/ProcessDefinitionDemo.java
@@ -85,7 +85,7 @@ public class ProcessDefinitionDemo {
             project = Project
                     .builder()
                     .name("demo")
-                    .code(CodeGenerateUtils.getInstance().genCode())
+                    .code(CodeGenerateUtils.genCode())
                     .description("")
                     .userId(loginUser.getId())
                     .userName(loginUser.getUserName())
@@ -167,7 +167,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 1; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);
@@ -242,7 +242,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 2; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);
@@ -334,7 +334,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 2; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);
@@ -420,7 +420,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 4; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);
@@ -537,7 +537,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 4; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);
@@ -656,7 +656,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 3; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);
@@ -755,7 +755,7 @@ public class ProcessDefinitionDemo {
         List<Long> taskCodes = new ArrayList<>();
         try {
             for (int i = 0; i < 1; i++) {
-                taskCodes.add(CodeGenerateUtils.getInstance().genCode());
+                taskCodes.add(CodeGenerateUtils.genCode());
             }
         } catch (CodeGenerateUtils.CodeGenerateException e) {
             log.error("task code get error, ", e);


### PR DESCRIPTION
## Purpose of the pull request

Right now the CodeGenerateUtils will not bind port, this means if we have multiple process which have the same host name, then these process will generate duplicate code.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
