### PR TITLE
[Fix 16211][java-task] Remove ExecutePath in buildJarCommand() to fix Java Task in Jar Mode

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-java/src/main/java/org/apache/dolphinscheduler/plugin/task/java/JavaTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-java/src/main/java/org/apache/dolphinscheduler/plugin/task/java/JavaTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.plugin.task.java;
 
-import static org.apache.dolphinscheduler.common.constants.Constants.FOLDER_SEPARATOR;
 import static org.apache.dolphinscheduler.plugin.task.java.JavaConstants.JAVA_HOME_VAR;
 import static org.apache.dolphinscheduler.plugin.task.java.JavaConstants.PUBLIC_CLASS_NAME_REGEX;
 
@@ -187,7 +186,6 @@ public class JavaTask extends AbstractTask {
                 .append("java").append(" ")
                 .append(buildResourcePath()).append(" ")
                 .append("-jar").append(" ")
-                .append(taskRequest.getExecutePath()).append(FOLDER_SEPARATOR)
                 .append(mainJarAbsolutePathInLocal).append(" ")
                 .append(javaParameters.getMainArgs().trim()).append(" ")
                 .append(javaParameters.getJvmArgs().trim());

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-java/src/test/java/org/apache/dolphinscheduler/plugin/task/java/JavaTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-java/src/test/java/org/apache/dolphinscheduler/plugin/task/java/JavaTaskTest.java
@@ -85,7 +85,7 @@ public class JavaTaskTest {
         JavaTask javaTask = runJarType();
         assertThat(javaTask.buildJarCommand())
                 .isEqualTo(
-                        "${JAVA_HOME}/bin/java -classpath .:/tmp/dolphinscheduler/test/executepath:opt/share/jar/resource2.jar -jar /tmp/dolphinscheduler/test/executepath/opt/share/jar/main.jar -host 127.0.0.1 -port 8080 -xms:50m");
+                        "${JAVA_HOME}/bin/java -classpath .:/tmp/dolphinscheduler/test/executepath:/tmp/dolphinscheduler/test/executepath/opt/share/jar/resource2.jar -jar /tmp/dolphinscheduler/test/executepath/opt/share/jar/main.jar -host 127.0.0.1 -port 8080 -xms:50m");
     }
 
     /**
@@ -107,7 +107,7 @@ public class JavaTaskTest {
             }
             assertThat(javaTask.buildJavaCompileCommand(sourceCode))
                     .isEqualTo(
-                            "${JAVA_HOME}/bin/javac -classpath .:/tmp/dolphinscheduler/test/executepath:opt/share/jar/resource2.jar /tmp/dolphinscheduler/test/executepath/JavaTaskTest.java");
+                            "${JAVA_HOME}/bin/javac -classpath .:/tmp/dolphinscheduler/test/executepath:/tmp/dolphinscheduler/test/executepath/opt/share/jar/resource2.jar /tmp/dolphinscheduler/test/executepath/JavaTaskTest.java");
         } finally {
             Path path = Paths.get(fileName);
             if (Files.exists(path)) {
@@ -137,7 +137,7 @@ public class JavaTaskTest {
         }
         assertThat(javaTask.buildJavaCommand())
                 .isEqualTo(
-                        "${JAVA_HOME}/bin/javac -classpath .:/tmp/dolphinscheduler/test/executepath:opt/share/jar/resource2.jar /tmp/dolphinscheduler/test/executepath/JavaTaskTest.java;${JAVA_HOME}/bin/java -classpath .:/tmp/dolphinscheduler/test/executepath:opt/share/jar/resource2.jar JavaTaskTest -host 127.0.0.1 -port 8080 -xms:50m");
+                        "${JAVA_HOME}/bin/javac -classpath .:/tmp/dolphinscheduler/test/executepath:/tmp/dolphinscheduler/test/executepath/opt/share/jar/resource2.jar /tmp/dolphinscheduler/test/executepath/JavaTaskTest.java;${JAVA_HOME}/bin/java -classpath .:/tmp/dolphinscheduler/test/executepath:/tmp/dolphinscheduler/test/executepath/opt/share/jar/resource2.jar JavaTaskTest -host 127.0.0.1 -port 8080 -xms:50m");
     }
 
     /**
@@ -254,15 +254,16 @@ public class JavaTaskTest {
         taskExecutionContext.setTaskAppId("runJavaType");
         ResourceContext.ResourceItem resourceItem1 = new ResourceContext.ResourceItem();
         resourceItem1.setResourceAbsolutePathInStorage("/opt/share/jar/resource2.jar");
-        resourceItem1.setResourceAbsolutePathInLocal("opt/share/jar/resource2.jar");
+        resourceItem1
+                .setResourceAbsolutePathInLocal("/tmp/dolphinscheduler/test/executepath/opt/share/jar/resource2.jar");
 
         ResourceContext.ResourceItem resourceItem2 = new ResourceContext.ResourceItem();
         resourceItem2.setResourceAbsolutePathInStorage("/opt/share/jar/main.jar");
-        resourceItem2.setResourceAbsolutePathInLocal("opt/share/jar/main.jar");
+        resourceItem2.setResourceAbsolutePathInLocal("/tmp/dolphinscheduler/test/executepath/opt/share/jar/main.jar");
 
         ResourceContext.ResourceItem resourceItem3 = new ResourceContext.ResourceItem();
         resourceItem3.setResourceAbsolutePathInStorage("/JavaTaskTest.java");
-        resourceItem3.setResourceAbsolutePathInLocal("JavaTaskTest.java");
+        resourceItem3.setResourceAbsolutePathInLocal("/tmp/dolphinscheduler/test/executepath/JavaTaskTest.java");
 
         ResourceContext resourceContext = new ResourceContext();
         resourceContext.addResourceItem(resourceItem1);
@@ -286,11 +287,12 @@ public class JavaTaskTest {
         taskExecutionContext.setTaskAppId("runJavaType");
         ResourceContext.ResourceItem resourceItem1 = new ResourceContext.ResourceItem();
         resourceItem1.setResourceAbsolutePathInStorage("/opt/share/jar/resource2.jar");
-        resourceItem1.setResourceAbsolutePathInLocal("opt/share/jar/resource2.jar");
+        resourceItem1
+                .setResourceAbsolutePathInLocal("/tmp/dolphinscheduler/test/executepath/opt/share/jar/resource2.jar");
 
         ResourceContext.ResourceItem resourceItem2 = new ResourceContext.ResourceItem();
         resourceItem2.setResourceAbsolutePathInStorage("/opt/share/jar/main.jar");
-        resourceItem2.setResourceAbsolutePathInLocal("opt/share/jar/main.jar");
+        resourceItem2.setResourceAbsolutePathInLocal("/tmp/dolphinscheduler/test/executepath/opt/share/jar/main.jar");
 
         ResourceContext resourceContext = new ResourceContext();
         resourceContext.addResourceItem(resourceItem1);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

# Pull Request Branch
fix-issue-16211

# Pull Request Content
## Purpose of the pull request
Fix [issue 16211](https://github.com/apache/dolphinscheduler/issues/16211)   
The comment says "duplicated with https://github.com/apache/dolphinscheduler/issues/15902"
And should be fixed by pr [15906](https://github.com/apache/dolphinscheduler/pull/15906)   
But I have tested and I think PR 15906 only fix the JavaTask Java Mode, Jar Mode still have bug  
ResourceAbsolutePathInLocal already have the ExecutePath, need remove it in buildJarCommand() method  
Also update the UnitTest  
Please check my reply in [issue 16211](https://github.com/apache/dolphinscheduler/issues/16211)  
I deployed the latest code in apache/dolphinscheduler dev branch in my own cluster and run JavaTask in Jar Mode and it failed  
After deployed my code in my own cluster, run JavaTask in Jar Mode and it succeed 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
[Fix issue 16211] Remove ExecutePath in buildJarCommand() to fix Java Task in Jar Mode
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is already covered by existing tests, such as *(please describe tests)*.
- *Updated JavaTaskTest to verify the change.*
- *Build dolphinscheduler-task-java and deployed to my own cluster and tested end to end, please check the comment in [issue 16211](https://github.com/apache/dolphinscheduler/issues/16211) about the log before and after this pull request  *
- *Run mvn spotless:apply and check the code format*

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

# Pull Request Code Style
Already run the mvn spotless:apply and checked no problem with the code style

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
