### PR TITLE
[Fix] fix SSO login bug

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoginController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoginController.java
@@ -158,7 +158,8 @@ public class LoginController extends BaseController {
             if (session.getAttribute(Constants.SSO_LOGIN_USER_STATE) == null) {
                 session.setAttribute(Constants.SSO_LOGIN_USER_STATE, randomState);
             }
-            return Result.success(((AbstractSsoAuthenticator) authenticator).getSignInUrl(randomState));
+            return Result.success(((AbstractSsoAuthenticator) authenticator)
+                    .getSignInUrl(session.getAttribute(Constants.SSO_LOGIN_USER_STATE).toString()));
         }
         return Result.success();
     }


### PR DESCRIPTION
when use sso login type, refresh login page and click sso login button, will dialog a error tips: State or code entered incorrectly. because the request url: login/sso will be requested when front page refresh every time, but when session attr not null, will not save new random code, so this bug will happen!


