### PR TITLE
Fix workflow instance restart failed due to duplicate key in varpool

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/ApiApplicationServer.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/ApiApplicationServer.java
@@ -24,6 +24,7 @@ import org.apache.dolphinscheduler.common.thread.DefaultUncaughtExceptionHandler
 import org.apache.dolphinscheduler.dao.DaoConfiguration;
 import org.apache.dolphinscheduler.dao.PluginDao;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
+import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceProcessorProvider;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageConfiguration;
 import org.apache.dolphinscheduler.plugin.task.api.TaskChannelFactory;
 import org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager;
@@ -69,6 +70,7 @@ public class ApiApplicationServer {
         log.info("Received spring application context ready event will load taskPlugin and write to DB");
         // install task plugin
         TaskPluginManager.loadPlugin();
+        DataSourceProcessorProvider.initialize();
         for (Map.Entry<String, TaskChannelFactory> entry : TaskPluginManager.getTaskChannelFactoryMap().entrySet()) {
             String taskPluginName = entry.getKey();
             TaskChannelFactory taskChannelFactory = entry.getValue();

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
@@ -367,10 +367,15 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
         }
         for (TaskInstance taskInstance : needToDeleteTaskInstances) {
             if (StringUtils.isNotBlank(taskInstance.getLogPath())) {
-                ILogService iLogService =
-                        SingletonJdkDynamicRpcClientProxyFactory.getProxyClient(taskInstance.getHost(),
-                                ILogService.class);
-                iLogService.removeTaskInstanceLog(taskInstance.getLogPath());
+                try {
+                    // Remove task instance log failed will not affect the deletion of task instance
+                    ILogService iLogService =
+                            SingletonJdkDynamicRpcClientProxyFactory.getProxyClient(taskInstance.getHost(),
+                                    ILogService.class);
+                    iLogService.removeTaskInstanceLog(taskInstance.getLogPath());
+                } catch (Exception ex) {
+                    log.error("Remove task instance log error", ex);
+                }
             }
         }
 

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/plugin/DataSourceProcessorProvider.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/plugin/DataSourceProcessorProvider.java
@@ -37,6 +37,10 @@ public class DataSourceProcessorProvider {
     private DataSourceProcessorProvider() {
     }
 
+    public static void initialize() {
+        log.info("Initialize DataSourceProcessorProvider");
+    }
+
     public static DataSourceProcessor getDataSourceProcessor(@NonNull DbType dbType) {
         return dataSourcePluginManager.getDataSourceProcessorMap().get(dbType.name());
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
@@ -26,6 +26,7 @@ import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.dao.DaoConfiguration;
 import org.apache.dolphinscheduler.meter.metrics.MetricsProvider;
 import org.apache.dolphinscheduler.meter.metrics.SystemMetrics;
+import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceProcessorProvider;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageConfiguration;
 import org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager;
 import org.apache.dolphinscheduler.registry.api.RegistryConfiguration;
@@ -108,6 +109,7 @@ public class MasterServer implements IStoppable {
 
         // install task plugin
         TaskPluginManager.loadPlugin();
+        DataSourceProcessorProvider.initialize();
 
         this.masterSlotManager.start();
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnableTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnableTest.java
@@ -71,6 +71,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationContext;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 @ExtendWith(MockitoExtension.class)
@@ -106,6 +107,8 @@ public class WorkflowExecuteRunnableTest {
 
     private TaskGroupCoordinator taskGroupCoordinator;
 
+    private WorkflowExecuteContext workflowExecuteContext;
+
     @BeforeEach
     public void init() throws Exception {
         applicationContext = Mockito.mock(ApplicationContext.class);
@@ -134,7 +137,7 @@ public class WorkflowExecuteRunnableTest {
         stateWheelExecuteThread = Mockito.mock(StateWheelExecuteThread.class);
         curingGlobalParamsService = Mockito.mock(CuringParamsService.class);
         ProcessAlertManager processAlertManager = Mockito.mock(ProcessAlertManager.class);
-        WorkflowExecuteContext workflowExecuteContext = Mockito.mock(WorkflowExecuteContext.class);
+        workflowExecuteContext = Mockito.mock(WorkflowExecuteContext.class);
         Mockito.when(workflowExecuteContext.getWorkflowInstance()).thenReturn(processInstance);
         IWorkflowGraph workflowGraph = Mockito.mock(IWorkflowGraph.class);
         Mockito.when(workflowExecuteContext.getWorkflowGraph()).thenReturn(workflowGraph);
@@ -209,11 +212,13 @@ public class WorkflowExecuteRunnableTest {
     }
 
     @Test
-    public void testGetPreVarPool() {
+    public void testInitializeTaskInstanceVarPool() {
         try {
-            Set<Long> preTaskName = new HashSet<>();
-            preTaskName.add(1L);
-            preTaskName.add(2L);
+            IWorkflowGraph workflowGraph = Mockito.mock(IWorkflowGraph.class);
+            Mockito.when(workflowExecuteContext.getWorkflowGraph()).thenReturn(workflowGraph);
+            TaskNode taskNode = Mockito.mock(TaskNode.class);
+            Mockito.when(workflowGraph.getTaskNodeByCode(Mockito.anyLong())).thenReturn(taskNode);
+            Mockito.when(taskNode.getPreTasks()).thenReturn(JSONUtils.toJsonString(Lists.newArrayList(1L, 2L)));
 
             TaskInstance taskInstance = new TaskInstance();
 
@@ -255,7 +260,7 @@ public class WorkflowExecuteRunnableTest {
             taskCodeInstanceMapField.setAccessible(true);
             taskCodeInstanceMapField.set(workflowExecuteThread, taskCodeInstanceMap);
 
-            workflowExecuteThread.getPreVarPool(taskInstance, preTaskName);
+            workflowExecuteThread.initializeTaskInstanceVarPool(taskInstance);
             Assertions.assertNotNull(taskInstance.getVarPool());
 
             taskInstance2.setVarPool("[{\"direct\":\"OUT\",\"prop\":\"test1\",\"type\":\"VARCHAR\",\"value\":\"2\"}]");
@@ -266,7 +271,7 @@ public class WorkflowExecuteRunnableTest {
             taskInstanceMapField.setAccessible(true);
             taskInstanceMapField.set(workflowExecuteThread, taskInstanceMap);
 
-            workflowExecuteThread.getPreVarPool(taskInstance, preTaskName);
+            workflowExecuteThread.initializeTaskInstanceVarPool(taskInstance);
             Assertions.assertNotNull(taskInstance.getVarPool());
         } catch (Exception e) {
             Assertions.fail();

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/model/Property.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/model/Property.java
@@ -23,6 +23,9 @@ import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
 import java.io.Serializable;
 import java.util.Objects;
 
+import lombok.Data;
+
+@Data
 public class Property implements Serializable {
 
     private static final long serialVersionUID = -4045513703397452451L;
@@ -54,62 +57,6 @@ public class Property implements Serializable {
         this.direct = direct;
         this.type = type;
         this.value = value;
-    }
-
-    /**
-     * getter method
-     *
-     * @return the prop
-     * @see Property#prop
-     */
-    public String getProp() {
-        return prop;
-    }
-
-    /**
-     * setter method
-     *
-     * @param prop the prop to set
-     * @see Property#prop
-     */
-    public void setProp(String prop) {
-        this.prop = prop;
-    }
-
-    /**
-     * getter method
-     *
-     * @return the value
-     * @see Property#value
-     */
-    public String getValue() {
-        return value;
-    }
-
-    /**
-     * setter method
-     *
-     * @param value the value to set
-     * @see Property#value
-     */
-    public void setValue(String value) {
-        this.value = value;
-    }
-
-    public Direct getDirect() {
-        return direct;
-    }
-
-    public void setDirect(Direct direct) {
-        this.direct = direct;
-    }
-
-    public DataType getType() {
-        return type;
-    }
-
-    public void setType(DataType type) {
-        this.type = type;
     }
 
     @Override

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/AbstractParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/AbstractParameters.java
@@ -25,6 +25,7 @@ import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.DataSourceParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.ResourceParametersHelper;
+import org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -35,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -82,6 +84,7 @@ public abstract class AbstractParameters implements IParameters {
 
     /**
      * get input local parameters map if the param direct is IN
+     *
      * @return parameters map
      */
     public Map<String, Property> getInputLocalParametersMap() {
@@ -121,44 +124,30 @@ public abstract class AbstractParameters implements IParameters {
     }
 
     public void dealOutParam(Map<String, String> taskOutputParams) {
-        if (CollectionUtils.isEmpty(localParams)) {
-            return;
-        }
         List<Property> outProperty = getOutProperty(localParams);
         if (CollectionUtils.isEmpty(outProperty)) {
             return;
         }
-        if (MapUtils.isEmpty(taskOutputParams)) {
-            outProperty.forEach(this::addPropertyToValPool);
-            return;
+        if (CollectionUtils.isNotEmpty(outProperty) && MapUtils.isNotEmpty(taskOutputParams)) {
+            // Inject the value
+            for (Property info : outProperty) {
+                String value = taskOutputParams.get(info.getProp());
+                if (value != null) {
+                    info.setValue(value);
+                }
+            }
         }
 
-        for (Property info : outProperty) {
-            String propValue = taskOutputParams.get(info.getProp());
-            if (StringUtils.isNotEmpty(propValue)) {
-                info.setValue(propValue);
-                addPropertyToValPool(info);
-                continue;
-            }
-            addPropertyToValPool(info);
-            if (StringUtils.isEmpty(info.getValue())) {
-                log.warn("The output parameter {} value is empty and cannot find the out parameter from task output",
-                        info);
-            }
-        }
+        varPool = VarPoolUtils.mergeVarPool(varPool, outProperty);
     }
 
-    public List<Property> getOutProperty(List<Property> params) {
+    protected List<Property> getOutProperty(List<Property> params) {
         if (CollectionUtils.isEmpty(params)) {
             return new ArrayList<>();
         }
-        List<Property> result = new ArrayList<>();
-        for (Property info : params) {
-            if (info.getDirect() == Direct.OUT) {
-                result.add(info);
-            }
-        }
-        return result;
+        return params.stream()
+                .filter(info -> info.getDirect() == Direct.OUT)
+                .collect(Collectors.toList());
     }
 
     public List<Map<String, String>> getListMapByString(String json) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/AbstractParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/AbstractParameters.java
@@ -44,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Lists;
 
 @Getter
 @Slf4j
@@ -138,7 +139,7 @@ public abstract class AbstractParameters implements IParameters {
             }
         }
 
-        varPool = VarPoolUtils.mergeVarPool(varPool, outProperty);
+        varPool = VarPoolUtils.mergeVarPool(Lists.newArrayList(varPool, outProperty));
     }
 
     protected List<Property> getOutProperty(List<Property> params) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/SqlParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/SqlParameters.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Enums;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 
 /**
  * Sql/Hql parameter
@@ -246,7 +247,7 @@ public class SqlParameters extends AbstractParameters {
             return;
         }
         if (StringUtils.isEmpty(result)) {
-            varPool = VarPoolUtils.mergeVarPool(varPool, outProperty);
+            varPool = VarPoolUtils.mergeVarPool(Lists.newArrayList(varPool, outProperty));
             return;
         }
         List<Map<String, String>> sqlResult = getListMapByString(result);
@@ -278,7 +279,7 @@ public class SqlParameters extends AbstractParameters {
                 info.setValue(String.valueOf(firstRow.get(info.getProp())));
             }
         }
-        varPool = VarPoolUtils.mergeVarPool(varPool, outProperty);
+        varPool = VarPoolUtils.mergeVarPool(Lists.newArrayList(varPool, outProperty));
 
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/SqlParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/SqlParameters.java
@@ -27,6 +27,7 @@ import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.DataSourceParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.ResourceParametersHelper;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.UdfFuncParameters;
+import org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -245,7 +246,7 @@ public class SqlParameters extends AbstractParameters {
             return;
         }
         if (StringUtils.isEmpty(result)) {
-            varPool.addAll(outProperty);
+            varPool = VarPoolUtils.mergeVarPool(varPool, outProperty);
             return;
         }
         List<Map<String, String>> sqlResult = getListMapByString(result);
@@ -268,7 +269,6 @@ public class SqlParameters extends AbstractParameters {
             for (Property info : outProperty) {
                 if (info.getType() == DataType.LIST) {
                     info.setValue(JSONUtils.toJsonString(sqlResultFormat.get(info.getProp())));
-                    varPool.add(info);
                 }
             }
         } else {
@@ -276,9 +276,9 @@ public class SqlParameters extends AbstractParameters {
             Map<String, String> firstRow = sqlResult.get(0);
             for (Property info : outProperty) {
                 info.setValue(String.valueOf(firstRow.get(info.getProp())));
-                varPool.add(info);
             }
         }
+        varPool = VarPoolUtils.mergeVarPool(varPool, outProperty);
 
     }
 
@@ -322,6 +322,7 @@ public class SqlParameters extends AbstractParameters {
 
     /**
      * TODO SQLTaskExecutionContext needs to be optimized
+     *
      * @param parametersHelper
      * @return
      */

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.utils;
+
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class VarPoolUtils {
+
+    /**
+     * Merge the given two varpools, and return the merged varpool.
+     * If the two varpools have the same property({@link Property#getProp()} and {@link Property#getDirect()} is same), the value of the property in varpool2 will be used.
+     * // todo: we may need to consider the datatype of the property
+     */
+    public List<Property> mergeVarPool(List<Property> varPool1, List<Property> varPool2) {
+        if (CollectionUtils.isEmpty(varPool1)) {
+            return varPool2;
+        }
+        if (CollectionUtils.isEmpty(varPool2)) {
+            return varPool1;
+        }
+        List<Property> result = new ArrayList<>();
+        for (Property v2 : varPool2) {
+            Optional<Property> v1Optional = varPool1
+                    .stream()
+                    .filter(v1 -> v1.getProp().equals(v2.getProp()) && v1.getDirect().equals(v2.getDirect()))
+                    .findFirst();
+            if (v1Optional.isPresent()) {
+                // todo: clone the property object rather directly change it
+                Property v1 = v1Optional.get();
+                v1.setValue(v2.getValue());
+                result.add(v1);
+            } else {
+                result.add(v2);
+            }
+        }
+        return result;
+    }
+
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtilsTest.java
@@ -32,22 +32,31 @@ class VarPoolUtilsTest {
 
     @Test
     void mergeVarPool() {
-        List<Property> varpool1 = null;
-        List<Property> varpool2 = null;
-        Truth.assertThat(VarPoolUtils.mergeVarPool(varpool1, varpool2)).isNull();
+        Truth.assertThat(VarPoolUtils.mergeVarPool(null)).isNull();
 
         // Override the value of the same property
         // Merge the property with different key.
-        varpool1 = Lists.newArrayList(new Property("name", Direct.OUT, DataType.VARCHAR, "tom"));
-        varpool2 = Lists.newArrayList(
+        List<Property> varpool1 = Lists.newArrayList(new Property("name", Direct.OUT, DataType.VARCHAR, "tom"));
+        List<Property> varpool2 = Lists.newArrayList(
                 new Property("name", Direct.OUT, DataType.VARCHAR, "tim"),
                 new Property("age", Direct.OUT, DataType.INTEGER, "10"));
 
-        Truth.assertThat(VarPoolUtils.mergeVarPool(varpool1, varpool2))
+        Truth.assertThat(VarPoolUtils.mergeVarPool(Lists.newArrayList(varpool1, varpool2)))
                 .containsExactly(
                         new Property("name", Direct.OUT, DataType.VARCHAR, "tim"),
                         new Property("age", Direct.OUT, DataType.INTEGER, "10"));
 
     }
 
+    @Test
+    void subtractVarPool() {
+        Truth.assertThat(VarPoolUtils.subtractVarPool(null, null)).isNull();
+        List<Property> varpool1 = Lists.newArrayList(new Property("name", Direct.OUT, DataType.VARCHAR, "tom"),
+                new Property("age", Direct.OUT, DataType.INTEGER, "10"));
+        List<Property> varpool2 = Lists.newArrayList(new Property("name", Direct.OUT, DataType.VARCHAR, "tom"));
+        List<Property> varpool3 = Lists.newArrayList(new Property("location", Direct.OUT, DataType.VARCHAR, "china"));
+
+        Truth.assertThat(VarPoolUtils.subtractVarPool(varpool1, Lists.newArrayList(varpool2, varpool3)))
+                .containsExactly(new Property("age", Direct.OUT, DataType.INTEGER, "10"));
+    }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtilsTest.java
@@ -1,0 +1,37 @@
+package org.apache.dolphinscheduler.plugin.task.api.utils;
+
+import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
+import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.truth.Truth;
+
+class VarPoolUtilsTest {
+
+    @Test
+    void mergeVarPool() {
+        List<Property> varpool1 = null;
+        List<Property> varpool2 = null;
+        Truth.assertThat(VarPoolUtils.mergeVarPool(varpool1, varpool2)).isNull();
+
+        // Override the value of the same property
+        // Merge the property with different key.
+        varpool1 = Lists.newArrayList(new Property("name", Direct.OUT, DataType.VARCHAR, "tom"));
+        varpool2 = Lists.newArrayList(
+                new Property("name", Direct.OUT, DataType.VARCHAR, "tim"),
+                new Property("age", Direct.OUT, DataType.INTEGER, "10"));
+
+        Truth.assertThat(VarPoolUtils.mergeVarPool(varpool1, varpool2))
+                .containsExactly(
+                        new Property("name", Direct.OUT, DataType.VARCHAR, "tim"),
+                        new Property("age", Direct.OUT, DataType.INTEGER, "10"));
+
+    }
+
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/VarPoolUtilsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.plugin.task.api.utils;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
@@ -6,7 +23,6 @@ import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -25,6 +25,7 @@ import org.apache.dolphinscheduler.common.thread.DefaultUncaughtExceptionHandler
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.meter.metrics.MetricsProvider;
 import org.apache.dolphinscheduler.meter.metrics.SystemMetrics;
+import org.apache.dolphinscheduler.plugin.datasource.api.plugin.DataSourceProcessorProvider;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageConfiguration;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager;
@@ -86,6 +87,7 @@ public class WorkerServer implements IStoppable {
     public void run() {
         this.workerRpcServer.start();
         TaskPluginManager.loadPlugin();
+        DataSourceProcessorProvider.initialize();
 
         this.workerRegistryClient.setRegistryStoppable(this);
         this.workerRegistryClient.start();

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecutor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecutor.java
@@ -283,6 +283,7 @@ public abstract class WorkerTaskExecutor implements Runnable {
 
         // upload out files and modify the "OUT FILE" property in VarPool
         TaskFilesTransferUtils.uploadOutputFiles(taskExecutionContext, storageOperate);
+
         log.info("Upload output files: {} successfully",
                 TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.OUT));
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
@@ -70,16 +70,17 @@ public class TaskFilesTransferUtils {
      */
     public static void uploadOutputFiles(TaskExecutionContext taskExecutionContext,
                                          StorageOperate storageOperate) throws TaskException {
-        List<Property> varPools = getVarPools(taskExecutionContext);
-        // get map of varPools for quick search
-        Map<String, Property> varPoolsMap = varPools.stream().collect(Collectors.toMap(Property::getProp, x -> x));
-
         // get OUTPUT FILE parameters
         List<Property> localParamsProperty = getFileLocalParams(taskExecutionContext, Direct.OUT);
-
         if (localParamsProperty.isEmpty()) {
             return;
         }
+
+        List<Property> varPools = getVarPools(taskExecutionContext);
+        // get map of varPools for quick search
+        Map<String, Property> varPoolsMap = varPools.stream()
+                .filter(property -> Direct.OUT.equals(property.getDirect()))
+                .collect(Collectors.toMap(Property::getProp, x -> x));
 
         log.info("Upload output files ...");
         for (Property property : localParamsProperty) {
@@ -137,16 +138,19 @@ public class TaskFilesTransferUtils {
      * @throws TaskException task exception
      */
     public static void downloadUpstreamFiles(TaskExecutionContext taskExecutionContext, StorageOperate storageOperate) {
-        List<Property> varPools = getVarPools(taskExecutionContext);
-        // get map of varPools for quick search
-        Map<String, Property> varPoolsMap = varPools.stream().collect(Collectors.toMap(Property::getProp, x -> x));
-
         // get "IN FILE" parameters
         List<Property> localParamsProperty = getFileLocalParams(taskExecutionContext, Direct.IN);
 
         if (localParamsProperty.isEmpty()) {
             return;
         }
+
+        List<Property> varPools = getVarPools(taskExecutionContext);
+        // get map of varPools for quick search
+        Map<String, Property> varPoolsMap = varPools
+                .stream()
+                .filter(property -> Direct.IN.equals(property.getDirect()))
+                .collect(Collectors.toMap(Property::getProp, x -> x));
 
         String executePath = taskExecutionContext.getExecutePath();
         // data path to download packaged data


### PR DESCRIPTION
## Purpose of the pull request

- Fix workflow instance restart failed when using varpool, since duplicate key exist in varpool with (Direct: OUT, IN)

<img width="1302" alt="image" src="https://github.com/apache/dolphinscheduler/assets/22415594/371b31b6-2782-4123-8639-97435825e739">

- Unify the direct to OUT in varpool, since it shouldn't be IN, only OUT will localparam will be put into varpool.
- After this PR the varpool will only exist one record for each key.


## Brief change log
- Fix the varpool merge logic will cause duplicate key in varpool.
- Fix delete taskInstance failed due to delete log error.
- Load the plugin when server startup, fix the load plugin log will exist in task instance log.


## Verify this pull request

Verify by manual.
