### PR TITLE
Fix the issue where "remaining connection slots are reserved for non-replication superuser connections" occasionally occurs

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -62,10 +62,13 @@ postgresql:
   postgresqlPassword: "root"
   # -- The database for internal PostgreSQL
   postgresqlDatabase: "dolphinscheduler"
+  # -- The database for MaxConnections
+  postgresqlMaxConnections: 300
   # -- The driverClassName for internal PostgreSQL
   driverClassName: "org.postgresql.Driver"
   # -- The params for internal PostgreSQL
   params: "characterEncoding=utf8"
+
   persistence:
     # -- Set postgresql.persistence.enabled to true to mount a new volume for internal PostgreSQL
     enabled: false

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -68,7 +68,6 @@ postgresql:
   driverClassName: "org.postgresql.Driver"
   # -- The params for internal PostgreSQL
   params: "characterEncoding=utf8"
-
   persistence:
     # -- Set postgresql.persistence.enabled to true to mount a new volume for internal PostgreSQL
     enabled: false


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
