### PR TITLE
[CI] Bump up owasp version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <jacoco.skip>false</jacoco.skip>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <owasp-dependency-check-maven.version>7.1.2</owasp-dependency-check-maven.version>
+        <owasp-dependency-check-maven.version>9.2.0</owasp-dependency-check-maven.version>
         <lombok.version>1.18.20</lombok.version>
         <awaitility.version>4.2.0</awaitility.version>
         <truth.version>1.4.2</truth.version>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Bump up owasp version due to `Versions earlier then 9.0.0 are no longer supported and could fail to work after Dec 15th, 2023.`

https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#900-upgrade-notice