### PR TITLE
[Fix-17111][registry] Fix zookeeper registry start failed message. 

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperRegistry.java
@@ -107,7 +107,7 @@ final class ZookeeperRegistry implements Registry {
                 client.close();
                 throw new RegistryException(
                         "zookeeper connect failed to: " + properties.getConnectString() + " in : "
-                                + properties.getBlockUntilConnected() + "ms");
+                                + properties.getBlockUntilConnected().toMillis() + "ms");
             }
             stopWatch.stop();
             log.info("ZookeeperRegistry started at: {}/ms", stopWatch.getTime());


### PR DESCRIPTION


<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
close #17111

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->


This pull request is already covered by existing tests, such as *(please describe tests)*.


<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
