### PR TITLE
[Fix][UI] ensure number type field has number type value when edting alarm instance

### DIFF
--- a/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
+++ b/dolphinscheduler-ui/src/views/security/alarm-instance-manage/use-form.ts
@@ -115,6 +115,15 @@ export function useForm() {
     state.detailForm.warningType = record.warningType
     if (record.pluginInstanceParams)
       state.json = JSON.parse(record.pluginInstanceParams)
+    // ensure number type field has number type value
+    state.json.forEach((item: any) => {
+      if (item.validate && item.validate.length) {
+        const numberTypeItem = item.validate.find(
+          (v: any) => v.type === 'number'
+        )
+        if (numberTypeItem) item.value = +item.value
+      }
+    })
   }
 
   return {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

to close #16084

## Brief change log
ensure number type field has number type value
## Verify this pull request
![image](https://github.com/apache/dolphinscheduler/assets/16065427/dc4efec5-c320-402f-aa31-b7f2e36f0be6)

