### PR TITLE
Revert "[Improvement] Abnormal characters check"

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.api.service.impl;
 
-import static org.apache.dolphinscheduler.api.utils.CheckUtils.checkFilePath;
 import static org.apache.dolphinscheduler.common.constants.Constants.ALIAS;
 import static org.apache.dolphinscheduler.common.constants.Constants.CONTENT;
 import static org.apache.dolphinscheduler.common.constants.Constants.EMPTY_STRING;
@@ -1290,10 +1289,6 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         }
         if (FOLDER_SEPARATOR.equalsIgnoreCase(fullName)) {
             return;
-        }
-        // abnormal characters check
-        if (!checkFilePath(fullName)) {
-            throw new ServiceException(Status.ILLEGAL_RESOURCE_PATH);
         }
         // Avoid returning to the parent directory
         if (fullName.contains("../")) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/CheckUtils.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/CheckUtils.java
@@ -158,14 +158,4 @@ public class CheckUtils {
 
         return pattern.matcher(str).matches();
     }
-
-    /**
-     * regex FilePath check,only use a to z, A to Z, 0 to 9, and _./- 
-     *
-     * @param str     input string
-     * @return true if regex pattern is right, otherwise return false
-     */
-    public static boolean checkFilePath(String str) {
-        return regexChecks(str, Constants.REGEX_FILE_PATH);
-    }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/CheckUtilsTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/utils/CheckUtilsTest.java
@@ -92,24 +92,4 @@ public class CheckUtilsTest {
         Assertions.assertTrue(CheckUtils.checkPhone("17362537263"));
     }
 
-    /**
-     * check file path
-     */
-    @Test
-    public void testCheckFilePath() {
-        // true
-        Assertions.assertTrue(CheckUtils.checkFilePath("/"));
-        Assertions.assertTrue(CheckUtils.checkFilePath("xx/"));
-        Assertions.assertTrue(CheckUtils.checkFilePath("/xx"));
-        Assertions.assertTrue(CheckUtils.checkFilePath("14567134578654"));
-        Assertions.assertTrue(CheckUtils.checkFilePath("/admin/root/"));
-        Assertions.assertTrue(CheckUtils.checkFilePath("/admin/root/1531531..13513/153135.."));
-        // false
-        Assertions.assertFalse(CheckUtils.checkFilePath(null));
-        Assertions.assertFalse(CheckUtils.checkFilePath("file://xxx/ss"));
-        Assertions.assertFalse(CheckUtils.checkFilePath("/xxx/ss;/dasd/123"));
-        Assertions.assertFalse(CheckUtils.checkFilePath("/xxx/ss && /dasd/123"));
-        Assertions.assertFalse(CheckUtils.checkFilePath("/xxx/ss || /dasd/123"));
-    }
-
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
@@ -250,11 +250,6 @@ public final class Constants {
     public static final Pattern REGEX_USER_NAME = Pattern.compile("^[a-zA-Z0-9._-]{3,39}$");
 
     /**
-     * file path regex 
-     */
-    public static final Pattern REGEX_FILE_PATH = Pattern.compile("^[a-zA-Z0-9_./-]+$");
-
-    /**
      * read permission
      */
     public static final int READ_PERMISSION = 2;


### PR DESCRIPTION
Since this pr make the resource center doesn't work, due to the check method is incorrect.

The file path will have prefix e.g. "hdfs://", 'file://'

close #16006 