### PR TITLE
[Improvement-16835][Worker] Clear empty directory under task working path after task instance finish

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -84,29 +84,11 @@ public class FileUtils {
     /**
      * directory of process execution
      *
-     * @param tenant               tenant
-     * @param projectCode          project code
-     * @param processDefineCode    process definition Code
-     * @param processDefineVersion process definition version
-     * @param processInstanceId    process instance id
      * @param taskInstanceId       task instance id
      * @return directory of process execution
      */
-    public static String getTaskInstanceWorkingDirectory(String tenant,
-                                                         long projectCode,
-                                                         long processDefineCode,
-                                                         int processDefineVersion,
-                                                         int processInstanceId,
-                                                         int taskInstanceId) {
-        return String.format(
-                "%s/exec/process/%s/%d/%d_%d/%d/%d",
-                DATA_BASEDIR,
-                tenant,
-                projectCode,
-                processDefineCode,
-                processDefineVersion,
-                processInstanceId,
-                taskInstanceId);
+    public static String getTaskInstanceWorkingDirectory(int taskInstanceId) {
+        return String.format("%s/exec/process/%d", DATA_BASEDIR, taskInstanceId);
     }
 
     /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/FileUtilsTest.java
@@ -48,8 +48,8 @@ public class FileUtilsTest {
 
     @Test
     public void testGetProcessExecDir() {
-        String dir = FileUtils.getTaskInstanceWorkingDirectory("test", 1L, 2L, 1, 3, 4);
-        Assertions.assertEquals("/tmp/dolphinscheduler/exec/process/test/1/2_1/3/4", dir);
+        String dir = FileUtils.getTaskInstanceWorkingDirectory(4);
+        Assertions.assertEquals("/tmp/dolphinscheduler/exec/process/4", dir);
     }
 
     @Test

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ProcessUtils.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/utils/ProcessUtils.java
@@ -54,13 +54,8 @@ public class ProcessUtils {
                 taskExecutionContext.setAppIds(String.join(TaskConstants.COMMA, appIds));
                 if (StringUtils.isEmpty(taskExecutionContext.getExecutePath())) {
                     taskExecutionContext
-                            .setExecutePath(FileUtils.getTaskInstanceWorkingDirectory(
-                                    taskExecutionContext.getTenantCode(),
-                                    taskExecutionContext.getProjectCode(),
-                                    taskExecutionContext.getWorkflowDefinitionCode(),
-                                    taskExecutionContext.getWorkflowDefinitionVersion(),
-                                    taskExecutionContext.getWorkflowInstanceId(),
-                                    taskExecutionContext.getTaskInstanceId()));
+                            .setExecutePath(FileUtils
+                                    .getTaskInstanceWorkingDirectory(taskExecutionContext.getTaskInstanceId()));
                 }
                 FileUtils.createDirectoryWith755(Paths.get(taskExecutionContext.getExecutePath()));
                 org.apache.dolphinscheduler.plugin.task.api.utils.ProcessUtils.cancelApplication(taskExecutionContext);

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
@@ -42,13 +42,8 @@ public class TaskExecutionContextUtils {
 
     public static void createTaskInstanceWorkingDirectory(TaskExecutionContext taskExecutionContext) throws TaskException {
         // local execute path
-        String taskInstanceWorkingDirectory = FileUtils.getTaskInstanceWorkingDirectory(
-                taskExecutionContext.getTenantCode(),
-                taskExecutionContext.getProjectCode(),
-                taskExecutionContext.getWorkflowDefinitionCode(),
-                taskExecutionContext.getWorkflowDefinitionVersion(),
-                taskExecutionContext.getWorkflowInstanceId(),
-                taskExecutionContext.getTaskInstanceId());
+        String taskInstanceWorkingDirectory =
+                FileUtils.getTaskInstanceWorkingDirectory(taskExecutionContext.getTaskInstanceId());
         try {
             if (new File(taskInstanceWorkingDirectory).exists()) {
                 FileUtils.deleteFile(taskInstanceWorkingDirectory);

--- a/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
+++ b/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
@@ -39,13 +39,8 @@ class TaskExecutionContextUtilsTest {
         taskExecutionContext.setWorkflowInstanceId(1);
         taskExecutionContext.setTaskInstanceId(1);
 
-        String taskWorkingDirectory = FileUtils.getTaskInstanceWorkingDirectory(
-                taskExecutionContext.getTenantCode(),
-                taskExecutionContext.getProjectCode(),
-                taskExecutionContext.getWorkflowDefinitionCode(),
-                taskExecutionContext.getWorkflowDefinitionVersion(),
-                taskExecutionContext.getWorkflowInstanceId(),
-                taskExecutionContext.getTaskInstanceId());
+        String taskWorkingDirectory =
+                FileUtils.getTaskInstanceWorkingDirectory(taskExecutionContext.getTaskInstanceId());
         try {
             // Test if the working directory is exist
             // will delete it and recreate


### PR DESCRIPTION
## Purpose of the pull request

close #16835

## Brief change log

- Remove projectcode, workflow instance/xx in task instance working directory path

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
