### PR TITLE
[Fix-15937] Add tenantCode propagation to DynamicCommandUtils.createCommand

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/dynamic/DynamicCommandUtils.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/task/dynamic/DynamicCommandUtils.java
@@ -65,6 +65,7 @@ public class DynamicCommandUtils {
         command.setProcessInstancePriority(processInstance.getProcessInstancePriority());
         command.setWorkerGroup(processInstance.getWorkerGroup());
         command.setDryRun(processInstance.getDryRun());
+        command.setTenantCode(processInstance.getTenantCode());
         return command;
     }
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/runner/task/dynamic/DynamicCommandUtilsTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/runner/task/dynamic/DynamicCommandUtilsTest.java
@@ -54,6 +54,7 @@ class DynamicCommandUtilsTest {
         processInstance.setWarningGroupId(1);
         processInstance.setProcessInstancePriority(null); // update this
         processInstance.setWorkerGroup("worker");
+        processInstance.setTenantCode("unit-root");
         processInstance.setDryRun(0);
     }
 
@@ -73,6 +74,7 @@ class DynamicCommandUtilsTest {
         Assertions.assertEquals(processInstance.getProcessInstancePriority(), command.getProcessInstancePriority());
         Assertions.assertEquals(processInstance.getWorkerGroup(), command.getWorkerGroup());
         Assertions.assertEquals(processInstance.getDryRun(), command.getDryRun());
+        Assertions.assertEquals(processInstance.getTenantCode(), command.getTenantCode());
     }
 
     @Test


### PR DESCRIPTION
Fix DynamicCommandUtils.createCommand method by adding command.setTenantCode(processInstance.getTenantCode()) line. This ensures that the tenantCode is correctly propagated to all subtasks in DolphinScheduler's Dynamic tasks, addressing an issue where the tenantCode wasn't being passed to subtasks, resulting in null tenantCodes for subtask commands. Closes: #15937

## Purpose of the pull request

This pull request addresses the issue described in #15937 by ensuring proper propagation of the tenantCode to all subtasks in DolphinScheduler's Dynamic tasks.

## Brief change log

- Add command.setTenantCode(processInstance.getTenantCode()) line to DynamicCommandUtils.createCommand method.

## Verify this pull request

This pull request is already covered by existing tests.