### PR TITLE
feat: Add K8sClientPool Support

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sClientPool.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sClientPool.java
@@ -39,9 +39,13 @@ public class K8sClientPool {
     }
 
     public static void removeClient(String server) {
-        KubernetesClient client = clientMap.get(server);
+        KubernetesClient client = clientMap.remove(server);
         if (client != null) {
-            client.close();
+            try {
+                client.close();
+            } catch (Exception e) {
+                throw new RuntimeException("fail to remove client",e);
+            }
         }
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sClientPool.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sClientPool.java
@@ -14,15 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.plugin.task.api.k8s.pool;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public class K8sClientPool {
 
@@ -34,8 +35,7 @@ public class K8sClientPool {
 
         return clientMap.computeIfAbsent(
                 server,
-                key -> createClient(configYml)
-        );
+                key -> createClient(configYml));
     }
 
     public static void removeClient(String server) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sClientPool.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sClientPool.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dolphinscheduler.plugin.task.api.k8s.pool;
+
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class K8sClientPool {
+
+    private static final ConcurrentMap<String, KubernetesClient> clientMap = new ConcurrentHashMap<>();
+
+    public static KubernetesClient getClient(String configYml) {
+
+        String server = getMasterUrl(configYml);
+
+        return clientMap.computeIfAbsent(
+                server,
+                key -> createClient(configYml)
+        );
+    }
+
+    public static void removeClient(String server) {
+        KubernetesClient client = clientMap.get(server);
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    public static void shutdown() {
+        clientMap.values().forEach(Client::close);
+        clientMap.clear();
+    }
+
+    private static String getMasterUrl(String configYml) {
+        return Config.fromKubeconfig(configYml).getMasterUrl();
+    }
+
+    private static KubernetesClient createClient(String configYml) {
+        Config config = Config.fromKubeconfig(configYml);
+
+        return new KubernetesClientBuilder()
+                .withConfig(config)
+                .build();
+    }
+
+    private static boolean clientExist(String server) {
+        return clientMap.containsKey(server);
+    }
+
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sExecutor.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dolphinscheduler.plugin.task.api.k8s.pool;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.dolphinscheduler.plugin.task.api.TaskException;
+
+public class K8sExecutor {
+
+    private static String clusterServer;
+
+    public void createJob(String namespace, Job job) {
+
+        KubernetesClient client;
+
+        try {
+            client = K8sClientPool.getClient(clusterServer);
+
+            client.batch()
+                    .v1()
+                    .jobs()
+                    .inNamespace(namespace)
+                    .create(job);
+
+        } catch (Exception e) {
+            throw new TaskException("fail to create job", e);
+        }
+    }
+
+    public boolean jobExists(String namespace, String jobName) {
+
+        KubernetesClient client;
+
+        try {
+            client = K8sClientPool.getClient(clusterServer);
+
+            Job job = client.batch()
+                    .v1()
+                    .jobs()
+                    .inNamespace(namespace)
+                    .withName(jobName)
+                    .get();
+
+            return job != null;
+        } catch (Exception e) {
+            throw new TaskException("fail to check job: ", e);
+        }
+    }
+
+    public void deleteJob(String namespace, String jobName) {
+
+        KubernetesClient client;
+
+        try {
+            client = K8sClientPool.getClient(clusterServer);
+
+            client.batch()
+                    .v1()
+                    .jobs()
+                    .inNamespace(namespace)
+                    .withName(jobName)
+                    .delete();
+        } catch (Exception e) {
+            throw new TaskException("fail to delete job", e);
+        }
+    }
+
+    public void buildClient(String configYml) {
+        clusterServer = getMasterUrl(configYml);
+    }
+
+    private static String getMasterUrl(String configYml) {
+        return Config.fromKubeconfig(configYml).getMasterUrl();
+    }
+
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sExecutor.java
@@ -14,23 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.plugin.task.api.k8s.pool;
 
-import io.fabric8.kubernetes.api.model.batch.v1.Job;
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.dolphinscheduler.plugin.task.api.TaskException;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.client.KubernetesClient;
 
 public class K8sExecutor {
 
-    private static String clusterServer;
+    private String configYml;
+
+    public K8sExecutor(String configYml) {
+        this.configYml = configYml;
+    }
 
     public void createJob(String namespace, Job job) {
 
         KubernetesClient client;
 
         try {
-            client = K8sClientPool.getClient(clusterServer);
+            client = K8sClientPool.getClient(configYml);
 
             client.batch()
                     .v1()
@@ -48,7 +53,7 @@ public class K8sExecutor {
         KubernetesClient client;
 
         try {
-            client = K8sClientPool.getClient(clusterServer);
+            client = K8sClientPool.getClient(configYml);
 
             Job job = client.batch()
                     .v1()
@@ -68,7 +73,7 @@ public class K8sExecutor {
         KubernetesClient client;
 
         try {
-            client = K8sClientPool.getClient(clusterServer);
+            client = K8sClientPool.getClient(configYml);
 
             client.batch()
                     .v1()
@@ -79,14 +84,6 @@ public class K8sExecutor {
         } catch (Exception e) {
             throw new TaskException("fail to delete job", e);
         }
-    }
-
-    public void buildClient(String configYml) {
-        clusterServer = getMasterUrl(configYml);
-    }
-
-    private static String getMasterUrl(String configYml) {
-        return Config.fromKubeconfig(configYml).getMasterUrl();
     }
 
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/k8s/pool/K8sExecutor.java
@@ -64,7 +64,7 @@ public class K8sExecutor {
 
             return job != null;
         } catch (Exception e) {
-            throw new TaskException("fail to check job: ", e);
+            throw new TaskException("fail to check job", e);
         }
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

This project aims to add K8s connection pool support to DolphinScheduler to enhance the utilization of K8s connections in the worker module. It also enables the worker to perform operations on a single K8s cluster using a shared K8s connection.
This pr is related to this issue https://github.com/apache/dolphinscheduler/issues/17128

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

Currently, two classes have been developed. Among them, K8sClientPool acts as a connection pool, maintaining a Map<String, KubernetesClient> where the cluster’s masterUrl is used to identify each cluster. Each cluster shares a single K8sClient. The other class, K8sExecutor, corresponds to the previous K8sUtils. However, instead of creating and maintaining a separate connection for each task as in the past, connections are now obtained from the connection pool.

As a connection pool, K8sClientPool implements connection creation, retrieval, graceful shutdown, and health checks for the pool. In the future, more features will be added based on the requirements of the production environment.

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
