### PR TITLE
[Improvement-16767] Takeover sub-workflow in sub-workflow-task

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.common.enums;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -91,6 +92,10 @@ public enum WorkflowExecutionStatus {
         return this == RUNNING_EXECUTION
                 || this == READY_PAUSE
                 || this == SERIAL_WAIT;
+    }
+
+    public boolean canFailover() {
+        return Arrays.stream(NEED_FAILOVER_STATES).anyMatch(x -> x == this.getCode());
     }
 
     public boolean canDirectPauseInDB() {

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
@@ -57,6 +57,15 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
                                                 @Param("states") int[] stateArray);
 
     /**
+     * query workflow instance by host and stateArray which is not sub workflow
+     *
+     * @param host       host
+     * @param stateArray stateArray
+     * @return workflow instance list
+     */
+    List<WorkflowInstance> queryMainWorkflowByHostAndStatus(@Param("host") String host,
+                                                            @Param("states") int[] stateArray);
+    /**
      * query workflow instance host by stateArray
      *
      * @param stateArray

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
@@ -170,7 +170,7 @@ public class WorkflowInstanceDaoImpl extends BaseDao<WorkflowInstance, WorkflowI
 
     @Override
     public List<WorkflowInstance> queryNeedFailoverWorkflowInstances(String masterAddress) {
-        return mybatisMapper.queryByHostAndStatus(masterAddress,
+        return mybatisMapper.queryMainWorkflowByHostAndStatus(masterAddress,
                 WorkflowExecutionStatus.getNeedFailoverWorkflowInstanceState());
     }
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.xml
@@ -50,6 +50,22 @@
         </if>
         order by id asc
     </select>
+    <select id="queryMainWorkflowByHostAndStatus" resultType="org.apache.dolphinscheduler.dao.entity.WorkflowInstance">
+        select
+        <include refid="baseSql"/>
+        from t_ds_workflow_instance
+        where is_sub_workflow=0
+        <if test="host != null and host != ''">
+            and host=#{host}
+        </if>
+        <if test="states != null and states.length != 0">
+            and state in
+            <foreach collection="states" item="i" open="(" close=")" separator=",">
+                #{i}
+            </foreach>
+        </if>
+        order by id asc
+    </select>
     <select id="queryNeedFailoverWorkflowInstanceHost" resultType="String">
         select distinct host
         from t_ds_workflow_instance

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
@@ -40,6 +40,7 @@ import org.apache.dolphinscheduler.server.master.engine.executor.plugin.Abstract
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
 import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
+import org.apache.dolphinscheduler.server.master.failover.WorkflowFailover;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
 
@@ -148,7 +149,11 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
             return triggerNewSubWorkflow();
         }
 
-        switch (workflowExecutionRunnable.getWorkflowInstance().getCommandType()) {
+        // In some cases, workflow instance's command type has not been changed,
+        // there should better to use command.type instead
+        switch (workflowExecutionRunnable.getWorkflowExecuteContext().getCommand().getCommandType()) {
+            case RECOVER_TOLERANCE_FAULT_PROCESS:
+                return recoverFromFaultTolerantTasks();
             case RECOVER_SUSPENDED_PROCESS:
                 return recoverFromSuspendTasks();
             case START_FAILURE_TASK_PROCESS:
@@ -156,7 +161,21 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
             default:
                 return triggerNewSubWorkflow();
         }
+    }
 
+    private SubWorkflowLogicTaskRuntimeContext recoverFromFaultTolerantTasks() {
+        final WorkflowInstanceDao workflowInstanceDao = applicationContext.getBean(WorkflowInstanceDao.class);
+        final WorkflowInstance subWorkflowInstance = workflowInstanceDao.queryById(
+                subWorkflowLogicTaskRuntimeContext.getSubWorkflowInstanceId());
+
+        if (subWorkflowInstance != null && subWorkflowInstance.getState().canFailover()) {
+            // Only handle sub-workflow's fail-over in SubWorkflowLogicTask's fail-over
+            applicationContext.getBean(WorkflowFailover.class).failoverWorkflow(subWorkflowInstance);
+            return subWorkflowLogicTaskRuntimeContext;
+        }
+
+        // The sub-workflow's state is bad, trigger a new sub-workflow instance
+        return triggerNewSubWorkflow();
     }
 
     private SubWorkflowLogicTaskRuntimeContext recoverFromFailedTasks() {

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/Repository.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/Repository.java
@@ -57,6 +57,10 @@ public class Repository {
         return workflowInstanceDao.queryById(workflowInstanceId);
     }
 
+    public List<WorkflowInstance> queryAllWorkflowInstance() {
+        return workflowInstanceDao.queryAll();
+    }
+
     /**
      * Return the list of task instances for a given workflow definition in ascending order of their IDs.
      */
@@ -77,6 +81,10 @@ public class Repository {
                 .stream()
                 .sorted(Comparator.comparingInt(TaskInstance::getId))
                 .collect(Collectors.toList());
+    }
+
+    public List<TaskInstance> queryAllTaskInstance() {
+        return taskInstanceDao.queryAll();
     }
 
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
@@ -24,7 +24,6 @@ import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.entity.WorkflowInstanceRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
 import org.apache.commons.collections4.CollectionUtils;

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
@@ -24,6 +24,7 @@ import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
+import org.apache.dolphinscheduler.dao.entity.WorkflowInstanceRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -45,11 +46,15 @@ public class WorkflowTestCaseContext {
 
     private WorkflowInstance workflowInstance;
 
+    private List<WorkflowInstance> workflowInstances;
+
     private List<TaskInstance> taskInstances;
 
     private List<TaskDefinition> tasks;
 
     private List<WorkflowTaskRelation> taskRelations;
+
+    private List<WorkflowInstanceRelation> workflowInstanceRelations;
 
     private List<TaskGroup> taskGroups;
 
@@ -61,5 +66,4 @@ public class WorkflowTestCaseContext {
         }
         return workflows.get(0);
     }
-
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
@@ -54,8 +54,6 @@ public class WorkflowTestCaseContext {
 
     private List<WorkflowTaskRelation> taskRelations;
 
-    private List<WorkflowInstanceRelation> workflowInstanceRelations;
-
     private List<TaskGroup> taskGroups;
 
     private List<Environment> environments;

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
@@ -43,8 +43,6 @@ public class WorkflowTestCaseContext {
 
     private List<WorkflowDefinition> workflows;
 
-    private WorkflowInstance workflowInstance;
-
     private List<WorkflowInstance> workflowInstances;
 
     private List<TaskInstance> taskInstances;

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContextFactory.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContextFactory.java
@@ -90,9 +90,7 @@ public class WorkflowTestCaseContextFactory {
         initializeWorkflowDefinitionToDB(workflowTestCaseContext.getWorkflows());
         initializeTaskDefinitionsToDB(workflowTestCaseContext.getTasks());
         initializeTaskRelationsToDB(workflowTestCaseContext.getTaskRelations());
-        if (workflowTestCaseContext.getWorkflowInstance() != null) {
-            initializeWorkflowInstanceToDB(workflowTestCaseContext.getWorkflowInstance());
-        } else {
+        if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getWorkflowInstances())) {
             initializeWorkflowInstancesToDB(workflowTestCaseContext.getWorkflowInstances());
         }
         if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getTaskInstances())) {
@@ -111,10 +109,6 @@ public class WorkflowTestCaseContextFactory {
         for (TaskInstance taskInstance : taskInstances) {
             taskInstanceDao.insert(taskInstance);
         }
-    }
-
-    private void initializeWorkflowInstanceToDB(WorkflowInstance workflowInstance) {
-        workflowInstanceDao.insert(workflowInstance);
     }
 
     private void initializeWorkflowInstancesToDB(List<WorkflowInstance> workflowInstances) {

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContextFactory.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContextFactory.java
@@ -92,6 +92,8 @@ public class WorkflowTestCaseContextFactory {
         initializeTaskRelationsToDB(workflowTestCaseContext.getTaskRelations());
         if (workflowTestCaseContext.getWorkflowInstance() != null) {
             initializeWorkflowInstanceToDB(workflowTestCaseContext.getWorkflowInstance());
+        } else {
+            initializeWorkflowInstancesToDB(workflowTestCaseContext.getWorkflowInstances());
         }
         if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getTaskInstances())) {
             initializeTaskInstancesToDB(workflowTestCaseContext.getTaskInstances());
@@ -113,6 +115,12 @@ public class WorkflowTestCaseContextFactory {
 
     private void initializeWorkflowInstanceToDB(WorkflowInstance workflowInstance) {
         workflowInstanceDao.insert(workflowInstance);
+    }
+
+    private void initializeWorkflowInstancesToDB(List<WorkflowInstance> workflowInstances) {
+        for (WorkflowInstance workflowInstance : workflowInstances) {
+            workflowInstanceDao.insert(workflowInstance);
+        }
     }
 
     private void initializeWorkflowDefinitionToDB(final List<WorkflowDefinition> workflowDefinitions) {

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -615,4 +615,64 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         masterContainer.assertAllResourceReleased();
 
     }
+
+    @Test
+    public void testGlobalFailover_runningWorkflow_takeOverSubWorkflow() {
+        final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running")).findFirst()
+                .orElse(null);
+        final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running")).findFirst().orElse(null);
+
+        assertThat(mainWorkflow).isNotNull();
+        assertThat(subWorkflow).isNotNull();
+
+        systemEventBus.publish(GlobalMasterFailoverEvent.of(new Date()));
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryAllWorkflowInstance())
+                            .hasSize(2)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(mainWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.SUCCESS);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("sub_workflow_task");
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(subWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.SUCCESS);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("fake_task_A");
+                            });
+                });
+
+        assertThat(repository.queryAllTaskInstance()).hasSize(4);
+
+        masterContainer.assertAllResourceReleased();
+
+    }
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceRecoverFailureTaskTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceRecoverFailureTaskTestCase.java
@@ -52,7 +52,7 @@ public class WorkflowInstanceRecoverFailureTaskTestCase extends AbstractMasterIn
         final String yaml = "/it/recover_failure_tasks/failure_workflow_with_two_serial_fake_task.yaml";
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
 
-        final Integer workflowInstanceId = context.getWorkflowInstance().getId();
+        final Integer workflowInstanceId = context.getWorkflowInstances().get(0).getId();
         workflowOperator.recoverFailureTasks(workflowInstanceId);
 
         await()
@@ -101,7 +101,7 @@ public class WorkflowInstanceRecoverFailureTaskTestCase extends AbstractMasterIn
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
         final WorkflowDefinition workflow = context.getOneWorkflow();
 
-        final Integer workflowInstanceId = context.getWorkflowInstance().getId();
+        final Integer workflowInstanceId = context.getWorkflowInstances().get(0).getId();
         workflowOperator.recoverFailureTasks(workflowInstanceId);
 
         await()

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceRecoverStopTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceRecoverStopTestCase.java
@@ -132,7 +132,7 @@ public class WorkflowInstanceRecoverStopTestCase extends AbstractMasterIntegrati
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
         final WorkflowDefinition workflow = context.getOneWorkflow();
 
-        final Integer workflowInstanceId = context.getWorkflowInstance().getId();
+        final Integer workflowInstanceId = context.getWorkflowInstances().get(0).getId();
         assertThat(workflowOperator.recoverSuspendWorkflowInstance(workflowInstanceId).isSuccess()).isTrue();
 
         await()

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceRepeatRunningTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceRepeatRunningTestCase.java
@@ -47,7 +47,7 @@ public class WorkflowInstanceRepeatRunningTestCase extends AbstractMasterIntegra
         final String yaml = "/it/repeat_running/success_workflow_with_one_fake_task_success.yaml";
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
 
-        final Integer workflowInstanceId = context.getWorkflowInstance().getId();
+        final Integer workflowInstanceId = context.getWorkflowInstances().get(0).getId();
         workflowOperator.repeatRunningWorkflowInstance(workflowInstanceId);
 
         await()
@@ -88,7 +88,7 @@ public class WorkflowInstanceRepeatRunningTestCase extends AbstractMasterIntegra
         final String yaml = "/it/repeat_running/failed_workflow_with_one_fake_task_failed.yaml";
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
 
-        final Integer workflowInstanceId = context.getWorkflowInstance().getId();
+        final Integer workflowInstanceId = context.getWorkflowInstances().get(0).getId();
         workflowOperator.repeatRunningWorkflowInstance(workflowInstanceId);
 
         await()
@@ -129,7 +129,7 @@ public class WorkflowInstanceRepeatRunningTestCase extends AbstractMasterIntegra
         final String yaml = "/it/repeat_running/success_workflow_with_task_only.yaml";
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
 
-        final Integer workflowInstanceId = context.getWorkflowInstance().getId();
+        final Integer workflowInstanceId = context.getWorkflowInstances().get(0).getId();
         workflowOperator.repeatRunningWorkflowInstance(workflowInstanceId);
 
         await()

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_dispatched_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_dispatched_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_PAUSE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_PAUSE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_failed_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_failed_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_PAUSE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_PAUSE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_paused_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_paused_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_PAUSE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_PAUSE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_submitted_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_submitted_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_PAUSE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_PAUSE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_success_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_one_success_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_PAUSE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_PAUSE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_dispatched_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_dispatched_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_STOP
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_STOP
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_failed_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_failed_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_STOP
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_STOP
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_killed_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_killed_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_STOP
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_STOP
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_submitted_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_submitted_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_STOP
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_STOP
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_success_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_one_success_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: READY_STOP
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_STOP
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_from_another_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_from_another_master.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_running-20250322201900000
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2025-03-22 20:19:00
-  endTime: null
-  runTimes: 1
-  host: "127.0.0.1:15678"
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2025-03-22 20:19:00
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_running-20250322201900000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2025-03-22 20:19:00
+    endTime: null
+    runTimes: 1
+    host: "127.0.0.1:15678"
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-03-22 20:19:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_dispatched_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_dispatched_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_failed_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_failed_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_running_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_running_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_running_fake_task_using_environment.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_running_fake_task_using_environment.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: running_workflowInstance_with_one_running_fake_task_using_environment-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: running_workflowInstance_with_one_running_fake_task_using_environment-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_submitted_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_submitted_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_success_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_one_success_fake_task.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: RUNNING_EXECUTION
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: null
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml
@@ -1,0 +1,194 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2025-04-24 00:00:00
+  updateTime: 2025-04-24 00:00:00
+
+workflows:
+  - name: workflow_with_one_sub_workflow_running
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a workflow with sub workflow task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+  - name: sub_workflow_running
+    code: 2
+    version: 1
+    projectCode: 1
+    description: This is a workflow with a fake task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: sub_workflow_task
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: fake_task_A
+    code: 2
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+
+
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 2
+    name: sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+
+
+taskInstances:
+  - id: 1
+    name: sub_workflow_task
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+  - id: 2
+    name: fake_task_A
+    taskType: LogicFakeTask
+    workflowInstanceId: 2
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 2
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 2
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+
+workflowInstanceRelations:
+  - id: 1
+    parentWorkflowInstanceId: 1
+    parentTaskInstanceId: 1
+    workflowInstanceId: 2

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml
@@ -186,9 +186,3 @@ taskRelations:
     postTaskVersion: 1
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
-
-workflowInstanceRelations:
-  - id: 1
-    parentWorkflowInstanceId: 1
-    parentTaskInstanceId: 1
-    workflowInstanceId: 2

--- a/dolphinscheduler-master/src/test/resources/it/recover_failure_tasks/failure_workflow_from_another_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/recover_failure_tasks/failure_workflow_from_another_master.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_killed-20250322201900000
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: FAILURE
-  recovery: NO
-  startTime: 2025-03-22 20:19:00
-  endTime: null
-  runTimes: 1
-  host: "127.0.0.1:15678"
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2025-03-22 20:19:00
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_killed-20250322201900000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: FAILURE
+    recovery: NO
+    startTime: 2025-03-22 20:19:00
+    endTime: null
+    runTimes: 1
+    host: "127.0.0.1:15678"
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-03-22 20:19:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/recover_failure_tasks/failure_workflow_with_two_serial_fake_task.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/recover_failure_tasks/failure_workflow_with_two_serial_fake_task.yaml
@@ -23,29 +23,29 @@ project:
   createTime: 2024-08-12 00:00:00
   updateTime: 2021-08-12 00:00:00
 
-workflowInstance:
-  id: 1
-  name: workflow_with_two_serial_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: FAILURE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: 2024-08-16 07:12:57
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_two_serial_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: FAILURE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: 2024-08-16 07:12:57
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/recover_stopped/stopped_workflow_from_another_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/recover_stopped/stopped_workflow_from_another_master.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_killed-20250322201900000
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: STOP
-  recovery: NO
-  startTime: 2025-03-22 20:19:00
-  endTime: null
-  runTimes: 1
-  host: "127.0.0.1:15678"
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2025-03-22 20:19:00
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_killed-20250322201900000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: STOP
+    recovery: NO
+    startTime: 2025-03-22 20:19:00
+    endTime: null
+    runTimes: 1
+    host: "127.0.0.1:15678"
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-03-22 20:19:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/repeat_running/failed_workflow_with_one_fake_task_failed.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/repeat_running/failed_workflow_with_one_fake_task_failed.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: FAILURE
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: 2024-08-16 07:12:57
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: FAILURE
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: 2024-08-16 07:12:57
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/repeat_running/success_workflow_with_one_fake_task_success.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/repeat_running/success_workflow_with_one_fake_task_success.yaml
@@ -36,29 +36,29 @@ workflows:
     userId: 1
     executionType: PARALLEL
 
-workflowInstance:
-  id: 1
-  name: workflow_with_one_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: SUCCESS
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: 2024-08-16 07:12:57
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_POST
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: SUCCESS
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: 2024-08-16 07:12:57
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1

--- a/dolphinscheduler-master/src/test/resources/it/repeat_running/success_workflow_with_task_only.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/repeat_running/success_workflow_with_task_only.yaml
@@ -24,29 +24,29 @@ project:
   createTime: 2024-08-12 00:00:00
   updateTime: 2021-08-12 00:00:00
 
-workflowInstance:
-  id: 1
-  name: workflow_with_two_parallel_fake_task_success-20240816071251690
-  workflowDefinitionCode: 1
-  workflowDefinitionVersion: 1
-  projectCode: 1
-  state: SUCCESS
-  recovery: NO
-  startTime: 2024-08-16 07:12:52
-  endTime: 2024-08-16 07:12:57
-  runTimes: 1
-  host: 127.0.0.1:5678
-  commandType: START_PROCESS
-  commandParam: '{"commandType":"START_PROCESS","startNodes":[1],"commandParams":[],"timeZone":"UTC"}'
-  taskDependType: TASK_ONLY
-  commandStartTime: 2024-08-16 07:12:52
-  isSubWorkflow: NO
-  executorId: 1
-  historyCmd: START_PROCESS
-  workerGroup: default
-  globalParams: '[]'
-  varPool: '[]'
-  dryRun: 0
+workflowInstances:
+  - id: 1
+    name: workflow_with_two_parallel_fake_task_success-20240816071251690
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: SUCCESS
+    recovery: NO
+    startTime: 2024-08-16 07:12:52
+    endTime: 2024-08-16 07:12:57
+    runTimes: 1
+    host: 127.0.0.1:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[1],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_ONLY
+    commandStartTime: 2024-08-16 07:12:52
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
 
 taskInstances:
   - id: 1


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #16767

## Brief change log

1. add try takeover sub-workflow in SubWorkflowTask.start() when failover, to avoid unhandled sub-workflow running in background.
2. move sub-workflow's failover into SubWorkflowTask to make sure sub-workflow's failover under control by task.

## Verify this pull request

This change added tests and can be verified as follows:

Added take-over sub-workflow in WorkflowInstanceFailoverTestCase.

@ruanwenjun