### PR TITLE
[Improvement-16182] Increase zk connect timeout

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/application.yaml
@@ -82,12 +82,12 @@ registry:
     namespace: dolphinscheduler
     connect-string: localhost:2181
     retry-policy:
-      base-sleep-time: 60ms
-      max-sleep: 300ms
+      base-sleep-time: 1s
+      max-sleep: 3s
       max-retries: 5
-    session-timeout: 30s
-    connection-timeout: 9s
-    block-until-connected: 600ms
+    session-timeout: 60s
+    connection-timeout: 15s
+    block-until-connected: 15s
     digest: ~
 
 metrics:

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -120,8 +120,8 @@ registry:
     namespace: dolphinscheduler
     connect-string: localhost:2181
     retry-policy:
-      base-sleep-time: 60ms
-      max-sleep: 300ms
+      base-sleep-time: 1s
+      max-sleep: 3s
       max-retries: 5
     session-timeout: 60s
     connection-timeout: 15s

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/repository/impl/CommandDaoImplTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/repository/impl/CommandDaoImplTest.java
@@ -35,6 +35,7 @@ import org.apache.dolphinscheduler.dao.repository.CommandDao;
 import org.apache.commons.lang3.RandomUtils;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,9 +63,9 @@ class CommandDaoImplTest extends BaseDaoTest {
         // Generate commandSize commands
         int id = 0;
         for (int j = 0; j < commandSize; j++) {
+            id += idStep;
             Command command = generateCommand(CommandType.START_PROCESS, 0);
             command.setId(id);
-            id += idStep;
             commandDao.insert(command);
         }
 
@@ -75,7 +76,8 @@ class CommandDaoImplTest extends BaseDaoTest {
                         ", idStep: " + idStep +
                         ", fetchSize: " + fetchSize +
                         ", total command size: " + commandSize +
-                        ", total commands: " + commandDao.queryAll());
+                        ", total commands: "
+                        + commandDao.queryAll().stream().map(Command::getId).collect(Collectors.toList()));
         assertThat(commands.size())
                 .isEqualTo(commandDao.queryAll()
                         .stream()

--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -74,12 +74,12 @@ registry:
     namespace: dolphinscheduler
     connect-string: localhost:2181
     retry-policy:
-      base-sleep-time: 60ms
-      max-sleep: 300ms
+      base-sleep-time: 1s
+      max-sleep: 3s
       max-retries: 5
-    session-timeout: 30s
-    connection-timeout: 9s
-    block-until-connected: 600ms
+    session-timeout: 60s
+    connection-timeout: 15s
+    block-until-connected: 15s
     digest: ~
 
 master:

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/runner/queue/DelayEntryTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/runner/queue/DelayEntryTest.java
@@ -29,7 +29,7 @@ class DelayEntryTest {
     void getDelay() {
         DelayEntry<String> delayEntry = new DelayEntry<>(5_000L, "Item");
         assertThat(delayEntry.getDelay(TimeUnit.NANOSECONDS))
-                .isWithin(500)
+                .isWithin(TimeUnit.NANOSECONDS.convert(500, TimeUnit.MILLISECONDS))
                 .of(TimeUnit.NANOSECONDS.convert(5_000L, TimeUnit.MILLISECONDS));
     }
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistryProperties.java
@@ -101,16 +101,16 @@ class ZookeeperRegistryProperties implements Validator {
         private String connectString;
         private RetryPolicy retryPolicy = new RetryPolicy();
         private String digest;
-        private Duration sessionTimeout = Duration.ofSeconds(30);
-        private Duration connectionTimeout = Duration.ofSeconds(9);
-        private Duration blockUntilConnected = Duration.ofMillis(600);
+        private Duration sessionTimeout = Duration.ofSeconds(60);
+        private Duration connectionTimeout = Duration.ofSeconds(15);
+        private Duration blockUntilConnected = Duration.ofSeconds(15);
 
         @Data
         public static final class RetryPolicy {
 
-            private Duration baseSleepTime = Duration.ofMillis(60);
-            private int maxRetries;
-            private Duration maxSleep = Duration.ofMillis(300);
+            private Duration baseSleepTime = Duration.ofSeconds(1);
+            private int maxRetries = 3;
+            private Duration maxSleep = Duration.ofSeconds(3);
 
         }
     }

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -85,12 +85,12 @@ registry:
     namespace: dolphinscheduler
     connect-string: localhost:2181
     retry-policy:
-      base-sleep-time: 60ms
-      max-sleep: 300ms
+      base-sleep-time: 1s
+      max-sleep: 3s
       max-retries: 5
-    session-timeout: 30s
-    connection-timeout: 9s
-    block-until-connected: 600ms
+    session-timeout: 60s
+    connection-timeout: 15s
+    block-until-connected: 15s
     digest: ~
 
 security:

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -31,12 +31,12 @@ registry:
     namespace: dolphinscheduler
     connect-string: localhost:2181
     retry-policy:
-      base-sleep-time: 60ms
-      max-sleep: 300ms
+      base-sleep-time: 1s
+      max-sleep: 3s
       max-retries: 5
-    session-timeout: 30s
-    connection-timeout: 9s
-    block-until-connected: 600ms
+    session-timeout: 60s
+    connection-timeout: 15s
+    block-until-connected: 15s
     digest: ~
 
 worker:


### PR DESCRIPTION
## Purpose of the pull request

close https://github.com/apache/dolphinscheduler/issues/16182

## Brief change log

- Set the connect timeout to 15s
- Change the retry interval to 1s~3s

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
