### PR TITLE
[Chore] Add E2E-K8S-Result to mergeable check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,6 +46,7 @@ github:
           - E2E
           - Docs
           - Frontend Build
+          - "E2E-K8S-Result"
           - "Mergeable: milestone-label-check"
           - "Title Validator"
       required_pull_request_reviews:

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -147,3 +147,20 @@ jobs:
               done
             done
           done
+  result:
+    name: E2E-K8S-Result
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [ e2e-k8s, paths-filter ]
+    if: always()
+    steps:
+      - name: Status
+        run: |
+          if [[ ${{ needs.paths-filter.outputs.not-ignore }} == 'false' && ${{ github.event_name }} == 'pull_request' ]]; then
+            echo "Skip E2E-K8S!"
+            exit 0
+          fi
+          if [[ ${{ needs.e2e-k8s.result }} != 'success' ]]; then
+            echo "E2E-K8S Failed!"
+            exit -1
+          fi


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
