### PR TITLE
Remove extra comparation of release_state in ProcessDefinitionMapper 

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
@@ -95,7 +95,7 @@
             <if test=" pd.name != null and pd.name != ''">
                 and name like concat('%', #{pd.name}, '%')
             </if>
-            <if test=" pd.releaseState != null and pd.releaseState != ''">
+            <if test=" pd.releaseState != null">
                 and release_state = #{pd.releaseState}
             </if>
         </where>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

This pull request fix /v2/workflows/query api.

In this api, there is a method called:

```
IPage<ProcessDefinition> filterProcessDefinition(IPage<ProcessDefinition> page,
                                                 @Param("pd") ProcessDefinition processDefinition);
```

In ProcessDefinition class, there is a filed: private ReleaseState releaseState.

It's an enum type, but in xml file, we compare it with String.

## Brief change log



Delete the mybatis sentence that compares releaseState to an empty String.



## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*

- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`