### PR TITLE
Create users on Linux system using tenant_id to solve user confusion caused by k8s environment service restart or physical machine environment service migration

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -144,18 +144,18 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
                                String tenantCode,
                                int queueId,
                                String desc) throws Exception {
-        if (!canOperatorPermissions(loginUser, null, AuthorizationType.TENANT, TENANT_CREATE)) {
+        if (checkTenantExists(tenantCode)) {
+            return tenantMapper.queryByTenantCode(tenantCode);
+        }
+        if(canOperator(loginUser,loginUser.getId())){
+            Tenant tenant = new Tenant(tenantCode, desc, queueId);
+            createTenantValid(tenant);
+            tenantMapper.insert(tenant);
+            storageOperate.createTenantDirIfNotExists(tenantCode);
+            return tenant;
+        }else {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        if (checkDescriptionLength(desc)) {
-            throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
-        }
-        Tenant tenant = new Tenant(tenantCode, desc, queueId);
-        createTenantValid(tenant);
-        tenantMapper.insert(tenant);
-
-        storageOperate.createTenantDirIfNotExists(tenantCode);
-        return tenant;
     }
 
     /**

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
@@ -218,6 +218,51 @@ public class OSUtils {
     }
 
     /**
+     * create user
+     *
+     * @param userId user id
+     * @param userName user name
+     * @return true if creation was successful, otherwise false
+     */
+    public static boolean createUser(int userId, String userName) {
+        try {
+            String userGroup = getGroup();
+            if (StringUtils.isEmpty(userGroup)) {
+                String errorLog = String.format("%s group does not exist for this operating system.", userGroup);
+                log.error(errorLog);
+                return false;
+            }
+            if (SystemUtils.IS_OS_MAC) {
+                createMacUser(userName, userGroup);
+            } else if (SystemUtils.IS_OS_WINDOWS) {
+                createWindowsUser(userName, userGroup);
+            } else {
+                createLinuxUser(userId,userName, userGroup);
+            }
+            return true;
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return false;
+    }
+
+    /**
+     * create user
+     *
+     * @param userId user id
+     * @param userName user name
+     */
+    public static void createUserIfAbsent(int userId, String userName) {
+        // if not exists this user, then create
+        if (!getUserList().contains(userName)) {
+            //boolean isSuccess = createUser(userName);
+            boolean isSuccess = createUser(userId, userName);
+            log.info("create user {} {} {}", userId, userName, isSuccess ? "success" : "fail");
+        }
+    }
+
+    /**
      * create linux user
      *
      * @param userName  user name
@@ -227,6 +272,21 @@ public class OSUtils {
     private static void createLinuxUser(String userName, String userGroup) throws IOException {
         log.info("create linux os user: {}", userName);
         String cmd = String.format("sudo useradd -m -g %s %s", userGroup, userName);
+        log.info("execute cmd: {}", cmd);
+        exeCmd(cmd);
+    }
+
+    /**
+     * create linux user
+     *
+     * @param userId  user id
+     * @param userName  user name
+     * @param userGroup user group
+     * @throws IOException in case of an I/O error
+     */
+    private static void createLinuxUser(int userId, String userName, String userGroup) throws IOException {
+        log.info("create linux os user id: {},userName:{}", userId, userName);
+        String cmd = String.format("sudo useradd -u %s -g %s %s", userId, userGroup, userName);
         log.info("execute cmd: {}", cmd);
         exeCmd(cmd);
     }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/ProcessInstance.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/ProcessInstance.java
@@ -126,6 +126,9 @@ public class ProcessInstance {
 
     private String tenantCode;
 
+    @TableField(exist = false)
+    private int tenantId;
+
     /**
      * queue
      */

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/builder/TaskExecutionContextBuilder.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/builder/TaskExecutionContextBuilder.java
@@ -103,6 +103,7 @@ public class TaskExecutionContextBuilder {
         taskExecutionContext.setGlobalParams(processInstance.getGlobalParams());
         taskExecutionContext.setExecutorId(processInstance.getExecutorId());
         taskExecutionContext.setCmdTypeIfComplement(processInstance.getCmdTypeIfComplement().getCode());
+        taskExecutionContext.setTenantId(processInstance.getTenantId());
         taskExecutionContext.setTenantCode(processInstance.getTenantCode());
         return this;
     }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -292,6 +292,10 @@ public class ProcessServiceImpl implements ProcessService {
             commandService.moveToErrorCommand(command, "process instance is null");
             return null;
         }
+
+        Tenant tenant = tenantMapper.queryByTenantCode(processInstance.getTenantCode());
+        processInstance.setTenantId(tenant.getId());
+
         processInstance.setCommandType(command.getCommandType());
         processInstance.addHistoryCmd(command.getCommandType());
         processInstance.setTestFlag(command.getTestFlag());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskExecutionContext.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/TaskExecutionContext.java
@@ -148,6 +148,11 @@ public class TaskExecutionContext implements Serializable {
     private String tenantCode;
 
     /**
+     * tenant id
+     */
+    private int tenantId;
+
+    /**
      * process define id
      */
     private int processDefineId;

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
@@ -50,11 +50,14 @@ public class TaskExecutionContextUtils {
             TenantConfig tenantConfig = workerConfig.getTenantConfig();
 
             String tenantCode = taskExecutionContext.getTenantCode();
+            final int tenantId = taskExecutionContext.getTenantId();
+
             if (TenantConstants.DEFAULT_TENANT_CODE.equals(tenantCode) && tenantConfig.isDefaultTenantEnabled()) {
                 log.info("Current tenant is default tenant, will use bootstrap user: {} to execute the task",
                         TenantConstants.BOOTSTRAPT_SYSTEM_USER);
                 return TenantConstants.BOOTSTRAPT_SYSTEM_USER;
             }
+            int userId = tenantId + 1000;
             boolean osUserExistFlag;
             // if Using distributed is true and Currently supported systems are linux,Should not let it
             // automatically
@@ -64,7 +67,7 @@ public class TaskExecutionContextUtils {
                 osUserExistFlag = OSUtils.existTenantCodeInLinux(tenantCode);
             } else if (OSUtils.isSudoEnable() && tenantConfig.isAutoCreateTenantEnabled()) {
                 // if not exists this user, then create
-                OSUtils.createUserIfAbsent(tenantCode);
+                OSUtils.createUserIfAbsent(userId,tenantCode);
                 osUserExistFlag = OSUtils.getUserList().contains(tenantCode);
             } else {
                 osUserExistFlag = OSUtils.getUserList().contains(tenantCode);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
This pull request aims to address the issue of user confusion caused by k8s environment service restart or physical machine environment service migration

## Brief change log
Add tenantId to ProcessInstance.java and TaskExecutionContext.java
Add method "createUser(int userId, String userName)" and "createUserIfAbsent(int userId, String userName)"  and "createLinuxUser(int userId, String userName, String userGroup)" to OSUtils.java
Modify method createTenant of TenantServiceImpl.java
Modify method handleCommand of  ProcessServiceImpl.java,add code "processInstance.setTenantId"
Modify method buildProcessInstanceRelatedInfo of  TaskExecutionContextBuilder.java,add code "taskExecutionContext.setTenantId"
Modify method getOrCreateTenant of TaskExecutionContextUtils.java, add user by tenantId

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

