### PR TITLE
Deprecated 2.0.9/3.0.6 upgrade test

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         db: ["mysql", "postgresql"]
-        version: ["2.0.9", "3.0.6", "3.1.9", "3.2.0"]
+        version: ["3.1.9", "3.2.0"]
     steps:
       - name: Set up JDK 8
         uses: actions/setup-java@v2

--- a/dolphinscheduler-tools/src/test/resources/3.0.0_schema/postgresql_3.0.0.sql
+++ b/dolphinscheduler-tools/src/test/resources/3.0.0_schema/postgresql_3.0.0.sql
@@ -630,7 +630,6 @@ CREATE TABLE t_ds_relation_project_user (
                                             PRIMARY KEY (id),
                                             CONSTRAINT t_ds_relation_project_user_un UNIQUE (user_id, project_id)
 ) ;
-create index relation_project_user_id_index on t_ds_relation_project_user (user_id);
 
 --
 -- Table structure for table t_ds_relation_resources_user


### PR DESCRIPTION
Due to 2.0.9 and 3.0.6 is not a LTS version, we don't need to continue add upgrade test for this. We only need to focus on upgrade from 3.1.x to latest, since 3.1.x will not change the database schema anymore.

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
