### PR TITLE
[Improvement-284][auth] Add generalized OIDC authentication with multi-provider support

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcAuthenticationConfig.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcAuthenticationConfig.java
@@ -1,0 +1,14 @@
+package org.apache.dolphinscheduler.api.configuration;
+
+import org.apache.dolphinscheduler.api.security.impl.sso.GenericOidcAuthenticator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OidcAuthenticationConfig {
+
+    @Bean
+    public GenericOidcAuthenticator genericOidcAuthenticator() {
+        return new GenericOidcAuthenticator();
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcAuthenticationConfig.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcAuthenticationConfig.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.api.configuration;
 
 import org.apache.dolphinscheduler.api.security.impl.sso.GenericOidcAuthenticator;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcConfiguration.java
@@ -1,0 +1,32 @@
+package org.apache.dolphinscheduler.api.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@Configuration
+@ConditionalOnProperty(prefix = "security.authentication.oidc", name = "enable", havingValue = "true")
+@ConfigurationProperties(prefix = "security.authentication.oidc")
+public class OidcConfiguration {
+
+    private Map<String, OidcProviderProperties> provider = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class OidcProviderProperties {
+        private String issuerUri;
+        private String clientId;
+        private String clientSecret;
+        private String redirectUri;
+        private String callbackUrl;
+        private String iconUri;
+        private String provider;
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcConfiguration.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/OidcConfiguration.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.api.configuration;
 
 import lombok.Getter;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoginController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoginController.java
@@ -38,6 +38,9 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.OkHttpUtils;
 import org.apache.dolphinscheduler.dao.entity.Session;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.api.configuration.OidcConfiguration;
+import org.apache.dolphinscheduler.api.security.impl.sso.GenericOidcAuthenticator;
+
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -84,6 +87,13 @@ public class LoginController extends BaseController {
 
     @Autowired
     private SessionService sessionService;
+
+    @Autowired(required = false)
+    private OidcConfiguration oidcConfiguration;
+
+    @Autowired(required = false)
+    private GenericOidcAuthenticator genericOidcAuthenticator;
+
 
     @Autowired
     private Authenticator authenticator;
@@ -206,6 +216,24 @@ public class LoginController extends BaseController {
         }).collect(Collectors.toList());
         return Result.success(providers);
     }
+    @SneakyThrows
+    @Operation(summary = "redirectToOidc", description = "REDIRECT_TO_OIDC_LOGIN")
+    @GetMapping("redirect/login/oidc")
+    public void loginByOidc(@RequestParam String code, @RequestParam String provider,
+                            HttpServletRequest request, HttpServletResponse response) {
+        try {
+            User user = ((GenericOidcAuthenticator) authenticator).login(provider, code);
+            Session session = sessionService.createSessionIfAbsent(user);
+            response.setStatus(HttpStatus.SC_MOVED_TEMPORARILY);
+            response.sendRedirect(String.format("%s?sessionId=%s&authType=oidc",
+                    oidcConfiguration.getProvider().get(provider).getCallbackUrl(), session.getId()));
+        } catch (Exception ex) {
+            log.error("OIDC Login failed", ex);
+            response.sendRedirect(String.format("%s?authType=oidc&error=auth_failed",
+                    oidcConfiguration.getProvider().get(provider).getCallbackUrl()));
+        }
+    }
+
 
     @SneakyThrows
     @Operation(summary = "redirectToOauth2", description = "REDIRECT_TO_OAUTH2_LOGIN")

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/Authenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/Authenticator.java
@@ -43,5 +43,5 @@ public interface Authenticator {
      * @param request http servlet request
      * @return user
      */
-    User getAuthUser(HttpServletRequest request);
+    User getAuthUser(HttpServletRequest re`quest);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/CasdoorOidcService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/CasdoorOidcService.java
@@ -1,0 +1,29 @@
+package org.apache.dolphinscheduler.api.security.impl.sso;
+
+import lombok.RequiredArgsConstructor;
+import org.casbin.casdoor.entity.CasdoorUser;
+import org.casbin.casdoor.service.CasdoorAuthService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CasdoorOidcService implements OidcService {
+
+    private final CasdoorAuthService casdoorAuthService;
+
+    @Override
+    public String getToken(String code, String state) {
+        return casdoorAuthService.getOAuthToken(code, state);
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo(String token) {
+        CasdoorUser casdoorUser = casdoorAuthService.parseJwtToken(token);
+        return new OidcUserInfo(casdoorUser.getName(), casdoorUser.getEmail());
+    }
+
+    @Override
+    public String getSignInUrl(String redirectUrl, String state) {
+        return casdoorAuthService.getSigninUrl(redirectUrl, state);
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/CasdoorOidcService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/CasdoorOidcService.java
@@ -1,3 +1,20 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dolphinscheduler.api.security.impl.sso;
 
 import lombok.RequiredArgsConstructor;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/GenericOidcAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/GenericOidcAuthenticator.java
@@ -1,0 +1,73 @@
+package org.apache.dolphinscheduler.api.security.impl.sso;
+
+import org.apache.dolphinscheduler.api.security.impl.AbstractSsoAuthenticator;
+import org.apache.dolphinscheduler.api.service.UsersService;
+import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.User;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.security.MessageDigest;
+import java.util.function.Function;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class GenericOidcAuthenticator extends AbstractSsoAuthenticator {
+
+    @Autowired
+    private UsersService usersService;
+
+    @Value("${security.authentication.oidc.redirect-url}")
+    private String redirectUrl;
+
+    @Value("${security.authentication.oidc.user.admin:#{null}}")
+    private String adminUserName;
+
+    @Autowired
+    private OidcService oidcService;
+
+    @Override
+    public User login(@NonNull String userName, String code) {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        String originalState = (String) request.getSession().getAttribute(Constants.SSO_LOGIN_USER_STATE);
+        request.getSession().setAttribute(Constants.SSO_LOGIN_USER_STATE, null);
+
+        if (originalState == null || !MessageDigest.isEqual(originalState.getBytes(), userName.getBytes())) {
+            log.warn("CSRF State validation failed");
+            return null;
+        }
+
+        String token = oidcService.getToken(code, userName);
+        OidcUserInfo userInfo = oidcService.getUserInfo(token);
+        if (userInfo == null || userInfo.getUsername() == null) {
+            log.warn("OIDC login failed, userInfo missing");
+            return null;
+        }
+
+        User user = usersService.getUserByUserName(userInfo.getUsername());
+        if (user == null) {
+            user = usersService.createUser(getUserType(userInfo.getUsername()), userInfo.getUsername(), userInfo.getEmail());
+        }
+
+        return user;
+    }
+
+    public UserType getUserType(String userName) {
+        return adminUserName != null && adminUserName.equalsIgnoreCase(userName) ? UserType.ADMIN_USER : UserType.GENERAL_USER;
+    }
+
+    @Override
+    public String getSignInUrl(String state) {
+        return oidcService.getSignInUrl(redirectUrl, state);
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/GenericOidcAuthenticator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/GenericOidcAuthenticator.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.api.security.impl.sso;
 
 import org.apache.dolphinscheduler.api.security.impl.AbstractSsoAuthenticator;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcService.java
@@ -1,0 +1,7 @@
+package org.apache.dolphinscheduler.api.security.impl.sso;
+
+public interface OidcService {
+    String getToken(String code, String state);
+    OidcUserInfo getUserInfo(String token);
+    String getSignInUrl(String redirectUrl, String state);
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcService.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.api.security.impl.sso;
 
 public interface OidcService {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcUserInfo.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcUserInfo.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.api.security.impl.sso;
 
 import lombok.AllArgsConstructor;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcUserInfo.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/security/impl/sso/OidcUserInfo.java
@@ -1,0 +1,11 @@
+package org.apache.dolphinscheduler.api.security.impl.sso;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class OidcUserInfo {
+    private String username;
+    private String email;
+}

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -170,6 +170,25 @@ metrics:
 
 security:
   authentication:
+    oidc:
+      enable: true
+      provider:
+        keycloak:
+          issuer-uri: "https://keycloak.example.com/realms/myrealm"
+          client-id: "dolphinscheduler-client"
+          client-secret: "your-client-secret"
+          redirect-uri: "http://localhost:12345/dolphinscheduler/redirect/login/oidc"
+          callback-url: "http://localhost:5173/login"
+          icon-uri: "https://www.keycloak.org/resources/images/keycloak-icon.png"
+          provider: keycloak
+        dex:
+          issuer-uri: "https://dex.example.com"
+          client-id: "dolphinscheduler-client"
+          client-secret: "your-client-secret"
+          redirect-uri: "http://localhost:12345/dolphinscheduler/redirect/login/oidc"
+          callback-url: "http://localhost:5173/login"
+          icon-uri: "https://dexidp.io/images/dex-logo.svg"
+          provider: dex
     # Authentication types (supported types: PASSWORD,LDAP,CASDOOR_SSO)
     type: PASSWORD
     # IF you set type `LDAP`, below config will be effective


### PR DESCRIPTION
GSoC 2025
- Introduced pluggable OIDC support that integrates with multiple Identity Providers (IdPs) such as Keycloak and Dex for generalized SSO.
- Implemented GenericOidcAuthenticator to dynamically manage authentication for any OIDC-compliant provider.
- Added utility classes:
                  OidcService: Handles token exchange and user session handling.
                 OidcUserInfo: Extracts user info from ID token.
- Created configuration classes:
                       OidcConfiguration
                        OidcAuthenticationConfig These allow dynamic provider setup via application.yaml.
- Modified LoginController.java to:
                     Redirect to the appropriate OIDC provider based on request.
                      Handle callback, extract user info, create session, and redirect back with session ID.