### PR TITLE
[Fix-15828] Replace the original question mark before regex replacement

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
@@ -52,6 +52,8 @@ public class ParameterUtils {
 
     private static final char PARAM_REPLACE_CHAR = '?';
 
+    private static final String UNIQUE_QUESTION_MARK = "@@QUESTION_UNIQUE_MARK@@";
+
     private ParameterUtils() {
         throw new UnsupportedOperationException("Construct ParameterUtils");
     }
@@ -342,4 +344,21 @@ public class ParameterUtils {
         return userDefParamsMaps;
     }
 
+    /**
+     * use unique mark replace "?" before process
+     * @param sql sql
+     * @return sql without "?"
+     */
+    public static String replaceSqlQuestionMark(String sql){
+        return sql.replaceAll("\\?", UNIQUE_QUESTION_MARK);
+    }
+
+    /**
+     * use "?" replace unique mark after process
+     * @param sql sql
+     * @return recovered sql
+     */
+    public static String recoverSqlQuestionMark(String sql){
+        return sql.replaceAll(UNIQUE_QUESTION_MARK, "?");
+    }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
@@ -52,7 +52,7 @@ public class ParameterUtils {
 
     private static final char PARAM_REPLACE_CHAR = '?';
 
-    private static final String UNIQUE_QUESTION_MARK = "@@QUESTION_UNIQUE_MARK@@";
+    public static final String UNIQUE_QUESTION_MARK = "@@QUESTION_UNIQUE_MARK@@";
 
     private ParameterUtils() {
         throw new UnsupportedOperationException("Construct ParameterUtils");

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
@@ -349,7 +349,7 @@ public class ParameterUtils {
      * @param sql sql
      * @return sql without "?"
      */
-    public static String replaceSqlQuestionMark(String sql){
+    public static String replaceSqlQuestionMark(String sql) {
         return sql.replaceAll("\\?", UNIQUE_QUESTION_MARK);
     }
 
@@ -358,7 +358,7 @@ public class ParameterUtils {
      * @param sql sql
      * @return recovered sql
      */
-    public static String recoverSqlQuestionMark(String sql){
+    public static String recoverSqlQuestionMark(String sql) {
         return sql.replaceAll(UNIQUE_QUESTION_MARK, "?");
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
@@ -117,10 +117,10 @@ public class ParameterUtilsTest {
     @Test
     public void testProcessSqlQuestionMark() {
         String querySql = "select id, concat('?', name) from test";
-        String expected = "select id, concat('@@QUESTION_UNIQUE_MARK@@', name) from test";
+        String expected = "select id, concat('" + ParameterUtils.UNIQUE_QUESTION_MARK + "', name) from test";
         Assertions.assertEquals(ParameterUtils.replaceSqlQuestionMark(querySql), expected);
 
-        querySql = "select id, concat('@@QUESTION_UNIQUE_MARK@@', name) from test";
+        querySql = "select id, concat('" + ParameterUtils.UNIQUE_QUESTION_MARK + "', name) from test";
         expected = "select id, concat('?', name) from test";
         Assertions.assertEquals(ParameterUtils.recoverSqlQuestionMark(querySql), expected);
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
@@ -113,4 +113,15 @@ public class ParameterUtilsTest {
         Assertions.assertEquals("test Parameter", ParameterUtils.handleEscapes("test Parameter"));
         Assertions.assertEquals("////%test////%Parameter", ParameterUtils.handleEscapes("%test%Parameter"));
     }
+
+    @Test
+    public void testProcessSqlQuestionMark(){
+        String querySql = "select id, concat('?', name) from test";
+        String expected = "select id, concat('@@QUESTION_UNIQUE_MARK@@', name) from test";
+        Assertions.assertEquals(ParameterUtils.replaceSqlQuestionMark(querySql), expected);
+
+        querySql = "select id, concat('@@QUESTION_UNIQUE_MARK@@', name) from test";
+        expected = "select id, concat('?', name) from test";
+        Assertions.assertEquals(ParameterUtils.recoverSqlQuestionMark(querySql), expected);
+    }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
@@ -115,7 +115,7 @@ public class ParameterUtilsTest {
     }
 
     @Test
-    public void testProcessSqlQuestionMark(){
+    public void testProcessSqlQuestionMark() {
         String querySql = "select id, concat('?', name) from test";
         String expected = "select id, concat('@@QUESTION_UNIQUE_MARK@@', name) from test";
         Assertions.assertEquals(ParameterUtils.replaceSqlQuestionMark(querySql), expected);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -454,9 +454,10 @@ public class SqlTask extends AbstractTask {
         String rgexo = "['\"]*\\!\\{(.*?)\\}['\"]*";
         sql = replaceOriginalValue(sql, rgexo, paramsMap);
         // replace the ${} of the SQL statement with the Placeholder
-        String formatSql = sql.replaceAll(rgex, "?");
+        // Convert the original question mark to another symbol in advance, and restore the question mark later
+        String formatSql = ParameterUtils.replaceSqlQuestionMark(sql).replaceAll(rgex, "?");
         // Convert the list parameter
-        formatSql = ParameterUtils.expandListParameter(sqlParamsMap, formatSql);
+        formatSql = ParameterUtils.recoverSqlQuestionMark(ParameterUtils.expandListParameter(sqlParamsMap, formatSql));
         sqlBuilder.append(formatSql);
         // print replace sql
         printReplacedSql(sql, formatSql, rgex, sqlParamsMap);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTaskTest.java
@@ -149,7 +149,8 @@ class SqlTaskTest {
         String querySql =
                 "select id, concat('?', year) from student where year=${year} and month=${month} and gender=1";
         String expected =
-                "select id, concat('@@QUESTION_UNIQUE_MARK@@', year) from student where year=? and month=? and gender=1";
+                "select id, concat('" + ParameterUtils.UNIQUE_QUESTION_MARK
+                        + "', year) from student where year=? and month=? and gender=1";
         Assertions.assertEquals(expected,
                 ParameterUtils.replaceSqlQuestionMark(querySql).replaceAll(sqlTask.rgex, "?"));
 
@@ -167,7 +168,8 @@ class SqlTaskTest {
         String formatSql = ParameterUtils.replaceSqlQuestionMark(querySql).replaceAll(sqlTask.rgex, "?");
         formatSql = ParameterUtils.expandListParameter(sqlParamsMap, formatSql);
         expected =
-                "select id, concat('@@QUESTION_UNIQUE_MARK@@', year) from student where year=? and month=? and gender=1";
+                "select id, concat('" + ParameterUtils.UNIQUE_QUESTION_MARK
+                        + "', year) from student where year=? and month=? and gender=1";
         Assertions.assertEquals(expected, formatSql);
 
         formatSql = ParameterUtils.recoverSqlQuestionMark(formatSql);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTaskTest.java
@@ -145,10 +145,13 @@ class SqlTaskTest {
     }
 
     @Test
-    void testReplacingSqlHasQuestionMarkAndParams(){
-        String querySql = "select id, concat('?', year) from student where year=${year} and month=${month} and gender=1";
-        String expected = "select id, concat('@@QUESTION_UNIQUE_MARK@@', year) from student where year=? and month=? and gender=1";
-        Assertions.assertEquals(expected, ParameterUtils.replaceSqlQuestionMark(querySql).replaceAll(sqlTask.rgex, "?"));
+    void testReplacingSqlHasQuestionMarkAndParams() {
+        String querySql =
+                "select id, concat('?', year) from student where year=${year} and month=${month} and gender=1";
+        String expected =
+                "select id, concat('@@QUESTION_UNIQUE_MARK@@', year) from student where year=? and month=? and gender=1";
+        Assertions.assertEquals(expected,
+                ParameterUtils.replaceSqlQuestionMark(querySql).replaceAll(sqlTask.rgex, "?"));
 
         Map<Integer, Property> sqlParamsMap = new HashMap<>();
         Map<Integer, Property> expectedSQLParamsMap = new HashMap<>();
@@ -157,12 +160,14 @@ class SqlTaskTest {
         Map<String, Property> paramsMap = new HashMap<>();
         paramsMap.put("year", new Property("year", Direct.IN, DataType.VARCHAR, "1970"));
         paramsMap.put("month", new Property("month", Direct.IN, DataType.VARCHAR, "12"));
-        sqlTask.setSqlParamsMap(ParameterUtils.replaceSqlQuestionMark(querySql), sqlTask.rgex, sqlParamsMap, paramsMap, 1);
+        sqlTask.setSqlParamsMap(ParameterUtils.replaceSqlQuestionMark(querySql), sqlTask.rgex, sqlParamsMap, paramsMap,
+                1);
         Assertions.assertEquals(sqlParamsMap, expectedSQLParamsMap);
 
         String formatSql = ParameterUtils.replaceSqlQuestionMark(querySql).replaceAll(sqlTask.rgex, "?");
         formatSql = ParameterUtils.expandListParameter(sqlParamsMap, formatSql);
-        expected = "select id, concat('@@QUESTION_UNIQUE_MARK@@', year) from student where year=? and month=? and gender=1";
+        expected =
+                "select id, concat('@@QUESTION_UNIQUE_MARK@@', year) from student where year=? and month=? and gender=1";
         Assertions.assertEquals(expected, formatSql);
 
         formatSql = ParameterUtils.recoverSqlQuestionMark(formatSql);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
- fix #15828 
- Before `sql.replaceAll(rgex, "?")`, replace the question mark in the `sql`. Recover the question mark after the `ParameterUtils.expandListParameter(sqlParamsMap, formatSql)` is completed
## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
