### PR TITLE
[Fix-16279] Support Java 8 date/time type `java.time.OffsetDateTime`

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -360,7 +360,11 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <!--protostuff-->
             <dependency>
                 <groupId>io.protostuff</groupId>

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -25,6 +25,7 @@ import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.dolphinscheduler.common.constants.DateConstants.YYYY_MM_DD_HH_MM_SS;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -81,6 +82,7 @@ public final class JSONUtils {
             .addModule(new SimpleModule()
                     .addSerializer(LocalDateTime.class, new LocalDateTimeSerializer())
                     .addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer()))
+            .addModule(new JavaTimeModule())
             .defaultTimeZone(TimeZone.getDefault())
             .defaultDateFormat(new SimpleDateFormat(YYYY_MM_DD_HH_MM_SS))
             .build();

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -79,10 +79,10 @@ public final class JSONUtils {
             .configure(READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(REQUIRE_SETTERS_FOR_GETTERS, true)
             .configure(FAIL_ON_EMPTY_BEANS, false)
+            .addModule(new JavaTimeModule())
             .addModule(new SimpleModule()
                     .addSerializer(LocalDateTime.class, new LocalDateTimeSerializer())
                     .addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer()))
-            .addModule(new JavaTimeModule())
             .defaultTimeZone(TimeZone.getDefault())
             .defaultDateFormat(new SimpleDateFormat(YYYY_MM_DD_HH_MM_SS))
             .build();

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -25,7 +25,6 @@ import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.dolphinscheduler.common.constants.DateConstants.YYYY_MM_DD_HH_MM_SS;
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -61,6 +60,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.base.Strings;
 
 /**

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -294,7 +294,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     jackson-core-asl 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-core-asl/1.9.13, Apache 2.0
     jackson-databind 2.13.4: https://github.com/FasterXML/jackson-databind, Apache 2.0
     jackson-datatype-jdk8 2.13.0: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.0, Apache 2.0
-    jackson-datatype-jsr310 2.13.0: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.0, Apache 2.0
+    jackson-datatype-jsr310 2.13.4: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.4, Apache 2.0
     jackson-mapper-asl 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-mapper-asl/1.9.13, Apache 2.0
     jackson-module-parameter-names 2.13.0: https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-parameter-names/2.13.0, Apache 2.0
     javax.jdo-3.2.0-m3: https://mvnrepository.com/artifact/org.datanucleus/javax.jdo/3.2.0-m3, Apache 2.0

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/JSONUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/JSONUtilsTest.java
@@ -275,14 +275,16 @@ public class JSONUtilsTest {
 
     @Test
     public void toOffsetDateTimeNodeTest() {
+        TimeZone timeZone = TimeZone.getTimeZone("UTC");
+        JSONUtils.setTimeZone(timeZone);
         LocalDateTime localDateTime = LocalDateTime.of(2024, 7, 10, 15, 0, 0);
-        OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(8));
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(0));
         Map<String, OffsetDateTime> map = new HashMap<>();
         map.put("time", offsetDateTime);
         JsonNode jsonNodes = JSONUtils.toJsonNode(map);
         String s = JSONUtils.toJsonString(jsonNodes);
 
-        String json = "{\"time\":\"2024-07-10T15:00:00+08:00\"}";
+        String json = "{\"time\":\"2024-07-10T15:00:00Z\"}";
         Assertions.assertEquals(json, s);
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/JSONUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/JSONUtilsTest.java
@@ -22,6 +22,9 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -268,6 +271,19 @@ public class JSONUtilsTest {
         Date date = JSONUtils.parseObject(json, Date.class);
         Assertions.assertEquals(DateUtils.stringToDate("2022-02-22 13:38:24"), date);
 
+    }
+
+    @Test
+    public void toOffsetDateTimeNodeTest(){
+        LocalDateTime localDateTime = LocalDateTime.of(2024, 7, 10, 15, 0, 0);
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(8));
+        Map<String, OffsetDateTime> map = new HashMap<>();
+        map.put("time", offsetDateTime);
+        JsonNode jsonNodes = JSONUtils.toJsonNode(map);
+        String s = JSONUtils.toJsonString(jsonNodes);
+
+        String json = "{\"time\":\"2024-07-10T15:00:00+08:00\"}";
+        Assertions.assertEquals(json, s);
     }
 
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/JSONUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/JSONUtilsTest.java
@@ -274,7 +274,7 @@ public class JSONUtilsTest {
     }
 
     @Test
-    public void toOffsetDateTimeNodeTest(){
+    public void toOffsetDateTimeNodeTest() {
         LocalDateTime localDateTime = LocalDateTime.of(2024, 7, 10, 15, 0, 0);
         OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(8));
         Map<String, OffsetDateTime> map = new HashMap<>();

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -115,7 +115,7 @@ jackson-databind-2.13.4.jar
 jackson-dataformat-cbor-2.13.3.jar
 jackson-dataformat-yaml-2.13.3.jar
 jackson-datatype-jdk8-2.13.3.jar
-jackson-datatype-jsr310-2.13.3.jar
+jackson-datatype-jsr310-2.13.4.jar
 jackson-jaxrs-base-2.13.3.jar
 jackson-jaxrs-json-provider-2.13.3.jar
 jackson-mapper-asl-1.9.13.jar


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
fix #16279 
- Support Java 8 date/time type `java.time.OffsetDateTime`

refer  https://github.com/FasterXML/jackson-modules-java8/issues/219

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
