### PR TITLE
Fix WorkerTaskExecutorThreadPool#isOverload is incorrect

### DIFF
--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecutorHolder.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/WorkerTaskExecutorHolder.java
@@ -48,6 +48,10 @@ public class WorkerTaskExecutorHolder {
         workerTaskExecutorMap.clear();
     }
 
+    public static int size() {
+        return workerTaskExecutorMap.size();
+    }
+
     public static Collection<WorkerTaskExecutor> getAllTaskExecutor() {
         return workerTaskExecutorMap.values();
     }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/operator/TaskInstanceKillOperationFunction.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/runner/operator/TaskInstanceKillOperationFunction.java
@@ -89,8 +89,8 @@ public class TaskInstanceKillOperationFunction
             taskExecutionContext
                     .setCurrentExecutionStatus(result ? TaskExecutionStatus.SUCCESS : TaskExecutionStatus.FAILURE);
 
-            WorkerTaskExecutorHolder.remove(taskExecutionContext.getTaskInstanceId());
-            messageRetryRunner.removeRetryMessages(taskExecutionContext.getTaskInstanceId());
+            WorkerTaskExecutorHolder.remove(taskInstanceId);
+            messageRetryRunner.removeRetryMessages(taskInstanceId);
             return TaskInstanceKillResponse.success(taskExecutionContext);
         } finally {
             LogUtils.removeTaskInstanceIdMDC();


### PR DESCRIPTION
## Purpose of the pull request

When we submit a task into ThreadPool, if all core threads has been created(In most of times, the core threads are created.),   then the task will be submit into task queue first.
So we cannot use `threadPoolExecutor.getQueue().size() > 0` to judge whether the thread pool is busy

## Brief change log

- Use WorkerTaskExecutorHolder to judge whether the worker is overload.

## Verify this pull request

Test by UT
