### PR TITLE
[Improvement-16807][UI] Optimize Statistics international display

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/monitor.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/monitor.ts
@@ -60,9 +60,17 @@ export default {
       'Currently, there are no DB nodes exist, please create a DB node and refresh this page'
   },
   statistics: {
-    command_number_of_waiting_for_running:
-      'Command Number Of Waiting For Running',
-    failure_command_number: 'Failure Command Number'
+    command_statistics_list: 'Command Statistics List',
+    failure_command_statistics_list: 'Failure Command Statistics List',
+    command_type: 'Command Type',
+    command_param: 'Command Param',
+    task_info: 'Task Info',
+    task_params: 'Task Params',
+    worker_info: 'Worker Info',
+    warning_info: 'Warning Info',
+    executor_id: 'Executor Id',
+    message: 'Message',
+    time: 'Time'
   },
   audit_log: {
     user_name: 'User Name',

--- a/dolphinscheduler-ui/src/locales/zh_CN/monitor.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/monitor.ts
@@ -59,8 +59,17 @@ export default {
     db_no_data_result_desc: '目前没有任何DB节点，请先创建DB节点，再访问该页面'
   },
   statistics: {
-    command_number_of_waiting_for_running: '待执行的命令数',
-    failure_command_number: '执行失败的命令数'
+    command_statistics_list: '命令统计列表',
+    failure_command_statistics_list: '失败命令统计列表',
+    command_type: '命令类型',
+    command_param: '命令参数',
+    task_info: '任务信息',
+    task_params: '任务参数',
+    worker_info: 'Worker信息',
+    warning_info: '警告信息',
+    executor_id: '执行用户Id',
+    message: '错误信息',
+    time: '时间'
   },
   audit_log: {
     user_name: '用户名称',

--- a/dolphinscheduler-ui/src/views/monitor/statistics/statistics/index.tsx
+++ b/dolphinscheduler-ui/src/views/monitor/statistics/statistics/index.tsx
@@ -19,12 +19,14 @@ import { defineComponent } from 'vue'
 import { NGrid, NGi, NTabs, NTabPane, NCard } from 'naive-ui'
 import ListCommandTable from './list-command-table'
 import ListErrorCommandTable from './list-error-command-table'
+import { useI18n } from 'vue-i18n'
 
 const statistics = defineComponent({
   name: 'statistics',
   setup() {},
 
   render() {
+    const { t } = useI18n()
     return (
       <NGrid x-gap='12' y-gap='8' cols='1' responsive='screen'>
         <NGi>
@@ -39,14 +41,14 @@ const statistics = defineComponent({
             >
               <NTabPane
                 name='command'
-                tab='Command Statistics List'
+                tab={t('monitor.statistics.command_statistics_list')}
                 display-directiv='show'
               >
                 <ListCommandTable></ListCommandTable>
               </NTabPane>
               <NTabPane
                 name='command-error'
-                tab='Failure Command Statistics List'
+                tab={t('monitor.statistics.failure_command_statistics_list')}
                 display-directiv='show'
               >
                 <ListErrorCommandTable></ListErrorCommandTable>

--- a/dolphinscheduler-ui/src/views/monitor/statistics/statistics/list-command-table.tsx
+++ b/dolphinscheduler-ui/src/views/monitor/statistics/statistics/list-command-table.tsx
@@ -59,18 +59,18 @@ const ListCommandTable = defineComponent({
           ...COLUMN_WIDTH_CONFIG['index']
         },
         {
-          title: 'Command Type',
+          title: t('monitor.statistics.command_type'),
           key: 'commandType',
-          ...COLUMN_WIDTH_CONFIG['userName']
+          ...COLUMN_WIDTH_CONFIG['name']
         },
         {
-          title: 'Command Param',
+          title: t('monitor.statistics.command_param'),
           key: 'commandParam',
           ...COLUMN_WIDTH_CONFIG['linkName']
         },
 
         {
-          title: 'Task Info',
+          title: t('monitor.statistics.task_info'),
           key: 'id',
           width: 300,
           render: (row: any) => {
@@ -87,7 +87,7 @@ const ListCommandTable = defineComponent({
         },
 
         {
-          title: 'Task Params',
+          title: t('monitor.statistics.task_params'),
           key: 'id',
           width: 300,
           render: (row: any) => {
@@ -104,7 +104,7 @@ const ListCommandTable = defineComponent({
         },
 
         {
-          title: 'Worker Info',
+          title: t('monitor.statistics.worker_info'),
           key: 'id',
           width: 220,
           render: (row: any) => {
@@ -119,7 +119,7 @@ const ListCommandTable = defineComponent({
         },
 
         {
-          title: 'Warning Info',
+          title: t('monitor.statistics.warning_info'),
           key: 'id',
           width: 200,
           render: (row: any) => {
@@ -131,12 +131,12 @@ const ListCommandTable = defineComponent({
           }
         },
         {
-          title: 'Executor Id',
+          title: t('monitor.statistics.executor_id'),
           key: 'executorId',
           ...COLUMN_WIDTH_CONFIG['type']
         },
         {
-          title: 'Time',
+          title: t('monitor.statistics.time'),
           key: 'startTime',
           width: 280,
           render: (row: any) => {

--- a/dolphinscheduler-ui/src/views/monitor/statistics/statistics/list-error-command-table.tsx
+++ b/dolphinscheduler-ui/src/views/monitor/statistics/statistics/list-error-command-table.tsx
@@ -59,18 +59,18 @@ const ListErrorCommandTable = defineComponent({
           ...COLUMN_WIDTH_CONFIG['index']
         },
         {
-          title: 'Command Type',
+          title: t('monitor.statistics.command_type'),
           key: 'commandType',
-          ...COLUMN_WIDTH_CONFIG['userName']
+          ...COLUMN_WIDTH_CONFIG['name']
         },
         {
-          title: 'Command Param',
+          title: t('monitor.statistics.command_param'),
           key: 'commandParam',
           ...COLUMN_WIDTH_CONFIG['linkName']
         },
 
         {
-          title: 'Task Info',
+          title: t('monitor.statistics.task_info'),
           key: 'id',
           width: 300,
           render: (row: any) => {
@@ -87,7 +87,7 @@ const ListErrorCommandTable = defineComponent({
         },
 
         {
-          title: 'Task Params',
+          title: t('monitor.statistics.task_params'),
           key: 'id',
           width: 300,
           render: (row: any) => {
@@ -104,7 +104,7 @@ const ListErrorCommandTable = defineComponent({
         },
 
         {
-          title: 'Worker Info',
+          title: t('monitor.statistics.worker_info'),
           key: 'id',
           width: 220,
           render: (row: any) => {
@@ -119,7 +119,7 @@ const ListErrorCommandTable = defineComponent({
         },
 
         {
-          title: 'Warning Info',
+          title: t('monitor.statistics.warning_info'),
           key: 'id',
           width: 200,
           render: (row: any) => {
@@ -131,17 +131,17 @@ const ListErrorCommandTable = defineComponent({
           }
         },
         {
-          title: 'Message',
+          title: t('monitor.statistics.message'),
           key: 'message',
           ...COLUMN_WIDTH_CONFIG['linkName']
         },
         {
-          title: 'Executor Id',
+          title: t('monitor.statistics.executor_id'),
           key: 'executorId',
           ...COLUMN_WIDTH_CONFIG['type']
         },
         {
-          title: 'Time',
+          title: t('monitor.statistics.time'),
           key: 'startTime',
           width: 280,
           render: (row: any) => {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close #16807 
Optimize the Command Type field
Before：
![image](https://github.com/user-attachments/assets/fa28c15e-ca61-4579-8a5e-f1c1b099b127)
After：
![image](https://github.com/user-attachments/assets/aa64d273-c4e4-43b7-810b-250921b8a2ab)


<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
