### PR TITLE
[Fix-16793] WorkerGroupChangeNotifier may can not detect cluster's first time change

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/ClusterManager.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/ClusterManager.java
@@ -51,6 +51,7 @@ public class ClusterManager {
         this.registryClient.subscribe(RegistryNodeType.MASTER.getRegistryPath(), masterClusters);
         this.registryClient.subscribe(RegistryNodeType.WORKER.getRegistryPath(), workerClusters);
         this.workerGroupChangeNotifier.subscribeWorkerGroupsChange(workerClusters);
+        this.workerGroupChangeNotifier.startScheduleThread();
         log.info("ClusterManager started...");
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/ClusterManager.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/ClusterManager.java
@@ -51,7 +51,7 @@ public class ClusterManager {
         this.registryClient.subscribe(RegistryNodeType.MASTER.getRegistryPath(), masterClusters);
         this.registryClient.subscribe(RegistryNodeType.WORKER.getRegistryPath(), workerClusters);
         this.workerGroupChangeNotifier.subscribeWorkerGroupsChange(workerClusters);
-        this.workerGroupChangeNotifier.startScheduleThread();
+        this.workerGroupChangeNotifier.start();
         log.info("ClusterManager started...");
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
@@ -25,7 +25,6 @@ import org.apache.dolphinscheduler.server.master.utils.MasterThreadFactory;
 
 import org.apache.commons.collections4.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
@@ -68,10 +68,6 @@ public class WorkerGroupChangeNotifier {
     }
 
     public void subscribeWorkerGroupsChange(WorkerGroupListener listener) {
-
-        // add all group when listener added
-        listener.onWorkerGroupAdd(new ArrayList<>(workerGroupMap.values()));
-
         listeners.add(listener);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
@@ -20,11 +20,12 @@ package org.apache.dolphinscheduler.server.master.cluster;
 import org.apache.dolphinscheduler.common.utils.MapComparator;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
+import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.utils.MasterThreadFactory;
 
 import org.apache.commons.collections4.CollectionUtils;
 
-import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -43,7 +45,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class WorkerGroupChangeNotifier {
 
-    private static final long DEFAULT_REFRESH_WORKER_INTERVAL = Duration.ofMinutes(1).toMillis();
+    @Autowired
+    private MasterConfig masterConfig;
 
     private final WorkerGroupDao workerGroupDao;
     private final List<WorkerGroupListener> listeners = new CopyOnWriteArrayList<>();
@@ -52,15 +55,23 @@ public class WorkerGroupChangeNotifier {
 
     public WorkerGroupChangeNotifier(WorkerGroupDao workerGroupDao) {
         this.workerGroupDao = workerGroupDao;
+    }
+
+    public void startScheduleThread() {
         detectWorkerGroupChanges();
+        final long workerGroupRefreshIntervalSeconds = masterConfig.getWorkerGroupRefreshInterval().getSeconds();
         MasterThreadFactory.getDefaultSchedulerThreadExecutor().scheduleWithFixedDelay(
                 this::detectWorkerGroupChanges,
-                DEFAULT_REFRESH_WORKER_INTERVAL,
-                DEFAULT_REFRESH_WORKER_INTERVAL,
+                workerGroupRefreshIntervalSeconds,
+                workerGroupRefreshIntervalSeconds,
                 TimeUnit.SECONDS);
     }
 
     public void subscribeWorkerGroupsChange(WorkerGroupListener listener) {
+
+        // add all group when listener added
+        listener.onWorkerGroupAdd(new ArrayList<>(workerGroupMap.values()));
+
         listeners.add(listener);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/WorkerGroupChangeNotifier.java
@@ -57,7 +57,7 @@ public class WorkerGroupChangeNotifier {
         this.workerGroupDao = workerGroupDao;
     }
 
-    public void startScheduleThread() {
+    public void start() {
         detectWorkerGroupChanges();
         final long workerGroupRefreshIntervalSeconds = masterConfig.getWorkerGroupRefreshInterval().getSeconds();
         MasterThreadFactory.getDefaultSchedulerThreadExecutor().scheduleWithFixedDelay(


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

Fix #16793 
-- i created a new branch, the old is broken. @SbloodyS 
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

1. add all groups to new listener when new listener added.

2. delete `DEFAULT_REFRESH_WORKER_INTERVAL` , add `startScheduleThread()` to get the parameter from `MasterConfig`.

3. add manual call `startScheduleThread()` in `ClusterManager.start()`

## Verify this pull request

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)