### PR TITLE
[Improvement-16641] Add thread name in logback

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-server/src/main/resources/logback-spring.xml
@@ -22,7 +22,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{96}:[%line] - %msg%n
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>

--- a/dolphinscheduler-api/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-api/src/main/resources/logback-spring.xml
@@ -23,7 +23,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>
@@ -40,7 +40,7 @@
         </rollingPolicy>
         <encoder>
             <pattern>
-                [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>

--- a/dolphinscheduler-master/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-master/src/main/resources/logback-spring.xml
@@ -23,7 +23,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>
@@ -42,7 +42,7 @@
                 <file>${taskInstanceLogFullPath}</file>
                 <encoder>
                     <pattern>
-                        [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %message%n
+                        %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] - %message%n
                     </pattern>
                     <charset>UTF-8</charset>
                 </encoder>
@@ -61,7 +61,7 @@
         </rollingPolicy>
         <encoder>
             <pattern>
-                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>

--- a/dolphinscheduler-master/src/test/resources/logback.xml
+++ b/dolphinscheduler-master/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>

--- a/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-standalone-server/src/main/resources/logback-spring.xml
@@ -23,7 +23,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>
@@ -38,7 +38,7 @@
         </rollingPolicy>
         <encoder>
             <pattern>
-                [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>
@@ -61,7 +61,7 @@
                 <file>${taskInstanceLogFullPath}</file>
                 <encoder>
                     <pattern>
-                        [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %message%n
+                        %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] - %message%n
                     </pattern>
                     <charset>UTF-8</charset>
                 </encoder>

--- a/dolphinscheduler-worker/src/main/resources/logback-spring.xml
+++ b/dolphinscheduler-worker/src/main/resources/logback-spring.xml
@@ -23,7 +23,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>
@@ -42,7 +42,7 @@
                 <file>${taskInstanceLogFullPath}</file>
                 <encoder>
                     <pattern>
-                        [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} - %message%n
+                        %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] - %message%n
                     </pattern>
                     <charset>UTF-8</charset>
                 </encoder>
@@ -61,7 +61,7 @@
         </rollingPolicy>
         <encoder>
             <pattern>
-                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - [%level] %date{yyyy-MM-dd HH:mm:ss.SSS Z} %logger{10}:[%line] - %msg%n
+                [WI-%X{workflowInstanceId:-0}][TI-%X{taskInstanceId:-0}] - %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:[%line] - %msg%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>


### PR DESCRIPTION
## Purpose of the pull request
close #16641
- Add thread name help to troubleshooting.

## Brief change log

The output looks like below
```
[WI-0][TI-0] - 2024-09-21 04:40:57.286 INFO  [main] o.a.d.c.m.BaseHeartBeatTask:[50] - Started WorkerHeartBeatTask, heartBeatInterval: 10000...
[WI-0][TI-0] - 2024-09-21 04:40:57.286 INFO  [main] o.a.d.s.w.r.WorkerRegistryClient:[115] - Worker node: 192.168.64.1:1234 registry finished
[WI-0][TI-0] - 2024-09-21 04:40:57.291 INFO  [main] o.a.d.s.w.m.MessageRetryRunner:[69] - Message retry runner staring
[WI-0][TI-0] - 2024-09-21 04:40:57.293 INFO  [main] o.a.d.s.w.m.MessageRetryRunner:[72] - Injected message sender: TaskExecutionDispatchEventSender
[WI-0][TI-0] - 2024-09-21 04:40:57.293 INFO  [main] o.a.d.s.w.m.MessageRetryRunner:[72] - Injected message sender: TaskExecutionFailedEventSender
[WI-0][TI-0] - 2024-09-21 04:40:57.293 INFO  [main] o.a.d.s.w.m.MessageRetryRunner:[72] - Injected message sender: TaskExecutionKilledEventSender
[WI-0][TI-0] - 2024-09-21 04:40:57.293 INFO  [main] o.a.d.s.w.m.MessageRetryRunner:[72] - Injected message sender: TaskExecutionPausedEventSender
[WI-0][TI-0] - 2024-09-21 04:40:57.293 INFO  [main] o.a.d.s.w.m.MessageRetryRunner:[72] - Injected message sender: TaskExecutionSuccessEventSender
```

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
