### PR TITLE
[Chore] Disable discover composite indicator

### DIFF
--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -75,6 +75,8 @@ spring:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
     static-path-pattern: /static/**
+  cloud.discovery.client.composite-indicator.enabled: false
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -51,6 +51,7 @@ spring:
       org.quartz.scheduler.makeSchedulerThreadDaemon: true
       org.quartz.jobStore.driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
       org.quartz.jobStore.clusterCheckinInterval: 5000
+  cloud.discovery.client.composite-indicator.enabled: false
 
 # Mybatis-plus configuration, you don't need to change it
 mybatis-plus:

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -64,6 +64,7 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+  cloud.discovery.client.composite-indicator.enabled: false
 
 mybatis-plus:
   mapper-locations: classpath:org/apache/dolphinscheduler/dao/mapper/*Mapper.xml

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -23,6 +23,7 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+  cloud.discovery.client.composite-indicator.enabled: false
 
 registry:
   type: zookeeper


### PR DESCRIPTION
## Purpose of the pull request

We don't use spring cloud discovery module, avoid get unknown discoveryComposite
<img width="602" alt="image" src="https://github.com/apache/dolphinscheduler/assets/22415594/923e11cb-a049-4377-b48c-bf37e3dc4474">


## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
