### PR TITLE
[Fix-16978][Master] Fix AbstractDelayEvent compare method is incorrect

### DIFF
--- a/dolphinscheduler-eventbus/src/main/java/org/apache/dolphinscheduler/eventbus/AbstractDelayEvent.java
+++ b/dolphinscheduler-eventbus/src/main/java/org/apache/dolphinscheduler/eventbus/AbstractDelayEvent.java
@@ -39,6 +39,8 @@ public abstract class AbstractDelayEvent implements IEvent, Delayed {
     @Builder.Default
     protected long createTimeInNano = System.nanoTime();
 
+    protected long expiredTimeInNano;
+
     public AbstractDelayEvent() {
         this(DEFAULT_DELAY_TIME);
     }
@@ -50,6 +52,7 @@ public abstract class AbstractDelayEvent implements IEvent, Delayed {
     public AbstractDelayEvent(final long delayTime, final long createTimeInNano) {
         this.delayTime = delayTime;
         this.createTimeInNano = createTimeInNano;
+        this.expiredTimeInNano = this.delayTime * 1_000_000 + this.createTimeInNano;
     }
 
     @Override
@@ -60,7 +63,7 @@ public abstract class AbstractDelayEvent implements IEvent, Delayed {
 
     @Override
     public int compareTo(Delayed other) {
-        return Long.compare(this.createTimeInNano, ((AbstractDelayEvent) other).createTimeInNano);
+        return Long.compare(this.expiredTimeInNano, ((AbstractDelayEvent) other).expiredTimeInNano);
     }
 
 }

--- a/dolphinscheduler-eventbus/src/main/java/org/apache/dolphinscheduler/eventbus/AbstractDelayEvent.java
+++ b/dolphinscheduler-eventbus/src/main/java/org/apache/dolphinscheduler/eventbus/AbstractDelayEvent.java
@@ -39,7 +39,9 @@ public abstract class AbstractDelayEvent implements IEvent, Delayed {
     @Builder.Default
     protected long createTimeInNano = System.nanoTime();
 
-    protected long expiredTimeInNano;
+    // set create time as default if the inheritor didn't call super()
+    @Builder.Default
+    protected long expiredTimeInNano = System.nanoTime();
 
     public AbstractDelayEvent() {
         this(DEFAULT_DELAY_TIME);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/IWorkflowExecutionGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/IWorkflowExecutionGraph.java
@@ -192,6 +192,11 @@ public interface IWorkflowExecutionGraph {
     boolean isTaskExecutionRunnableForbidden(final ITaskExecutionRunnable taskExecutionRunnable);
 
     /**
+     * Whether the given task's execution is failure and waiting for retry.
+     */
+    boolean isTaskExecutionRunnableRetrying(final ITaskExecutionRunnable taskExecutionRunnable);
+
+    /**
      * Whether all predecessors task is skipped.
      * <p> Once all predecessors are marked as skipped, then the task will be marked as skipped, and will trigger its successors.
      */

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowExecutionGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowExecutionGraph.java
@@ -140,7 +140,7 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
 
     @Override
     public boolean isTaskExecutionRunnableActive(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return activeTaskExecutionRunnable.add(taskExecutionRunnable.getName());
+        return activeTaskExecutionRunnable.contains(taskExecutionRunnable.getName());
     }
 
     @Override
@@ -254,6 +254,16 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
     @Override
     public boolean isTaskExecutionRunnableForbidden(final ITaskExecutionRunnable taskExecutionRunnable) {
         return (taskExecutionRunnable.getTaskDefinition().getFlag() == Flag.NO);
+    }
+
+    @Override
+    public boolean isTaskExecutionRunnableRetrying(final ITaskExecutionRunnable taskExecutionRunnable) {
+        if (!taskExecutionRunnable.isTaskInstanceInitialized()) {
+            return false;
+        }
+        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        return taskInstance.getState() == TaskExecutionStatus.FAILURE && taskExecutionRunnable.isTaskInstanceCanRetry()
+                && isTaskExecutionRunnableActive(taskExecutionRunnable);
     }
 
     /**

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -130,7 +130,6 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                 final ITaskExecutionRunnable taskExecutionRunnable,
                                 final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
         // for now, killEventAction can be fired on failure with retry
         // there is no task executor now, shouldn't call workflowExecutionGraph.isTaskExecutionRunnableActive()
         // it's better to call super.killedEventAction() direct

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -105,7 +105,7 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                  final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // When the failed task is awaiting retry, we can mark it as 'paused' to ignore the retry event.
-        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+        if (isTaskRetrying(taskExecutionRunnable)) {
             super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
                     TaskPausedLifecycleEvent.of(taskExecutionRunnable));
             return;
@@ -121,7 +121,7 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
-        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+        if (isTaskRetrying(taskExecutionRunnable)) {
             super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
             return;
         }
@@ -134,7 +134,7 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                 final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // When the failed task is awaiting retry, we can mark it as 'killed' to ignore the retry event.
-        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+        if (isTaskRetrying(taskExecutionRunnable)) {
             super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
                     TaskKilledLifecycleEvent.of(taskExecutionRunnable));
             return;
@@ -150,7 +150,7 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
-        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+        if (isTaskRetrying(taskExecutionRunnable)) {
             super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
             return;
         }
@@ -186,9 +186,7 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
         return TaskExecutionStatus.FAILURE;
     }
 
-    private boolean isTaskRetrying(
-                                   final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable) {
+    private boolean isTaskRetrying(final ITaskExecutionRunnable taskExecutionRunnable) {
         final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
         return workflowExecutionGraph.isTaskExecutionRunnableRetrying(taskExecutionRunnable);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -135,9 +135,10 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
         // there is no task executor now, shouldn't call workflowExecutionGraph.isTaskExecutionRunnableActive()
         // it's better to call super.killedEventAction() direct
         if (taskExecutionRunnable.isTaskInstanceCanRetry()
-            //        && workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)
+        // && workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)
         ) {
-            super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, TaskKilledLifecycleEvent.of(taskExecutionRunnable));
+            super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
+                    TaskKilledLifecycleEvent.of(taskExecutionRunnable));
             return;
         }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -104,6 +104,12 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                  final ITaskExecutionRunnable taskExecutionRunnable,
                                  final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        // When the failed task is awaiting retry, we can mark it as 'paused' to ignore the retry event.
+        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+            super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
+                    TaskPausedLifecycleEvent.of(taskExecutionRunnable));
+            return;
+        }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
     }
 
@@ -112,14 +118,11 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                   final ITaskExecutionRunnable taskExecutionRunnable,
                                   final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
-        if (taskExecutionRunnable.isTaskInstanceCanRetry()
-                && workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)) {
-            workflowExecutionGraph.markTaskExecutionRunnableChainPause(taskExecutionRunnable);
-            publishWorkflowInstanceTopologyLogicalTransitionEvent(taskExecutionRunnable);
+        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+            super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
             return;
         }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
@@ -130,12 +133,8 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                 final ITaskExecutionRunnable taskExecutionRunnable,
                                 final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        // for now, killEventAction can be fired on failure with retry
-        // there is no task executor now, shouldn't call workflowExecutionGraph.isTaskExecutionRunnableActive()
-        // it's better to call super.killedEventAction() direct
-        if (taskExecutionRunnable.isTaskInstanceCanRetry()
-        // && workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)
-        ) {
+        // When the failed task is awaiting retry, we can mark it as 'killed' to ignore the retry event.
+        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
             super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
                     TaskKilledLifecycleEvent.of(taskExecutionRunnable));
             return;
@@ -148,14 +147,11 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                   final ITaskExecutionRunnable taskExecutionRunnable,
                                   final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
-        if (taskExecutionRunnable.isTaskInstanceCanRetry()
-                && workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)) {
-            workflowExecutionGraph.markTaskExecutionRunnableChainKill(taskExecutionRunnable);
-            publishWorkflowInstanceTopologyLogicalTransitionEvent(taskExecutionRunnable);
+        if (isTaskRetrying(workflowExecutionRunnable, taskExecutionRunnable)) {
+            super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
             return;
         }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
@@ -188,5 +184,12 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
     @Override
     public TaskExecutionStatus matchState() {
         return TaskExecutionStatus.FAILURE;
+    }
+
+    private boolean isTaskRetrying(
+                                   final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                   final ITaskExecutionRunnable taskExecutionRunnable) {
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
+        return workflowExecutionGraph.isTaskExecutionRunnableRetrying(taskExecutionRunnable);
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -130,6 +130,16 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
                                 final ITaskExecutionRunnable taskExecutionRunnable,
                                 final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
+        // for now, killEventAction can be fired on failure with retry
+        // there is no task executor now, shouldn't call workflowExecutionGraph.isTaskExecutionRunnableActive()
+        // it's better to call super.killedEventAction() direct
+        if (taskExecutionRunnable.isTaskInstanceCanRetry()
+            //        && workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)
+        ) {
+            super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, TaskKilledLifecycleEvent.of(taskExecutionRunnable));
+            return;
+        }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
     }
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceStopTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceStopTestCase.java
@@ -246,4 +246,54 @@ public class WorkflowInstanceStopTestCase extends AbstractMasterIntegrationTestC
 
         masterContainer.assertAllResourceReleased();
     }
+
+    @Test
+    @DisplayName("Test stop a workflow with failed retrying task")
+    public void testStopWorkflow_with_failedRetryingTask() {
+        final String yaml = "/it/stop/workflow_with_fake_task_failed_retrying.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition workflow = context.getOneWorkflow();
+
+        final WorkflowOperator.WorkflowTriggerDTO workflowTriggerDTO = WorkflowOperator.WorkflowTriggerDTO.builder()
+                .workflowDefinition(workflow)
+                .runWorkflowCommandParam(new RunWorkflowCommandParam())
+                .build();
+        final Integer workflowInstanceId = workflowOperator.manualTriggerWorkflow(workflowTriggerDTO);
+
+        await()
+                .pollInterval(Duration.ofMillis(100))
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(workflowInstanceId).getState())
+                            .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
+
+                    assertThat(repository.queryTaskInstance(workflowInstanceId))
+                            .satisfiesExactly(
+                                    taskInstance -> {
+                                        assertThat(taskInstance.getName()).isEqualTo("FAILED-RETRY");
+                                        assertThat(taskInstance.getState()).isEqualTo(TaskExecutionStatus.FAILURE);
+                                    });
+                });
+
+        assertThat(workflowOperator.stopWorkflowInstance(workflowInstanceId).isSuccess());
+
+        await()
+                .pollInterval(Duration.ofMillis(100))
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(workflowInstanceId))
+                            .satisfies(
+                                    workflowInstance -> {
+                                        assertThat(workflowInstance.getState()).isEqualTo(WorkflowExecutionStatus.STOP);
+                                    });
+
+                    assertThat(repository.queryTaskInstance(workflowInstanceId))
+                            .satisfiesExactly(
+                                    taskInstance -> {
+                                        assertThat(taskInstance.getName()).isEqualTo("FAILED-RETRY");
+                                        assertThat(taskInstance.getState()).isEqualTo(TaskExecutionStatus.KILL);
+                                    });
+                });
+        masterContainer.assertAllResourceReleased();
+    }
 }

--- a/dolphinscheduler-master/src/test/resources/it/pause/workflow_with_fake_task_failed_retrying.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/pause/workflow_with_fake_task_failed_retrying.yaml
@@ -43,7 +43,7 @@ tasks:
     projectCode: 1
     userId: 1
     taskType: LogicFakeTask
-    taskParams: '{"localParams":null,"varPool":[],"shellScript":"sleep 5 && ls /-"}'
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls /-"}'
     workerGroup: default
     createTime: 2024-08-12 00:00:00
     updateTime: 2021-08-12 00:00:00

--- a/dolphinscheduler-master/src/test/resources/it/pause/workflow_with_fake_task_failed_retrying.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/pause/workflow_with_fake_task_failed_retrying.yaml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2024-08-12 00:00:00
+  updateTime: 2021-08-12 00:00:00
+
+workflows:
+  - name: workflow_with_one_fake_task_failed
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a fake workflow with single task
+    releaseState: ONLINE
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: FAILED-RETRY
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"sleep 5 && ls /-"}'
+    workerGroup: default
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    taskExecuteType: BATCH
+    failRetryTimes: 10
+    failRetryInterval: 10
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2024-08-12 00:00:00
+

--- a/dolphinscheduler-master/src/test/resources/it/stop/workflow_with_fake_task_failed_retrying.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/stop/workflow_with_fake_task_failed_retrying.yaml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2024-08-12 00:00:00
+  updateTime: 2021-08-12 00:00:00
+
+workflows:
+  - name: workflow_with_one_fake_task_failed
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a fake workflow with single task
+    releaseState: ONLINE
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: FAILED-RETRY
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls /-"}'
+    workerGroup: default
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    taskExecuteType: BATCH
+    failRetryTimes: 10
+    failRetryInterval: 10
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2024-08-12 00:00:00
+


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Fix AbstractDelayEventBus block events issue fix #16978.

## Brief change log

1. Fix AbstractDelayEvent compare method is incorrect.
2. Modify TaskFailureStateAction to allow killEventAction when task instance can retry.
3. modify WorkflowInstanceTopTestCase and WorkflowInstancePauseTestCase, add affected workflow stop and pause with failed retrying task test cases.
4. fix (I)WorkflowExecutionGraph.isTaskExecutionRunnableActive method is incorrect.

## Verify this pull request

Stop a workflow with failed task when waiting to retry.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
