### PR TITLE
[Chore] Fix JdbcRegistryTestCase might failed due to purge dead clients interval is too small

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/thread/ThreadUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/thread/ThreadUtils.java
@@ -80,4 +80,15 @@ public class ThreadUtils {
             log.error("Current thread sleep error", interruptedException);
         }
     }
+
+    public static void rethrowInterruptedException(InterruptedException interruptedException) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Current thread: " + Thread.currentThread().getName() + " is interrupted",
+                interruptedException);
+    }
+
+    public static void consumeInterruptedException(InterruptedException interruptedException) {
+        log.info("Current thread: {} is interrupted", Thread.currentThread().getName(), interruptedException);
+        Thread.currentThread().interrupt();
+    }
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/rpc/MasterRpcServerTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/rpc/MasterRpcServerTest.java
@@ -27,12 +27,8 @@ class MasterRpcServerTest {
     private final MasterRpcServer masterRpcServer = new MasterRpcServer(new MasterConfig());
 
     @Test
-    void testStart() {
+    void testStartAndClose() {
         Assertions.assertDoesNotThrow(masterRpcServer::start);
-    }
-
-    @Test
-    void testClose() {
         Assertions.assertDoesNotThrow(masterRpcServer::close);
     }
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/Registry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/Registry.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.registry.api;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 
@@ -109,4 +110,7 @@ public interface Registry extends Closeable {
      * Release the lock of the prefix {@param key}
      */
     boolean releaseLock(String key);
+
+    @Override
+    void close() throws IOException;
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-it/src/test/java/org/apache/dolphinscheduler/plugin/registry/RegistryTestCase.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-it/src/test/java/org/apache/dolphinscheduler/plugin/registry/RegistryTestCase.java
@@ -28,6 +28,7 @@ import org.apache.dolphinscheduler.registry.api.RegistryException;
 import org.apache.dolphinscheduler.registry.api.SubscribeListener;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -172,8 +173,8 @@ public abstract class RegistryTestCase<R extends Registry> {
         registry.put(master1, value, true);
         registry.put(master2, value, true);
         assertThat(registry.children("/nodes/children")).containsExactly("childGroup1");
-        assertThat(registry.children("/nodes/children/childGroup1")).containsExactly("127.0.0.1:8080",
-                "127.0.0.2:8080");
+        assertThat(registry.children("/nodes/children/childGroup1")).containsExactlyElementsIn(
+                Arrays.asList("127.0.0.1:8080", "127.0.0.2:8080"));
     }
 
     @Test

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistry.java
@@ -58,8 +58,8 @@ public final class JdbcRegistry implements Registry {
     JdbcRegistry(JdbcRegistryProperties jdbcRegistryProperties, IJdbcRegistryServer jdbcRegistryServer) {
         this.jdbcRegistryProperties = jdbcRegistryProperties;
         this.jdbcRegistryServer = jdbcRegistryServer;
-        this.jdbcRegistryClient = new JdbcRegistryClient(jdbcRegistryProperties, jdbcRegistryServer);
-        log.info("Initialize Jdbc Registry...");
+        this.jdbcRegistryClient = new JdbcRegistryClient(jdbcRegistryServer);
+        log.info("Initialized Jdbc Registry...");
     }
 
     @Override
@@ -259,13 +259,14 @@ public final class JdbcRegistry implements Registry {
 
     @Override
     public void close() {
-        log.info("Closing Jdbc Registry...");
+        log.info("Closing JdbcRegistry...");
         // remove the current Ephemeral node, if can connect to jdbc
-        try (JdbcRegistryClient closed1 = jdbcRegistryClient) {
-            JdbcRegistryThreadFactory.getDefaultSchedulerThreadExecutor().shutdownNow();
+        JdbcRegistryThreadFactory.getDefaultSchedulerThreadExecutor().shutdownNow();
+        try (final JdbcRegistryClient closed1 = jdbcRegistryClient) {
+            // ignore
         } catch (Exception e) {
-            log.error("Close Jdbc Registry error", e);
+            log.error("Close JdbcRegistry error", e);
         }
-        log.info("Closed Jdbc Registry...");
+        log.info("Closed JdbcRegistry...");
     }
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/client/JdbcRegistryClient.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/client/JdbcRegistryClient.java
@@ -20,7 +20,6 @@ package org.apache.dolphinscheduler.plugin.registry.jdbc.client;
 import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
-import org.apache.dolphinscheduler.plugin.registry.jdbc.JdbcRegistryProperties;
 import org.apache.dolphinscheduler.plugin.registry.jdbc.model.DTO.DataType;
 import org.apache.dolphinscheduler.plugin.registry.jdbc.model.DTO.JdbcRegistryDataDTO;
 import org.apache.dolphinscheduler.plugin.registry.jdbc.server.ConnectionStateListener;
@@ -41,14 +40,11 @@ public class JdbcRegistryClient implements IJdbcRegistryClient {
 
     private static final String DEFAULT_CLIENT_NAME = NetUtils.getHost() + "_" + OSUtils.getProcessID();
 
-    private final JdbcRegistryProperties jdbcRegistryProperties;
-
     private final JdbcRegistryClientIdentify jdbcRegistryClientIdentify;
 
     private final IJdbcRegistryServer jdbcRegistryServer;
 
-    public JdbcRegistryClient(JdbcRegistryProperties jdbcRegistryProperties, IJdbcRegistryServer jdbcRegistryServer) {
-        this.jdbcRegistryProperties = jdbcRegistryProperties;
+    public JdbcRegistryClient(IJdbcRegistryServer jdbcRegistryServer) {
         this.jdbcRegistryServer = jdbcRegistryServer;
         this.jdbcRegistryClientIdentify =
                 new JdbcRegistryClientIdentify(CodeGenerateUtils.genCode(), DEFAULT_CLIENT_NAME);

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryServer.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryServer.java
@@ -107,8 +107,8 @@ public class JdbcRegistryServer implements IJdbcRegistryServer {
         purgeInvalidJdbcRegistryMetadata();
         JdbcRegistryThreadFactory.getDefaultSchedulerThreadExecutor().scheduleWithFixedDelay(
                 this::purgeInvalidJdbcRegistryMetadata,
-                jdbcRegistryProperties.getHeartbeatRefreshInterval().toMillis(),
-                jdbcRegistryProperties.getHeartbeatRefreshInterval().toMillis(),
+                jdbcRegistryProperties.getSessionTimeout().toMillis(),
+                jdbcRegistryProperties.getSessionTimeout().toMillis(),
                 TimeUnit.MILLISECONDS);
         jdbcRegistryDataManager.start();
         jdbcRegistryServerState = JdbcRegistryServerState.STARTED;
@@ -149,13 +149,13 @@ public class JdbcRegistryServer implements IJdbcRegistryServer {
     @Override
     public void deregisterClient(IJdbcRegistryClient jdbcRegistryClient) {
         checkNotNull(jdbcRegistryClient);
-        jdbcRegistryClients.remove(jdbcRegistryClient);
+        final JdbcRegistryClientIdentify clientIdentify = jdbcRegistryClient.getJdbcRegistryClientIdentify();
+        checkNotNull(clientIdentify);
+
+        jdbcRegistryClients.removeIf(client -> clientIdentify.equals(client.getJdbcRegistryClientIdentify()));
         jdbcRegistryClientDTOMap.remove(jdbcRegistryClient.getJdbcRegistryClientIdentify());
 
-        JdbcRegistryClientIdentify jdbcRegistryClientIdentify = jdbcRegistryClient.getJdbcRegistryClientIdentify();
-        checkNotNull(jdbcRegistryClientIdentify);
-
-        doPurgeJdbcRegistryClientInDB(Lists.newArrayList(jdbcRegistryClientIdentify.getClientId()));
+        doPurgeJdbcRegistryClientInDB(Lists.newArrayList(clientIdentify.getClientId()));
     }
 
     @Override


### PR DESCRIPTION
## Purpose of the pull request

- Use session timeout as the purge interval.
- Close the NettyServerChannel to unbind the port.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
