### PR TITLE
[Fix-16914] [Task] ParameterUtils will throw exception when the input contains '$[xx]'

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/PropertyPlaceholderHelper.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/PropertyPlaceholderHelper.java
@@ -119,7 +119,7 @@ public class PropertyPlaceholderHelper {
      */
     public String replacePlaceholders(String value, PlaceholderResolver placeholderResolver) {
         notNull(value, "'value' must not be null");
-        return parseStringValue(value, placeholderResolver, new HashSet<String>());
+        return parseStringValue(value, placeholderResolver, new HashSet<>());
     }
 
     protected String parseStringValue(

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtils.java
@@ -49,8 +49,6 @@ public class ParameterUtils {
 
     private static final Pattern DATE_PARSE_PATTERN = Pattern.compile("\\$\\[([^\\$\\]]+)]");
 
-    private static final Pattern DATE_START_PATTERN = Pattern.compile("^[0-9]");
-
     private static final char PARAM_REPLACE_CHAR = '?';
 
     private ParameterUtils() {
@@ -288,21 +286,24 @@ public class ParameterUtils {
         return map;
     }
 
-    private static String dateTemplateParse(String templateStr, Date date) {
-        if (templateStr == null) {
-            return null;
+    // Replace the time placeholder in the template string with the given actual time value
+    // If the templateStr does not contain a time placeholder, will return the original string
+    private static String dateTemplateParse(final String templateStr, final Date date) {
+        if (StringUtils.isEmpty(templateStr)) {
+            return templateStr;
         }
 
-        StringBuffer newValue = new StringBuffer(templateStr.length());
+        final StringBuffer newValue = new StringBuffer(templateStr.length());
 
-        Matcher matcher = DATE_PARSE_PATTERN.matcher(templateStr);
+        final Matcher matcher = DATE_PARSE_PATTERN.matcher(templateStr);
 
         while (matcher.find()) {
-            String key = matcher.group(1);
-            if (DATE_START_PATTERN.matcher(key).matches()) {
+            final String key = matcher.group(1);
+            String value = TimePlaceholderUtils.formatTimeExpression(key, date, true);
+            if (StringUtils.equals(key, value)) {
+                // There is no corresponding time format, so the original string is retained
                 continue;
             }
-            String value = TimePlaceholderUtils.getPlaceHolderTime(key, date);
             matcher.appendReplacement(newValue, value);
         }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtilsTest.java
@@ -27,7 +27,6 @@ import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 import java.util.Date;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TimePlaceholderUtilsTest {
@@ -131,10 +130,8 @@ public class TimePlaceholderUtilsTest {
     }
 
     @Test
-    void getPlaceHolderTime() {
-        IllegalArgumentException illegalArgumentException = Assertions.assertThrows(IllegalArgumentException.class,
-                () -> TimePlaceholderUtils.getPlaceHolderTime("$[week_last_day(yyyy-MM-dd,0) - 1]", new Date()));
-        assertEquals("Unsupported placeholder expression: $[week_last_day(yyyy-MM-dd,0) - 1]",
-                illegalArgumentException.getMessage());
+    void formatTimeExpressionWithInvalidExpression() {
+        assertEquals("$[week_last_day(yyyy-MM-dd,0) - 1]",
+                TimePlaceholderUtils.formatTimeExpression("$[week_last_day(yyyy-MM-dd,0) - 1]", new Date(), true));
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
@@ -17,18 +17,16 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.utils;
 
-import static org.apache.dolphinscheduler.plugin.task.api.parser.TimePlaceholderUtils.replacePlaceholders;
+import static org.apache.dolphinscheduler.plugin.task.api.parser.PlaceholderUtils.replacePlaceholders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.dolphinscheduler.common.constants.DateConstants;
-import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
-import org.apache.dolphinscheduler.plugin.task.api.parser.PlaceholderUtils;
 
 import java.text.ParseException;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,8 +49,8 @@ public class ParameterUtilsTest {
                 JSONUtils.toJsonString(Lists.newArrayList(3.1415, 2.44, 3.44))));
         String sql = ParameterUtils.expandListParameter(params,
                 "select * from test where col1 in ('${col1}') and date='${date}' and col2 in ('${col2}')");
-        Assertions.assertEquals("select * from test where col1 in (?,?,?) and date=? and col2 in (?,?,?)", sql);
-        Assertions.assertEquals(7, params.size());
+        assertEquals("select * from test where col1 in (?,?,?) and date=? and col2 in (?,?,?)", sql);
+        assertEquals(7, params.size());
 
         Map<Integer, Property> params2 = new HashMap<>();
         params2.put(1,
@@ -60,8 +58,8 @@ public class ParameterUtilsTest {
         params2.put(2, new Property("date", Direct.IN, DataType.DATE, "2020-06-30"));
         String sql2 = ParameterUtils.expandListParameter(params2,
                 "select * from test where col1 in ('${col}') and date='${date}'");
-        Assertions.assertEquals("select * from test where col1 in (?) and date=?", sql2);
-        Assertions.assertEquals(2, params2.size());
+        assertEquals("select * from test where col1 in (?) and date=?", sql2);
+        assertEquals(2, params2.size());
 
     }
 
@@ -77,21 +75,14 @@ public class ParameterUtilsTest {
 
         // parameterString、parameterMap is not null
         String parameterString = "test_parameter";
-        Assertions.assertEquals(parameterString,
+        assertEquals(parameterString,
                 ParameterUtils.convertParameterPlaceholders(parameterString, parameterMap));
 
         // replace variable ${} form
         parameterMap.put("testParameter2", "${testParameter}");
-        Assertions.assertEquals(parameterString,
-                PlaceholderUtils.replacePlaceholders(parameterString, parameterMap, true));
+        assertEquals(parameterString,
+                replacePlaceholders(parameterString, parameterMap, true));
 
-        // replace time $[...] form, eg. $[yyyyMMdd]
-        Date cronTime = new Date();
-        Assertions.assertEquals(parameterString, replacePlaceholders(parameterString, cronTime, true));
-
-        // replace time $[...] form, eg. $[yyyyMMdd]
-        Date cronTimeStr = DateUtils.stringToDate("2019-02-02 00:00:00");
-        Assertions.assertEquals(parameterString, replacePlaceholders(parameterString, cronTimeStr, true));
     }
 
     @Test
@@ -103,20 +94,30 @@ public class ParameterUtilsTest {
         parameterMap.put("user", "Kris");
         parameterMap.put(DateConstants.PARAMETER_DATETIME, "20201201123000");
         parameterString = ParameterUtils.convertParameterPlaceholders(parameterString, parameterMap);
-        Assertions.assertEquals(
+        assertEquals(
                 "Kris is userName, '$[1]' '20221201' '20181201' '20210301' '20200801' '20201215' '20201117'  '20201204'  '$[0]' '20201128' '143000' '113000' '123300' '122800'  '$[3]'",
                 parameterString);
+    }
+
+    @Test
+    public void convertParameterPlaceholdersWithPunct() {
+        final String sql = "get_json_object(json_array, '$[*].pageId')";
+        final Map<String, String> paramsMap = new HashMap<>();
+        paramsMap.put("key", "value");
+
+        assertEquals("get_json_object(json_array, '$[*].pageId')",
+                ParameterUtils.convertParameterPlaceholders(sql, paramsMap));
     }
 
     /**
      * Test handleEscapes
      */
     @Test
-    public void testHandleEscapes() throws Exception {
+    public void testHandleEscapes() {
         Assertions.assertNull(ParameterUtils.handleEscapes(null));
-        Assertions.assertEquals("", ParameterUtils.handleEscapes(""));
-        Assertions.assertEquals("test Parameter", ParameterUtils.handleEscapes("test Parameter"));
-        Assertions.assertEquals("////%test////%Parameter", ParameterUtils.handleEscapes("%test%Parameter"));
+        assertEquals("", ParameterUtils.handleEscapes(""));
+        assertEquals("test Parameter", ParameterUtils.handleEscapes("test Parameter"));
+        assertEquals("////%test////%Parameter", ParameterUtils.handleEscapes("%test%Parameter"));
     }
 
 }


### PR DESCRIPTION
## Purpose of the pull request

close #16914

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contain incompatible change, you should also add it to `docs/docs/en/guide/upgrede/incompatible.md`
