### PR TITLE
[Chore][docs] Update documentation notice content sync with website readme

### DIFF
--- a/docs/docs/en/contribute/join/document.md
+++ b/docs/docs/en/contribute/join/document.md
@@ -17,7 +17,7 @@ git clone https://github.com/<your-github-user-name>/dolphinscheduler-website
 1. Run `yarn` in the root directory to install the dependencies.
 2. Run commands to collect resources
    2.1. Run `export PROTOCOL_MODE=ssh` tells Git clone resource via SSH protocol instead of HTTPS protocol
-   2.2. Run `./scripts/prepare_docs.sh` prepare all related resources, for more information you could see [how prepare script work](HOW_PREPARE_WORK.md)
+   2.2. Run `./scripts/prepare_docs.sh` prepare all related resources, for more information you could see [how prepare script work](https://github.com/apache/dolphinscheduler-website/blob/master/HOW_PREPARE_WORK.md)
 3. Run `yarn generate` in the root directory to format and perpare the data.
 4. Run `yarn dev` in the root directory to start a local server, you will see the website in 'http://localhost:3000'.
 

--- a/docs/docs/en/contribute/join/document.md
+++ b/docs/docs/en/contribute/join/document.md
@@ -18,15 +18,15 @@ git clone https://github.com/<your-github-user-name>/dolphinscheduler-website
 2. Run commands to collect resources
    2.1. Run `export PROTOCOL_MODE=ssh` tells Git clone resource via SSH protocol instead of HTTPS protocol
    2.2. Run `./scripts/prepare_docs.sh` prepare all related resources, for more information you could see [how prepare script work](https://github.com/apache/dolphinscheduler-website/blob/master/HOW_PREPARE_WORK.md)
-3. Run `yarn generate` in the root directory to format and perpare the data.
+3. Run `yarn generate` in the root directory to format and prepare the data.
 4. Run `yarn dev` in the root directory to start a local server, you will see the website in 'http://localhost:3000'.
 
 ```
 Note: if you clone the code in Windows, not Mac or Linux. Please read the details below.
 If you execute the commands like the two steps above, you will get the exception "UnhandledPromiseRejectionWarning: Error: EPERM: operation not permitted, symlink '2.0.3' -> 'latest'".
 If you get the exception "Can't resolve 'antd' in xxx",you can run `yarn add antd` and `yarn install`.
-Because the two steps run command `./scripts/prepare_docs.sh` should Linux environment,so if you are a windwos system you can use WSL do it.
-When meeting this problem. You can run two steps in the cmd.exe as an ADMINISTRATOR MEMBER.
+Because the `./scripts/prepare_docs.sh` command requires a Linux environment, if you are on a Windows system, you can use WSL to complete this step.
+When you encounter this problem. You can run the two steps in cmd.exe as an administrator on your Windows system.
 ```
 
 5. Run `yarn build` to build source code, this will automatically generate a directory called `build`, wait for the execution to complete and into `build` directory.

--- a/docs/docs/en/contribute/join/document.md
+++ b/docs/docs/en/contribute/join/document.md
@@ -12,33 +12,33 @@ First you need to fork the document project into your own github repository, and
 git clone https://github.com/<your-github-user-name>/dolphinscheduler-website
 ```
 
-### The document environment
-
-The DolphinScheduler website is supported by [docsite](https://github.com/chengshiwen/docsite-ext)
-
-Make sure that your node version is 10+, docsite does not yet support versions higher than 10.x.
-
 ### Document build guide
 
-1. Run `npm install` in the root directory to install the dependencies.
+1. Run `yarn` in the root directory to install the dependencies.
+2. Run commands to collect resources
+   2.1. Run `export PROTOCOL_MODE=ssh` tells Git clone resource via SSH protocol instead of HTTPS protocol
+   2.2. Run `./scripts/prepare_docs.sh` prepare all related resources, for more information you could see [how prepare script work](HOW_PREPARE_WORK.md)
+3. Run `yarn generate` in the root directory to format and perpare the data.
+4. Run `yarn dev` in the root directory to start a local server, you will see the website in 'http://localhost:3000'.
 
-2. Run commands to collect resources 2.1.Run `export PROTOCOL_MODE=ssh` tells Git clone resource via SSH protocol instead of HTTPS protocol. 2.2.Run `./scripts/prepare_docs.sh` prepare all related resources, for more information you could see [how prepare script work](https://github.com/apache/dolphinscheduler-website/blob/master/HOW_PREPARE_WORK.md).
+```
+Note: if you clone the code in Windows, not Mac or Linux. Please read the details below.
+If you execute the commands like the two steps above, you will get the exception "UnhandledPromiseRejectionWarning: Error: EPERM: operation not permitted, symlink '2.0.3' -> 'latest'".
+If you get the exception "Can't resolve 'antd' in xxx",you can run `yarn add antd` and `yarn install`.
+Because the two steps run command `./scripts/prepare_docs.sh` should Linux environment,so if you are a windwos system you can use WSL do it.
+When meeting this problem. You can run two steps in the cmd.exe as an ADMINISTRATOR MEMBER.
+```
 
-3. Run `npm run start` in the root directory to start a local server, you will see the website in 'http://localhost:8080'.
+5. Run `yarn build` to build source code, this will automatically generate a directory called `build`, wait for the execution to complete and into `build` directory.
+6. Verify your change locally: `python -m SimpleHTTPServer 8000`, when your python version is 3 use :`python3 -m http.server 8000` instead.
 
-4. Run `npm run build` to build source code into dist directory.
+If you have higher version of node installed, you may consider `nvm` to allow different versions of `node` coexisting on your machine.
 
-5. Verify your change locally: `python -m SimpleHTTPServer 8000`, when your python version is 3 use :`python3 -m http.server 8000` instead.
+1. Follow the [instructions](http://nvm.sh) to install nvm
+2. Run `nvm install v18.12.1` to install node v18
+3. Run `nvm use v18.12.1` to switch the working environment to node v18
 
-If the latest version of node is installed locally, consider using `nvm` to allow different versions of `node` to run on your computer.
-
-1. Refer to the [Instructions](http://nvm.sh) to install nvm.
-
-2. Run `nvm install v10.23.1` to install node v10.
-
-3. Run `nvm use v10.23.1` to switch the current working environment to node v10.
-
-Now you can run and build the website in your local environment.
+Then you are all set to run and build the website. Follow the build instruction above for the details.
 
 ### The document specification
 

--- a/docs/docs/zh/contribute/join/document.md
+++ b/docs/docs/zh/contribute/join/document.md
@@ -26,7 +26,7 @@ git clone https://github.com/<your-github-user-name>/dolphinscheduler-website
 注意：如果您在 Windows 而非 Mac 或 Linux 中克隆代码。请阅读下面的详细信息。
 如果执行上述两个步骤中的命令，将出现异常 “UnhandledPromiseRejectionWarning.Error:”： Error： EPERM: operation not permitted, symlink ‘2.0.3’ -> ‘latest’".
 如果出现异常 “Can't resolve ‘antd’ in xxx”，你可以运行 `yarn add antd` 和 `yarn install`。
-因为这两个步骤运行的命令`./scripts/prepare_docs.sh`应该是 Linux 环境，所以如果你是 windwos 系统，可以使用 WSL 来完成。
+因为这两个步骤运行的命令`./scripts/prepare_docs.sh`应该是 Linux 环境，所以如果你是 Windows 系统，可以使用 WSL 来完成。
 遇到这个问题时。你可以以管理员身份运行 cmd.exe 中的两个步骤。
 ```
 

--- a/docs/docs/zh/contribute/join/document.md
+++ b/docs/docs/zh/contribute/join/document.md
@@ -12,31 +12,35 @@ DolphinScheduler 项目的文档维护在独立的 [git 仓库](https://github.c
 git clone https://github.com/<your-github-user-name>/dolphinscheduler-website
 ```
 
-### 文档环境
-
-DolphinScheduler 网站由 [docsite](https://github.com/chengshiwen/docsite-ext) 提供支持。
-
-请确保你的 node 版本是 10+，docsite 尚不支持高于 10.x 的版本。
-
 ### 文档构建指南
 
-1. 在根目录中运行 `npm install` 以安装依赖项。
+1. 在根目录中运行 `yarn` 以安装依赖项。
 
 2. 运行命令收集资源：2.1.运行 `export PROTOCOL_MODE=ssh` 告诉Git克隆资源，通过SSH协议而不是HTTPS协议。 2.2.运行 `./scripts/prepare_docs.sh` 准备所有相关资源，关更多信息，您可以查看[how prepare script work](https://github.com/apache/dolphinscheduler-website/blob/master/HOW_PREPARE_WORK.md)。
 
-3. 在根目录下运行 `npm run start` 启动本地服务器，其将允许在 http://localhost:8080。
+3. 在根目录下运行 `yarn generate` 来格式化和准备数据。
 
-4. 运行 `npm run build` 可以生成文档网站源代码。
+4. 在根目录下运行 `yarn dev` 启动本地服务器，其将允许在 http://localhost:3000。
 
-5. 在本地验证你的更改：`python -m SimpleHTTPServer 8000`，当 python 版本为 3 时，请使用：`python3 -m http.server 8000`。
+```
+注意：如果您在 Windows 而非 Mac 或 Linux 中克隆代码。请阅读下面的详细信息。
+如果执行上述两个步骤中的命令，将出现异常 “UnhandledPromiseRejectionWarning.Error:”： Error： EPERM: operation not permitted, symlink ‘2.0.3’ -> ‘latest’".
+如果出现异常 “Can't resolve ‘antd’ in xxx”，你可以运行 `yarn add antd` 和 `yarn install`。
+因为这两个步骤运行的命令`./scripts/prepare_docs.sh`应该是 Linux 环境，所以如果你是 windwos 系统，可以使用 WSL 来完成。
+遇到这个问题时。你可以以管理员身份运行 cmd.exe 中的两个步骤。
+```
+
+5. 运行 `yarn build` 来构建源代码，此时会自动生成一个名为 `build` 目录，等待执行完成之后进入 `build` 目录。
+
+6. 在本地验证你的更改：`python -m SimpleHTTPServer 8000`，当 python 版本为 3 时，请使用：`python3 -m http.server 8000`。
 
 如果本地安装了更高版本的 node，可以考虑使用 `nvm` 来允许不同版本的 `node` 在你的计算机上运行。
 
 1. 参考[说明](http://nvm.sh)安装 nvm
 
-2. 运行 `nvm install v10.23.1` 安装 node v10
+2. 运行 `nvm install v18.12.1` 安装 node v18
 
-3. 运行 `nvm use v10.23.1` 将当前工作环境切换到 node v10
+3. 运行 `nvm use v18.12.1` 将当前工作环境切换到 node v18
 
 然后你就可以在本地环境运行和建立网站了。
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Update documentation notice section content keep synchronized with https://github.com/apache/dolphinscheduler-website readme

The current content of the document is old and does not work properly. 

## Brief change log

Part of the documentation notice section in English and Chinese.

## Verify this pull request

Documentation update only, I have checked

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
