### PR TITLE
[Fix-16272][Alert Server] Alarm server failed to send alarm

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/service/AbstractEventSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/java/org/apache/dolphinscheduler/alert/service/AbstractEventSender.java
@@ -122,7 +122,7 @@ public abstract class AbstractEventSender<T> implements EventSender<T> {
 
         AlertInfo alertInfo = AlertInfo.builder()
                 .alertData(alertData)
-                .alertParams(PluginParamsTransfer.getPluginParamsMap(instance.getPluginInstanceParams()))
+                .alertParams(JSONUtils.toMap(instance.getPluginInstanceParams()))
                 .alertPluginInstanceId(instance.getId())
                 .build();
         try {


### PR DESCRIPTION
# Purpose of the pull request
close https://github.com/apache/dolphinscheduler/issues/16272
Fix Alarm server failed to send alarm

# Cause analysis
because json Conversion exception.
like this script alert plugin:
<img width="639" alt="image" src="https://github.com/apache/dolphinscheduler/assets/48642743/e960be35-3000-4ff5-8e17-5f6e935507b8">
and debug then get the json string:
<img width="1033" alt="image" src="https://github.com/apache/dolphinscheduler/assets/48642743/948f8300-35ed-4fc1-8bcb-a6b554ac1871">
then want to conversion to PluginParams.class:
<img width="752" alt="image" src="https://github.com/apache/dolphinscheduler/assets/48642743/c20f44e8-37a7-49d0-920f-e4775db969bf">
but ,the PluginParams is not what we want, the params will Construct ScriptSender：
<img width="749" alt="image" src="https://github.com/apache/dolphinscheduler/assets/48642743/14806d6c-7aeb-4870-b5a8-43cc83d1efce">
<img width="855" alt="image" src="https://github.com/apache/dolphinscheduler/assets/48642743/0c88d95f-26b1-4dde-bfa5-658648cd8c22">
so, we just need to Conversion json to map