### PR TITLE
[Hotfix] Fix NettyRemotingClient might throw IllegalMonitorStateException

### DIFF
--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/client/NettyRemotingClient.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/client/NettyRemotingClient.java
@@ -141,7 +141,7 @@ public class NettyRemotingClient implements AutoCloseable {
         return iRpcResponse;
     }
 
-    private Channel getOrCreateChannel(Host host) {
+    Channel getOrCreateChannel(Host host) {
         Channel channel = channels.get(host);
         if (channel != null && channel.isActive()) {
             return channel;
@@ -166,13 +166,10 @@ public class NettyRemotingClient implements AutoCloseable {
      * @param host host
      * @return channel
      */
-    private Channel createChannel(Host host) {
+    Channel createChannel(Host host) {
         try {
-            ChannelFuture future;
-            synchronized (bootstrap) {
-                future = bootstrap.connect(new InetSocketAddress(host.getIp(), host.getPort()));
-            }
-            future.await(clientConfig.getConnectTimeoutMillis());
+            ChannelFuture future = bootstrap.connect(new InetSocketAddress(host.getIp(), host.getPort()));
+            future = future.sync();
             if (future.isSuccess()) {
                 return future.channel();
             } else {


### PR DESCRIPTION
## Purpose of the pull request

Since future.await will release the monitor, if others want to notify the wait thread but doesn't get the log, then will throw IllegalMonitorStateException.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
