### PR TITLE
[Chore][CI][Hotfix] Fix sqlserver e2e test ci error

### DIFF
--- a/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/datasource-sqlserver/docker-compose.yaml
+++ b/dolphinscheduler-e2e/dolphinscheduler-e2e-case/src/test/resources/docker/datasource-sqlserver/docker-compose.yaml
@@ -36,13 +36,16 @@ services:
       sqlserver:
         condition: service_healthy
   sqlserver:
-    image: alexk002/sqlserver2019_demo:1
+    image: mcr.microsoft.com/mssql/server:2019-latest
     ports:
       - "1433:1433"
+    environment:
+      - MSSQL_SA_PASSWORD=OcP2020123
+      - ACCEPT_EULA=Y
     networks:
       - e2e
     healthcheck:
-      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P OcP2020123 -Q "SELECT 1"
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P OcP2020123 -Q "SELECT 1" -C
       interval: 5s
       timeout: 5s
       retries: 120


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix sqlserver docker image error in https://github.com/apache/dolphinscheduler/actions/runs/10933997621/job/30359730822?pr=16630

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
