### PR TITLE
[Fix-17004] Fix process termination logic in cancelApplication method

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -220,7 +220,7 @@ public abstract class AbstractCommandExecutor {
             // Try to kill process tree first
             boolean killed = ProcessUtils.kill(taskRequest);
             if (killed) {
-                log.info("Successfully killed process tree for task: {}, pid: {}",
+                log.info("Process tree for task: {} is killed or already finished, pid: {}",
                         taskRequest.getTaskAppId(), taskRequest.getProcessId());
                 return;
             }
@@ -237,8 +237,6 @@ public abstract class AbstractCommandExecutor {
 
         } catch (Exception e) {
             log.error("Error while killing process, pid: {}", taskRequest.getProcessId(), e);
-            // Try destroyForcibly as last resort
-            process.destroyForcibly();
         }
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -216,13 +216,30 @@ public abstract class AbstractCommandExecutor {
             return;
         }
 
-        // soft kill
-        log.info("Begin to kill process process, pid is : {}", taskRequest.getProcessId());
-        process.destroy();
-        if (!process.waitFor(5, TimeUnit.SECONDS)) {
+        try {
+            // Try to kill process tree first
+            boolean killed = ProcessUtils.kill(taskRequest);
+            if (killed) {
+                log.info("Successfully killed process tree for task: {}, pid: {}",
+                        taskRequest.getTaskAppId(), taskRequest.getProcessId());
+                return;
+            }
+
+            // If killing process tree fails, try to destroy the process directly
+            log.info("Failed to kill process tree, trying to destroy process directly");
+            process.destroy();
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                log.info("Process did not exit after destroy, forcing termination");
+                process.destroyForcibly();
+            }
+            log.info("Successfully killed process tree for task: {}, pid: {}",
+                    taskRequest.getTaskAppId(), taskRequest.getProcessId());
+
+        } catch (Exception e) {
+            log.error("Error while killing process, pid: {}", taskRequest.getProcessId(), e);
+            // Try destroyForcibly as last resort
             process.destroyForcibly();
         }
-        log.info("Success kill task: {}, pid: {}", taskRequest.getTaskAppId(), taskRequest.getProcessId());
     }
 
     private void collectPodLogIfNeeded() {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -216,27 +216,14 @@ public abstract class AbstractCommandExecutor {
             return;
         }
 
-        try {
-            // Try to kill process tree first
-            boolean killed = ProcessUtils.kill(taskRequest);
-            if (killed) {
-                log.info("Process tree for task: {} is killed or already finished, pid: {}",
-                        taskRequest.getTaskAppId(), taskRequest.getProcessId());
-                return;
-            }
-
-            // If killing process tree fails, try to destroy the process directly
-            log.info("Failed to kill process tree, trying to destroy process directly");
-            process.destroy();
-            if (!process.waitFor(5, TimeUnit.SECONDS)) {
-                log.info("Process did not exit after destroy, forcing termination");
-                process.destroyForcibly();
-            }
-            log.info("Successfully killed process tree for task: {}, pid: {}",
+        // Try to kill process tree
+        boolean killed = ProcessUtils.kill(taskRequest);
+        if (killed) {
+            log.info("Process tree for task: {} is killed or already finished, pid: {}",
                     taskRequest.getTaskAppId(), taskRequest.getProcessId());
-
-        } catch (Exception e) {
-            log.error("Error while killing process, pid: {}", taskRequest.getProcessId(), e);
+        } else {
+            log.error("Failed to kill process tree for task: {}, pid: {}",
+                    taskRequest.getTaskAppId(), taskRequest.getProcessId());
         }
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -85,27 +85,101 @@ public final class ProcessUtils {
     private static final Pattern LINUXPATTERN = Pattern.compile("\\((\\d+)\\)");
 
     /**
-     * kill tasks according to different task types.
+     * Terminate the task process, support multi-level signal processing and fallback strategy
+     * @param request Task execution context
+     * @return Whether the process was successfully terminated
      */
-    @Deprecated
     public static boolean kill(@NonNull TaskExecutionContext request) {
         try {
-            log.info("Begin kill task instance, processId: {}", request.getProcessId());
+            log.info("Begin killing task instance, processId: {}", request.getProcessId());
             int processId = request.getProcessId();
             if (processId == 0) {
-                log.error("Task instance kill failed, processId is not exist");
+                log.error("Task instance kill failed, processId is not available");
                 return false;
             }
 
-            String cmd = String.format("kill -9 %s", getPidsStr(processId));
-            cmd = OSUtils.getSudoCmd(request.getTenantCode(), cmd);
-            log.info("process id:{}, cmd:{}", processId, cmd);
+            // Get all child processes
+            String pids = getPidsStr(processId);
+            String[] pidArray = pids.split("\\s+");
+            if (pidArray.length == 0) {
+                log.warn("No valid PIDs found for process: {}", processId);
+                return true;
+            }
 
-            OSUtils.exeCmd(cmd);
-            log.info("Success kill task instance, processId: {}", request.getProcessId());
+            // 1. Try to terminate gracefully (SIGINT)
+            boolean gracefulKillSuccess = sendKillSignal("SIGINT", pids, request.getTenantCode(), 2000);
+            if (gracefulKillSuccess) {
+                log.info("Successfully killed process tree using SIGINT, processId: {}", processId);
+                return true;
+            }
+
+            // 2. Try to terminate forcefully (SIGTERM)
+            boolean termKillSuccess = sendKillSignal("SIGTERM", pids, request.getTenantCode(), 2000);
+            if (termKillSuccess) {
+                log.info("Successfully killed process tree using SIGTERM, processId: {}", processId);
+                return true;
+            }
+
+            // 3. As a last resort, use `kill -9`
+            log.warn("SIGINT & SIGTERM failed, using SIGKILL as a last resort for processId: {}", processId);
+            boolean forceKillSuccess = sendKillSignal("SIGKILL", pids, request.getTenantCode(), 3000);
+            if (forceKillSuccess) {
+                log.info("Successfully killed process tree using SIGKILL, processId: {}", processId);
+                return true;
+            }
+
+            // 4. Finally, check if the process is still alive
+            for (String pid : pidArray) {
+                if (isProcessAlive(pid)) {
+                    log.error("Failed to kill process {}, even after multiple attempts", pid);
+                    return false;
+                }
+            }
+
+            log.info("Success: process {} is no longer running", processId);
             return true;
+
         } catch (Exception e) {
             log.error("Kill task instance error, processId: {}", request.getProcessId(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Send a kill signal to a process group and wait for it to terminate, but it may not be successful to kill the process
+     * @param signal Signal type (SIGINT, SIGTERM, SIGKILL)
+     * @param pids Process ID list
+     * @param tenantCode Tenant code
+     * @param waitTimeMs Wait time
+     */
+    private static boolean sendKillSignal(String signal, String pids, String tenantCode, int waitTimeMs) {
+        try {
+            String killCmd = String.format("kill -s %s %s", signal, pids);
+            killCmd = OSUtils.getSudoCmd(tenantCode, killCmd);
+            log.info("Sending {} to process group: {}, command: {}", signal, pids, killCmd);
+            OSUtils.exeCmd(killCmd);
+
+            // Wait for a while and check if the process is still alive
+            Thread.sleep(waitTimeMs);
+            return true;
+        } catch (Exception e) {
+            log.error("Error sending {} to process: {}", signal, pids, e);
+            return false;
+        }
+    }
+
+    /**
+     * Check if a process is still alive
+     * @param pid Process ID
+     * @return Whether the process is still alive
+     */
+    private static boolean isProcessAlive(String pid) {
+        try {
+            String checkCmd = String.format("ps -p %s", pid);
+            String result = OSUtils.exeCmd(checkCmd);
+            return result != null && result.contains(pid);
+        } catch (Exception e) {
+            log.info("Error checking process status for pid {}", pid);
             return false;
         }
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -94,8 +94,8 @@ public final class ProcessUtils {
             log.info("Begin killing task instance, processId: {}", request.getProcessId());
             int processId = request.getProcessId();
             if (processId == 0) {
-                log.error("Task instance kill failed, processId is not available");
-                return false;
+                log.info("Task instance has already finished, no need to kill");
+                return true;
             }
 
             // Get all child processes
@@ -107,14 +107,14 @@ public final class ProcessUtils {
             }
 
             // 1. Try to terminate gracefully (SIGINT)
-            boolean gracefulKillSuccess = sendKillSignal("SIGINT", pids, request.getTenantCode(), 2000);
+            boolean gracefulKillSuccess = sendKillSignal("SIGINT", pids, request.getTenantCode());
             if (gracefulKillSuccess) {
                 log.info("Successfully killed process tree using SIGINT, processId: {}", processId);
                 return true;
             }
 
             // 2. Try to terminate forcefully (SIGTERM)
-            boolean termKillSuccess = sendKillSignal("SIGTERM", pids, request.getTenantCode(), 2000);
+            boolean termKillSuccess = sendKillSignal("SIGTERM", pids, request.getTenantCode());
             if (termKillSuccess) {
                 log.info("Successfully killed process tree using SIGTERM, processId: {}", processId);
                 return true;
@@ -122,22 +122,13 @@ public final class ProcessUtils {
 
             // 3. As a last resort, use `kill -9`
             log.warn("SIGINT & SIGTERM failed, using SIGKILL as a last resort for processId: {}", processId);
-            boolean forceKillSuccess = sendKillSignal("SIGKILL", pids, request.getTenantCode(), 3000);
+            boolean forceKillSuccess = sendKillSignal("SIGKILL", pids, request.getTenantCode());
             if (forceKillSuccess) {
-                log.info("Successfully killed process tree using SIGKILL, processId: {}", processId);
-                return true;
+                log.info("Successfully sent SIGKILL signal to process tree, processId: {}", processId);
+            } else {
+                log.error("Error sending SIGKILL signal to process tree, processId: {}", processId);
             }
-
-            // 4. Finally, check if the process is still alive
-            for (String pid : pidArray) {
-                if (isProcessAlive(pid)) {
-                    log.error("Failed to kill process {}, even after multiple attempts", pid);
-                    return false;
-                }
-            }
-
-            log.info("Success: process {} is no longer running", processId);
-            return true;
+            return forceKillSuccess;
 
         } catch (Exception e) {
             log.error("Kill task instance error, processId: {}", request.getProcessId(), e);
@@ -146,40 +137,21 @@ public final class ProcessUtils {
     }
 
     /**
-     * Send a kill signal to a process group and wait for it to terminate, but it may not be successful to kill the process
+     * Send a kill signal to a process group
      * @param signal Signal type (SIGINT, SIGTERM, SIGKILL)
      * @param pids Process ID list
      * @param tenantCode Tenant code
-     * @param waitTimeMs Wait time
      */
-    private static boolean sendKillSignal(String signal, String pids, String tenantCode, int waitTimeMs) {
+    private static boolean sendKillSignal(String signal, String pids, String tenantCode) {
         try {
             String killCmd = String.format("kill -s %s %s", signal, pids);
             killCmd = OSUtils.getSudoCmd(tenantCode, killCmd);
             log.info("Sending {} to process group: {}, command: {}", signal, pids, killCmd);
             OSUtils.exeCmd(killCmd);
 
-            // Wait for a while and check if the process is still alive
-            Thread.sleep(waitTimeMs);
             return true;
         } catch (Exception e) {
             log.error("Error sending {} to process: {}", signal, pids, e);
-            return false;
-        }
-    }
-
-    /**
-     * Check if a process is still alive
-     * @param pid Process ID
-     * @return Whether the process is still alive
-     */
-    private static boolean isProcessAlive(String pid) {
-        try {
-            String checkCmd = String.format("ps -p %s", pid);
-            String result = OSUtils.exeCmd(checkCmd);
-            return result != null && result.contains(pid);
-        } catch (Exception e) {
-            log.info("Error checking process status for pid {}", pid);
             return false;
         }
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
@@ -147,6 +147,6 @@ public class ProcessUtilsTest {
         boolean result = ProcessUtils.kill(taskRequest);
 
         // Assert
-        Assertions.assertFalse(result);
+        Assertions.assertTrue(result);
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
@@ -19,16 +19,32 @@ package org.apache.dolphinscheduler.plugin.task.api.utils;
 
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 
 import org.apache.commons.lang3.SystemUtils;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class ProcessUtilsTest {
 
+    private MockedStatic<OSUtils> mockedOSUtils;
+
+    @BeforeEach
+    void setUp() {
+        mockedOSUtils = Mockito.mockStatic(OSUtils.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedOSUtils != null) {
+            mockedOSUtils.close();
+        }
+    }
     @Test
     public void testGetPidsStr() throws Exception {
         // first
@@ -36,7 +52,6 @@ public class ProcessUtilsTest {
         int processId = 6279;
         String exceptPidsStr = "6279 6282 6354";
         String command;
-        MockedStatic<OSUtils> osUtilsMockedStatic = Mockito.mockStatic(OSUtils.class);
         if (SystemUtils.IS_OS_MAC) {
             pids = "-+= 6279 sudo -+- 6282 558_1497.sh --- 6354 sleep";
             command = String.format("%s -sp %d", TaskConstants.PSTREE, processId);
@@ -45,7 +60,7 @@ public class ProcessUtilsTest {
         } else {
             command = String.format("%s -p %d", TaskConstants.PSTREE, processId);
         }
-        osUtilsMockedStatic.when(() -> OSUtils.exeCmd(command)).thenReturn(pids);
+        mockedOSUtils.when(() -> OSUtils.exeCmd(command)).thenReturn(pids);
         String actualPidsStr = ProcessUtils.getPidsStr(processId);
         Assertions.assertEquals(exceptPidsStr, actualPidsStr);
 
@@ -62,7 +77,7 @@ public class ProcessUtilsTest {
         } else {
             command2 = String.format("%s -p %d", TaskConstants.PSTREE, processId2);
         }
-        osUtilsMockedStatic.when(() -> OSUtils.exeCmd(command2)).thenReturn(pids2);
+        mockedOSUtils.when(() -> OSUtils.exeCmd(command2)).thenReturn(pids2);
         String actualPidsStr2 = ProcessUtils.getPidsStr(processId2);
         Assertions.assertEquals(exceptPidsStr2, actualPidsStr2);
 
@@ -79,7 +94,7 @@ public class ProcessUtilsTest {
         } else {
             command3 = String.format("%s -p %d", TaskConstants.PSTREE, processId3);
         }
-        osUtilsMockedStatic.when(() -> OSUtils.exeCmd(command3)).thenReturn(pids3);
+        mockedOSUtils.when(() -> OSUtils.exeCmd(command3)).thenReturn(pids3);
         String actualPidsStr3 = ProcessUtils.getPidsStr(processId3);
         Assertions.assertEquals(exceptPidsStr3, actualPidsStr3);
     }
@@ -95,4 +110,43 @@ public class ProcessUtilsTest {
         });
     }
 
+    @Test
+    void testKillProcessSuccessWithSigInt() throws Exception {
+        // Arrange
+        TaskExecutionContext taskRequest = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskRequest.getProcessId()).thenReturn(12345);
+        Mockito.when(taskRequest.getTenantCode()).thenReturn("testTenant");
+
+        // Mock getPidsStr
+        mockedOSUtils.when(() -> OSUtils.exeCmd(Mockito.matches(".*pstree.*12345"))).thenReturn("1234 12345");
+
+        // Mock SIGINT command
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -s SIGINT.*")))
+                .thenReturn("kill -s SIGINT 12345");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -s SIGINT 12345")).thenReturn("");
+
+        // Mock process check - process dies after SIGINT
+        mockedOSUtils.when(() -> OSUtils.exeCmd("ps -p 12345")).thenReturn(null);
+
+        // Act
+        boolean result = ProcessUtils.kill(taskRequest);
+
+        // Assert
+        Assertions.assertTrue(result);
+        // Verify SIGKILL was never called
+        mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -9 12345"), Mockito.never());
+    }
+
+    @Test
+    void testKillNonExistentProcess() {
+        // Arrange
+        TaskExecutionContext taskRequest = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskRequest.getProcessId()).thenReturn(0);
+
+        // Act
+        boolean result = ProcessUtils.kill(taskRequest);
+
+        // Assert
+        Assertions.assertFalse(result);
+    }
 }


### PR DESCRIPTION
- update the ProcessUtils.kill method to ensure it correctly handles process tree termination and direct process destruction.
- update the AbstractCommandExecutor.cancelApplication method to ensure it correctly handles process termination, including logging and error handling.

close https://github.com/apache/dolphinscheduler/issues/17004