### PR TITLE
Fix the issue of failing to retrieve logs for K8S tasks.

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-k8s/src/main/java/org/apache/dolphinscheduler/plugin/task/k8s/K8sTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-k8s/src/main/java/org/apache/dolphinscheduler/plugin/task/k8s/K8sTask.java
@@ -79,6 +79,7 @@ public class K8sTask extends AbstractK8sTask {
         k8sTaskParameters.setNamespace(k8sConnectionParam.getNamespace());
         k8sTaskParameters.setKubeConfig(kubeConfig);
         k8sTaskExecutionContext.setConfigYaml(kubeConfig);
+        k8sTaskExecutionContext.setNamespace(k8sConnectionParam.getNamespace());
         taskRequest.setK8sTaskExecutionContext(k8sTaskExecutionContext);
         log.info("Initialize k8s task params:{}", JSONUtils.toPrettyJsonString(k8sTaskParameters));
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Unable to view logs for k8s type tasks because the namespace attribute was not set when retrieving the logs.

## Brief change log

set namespace to k8sTaskExecutionContext

## Verify this pull request

This pull request is code cleanup without any test coverage.