### PR TITLE
[Fix-17073]Fix DataSource/JDBC connection failure

### DIFF
--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-kyuubi/src/main/java/org/apache/dolphinscheduler/plugin/datasource/kyuubi/param/KyuubiDataSourceProcessor.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-kyuubi/src/main/java/org/apache/dolphinscheduler/plugin/datasource/kyuubi/param/KyuubiDataSourceProcessor.java
@@ -112,7 +112,7 @@ public class KyuubiDataSourceProcessor extends AbstractDataSourceProcessor {
         String jdbcUrl = kyuubiConnectionParam.getJdbcUrl();
 
         if (MapUtils.isNotEmpty(kyuubiConnectionParam.getOther())) {
-            return jdbcUrl + "?" + transformOther(kyuubiConnectionParam.getOther());
+            return jdbcUrl + ";" + transformOther(kyuubiConnectionParam.getOther());
         }
         return jdbcUrl;
     }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-kyuubi/src/test/java/org/apache/dolphinscheduler/plugin/datasource/kyuubi/param/KyuubiDataSourceProcessorTest.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-kyuubi/src/test/java/org/apache/dolphinscheduler/plugin/datasource/kyuubi/param/KyuubiDataSourceProcessorTest.java
@@ -136,7 +136,7 @@ public class KyuubiDataSourceProcessorTest {
         Map<String, String> other = new HashMap<>();
         other.put("serverTimezone", "Asia/Shanghai");
         connectionParam.setOther(other);
-        Assertions.assertEquals("jdbc:kyuubi://localhost1:5142,localhost2:5142/default?serverTimezone=Asia/Shanghai",
+        Assertions.assertEquals("jdbc:kyuubi://localhost1:5142,localhost2:5142/default;serverTimezone=Asia/Shanghai",
                 kyuubiDatasourceProcessor.getJdbcUrl(connectionParam));
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

[Bug][DataSource] kyuubi ha connection #17073](https://github.com/apache/dolphinscheduler/issues/17073)


## Purpose of the pull request

This Pull Request fixes a bug that fail JDBC connection to Hive, specifically due to an issue with the constructed JDBC URL, and aims to close https://github.com/apache/dolphinscheduler/issues/17073.



## Brief change log

Modified the getJdbcUrl method to use a (;) instead of (?) to separate base URL from the connection parameters.
<img width="824" alt="Screenshot 2025-03-25 at 12 40 14 AM" src="https://github.com/user-attachments/assets/f77c3073-d65a-469c-a2e0-9d3a277812cf" />

also updated its corresponding test case to pass this change i.e. testGetJdbcUrl() method in KyuubiDataSourceProcessorTest class 
<img width="977" alt="Screenshot 2025-03-25 at 1 18 08 AM" src="https://github.com/user-attachments/assets/95e993f1-e6c7-444d-b476-c7e7371250a7" />



## Verify this pull request
This pull request is already covered by existing tests, such as:
KyuubiDataSourceProcessorTest class 

fix issue: kyuubi ha connection #17073

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
