### PR TITLE
[Doc] Update ZooKeeper download link

### DIFF
--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -153,7 +153,7 @@ The browser access address [http://localhost:5173](http://localhost:5173) can lo
 
 #### zookeeper
 
-Download [ZooKeeper](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.3), and extract it.
+Download [ZooKeeper](https://zookeeper.apache.org/releases.html), and extract it.
 
 - Create directory `zkData` and `zkLog`
 - Go to the zookeeper installation directory, copy configure file `zoo_sample.cfg` to `conf/zoo.cfg`, and change value of dataDir in conf/zoo.cfg to dataDir=./tmp/zookeeper

--- a/docs/docs/zh/contribute/development-environment-setup.md
+++ b/docs/docs/zh/contribute/development-environment-setup.md
@@ -148,7 +148,7 @@ pnpm run dev
 
 #### zookeeper
 
-下载 [ZooKeeper](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.3)，解压
+下载 [ZooKeeper](https://zookeeper.apache.org/releases.html)，解压
 
 * 在 ZooKeeper 的目录下新建 zkData、zkLog文件夹
 * 将 conf 目录下的 `zoo_sample.cfg` 文件，复制一份，重命名为 `zoo.cfg`，修改其中数据和日志的配置，如：


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

This pull request updates the download link for ZooKeeper as the original one is no longer accessible.
Replaced the old link with the general ZooKeeper download link.

Old link:
<img width="775" alt="Screenshot 2024-05-28 at 6 33 49 PM" src="https://github.com/apache/dolphinscheduler/assets/97560867/7da45ef3-0540-41b4-8345-f96deb900ffb">
New link:
<img width="779" alt="Screenshot 2024-05-28 at 6 34 41 PM" src="https://github.com/apache/dolphinscheduler/assets/97560867/047a94da-f114-4413-b528-cd269e62b6ea">

