### PR TITLE
Fix SqlServer split merge sql will miss ;

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/main/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/main/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessor.java
@@ -35,6 +35,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.alibaba.druid.sql.parser.SQLParserUtils;
 import com.google.auto.service.AutoService;
@@ -128,8 +129,10 @@ public class SQLServerDataSourceProcessor extends AbstractDataSourceProcessor {
 
     @Override
     public List<String> splitAndRemoveComment(String sql) {
-        String cleanSQL = SQLParserUtils.removeComment(sql, com.alibaba.druid.DbType.sqlserver);
-        return SQLParserUtils.split(cleanSQL, com.alibaba.druid.DbType.sqlserver);
+        return SQLParserUtils.splitAndRemoveComment(sql, com.alibaba.druid.DbType.sqlserver)
+                .stream()
+                .map(subSql -> subSql.concat(";"))
+                .collect(Collectors.toList());
     }
 
     private String transformOther(Map<String, String> otherMap) {

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-sqlserver/src/test/java/org/apache/dolphinscheduler/plugin/datasource/sqlserver/param/SQLServerDataSourceProcessorTest.java
@@ -17,12 +17,15 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.sqlserver.param;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.apache.dolphinscheduler.common.constants.DataSourceConstants;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.spi.enums.DbType;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -94,5 +97,33 @@ public class SQLServerDataSourceProcessorTest {
     public void testGetValidationQuery() {
         Assertions.assertEquals(DataSourceConstants.SQLSERVER_VALIDATION_QUERY,
                 sqlServerDatasourceProcessor.getValidationQuery());
+    }
+
+    @Test
+    void splitAndRemoveComment_singleSelect() {
+        String sql = "select * from table;";
+        List<String> subSqls = sqlServerDatasourceProcessor.splitAndRemoveComment(sql);
+        assertThat(subSqls).hasSize(1);
+        assertThat(subSqls.get(0)).isEqualTo("select * from table;");
+    }
+
+    @Test
+    void splitAndRemoveComment_singleMerge() {
+        String sql = "MERGE\n" +
+                "    [ TOP ( expression ) [ PERCENT ] ]\n" +
+                "    [ INTO ] <target_table> [ WITH ( <merge_hint> ) ] [ [ AS ] table_alias ]\n" +
+                "    USING <table_source> [ [ AS ] table_alias ]\n" +
+                "    ON <merge_search_condition>\n" +
+                "    [ WHEN MATCHED [ AND <clause_search_condition> ]\n" +
+                "        THEN <merge_matched> ] [ ...n ]\n" +
+                "    [ WHEN NOT MATCHED [ BY TARGET ] [ AND <clause_search_condition> ]\n" +
+                "        THEN <merge_not_matched> ]\n" +
+                "    [ WHEN NOT MATCHED BY SOURCE [ AND <clause_search_condition> ]\n" +
+                "        THEN <merge_matched> ] [ ...n ]\n" +
+                "    [ <output_clause> ]\n" +
+                "    [ OPTION ( <query_hint> [ ,...n ] ) ];";
+        List<String> subSqls = sqlServerDatasourceProcessor.splitAndRemoveComment(sql);
+        assertThat(subSqls).hasSize(1);
+        assertThat(subSqls.get(0)).isEqualTo(sql);
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

Fix SqlServer split merge sql will drop the `;`, but `merge` sql needs `;`  
https://learn.microsoft.com/zh-tw/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver16

## Brief change log


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
