### PR TITLE
[Improvement-8295][Document] Standalone Deployment doc should instruct users to configure sudo without password

### DIFF
--- a/docs/docs/en/guide/installation/pseudo-cluster.md
+++ b/docs/docs/en/guide/installation/pseudo-cluster.md
@@ -33,7 +33,7 @@ echo "dolphinscheduler" | passwd --stdin dolphinscheduler
 
 # Configure sudo without password
 sed -i '$adolphinscheduler  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers
-sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 # Modify directory permissions and grant permissions for user you created above
 chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
@@ -43,7 +43,7 @@ chmod -R 755 apache-dolphinscheduler-*-bin
 > **_NOTICE:_**
 >
 > - Due to DolphinScheduler's multi-tenant task switch user using command `sudo -u {linux-user} -i`, the deployment user needs to have `sudo` privileges and be password-free. If novice learners don’t understand, you can ignore this point for now.
-> - If you find the line "Defaults requirett" in the `/etc/sudoers` file, please comment the content.
+> - If you find the line "Defaults requiretty" in the `/etc/sudoers` file, please comment the content.
 
 ### Prepare Zookeeper
 

--- a/docs/docs/en/guide/installation/pseudo-cluster.md
+++ b/docs/docs/en/guide/installation/pseudo-cluster.md
@@ -45,6 +45,10 @@ chmod -R 755 apache-dolphinscheduler-*-bin
 > - Due to DolphinScheduler's multi-tenant task switch user using command `sudo -u {linux-user} -i`, the deployment user needs to have `sudo` privileges and be password-free. If novice learners don’t understand, you can ignore this point for now.
 > - If you find the line "Defaults requirett" in the `/etc/sudoers` file, please comment the content.
 
+### Prepare Zookeeper
+
+If you use Zookeeper as the registry center, you need to install Zookeeper and start it first.
+
 ## Modify Configuration
 
 After completing the preparation of the basic environment, you need to modify the configuration file according to the

--- a/docs/docs/en/guide/installation/standalone.md
+++ b/docs/docs/en/guide/installation/standalone.md
@@ -27,7 +27,7 @@ echo "dolphinscheduler" | passwd --stdin dolphinscheduler
 
 # Configure sudo without password
 sed -i '$adolphinscheduler  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers
-sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 # Modify directory permissions and grant permissions for user you created above
 chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
@@ -37,7 +37,7 @@ chmod -R 755 apache-dolphinscheduler-*-bin
 > **_NOTICE:_**
 >
 > - Due to DolphinScheduler's multi-tenant task switch user using command `sudo -u {linux-user} -i`, the deployment user needs to have `sudo` privileges and be password-free. If novice learners don’t understand, you can ignore this point for now.
-> - If you find the line "Defaults requirett" in the `/etc/sudoers` file, please comment the content.
+> - If you find the line "Defaults requiretty" in the `/etc/sudoers` file, please comment the content.
 
 ## Start DolphinScheduler Standalone Server
 

--- a/docs/docs/en/guide/installation/standalone.md
+++ b/docs/docs/en/guide/installation/standalone.md
@@ -14,6 +14,31 @@ If you want to deploy DolphinScheduler in production, we recommend you follow [c
 - JDK：download [JDK][jdk] (1.8 or 11), install and configure environment variable `JAVA_HOME` and append `bin` dir (included in `JAVA_HOME`) to `PATH` variable. You can skip this step if it already exists in your environment.
 - Binary package: download the DolphinScheduler binary package at [download page](https://dolphinscheduler.apache.org/en-us/download/<version>).  <!-- markdown-link-check-disable-line -->
 
+### Configure User Exemption and Permissions
+
+Create a deployment user, and make sure to configure `sudo` without password. Here make an example to create user `dolphinscheduler`:
+
+```shell
+# To create a user, login as root
+useradd dolphinscheduler
+
+# Add password
+echo "dolphinscheduler" | passwd --stdin dolphinscheduler
+
+# Configure sudo without password
+sed -i '$adolphinscheduler  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers
+sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
+
+# Modify directory permissions and grant permissions for user you created above
+chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
+chmod -R 755 apache-dolphinscheduler-*-bin
+```
+
+> **_NOTICE:_**
+>
+> - Due to DolphinScheduler's multi-tenant task switch user using command `sudo -u {linux-user} -i`, the deployment user needs to have `sudo` privileges and be password-free. If novice learners don’t understand, you can ignore this point for now.
+> - If you find the line "Defaults requirett" in the `/etc/sudoers` file, please comment the content.
+
 ## Start DolphinScheduler Standalone Server
 
 ### Extract and Start DolphinScheduler

--- a/docs/docs/zh/guide/installation/pseudo-cluster.md
+++ b/docs/docs/zh/guide/installation/pseudo-cluster.md
@@ -33,7 +33,7 @@ echo "dolphinscheduler" | passwd --stdin dolphinscheduler
 
 # 配置 sudo 免密
 sed -i '$adolphinscheduler  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers
-sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 # 修改目录权限，使得部署用户对二进制包解压后的 apache-dolphinscheduler-*-bin 目录有操作权限
 chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
@@ -43,7 +43,7 @@ chmod -R 755 apache-dolphinscheduler-*-bin
 > **_注意:_**
 >
 > - 因为任务执行服务是以 `sudo -u {linux-user} -i` 切换不同 linux 用户的方式来实现多租户运行作业，所以部署用户需要有 sudo 权限，而且是免密的。初学习者不理解的话，完全可以暂时忽略这一点
-> - 如果发现 `/etc/sudoers` 文件中有 "Defaults requirett" 这行，也请注释掉
+> - 如果发现 `/etc/sudoers` 文件中有 "Defaults requiretty" 这行，也请注释掉
 
 ### 准备 zookeeper
 

--- a/docs/docs/zh/guide/installation/pseudo-cluster.md
+++ b/docs/docs/zh/guide/installation/pseudo-cluster.md
@@ -45,14 +45,9 @@ chmod -R 755 apache-dolphinscheduler-*-bin
 > - 因为任务执行服务是以 `sudo -u {linux-user} -i` 切换不同 linux 用户的方式来实现多租户运行作业，所以部署用户需要有 sudo 权限，而且是免密的。初学习者不理解的话，完全可以暂时忽略这一点
 > - 如果发现 `/etc/sudoers` 文件中有 "Defaults requirett" 这行，也请注释掉
 
-### 启动 zookeeper
+### 准备 zookeeper
 
-进入 zookeeper 的安装目录，将 `zoo_sample.cfg` 配置文件复制到 `conf/zoo.cfg`，并将 `conf/zoo.cfg` 中 dataDir 中的值改成 `dataDir=./tmp/zookeeper`
-
-```shell
-# 启动 zookeeper
-./bin/zkServer.sh start
-```
+如果使用 Zookeeper 作为注册中心，需要先安装 Zookeeper 并启动。
 
 ## 修改相关配置
 

--- a/docs/docs/zh/guide/installation/standalone.md
+++ b/docs/docs/zh/guide/installation/standalone.md
@@ -12,6 +12,31 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 - JDK：下载[JDK][jdk] (1.8 or 11)，安装并配置 `JAVA_HOME` 环境变量，并将其下的 `bin` 目录追加到 `PATH` 环境变量中。如果你的环境中已存在，可以跳过这步。
 - 二进制包：在[下载页面](https://dolphinscheduler.apache.org/en-us/download/<version>)下载 DolphinScheduler 二进制包  <!-- markdown-link-check-disable-line -->
 
+## 配置用户免密及权限
+
+创建部署用户，并且一定要配置 `sudo` 免密。以创建 dolphinscheduler 用户为例
+
+```shell
+# 创建用户需使用 root 登录
+useradd dolphinscheduler
+
+# 添加密码
+echo "dolphinscheduler" | passwd --stdin dolphinscheduler
+
+# 配置 sudo 免密
+sed -i '$adolphinscheduler  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers
+sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
+
+# 修改目录权限，使得部署用户对二进制包解压后的 apache-dolphinscheduler-*-bin 目录有操作权限
+chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
+chmod -R 755 apache-dolphinscheduler-*-bin
+```
+
+> **_注意:_**
+>
+> - 因为任务执行服务是以 `sudo -u {linux-user} -i` 切换不同 linux 用户的方式来实现多租户运行作业，所以部署用户需要有 sudo 权限，而且是免密的。初学习者不理解的话，完全可以暂时忽略这一点
+> - 如果发现 `/etc/sudoers` 文件中有 "Defaults requirett" 这行，也请注释掉
+
 ## 启动 DolphinScheduler Standalone Server
 
 ### 解压并启动 DolphinScheduler

--- a/docs/docs/zh/guide/installation/standalone.md
+++ b/docs/docs/zh/guide/installation/standalone.md
@@ -25,7 +25,7 @@ echo "dolphinscheduler" | passwd --stdin dolphinscheduler
 
 # 配置 sudo 免密
 sed -i '$adolphinscheduler  ALL=(ALL)  NOPASSWD: NOPASSWD: ALL' /etc/sudoers
-sed -i 's/Defaults    requirett/#Defaults    requirett/g' /etc/sudoers
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 # 修改目录权限，使得部署用户对二进制包解压后的 apache-dolphinscheduler-*-bin 目录有操作权限
 chown -R dolphinscheduler:dolphinscheduler apache-dolphinscheduler-*-bin
@@ -35,7 +35,7 @@ chmod -R 755 apache-dolphinscheduler-*-bin
 > **_注意:_**
 >
 > - 因为任务执行服务是以 `sudo -u {linux-user} -i` 切换不同 linux 用户的方式来实现多租户运行作业，所以部署用户需要有 sudo 权限，而且是免密的。初学习者不理解的话，完全可以暂时忽略这一点
-> - 如果发现 `/etc/sudoers` 文件中有 "Defaults requirett" 这行，也请注释掉
+> - 如果发现 `/etc/sudoers` 文件中有 "Defaults requiretty" 这行，也请注释掉
 
 ## 启动 DolphinScheduler Standalone Server
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #8295

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
