### PR TITLE
[Improvement-17057][Master] Check if the WorkflowGrapth is a dag at constructor

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
@@ -30,8 +32,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WorkflowGraph implements IWorkflowGraph {
 
@@ -61,7 +61,7 @@ public class WorkflowGraph implements IWorkflowGraph {
     }
 
     private void checkIfDAG(List<WorkflowTaskRelation> workflowTaskRelations, List<TaskDefinition> taskDefinitions) {
-        //If topology-sort-result`s size less than taskDefinitions`s size, then not a DAG
+        // If topology-sort-result`s size less than taskDefinitions`s size, then not a DAG
         Map<Long, List<Long>> preTaskCodeMap = workflowTaskRelations
                 .stream()
                 .collect(Collectors.groupingBy(WorkflowTaskRelation::getPostTaskCode,

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
@@ -19,15 +19,16 @@ package org.apache.dolphinscheduler.server.master.engine.graph;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.apache.dolphinscheduler.common.graph.DAG;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -60,18 +61,58 @@ public class WorkflowGraph implements IWorkflowGraph {
     }
 
     private void checkIfDAG(List<WorkflowTaskRelation> workflowTaskRelations, List<TaskDefinition> taskDefinitions) {
-        DAG<Long, TaskDefinition, WorkflowTaskRelation> graph = new DAG<>();
-        // Fill the vertices
+        // If topology-sort-result`s size less than taskDefinitions`s size, then not a DAG
+        Map<Long, List<Long>> preTaskCodeMap = workflowTaskRelations
+                .stream()
+                .filter(relation -> relation.getPreTaskCode() != 0)
+                .collect(Collectors.groupingBy(WorkflowTaskRelation::getPostTaskCode,
+                        Collectors.mapping(WorkflowTaskRelation::getPreTaskCode, Collectors.toList())));
+        Map<Long, List<Long>> postTaskCodeMap = workflowTaskRelations
+                .stream()
+                .collect(Collectors.groupingBy(WorkflowTaskRelation::getPreTaskCode,
+                        Collectors.mapping(WorkflowTaskRelation::getPostTaskCode, Collectors.toList())));
+
+        // build in-degree count
+        Map<Long, Integer> inDegreeCount = new HashMap<>();
         for (TaskDefinition taskDefinition : taskDefinitions) {
-            graph.addNode(taskDefinition.getCode(), taskDefinition);
-        }
-        // Fill edge relations
-        for (WorkflowTaskRelation relation : workflowTaskRelations) {
-            long preTaskCode = relation.getPreTaskCode();
-            // When exist a ring cycle, then not a DAG.
-            if (preTaskCode != 0 && !graph.addEdge(preTaskCode, relation.getPostTaskCode())) {
-                throw new IllegalArgumentException("The workflow graph is not a DAG");
+            List<Long> preTasks = preTaskCodeMap.get(taskDefinition.getCode());
+            if (preTasks == null) {
+                inDegreeCount.put(taskDefinition.getCode(), 0);
+            } else {
+                inDegreeCount.put(taskDefinition.getCode(), preTasks.size());
             }
+        }
+
+        // Adds the task with zero-in-degree to the queue
+        Set<Long> visitTable = new HashSet<>();
+        Queue<Long> queue = new ArrayDeque<>();
+        for (Map.Entry<Long, Integer> entry : inDegreeCount.entrySet()) {
+            if (entry.getValue() == 0 && visitTable.add(entry.getKey())) {
+                queue.offer(entry.getKey());
+            }
+        }
+
+        // topology sort
+        Set<Long> resultTable = new HashSet<>();
+        while (!queue.isEmpty()) {
+            Long taskCode = queue.poll();
+            resultTable.add(taskCode);
+
+            List<Long> postCodes = postTaskCodeMap.get(taskCode);
+            if (postCodes == null) {
+                continue;
+            }
+            for (Long postCode : postCodes) {
+                inDegreeCount.put(postCode, inDegreeCount.get(postCode) - 1);
+
+                if (inDegreeCount.get(postCode) == 0) {
+                    queue.offer(postCode);
+                }
+            }
+        }
+
+        if (resultTable.size() < taskDefinitions.size()) {
+            throw new IllegalArgumentException("The workflow task relation is not a DAG");
         }
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
@@ -19,16 +19,15 @@ package org.apache.dolphinscheduler.server.master.engine.graph;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.apache.dolphinscheduler.common.graph.DAG;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -61,57 +60,18 @@ public class WorkflowGraph implements IWorkflowGraph {
     }
 
     private void checkIfDAG(List<WorkflowTaskRelation> workflowTaskRelations, List<TaskDefinition> taskDefinitions) {
-        // If topology-sort-result`s size less than taskDefinitions`s size, then not a DAG
-        Map<Long, List<Long>> preTaskCodeMap = workflowTaskRelations
-                .stream()
-                .collect(Collectors.groupingBy(WorkflowTaskRelation::getPostTaskCode,
-                        Collectors.mapping(WorkflowTaskRelation::getPreTaskCode, Collectors.toList())));
-        Map<Long, List<Long>> postTaskCodeMap = workflowTaskRelations
-                .stream()
-                .collect(Collectors.groupingBy(WorkflowTaskRelation::getPreTaskCode,
-                        Collectors.mapping(WorkflowTaskRelation::getPostTaskCode, Collectors.toList())));
-
-        // build in-degree count
-        Map<Long, Integer> inDegreeCount = new HashMap<>();
+        DAG<Long, TaskDefinition, WorkflowTaskRelation> graph = new DAG<>();
+        // Fill the vertices
         for (TaskDefinition taskDefinition : taskDefinitions) {
-            List<Long> preTasks = preTaskCodeMap.get(taskDefinition.getCode());
-            if (preTasks == null) {
-                inDegreeCount.put(taskDefinition.getCode(), 0);
-            } else {
-                inDegreeCount.put(taskDefinition.getCode(), preTasks.size());
-            }
+            graph.addNode(taskDefinition.getCode(), taskDefinition);
         }
-
-        // Adds the task with zero-in-degree to the queue
-        Set<Long> visitTable = new HashSet<>();
-        Queue<Long> queue = new ArrayDeque<>();
-        for (Map.Entry<Long, Integer> entry : inDegreeCount.entrySet()) {
-            if (entry.getValue() == 0 && visitTable.add(entry.getKey())) {
-                queue.offer(entry.getKey());
+        // Fill edge relations
+        for (WorkflowTaskRelation relation : workflowTaskRelations) {
+            long preTaskCode = relation.getPreTaskCode();
+            // When exist a ring cycle, then not a DAG.
+            if (preTaskCode != 0 && !graph.addEdge(preTaskCode, relation.getPostTaskCode())) {
+                throw new IllegalArgumentException("The workflow graph is not a DAG");
             }
-        }
-
-        // topology sort
-        Set<Long> resultTable = new HashSet<>();
-        while (!queue.isEmpty()) {
-            Long taskCode = queue.poll();
-            resultTable.add(taskCode);
-
-            List<Long> postCodes = postTaskCodeMap.get(taskCode);
-            if (postCodes == null) {
-                continue;
-            }
-            for (Long postCode : postCodes) {
-                inDegreeCount.put(postCode, inDegreeCount.get(postCode) - 1);
-
-                if (inDegreeCount.get(postCode) == 0) {
-                    queue.offer(postCode);
-                }
-            }
-        }
-
-        if (resultTable.size() < taskDefinitions.size()) {
-            throw new IllegalArgumentException("The workflow task relation is not a DAG");
         }
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
@@ -17,19 +17,21 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WorkflowGraph implements IWorkflowGraph {
 
@@ -43,6 +45,7 @@ public class WorkflowGraph implements IWorkflowGraph {
     public WorkflowGraph(List<WorkflowTaskRelation> workflowTaskRelations, List<TaskDefinition> taskDefinitions) {
         checkNotNull(taskDefinitions, "taskDefinitions can not be null");
         checkNotNull(workflowTaskRelations, "taskDefinitions can not be null");
+        checkIfDAG(workflowTaskRelations, taskDefinitions);
         this.predecessors = new HashMap<>();
         this.successors = new HashMap<>();
 
@@ -55,6 +58,61 @@ public class WorkflowGraph implements IWorkflowGraph {
 
         addTaskNodes(taskDefinitions);
         addTaskEdge(workflowTaskRelations);
+    }
+
+    private void checkIfDAG(List<WorkflowTaskRelation> workflowTaskRelations, List<TaskDefinition> taskDefinitions) {
+        //If topology-sort-result`s size less than taskDefinitions`s size, then not a DAG
+        Map<Long, List<Long>> preTaskCodeMap = workflowTaskRelations
+                .stream()
+                .collect(Collectors.groupingBy(WorkflowTaskRelation::getPostTaskCode,
+                        Collectors.mapping(WorkflowTaskRelation::getPreTaskCode, Collectors.toList())));
+        Map<Long, List<Long>> postTaskCodeMap = workflowTaskRelations
+                .stream()
+                .collect(Collectors.groupingBy(WorkflowTaskRelation::getPreTaskCode,
+                        Collectors.mapping(WorkflowTaskRelation::getPostTaskCode, Collectors.toList())));
+
+        // build in-degree count
+        Map<Long, Integer> inDegreeCount = new HashMap<>();
+        for (TaskDefinition taskDefinition : taskDefinitions) {
+            List<Long> preTasks = preTaskCodeMap.get(taskDefinition.getCode());
+            if (preTasks == null) {
+                inDegreeCount.put(taskDefinition.getCode(), 0);
+            } else {
+                inDegreeCount.put(taskDefinition.getCode(), preTasks.size());
+            }
+        }
+
+        // Adds the task with zero-in-degree to the queue
+        Set<Long> visitTable = new HashSet<>();
+        Queue<Long> queue = new ArrayDeque<>();
+        for (Map.Entry<Long, Integer> entry : inDegreeCount.entrySet()) {
+            if (entry.getValue() == 0 && visitTable.add(entry.getKey())) {
+                queue.offer(entry.getKey());
+            }
+        }
+
+        // topology sort
+        Set<Long> resultTable = new HashSet<>();
+        while (!queue.isEmpty()) {
+            Long taskCode = queue.poll();
+            resultTable.add(taskCode);
+
+            List<Long> postCodes = postTaskCodeMap.get(taskCode);
+            if (postCodes == null) {
+                continue;
+            }
+            for (Long postCode : postCodes) {
+                inDegreeCount.put(postCode, inDegreeCount.get(postCode) - 1);
+
+                if (inDegreeCount.get(postCode) == 0) {
+                    queue.offer(postCode);
+                }
+            }
+        }
+
+        if (resultTable.size() < taskDefinitions.size()) {
+            throw new IllegalArgumentException("The workflow task relation is not a DAG");
+        }
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
@@ -30,8 +32,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WorkflowGraph implements IWorkflowGraph {
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraph.java
@@ -17,8 +17,6 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
@@ -32,6 +30,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WorkflowGraph implements IWorkflowGraph {
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
@@ -1,14 +1,31 @@
-package org.apache.dolphinscheduler.server.master.engine.graph;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.apache.dolphinscheduler.server.master.engine.graph;
 
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class WorkflowGraphCheckIfDAGTest {
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
-
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
+
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
@@ -1,0 +1,200 @@
+package org.apache.dolphinscheduler.server.master.engine.graph;
+
+
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WorkflowGraphCheckIfDAGTest {
+
+    private List<TaskDefinition> taskDefinitions;
+    private List<WorkflowTaskRelation> workflowTaskRelations;
+
+    @BeforeEach
+    public void setUp() {
+        taskDefinitions = new ArrayList<>();
+        workflowTaskRelations = new ArrayList<>();
+    }
+
+    @Test
+    public void checkIfDAGSingleTaskNoException() {
+        TaskDefinition taskDefinition = new TaskDefinition(1L, 1);
+        taskDefinitions.add(taskDefinition);
+
+        Assertions.assertDoesNotThrow(() -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
+    }
+
+    @Test
+    public void checkIfDAGSimpleDAGNoException() {
+        TaskDefinition task1 = new TaskDefinition(1L, 1);
+        task1.setName("task1");
+        TaskDefinition task2 = new TaskDefinition(2L, 1);
+        task2.setName("task2");
+        taskDefinitions.add(task1);
+        taskDefinitions.add(task2);
+
+        WorkflowTaskRelation relation = new WorkflowTaskRelation();
+        relation.setPreTaskCode(1L);
+        relation.setPreTaskVersion(1);
+        relation.setPostTaskCode(2L);
+        relation.setPostTaskVersion(1);
+        workflowTaskRelations.add(relation);
+
+        Assertions.assertDoesNotThrow(() -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
+    }
+
+    @Test
+    public void checkIfDAGCycleThrowsException() {
+        TaskDefinition task1 = new TaskDefinition(1L, 1);
+        TaskDefinition task2 = new TaskDefinition(2L, 1);
+        taskDefinitions.add(task1);
+        taskDefinitions.add(task2);
+
+        WorkflowTaskRelation relation1 = new WorkflowTaskRelation();
+        relation1.setPreTaskCode(1L);
+        relation1.setPreTaskVersion(1);
+        relation1.setPostTaskCode(2L);
+        relation1.setPostTaskVersion(1);
+        WorkflowTaskRelation relation2 = new WorkflowTaskRelation();
+        relation2.setPreTaskCode(2L);
+        relation2.setPreTaskVersion(1);
+        relation2.setPostTaskCode(1L);
+        relation2.setPostTaskVersion(1);
+        workflowTaskRelations.add(relation1);
+        workflowTaskRelations.add(relation2);
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
+    }
+
+    @Test
+    public void checkIfDAGMultipleZeroInDegreeNoException() {
+        TaskDefinition task1 = new TaskDefinition(1L, 1);
+        task1.setName("task1");
+        TaskDefinition task2 = new TaskDefinition(2L, 1);
+        task2.setName("task2");
+        TaskDefinition task3 = new TaskDefinition(3L, 1);
+        task3.setName("task3");
+        taskDefinitions.add(task1);
+        taskDefinitions.add(task2);
+        taskDefinitions.add(task3);
+
+        WorkflowTaskRelation relation1 = new WorkflowTaskRelation();
+        relation1.setPreTaskCode(1L);
+        relation1.setPreTaskVersion(1);
+        relation1.setPostTaskCode(2L);
+        relation1.setPostTaskVersion(1);
+        WorkflowTaskRelation relation2 = new WorkflowTaskRelation();
+        relation2.setPreTaskCode(1L);
+        relation2.setPreTaskVersion(1);
+        relation2.setPostTaskCode(3L);
+        relation2.setPostTaskVersion(1);
+        workflowTaskRelations.add(relation1);
+        workflowTaskRelations.add(relation2);
+
+        Assertions.assertDoesNotThrow(() -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
+    }
+
+    @Test
+    public void checkIfDAGComplexDAGNoException() {
+        TaskDefinition task1 = new TaskDefinition(1L, 1);
+        task1.setName("task1");
+        TaskDefinition task2 = new TaskDefinition(2L, 1);
+        task2.setName("task2");
+        TaskDefinition task3 = new TaskDefinition(3L, 1);
+        task3.setName("task3");
+        TaskDefinition task4 = new TaskDefinition(4L, 1);
+        task4.setName("task4");
+        taskDefinitions.add(task1);
+        taskDefinitions.add(task2);
+        taskDefinitions.add(task3);
+        taskDefinitions.add(task4);
+
+        WorkflowTaskRelation relation1 = new WorkflowTaskRelation();
+        relation1.setPreTaskCode(1L);
+        relation1.setPreTaskVersion(1);
+        relation1.setPostTaskCode(2L);
+        relation1.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation2 = new WorkflowTaskRelation();
+        relation2.setPreTaskCode(1L);
+        relation2.setPreTaskVersion(1);
+        relation2.setPostTaskCode(3L);
+        relation2.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation3 = new WorkflowTaskRelation();
+        relation3.setPreTaskCode(2L);
+        relation3.setPreTaskVersion(1);
+        relation3.setPostTaskCode(4L);
+        relation3.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation4 = new WorkflowTaskRelation();
+        relation4.setPreTaskCode(3L);
+        relation4.setPreTaskVersion(1);
+        relation4.setPostTaskCode(4L);
+        relation4.setPostTaskVersion(1);
+
+        workflowTaskRelations.add(relation1);
+        workflowTaskRelations.add(relation2);
+        workflowTaskRelations.add(relation3);
+        workflowTaskRelations.add(relation4);
+
+        Assertions.assertDoesNotThrow(() -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
+    }
+
+    @Test
+    public void checkIfDAGComplexDAGThrowsException() {
+        TaskDefinition task1 = new TaskDefinition(1L, 1);
+        TaskDefinition task2 = new TaskDefinition(2L, 1);
+        TaskDefinition task3 = new TaskDefinition(3L, 1);
+        TaskDefinition task4 = new TaskDefinition(4L, 1);
+        taskDefinitions.add(task1);
+        taskDefinitions.add(task2);
+        taskDefinitions.add(task3);
+        taskDefinitions.add(task4);
+
+        WorkflowTaskRelation relation1 = new WorkflowTaskRelation();
+        relation1.setPreTaskCode(1L);
+        relation1.setPreTaskVersion(1);
+        relation1.setPostTaskCode(2L);
+        relation1.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation2 = new WorkflowTaskRelation();
+        relation2.setPreTaskCode(1L);
+        relation2.setPreTaskVersion(1);
+        relation2.setPostTaskCode(3L);
+        relation2.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation3 = new WorkflowTaskRelation();
+        relation3.setPreTaskCode(2L);
+        relation3.setPreTaskVersion(1);
+        relation3.setPostTaskCode(4L);
+        relation3.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation4 = new WorkflowTaskRelation();
+        relation4.setPreTaskCode(3L);
+        relation4.setPreTaskVersion(1);
+        relation4.setPostTaskCode(4L);
+        relation4.setPostTaskVersion(1);
+
+        WorkflowTaskRelation relation5 = new WorkflowTaskRelation();
+        relation5.setPreTaskCode(4L);
+        relation5.setPreTaskVersion(1);
+        relation5.setPostTaskCode(3L);
+        relation5.setPostTaskVersion(1);
+
+        workflowTaskRelations.add(relation1);
+        workflowTaskRelations.add(relation2);
+        workflowTaskRelations.add(relation3);
+        workflowTaskRelations.add(relation4);
+        workflowTaskRelations.add(relation5);
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
+    }
+}

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowGraphCheckIfDAGTest.java
@@ -43,6 +43,11 @@ public class WorkflowGraphCheckIfDAGTest {
         TaskDefinition taskDefinition = new TaskDefinition(1L, 1);
         taskDefinitions.add(taskDefinition);
 
+        WorkflowTaskRelation relation = new WorkflowTaskRelation();
+        relation.setPreTaskCode(0);
+        relation.setPostTaskCode(1);
+        workflowTaskRelations.add(relation);
+
         Assertions.assertDoesNotThrow(() -> new WorkflowGraph(workflowTaskRelations, taskDefinitions));
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
Check if the WorkflowGrapth is a dag close #17057

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
Conclusion: A graph is not a DAG if its task length is less than the total number of tasks after topological sorting

## Verify this pull request

<!--*(Please pick either of the following options)*-->


This change added tests and can be verified as follows: 

- WorkflowGraphCheckIfDAGTest

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
