### PR TITLE
Fix task instance which status is dispatch will not be failover

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/WorkflowExecuteRunnable.java
@@ -1226,12 +1226,12 @@ public class WorkflowExecuteRunnable implements IWorkflowExecuteRunnable {
                         || state == TaskExecutionStatus.DISPATCH
                         || state == TaskExecutionStatus.SUBMITTED_SUCCESS
                         || state == TaskExecutionStatus.DELAY_EXECUTION) {
-                    // try to take over task instance
-                    if (state == TaskExecutionStatus.SUBMITTED_SUCCESS || state == TaskExecutionStatus.DELAY_EXECUTION
-                            || state == TaskExecutionStatus.DISPATCH) {
+                    if (state == TaskExecutionStatus.SUBMITTED_SUCCESS
+                            || state == TaskExecutionStatus.DELAY_EXECUTION) {
                         // The taskInstance is not in running, directly takeover it
                     } else if (tryToTakeOverTaskInstance(existTaskInstance)) {
-                        log.info("Success take over task {}", existTaskInstance.getName());
+                        // If the taskInstance has already dispatched to worker then will try to take-over it
+                        log.info("Success take over task {} -> status: {}", existTaskInstance.getName(), state);
                         continue;
                     } else {
                         // set the task instance state to fault tolerance


### PR DESCRIPTION
(cherry picked from commit a59ecf2aa19f4acd8d9981d14abe4d0c0d8e7fec)

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
