### PR TITLE
[Fix-16295][Task] Remote Shell Task plugin run error

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-remoteshell/src/main/java/org/apache/dolphinscheduler/plugin/task/remoteshell/RemoteExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-remoteshell/src/main/java/org/apache/dolphinscheduler/plugin/task/remoteshell/RemoteExecutor.java
@@ -131,7 +131,7 @@ public class RemoteExecutor implements AutoCloseable {
         int exitCode = -1;
         log.info("Remote shell task run status: {}", logLine);
         if (logLine.contains(STATUS_TAG_MESSAGE)) {
-            String status = StringUtils.substringAfter(logLine, STATUS_TAG_MESSAGE);
+            String status = StringUtils.substringAfter(logLine, STATUS_TAG_MESSAGE).trim();
             if (status.equals("0")) {
                 log.info("Remote shell task success");
                 exitCode = 0;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close https://github.com/apache/dolphinscheduler/issues/16295
Fix Remote Shell Task plugin run error 


## Reason
An additional line break was added at the end of logLine

![ac5e5f2494fcdc3556fecb18e4d5332c](https://github.com/apache/dolphinscheduler/assets/48642743/8c11c567-dd20-480c-a947-d5ac68348423)
