### PR TITLE
[Chore] Add notification in asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -55,3 +55,9 @@ github:
         required_approving_review_count: 2
   features:
     discussions: true
+
+notifications:
+  commits: commits@dolphinscheduler.apache.org
+  issues: commits@dolphinscheduler.apache.org
+  pullrequests: commits@dolphinscheduler.apache.org
+  discussions: commits@dolphinscheduler.apache.org


### PR DESCRIPTION
we try to recover discussion in #17069 but when I merged into master, I got error email

```
An error occurred while processing the github feature in .asf.yaml:

GitHub discussions can only be enabled if a mailing list target exists for it.
```

I check and find we should also add `notification` section to make it effect, according to https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#repository-features

so this patch it to correct #17069

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
