### PR TITLE
[Chore] Fix publish docker error in CI

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -81,7 +81,6 @@ jobs:
         run: |
           ./mvnw -B clean install \
           -Dmaven.test.skip=true \
-          -Dmaven.javadoc.skip=true \
           -Dspotless.skip=true \
           -Pdocker,staging -Ddocker.tag=ci
       - name: Export Docker Images

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -51,7 +51,6 @@ jobs:
     - run: |
         ./mvnw -B clean install \
           -Dmaven.test.skip \
-          -Dmaven.javadoc.skip \
           -Dspotless.skip=true \
           -Prelease
 

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -71,7 +71,6 @@ jobs:
         run: |
           ./mvnw -B clean package \
           -Dmaven.test.skip=true \
-          -Dmaven.javadoc.skip=true \
           -Dspotless.skip=true \
           -Pdocker,staging -Ddocker.tag=ci
       - name: Create k8s Kind Cluster

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,7 +83,6 @@ jobs:
         run: |
           ./mvnw -B clean install \
           -Dmaven.test.skip=true \
-          -Dmaven.javadoc.skip=true \
           -Dspotless.skip=true \
           -Pdocker,staging -Ddocker.tag=ci
       - name: Export Docker Images

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -85,7 +85,6 @@ jobs:
         run: |
           ./mvnw -B clean deploy \
           -Dmaven.test.skip \
-          -Dmaven.javadoc.skip \
           -Dspotless.skip=true \
           -Ddocker.tag=${{ env.DOCKER_TAG }} \
           -Ddocker.hub=${{ env.HUB }} \

--- a/.github/workflows/publish-nexus.yaml
+++ b/.github/workflows/publish-nexus.yaml
@@ -72,4 +72,5 @@ jobs:
           -s ${{ env.SETTINGS_PATH }} \
           -Dmaven.test.skip=true \
           -Dspotless.skip=true \
+          -Dmaven.deploy.skip=false \
           -Pstaging

--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -64,7 +64,6 @@ DolphinScheduler will release new Docker images after it released, you could fin
 cd dolphinscheduler
 ./mvnw -B clean package \
        -Dmaven.test.skip \
-       -Dmaven.javadoc.skip \
        -Dspotless.skip = true \
        -Ddocker.tag=<TAG> \
        -Pdocker,release
@@ -78,7 +77,6 @@ When the command is finished you could find them by command `docker images`.
 cd dolphinscheduler
 ./mvnw -B clean deploy \
        -Dmaven.test.skip \
-       -Dmaven.javadoc.skip \
        -Dspotless.skip = true \
        -Ddocker.tag=<TAG> \
        -Ddocker.hub=<HUB_URL> \

--- a/docs/docs/en/contribute/release.md
+++ b/docs/docs/en/contribute/release.md
@@ -225,7 +225,7 @@ git push "${GH_REMOTE}" "${VERSION}"-release
 > first to clone the source code. And then make sure you set `GH_REMOTE="origin"` to make all command work fine.
 
 ```shell
-mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DdryRun=true -Dusername="${GH_USERNAME}"
+mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DdryRun=true -Dusername="${GH_USERNAME}"
 ```
 
 - `-Prelease`: choose release profile, which will pack all the source codes, jar files and executable binary packages.
@@ -243,7 +243,7 @@ mvn release:clean
 Then, prepare to execute the release.
 
 ```shell
-mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DpushChanges=false -Dusername="${GH_USERNAME}"
+mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DpushChanges=false -Dusername="${GH_USERNAME}"
 ```
 
 It is basically the same as the previous rehearsal command, but deleting `-DdryRun=true` parameter.
@@ -275,7 +275,7 @@ git push "${GH_REMOTE}" --tags
 #### Maven Release Deploy
 
 ```shell
-mvn release:perform -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -Dusername="${GH_USERNAME}"
+mvn release:perform -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -Dusername="${GH_USERNAME}"
 ```
 
 After that command is executed, the version to be released will be uploaded to Apache staging repository automatically.

--- a/docs/docs/zh/contribute/development-environment-setup.md
+++ b/docs/docs/zh/contribute/development-environment-setup.md
@@ -61,7 +61,6 @@ DolphinScheduler 每次发版都会同时发布 Docker 镜像，你可以在 [Do
 cd dolphinscheduler
 ./mvnw -B clean package \
        -Dmaven.test.skip \
-       -Dmaven.javadoc.skip \
        -Dspotless.skip=true \
        -Ddocker.tag=<TAG> \
        -Pdocker,release
@@ -75,7 +74,6 @@ cd dolphinscheduler
 cd dolphinscheduler
 ./mvnw -B clean deploy \
        -Dmaven.test.skip \
-       -Dmaven.javadoc.skip \
        -Dspotless.skip = true \
        -Ddocker.tag=<TAG> \
        -Ddocker.hub=<HUB_URL> \

--- a/docs/docs/zh/contribute/release.md
+++ b/docs/docs/zh/contribute/release.md
@@ -232,7 +232,7 @@ git push "${GH_REMOTE}" "${VERSION}"-release
 
 ```shell
 # 运行发版校验
-mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DdryRun=true -Dusername="${GH_USERNAME}"
+mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DdryRun=true -Dusername="${GH_USERNAME}"
 ```
 
 - `-Prelease`: 选择 release 的 profile，这个 profile 会打包所有源码、jar 文件以及可执行二进制包。
@@ -250,7 +250,7 @@ mvn release:clean
 然后准备执行发布。
 
 ```shell
-mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true  -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DpushChanges=false -Dusername="${GH_USERNAME}"
+mvn release:prepare -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -DpushChanges=false -Dusername="${GH_USERNAME}"
 ```
 
 和上一步演练的命令基本相同，去掉了 `-DdryRun=true` 参数。
@@ -279,7 +279,7 @@ git push "${GH_REMOTE}" --tags
 #### 部署发布
 
 ```shell
-mvn release:perform -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -Dusername="${GH_USERNAME}"
+mvn release:perform -Prelease -Darguments="-Dmaven.test.skip=true -Dspotless.skip=true -Dspotless.check.skip=true" -DautoVersionSubmodules=true -Dusername="${GH_USERNAME}"
 ```
 
 执行完该命令后，待发布版本会自动上传到 Apache 的临时筹备仓库(staging repository)。你可以通过访问 [apache staging repositories](https://repository.apache.org/#stagingRepositories)

--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -181,7 +181,7 @@
                                     <environmentVariables>
                                         <DOCKER_BUILDKIT>1</DOCKER_BUILDKIT>
                                     </environmentVariables>
-                                    <executable>docker</executable>
+                                    <executable>bash</executable>
                                     <workingDirectory>${project.basedir}</workingDirectory>
                                     <arguments>
                                         <argument>src/main/docker/docker-push.sh</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <build.plugins.skip>false</build.plugins.skip>
         <build.assembly.skip>true</build.assembly.skip>
         <spotless.skip>false</spotless.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
 
         <skipUT>false</skipUT>
     </properties>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

- Fix CI error in https://github.com/apache/dolphinscheduler/actions/runs/11052206647/job/30703766639
- Remove useless `maven.javadoc.skip`

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
