### PR TITLE
[Fix-17019][Task Api] Missing execute path in resource limit mode.

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/shell/BaseLinuxShellInterceptorBuilder.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/shell/BaseLinuxShellInterceptorBuilder.java
@@ -171,6 +171,7 @@ public abstract class BaseLinuxShellInterceptorBuilder<T extends BaseLinuxShellI
         }
 
         bootstrapCommand.add(String.format("--uid=%s", runUser));
+        bootstrapCommand.add(shellAbsolutePath().toString());
         return bootstrapCommand;
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/shell/BaseLinuxShellInterceptorBuilderTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/shell/BaseLinuxShellInterceptorBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.shell;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+import org.apache.dolphinscheduler.plugin.task.api.shell.bash.BashShellInterceptorBuilder;
+import org.apache.dolphinscheduler.plugin.task.api.utils.AbstractCommandExecutorConstants;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class BaseLinuxShellInterceptorBuilderTest {
+
+    @Test
+    void generateBootstrapCommandTest() {
+        BashShellInterceptorBuilder builder = new BashShellInterceptorBuilder()
+                .shellDirectory("/tmp")
+                .shellName("test")
+                .runUser("root")
+                .cpuQuota(10)
+                .memoryQuota(1024)
+                .sudoMode(false);
+        try (MockedStatic<PropertyUtils> mockStatic = mockStatic(PropertyUtils.class)) {
+            // default
+            List<String> defaultCommands = builder.generateBootstrapCommand();
+            assertEquals("bash /tmp/test.sh", String.join(" ", defaultCommands));
+
+            // sudo mode
+            builder.sudoMode(true);
+            List<String> sudoCommands = builder.generateBootstrapCommand();
+            assertEquals("sudo -u root -i /tmp/test.sh", String.join(" ", sudoCommands));
+
+            // resource limit mode
+            mockStatic.when(
+                    () -> PropertyUtils.getBoolean(AbstractCommandExecutorConstants.TASK_RESOURCE_LIMIT_STATE, false))
+                    .thenReturn(true);
+            List<String> limitModeCommands = builder.generateBootstrapCommand();
+            assertEquals("sudo systemd-run -q --scope -p CPUQuota=10% -p MemoryLimit=1024M --uid=root /tmp/test.sh",
+                    String.join(" ", limitModeCommands));
+        }
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
This PR is close https://github.com/apache/dolphinscheduler/issues/17019

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
