### PR TITLE
Make workflow failed when sonar check failed

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -94,28 +94,20 @@ jobs:
           -Dspotless.skip=true
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=apache
+          -Dsonar.qualitygate.wait=true
           -Dsonar.core.codeCoveragePlugin=jacoco
           -Dsonar.projectKey=apache-dolphinscheduler
           -Dsonar.login=e4058004bc6be89decf558ac819aa1ecbee57682
           -Dsonar.exclusions=,dolphinscheduler-ui/src/**/i18n/locale/*.js,dolphinscheduler-microbench/src/**/*
-          -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          -DskipUT=true -DskipIT=true
+          -Dhttp.keepAlive=false 
+          -Dmaven.wagon.http.pool=false 
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          -DskipUT=true 
+          -DskipIT=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Collect logs
-        continue-on-error: true
-        run: |
-          mkdir -p ${LOG_DIR}
-          docker-compose -f $(pwd)/docker/docker-swarm/docker-compose.yml logs dolphinscheduler-postgresql > ${LOG_DIR}/db.txt
-
-      - name: Upload logs
-        uses: actions/upload-artifact@v2
-        continue-on-error: true
-        with:
-          name: unit-test-logs
-          path: ${LOG_DIR}
   result:
     name: Unit Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
