### PR TITLE
[Fix-16466][ui] Add logic_operator handling in format-data and types

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -302,7 +302,8 @@ export function formatParams(data: INodeData): {
       target_database: data.target_database,
       target_table: data.target_table,
       threshold: data.threshold,
-      mapping_columns: JSON.stringify(data.mapping_columns)
+      mapping_columns: JSON.stringify(data.mapping_columns),
+      logic_operator: data?.logic_operator
     }
     taskParams.sparkParameters = {
       deployMode: data.deployMode,
@@ -727,6 +728,8 @@ export function formatModel(data: ITaskData) {
       params.mapping_columns = JSON.parse(
         data.taskParams.ruleInputParameter.mapping_columns
       )
+    if (data.taskParams.ruleInputParameter.logic_operator)
+      params.logic_operator = data.taskParams.ruleInputParameter.logic_operator
   }
   if (data.taskParams?.sparkParameters) {
     params.deployMode = data.taskParams.sparkParameters.deployMode

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
@@ -258,6 +258,7 @@ interface IRuleParameters {
   target_table?: string
   threshold?: string
   mapping_columns?: string
+  logic_operator?: string
 }
 
 interface ITaskParams {


### PR DESCRIPTION
fix: Add `logic_operator` handling in format-data and types

- Updated `formatParams` and `formatModel` functions to include `logic_operator` in the task parameters.
- Modified `IRuleParameters` interface to include `logic_operator` as an optional string.
