### PR TITLE
Fix auto create tennat concurrently will cause the task failed

### DIFF
--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
@@ -78,7 +78,7 @@ public class TaskExecutionContextUtils {
             throw ex;
         } catch (Exception ex) {
             throw new TaskException(
-                    String.format("TenantCode: %s doesn't exist", taskExecutionContext.getTenantCode()));
+                    String.format("TenantCode: %s doesn't exist", taskExecutionContext.getTenantCode()), ex);
         }
     }
 


### PR DESCRIPTION
## Purpose of the pull request

When there exist multiple tasks using the same tenant are going to the same worker concurrently, if the tenant doesn't exist, and `autoCreateTenantEnabled` is true, then each task will try to create task, but only the first task will success, others will failed, due to the tenant is already exist.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
