### PR TITLE
[DSIP-40][APIService] Add LogClient to fetch log

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClient.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClient.java
@@ -25,9 +25,12 @@ import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFil
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class LocalLogClient {
 
     /**
@@ -56,36 +59,30 @@ public class LocalLogClient {
         return getLocalPartLog(taskInstance, skipLineNum, limit);
     }
 
-    private static TaskInstanceLogFileDownloadResponse getLocalWholeLog(TaskInstance taskInstance) {
-        TaskInstanceLogFileDownloadRequest request = buildLogFileDownloadRequest(taskInstance);
+    private TaskInstanceLogFileDownloadResponse getLocalWholeLog(TaskInstance taskInstance) {
+        TaskInstanceLogFileDownloadRequest request = new TaskInstanceLogFileDownloadRequest(
+                taskInstance.getId(),
+                taskInstance.getLogPath());
         return getProxyLogService(taskInstance).getTaskInstanceWholeLogFileBytes(request);
     }
 
-    private static TaskInstanceLogPageQueryResponse getLocalPartLog(TaskInstance taskInstance, int skipLineNum,
-                                                                    int limit) {
-        TaskInstanceLogPageQueryRequest request = buildLogPageQueryRequest(taskInstance, skipLineNum, limit);
-        return getProxyLogService(taskInstance).pageQueryTaskInstanceLog(request);
-    }
-
-    private static TaskInstanceLogFileDownloadRequest buildLogFileDownloadRequest(TaskInstance taskInstance) {
-        return new TaskInstanceLogFileDownloadRequest(
-                taskInstance.getId(),
-                taskInstance.getLogPath());
-    }
-
-    private static TaskInstanceLogPageQueryRequest buildLogPageQueryRequest(TaskInstance taskInstance, int skipLineNum,
-                                                                            int limit) {
-        return TaskInstanceLogPageQueryRequest.builder()
+    private TaskInstanceLogPageQueryResponse getLocalPartLog(TaskInstance taskInstance, int skipLineNum,
+                                                             int limit) {
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest
+                .builder()
                 .taskInstanceId(taskInstance.getId())
                 .taskInstanceLogAbsolutePath(taskInstance.getLogPath())
                 .skipLineNum(skipLineNum)
                 .limit(limit)
                 .build();
+        return getProxyLogService(taskInstance).pageQueryTaskInstanceLog(request);
     }
 
-    private static ILogService getProxyLogService(TaskInstance taskInstance) {
-        return Clients
+    private ILogService getProxyLogService(TaskInstance taskInstance) {
+        ILogService logService = Clients
                 .withService(ILogService.class)
                 .withHost(taskInstance.getHost());
+        log.debug("Created log service for host: {}", taskInstance.getHost());
+        return logService;
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClient.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClient.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.executor.logging;
+
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.extract.base.client.Clients;
+import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalLogClient {
+
+    /**
+     * Download the complete log of a task instance.
+     * This method is used to retrieve all log information from the start to the end of a task instance,
+     * suitable for scenarios where a complete log record is required.
+     *
+     * @param taskInstance The task instance object, containing information needed to retrieve the log.
+     * @return The complete log file download response of the task instance, including log content and metadata.
+     */
+    public TaskInstanceLogFileDownloadResponse getWholeLog(TaskInstance taskInstance) {
+        return getLocalWholeLog(taskInstance);
+    }
+
+    /**
+     * Query a portion of the log of a task instance.
+     * This method is used to query log information of a task instance in a paginated manner,
+     * suitable for scenarios where the log content is large and needs to be retrieved in batches.
+     *
+     * @param taskInstance The task instance object, containing information needed to retrieve the log.
+     * @param skipLineNum The number of lines to skip, indicating from which line to start reading the log.
+     * @param limit The maximum number of lines to read, indicating the maximum number of lines to retrieve in this query.
+     * @return The partial log query response, including log content within the specified range and metadata.
+     */
+    public TaskInstanceLogPageQueryResponse getPartLog(TaskInstance taskInstance, int skipLineNum, int limit) {
+        return getLocalPartLog(taskInstance, skipLineNum, limit);
+    }
+
+    private static TaskInstanceLogFileDownloadResponse getLocalWholeLog(TaskInstance taskInstance) {
+        TaskInstanceLogFileDownloadRequest request = buildLogFileDownloadRequest(taskInstance);
+        return getProxyLogService(taskInstance).getTaskInstanceWholeLogFileBytes(request);
+    }
+
+    private static TaskInstanceLogPageQueryResponse getLocalPartLog(TaskInstance taskInstance, int skipLineNum,
+                                                                    int limit) {
+        TaskInstanceLogPageQueryRequest request = buildLogPageQueryRequest(taskInstance, skipLineNum, limit);
+        return getProxyLogService(taskInstance).pageQueryTaskInstanceLog(request);
+    }
+
+    private static TaskInstanceLogFileDownloadRequest buildLogFileDownloadRequest(TaskInstance taskInstance) {
+        return new TaskInstanceLogFileDownloadRequest(
+                taskInstance.getId(),
+                taskInstance.getLogPath());
+    }
+
+    private static TaskInstanceLogPageQueryRequest buildLogPageQueryRequest(TaskInstance taskInstance, int skipLineNum,
+                                                                            int limit) {
+        return TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(taskInstance.getId())
+                .taskInstanceLogAbsolutePath(taskInstance.getLogPath())
+                .skipLineNum(skipLineNum)
+                .limit(limit)
+                .build();
+    }
+
+    private static ILogService getProxyLogService(TaskInstance taskInstance) {
+        return Clients
+                .withService(ILogService.class)
+                .withHost(taskInstance.getHost());
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.api.executor.logging;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
@@ -51,12 +52,16 @@ public class LogClientDelegate {
      */
     public String getPartLogString(TaskInstance taskInstance, int skipLineNum, int limit) {
         checkArgs(taskInstance);
-        checkNodeExists(taskInstance);
-        TaskInstanceLogPageQueryResponse response = localLogClient.getPartLog(taskInstance, skipLineNum, limit);
-        if (response.getCode() == 0) {
-            return response.getLogContent();
+        if (checkNodeExists(taskInstance)) {
+            TaskInstanceLogPageQueryResponse response = localLogClient.getPartLog(taskInstance, skipLineNum, limit);
+            if (response.getCode() == LogResponseStatus.SUCCESS) {
+                return response.getLogContent();
+            } else {
+                log.warn("get part log string is not success for task instance {}; reason :{}",
+                        taskInstance.getId(), response.getMessage());
+                return remoteLogClient.getPartLog(taskInstance, skipLineNum, limit);
+            }
         } else {
-            log.warn("trying fetch remote part log: {}", taskInstance.getLogPath());
             return remoteLogClient.getPartLog(taskInstance, skipLineNum, limit);
         }
     }
@@ -70,12 +75,16 @@ public class LogClientDelegate {
      */
     public byte[] getWholeLogBytes(TaskInstance taskInstance) {
         checkArgs(taskInstance);
-        checkNodeExists(taskInstance);
-        TaskInstanceLogFileDownloadResponse response = localLogClient.getWholeLog(taskInstance);
-        if (response.getCode() == 0) {
-            return response.getLogBytes();
+        if (checkNodeExists(taskInstance)) {
+            TaskInstanceLogFileDownloadResponse response = localLogClient.getWholeLog(taskInstance);
+            if (response.getCode() == LogResponseStatus.SUCCESS) {
+                return response.getLogBytes();
+            } else {
+                log.warn("get whole log bytes is not success for task instance {}; reason :{}", taskInstance.getId(),
+                        response.getMessage());
+                return remoteLogClient.getWholeLog(taskInstance);
+            }
         } else {
-            log.warn("trying fetch remote whole log: {}", taskInstance.getLogPath());
             return remoteLogClient.getWholeLog(taskInstance);
         }
     }
@@ -86,15 +95,18 @@ public class LogClientDelegate {
         }
     }
 
-    private void checkNodeExists(TaskInstance taskInstance) {
+    private boolean checkNodeExists(TaskInstance taskInstance) {
         RegistryNodeType nodeType;
         if (TaskTypeUtils.isLogicTask(taskInstance.getTaskType())) {
             nodeType = RegistryNodeType.MASTER;
         } else {
             nodeType = RegistryNodeType.WORKER;
         }
-        if (!registryClient.checkNodeExists(taskInstance.getHost(), nodeType)) {
-            throw new IllegalArgumentException("canFetchLog node " + taskInstance.getHost() + " is not exists");
+        boolean exists = registryClient.checkNodeExists(taskInstance.getHost(), nodeType);
+        if (!exists) {
+            log.warn("Node {} does not exist for task instance {}", taskInstance.getHost(), taskInstance.getId());
         }
+        return exists;
     }
+
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.executor.logging;
+
+import org.apache.dolphinscheduler.common.utils.LogUtils;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.extract.base.client.Clients;
+import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class LogClientDelegate {
+
+    /**
+     * Retrieves a portion of the log string for a given task instance.
+     * This method first attempts to fetch the log from local storage; if unsuccessful, it tries to obtain the log from remote storage.
+     *
+     * @param taskInstance The task instance object, containing information needed for log retrieval.
+     * @param skipLineNum The number of log lines to skip from the beginning.
+     * @param limit The maximum number of log lines to retrieve.
+     * @return A string containing the specified portion of the log.
+     */
+    public String getPartLogString(TaskInstance taskInstance, int skipLineNum, int limit) {
+        TaskInstanceLogPageQueryResponse response = getLocalPartLog(taskInstance, skipLineNum, limit);
+        if (response.getCode() == 0) {
+            return response.getLogContent();
+        } else {
+            log.warn("Failed to get local part log, trying remote: {}", response.getMessage());
+            // todo We can optimize requests by the actual range, reducing disk usage and network traffic.
+            return LogUtils.rollViewLogLines(
+                    LogUtils.readPartFileContentFromRemote(taskInstance.getLogPath(), skipLineNum, limit));
+        }
+    }
+
+    /**
+     * Retrieves the complete log content for a given task instance as a byte array.
+     * This method first attempts to fetch the log from local storage; if unsuccessful, it tries to obtain the log from remote storage.
+     *
+     * @param taskInstance The task instance object, containing information needed for log retrieval.
+     * @return A byte array containing the complete log content.
+     */
+    public byte[] getWholeLogBytes(TaskInstance taskInstance) {
+        TaskInstanceLogFileDownloadResponse response = getLocalWholeLog(taskInstance);
+        if (response.getCode() == 0) {
+            return response.getLogBytes();
+        } else {
+            log.warn("Failed to get local whole log, trying remote: {}", response.getMessage());
+            return getRemoteWholeLog(taskInstance.getLogPath());
+        }
+    }
+
+    private byte[] getRemoteWholeLog(String logPath) {
+        return LogUtils.getFileContentBytesFromRemote(logPath);
+    }
+
+    private TaskInstanceLogFileDownloadResponse getLocalWholeLog(TaskInstance taskInstance) {
+        TaskInstanceLogFileDownloadRequest request = buildLogFileDownloadRequest(taskInstance);
+        return getProxyLogService(taskInstance).getTaskInstanceWholeLogFileBytes(request);
+    }
+
+    private TaskInstanceLogPageQueryResponse getLocalPartLog(TaskInstance taskInstance, int skipLineNum, int limit) {
+        TaskInstanceLogPageQueryRequest request = buildLogPageQueryRequest(taskInstance, skipLineNum, limit);
+        return getProxyLogService(taskInstance).pageQueryTaskInstanceLog(request);
+    }
+
+    private TaskInstanceLogFileDownloadRequest buildLogFileDownloadRequest(TaskInstance taskInstance) {
+        return new TaskInstanceLogFileDownloadRequest(
+                taskInstance.getId(),
+                taskInstance.getLogPath());
+    }
+
+    private TaskInstanceLogPageQueryRequest buildLogPageQueryRequest(TaskInstance taskInstance, int skipLineNum,
+                                                                     int limit) {
+        return TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(taskInstance.getId())
+                .taskInstanceLogAbsolutePath(taskInstance.getLogPath())
+                .skipLineNum(skipLineNum)
+                .limit(limit)
+                .build();
+    }
+
+    private ILogService getProxyLogService(TaskInstance taskInstance) {
+        return Clients
+                .withService(ILogService.class)
+                .withHost(taskInstance.getHost());
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
@@ -17,22 +17,28 @@
 
 package org.apache.dolphinscheduler.api.executor.logging;
 
-import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.extract.base.client.Clients;
-import org.apache.dolphinscheduler.extract.common.ILogService;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
+import org.apache.dolphinscheduler.registry.api.RegistryClient;
+import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 public class LogClientDelegate {
+
+    @Autowired
+    private LocalLogClient localLogClient;
+    @Autowired
+    private RemoteLogClient remoteLogClient;
+    @Autowired
+    private RegistryClient registryClient;
 
     /**
      * Retrieves a portion of the log string for a given task instance.
@@ -44,14 +50,14 @@ public class LogClientDelegate {
      * @return A string containing the specified portion of the log.
      */
     public String getPartLogString(TaskInstance taskInstance, int skipLineNum, int limit) {
-        TaskInstanceLogPageQueryResponse response = getLocalPartLog(taskInstance, skipLineNum, limit);
+        checkArgs(taskInstance);
+        checkNodeExists(taskInstance);
+        TaskInstanceLogPageQueryResponse response = localLogClient.getPartLog(taskInstance, skipLineNum, limit);
         if (response.getCode() == 0) {
             return response.getLogContent();
         } else {
-            log.warn("Failed to get local part log, trying remote: {}", response.getMessage());
-            // todo We can optimize requests by the actual range, reducing disk usage and network traffic.
-            return LogUtils.rollViewLogLines(
-                    LogUtils.readPartFileContentFromRemote(taskInstance.getLogPath(), skipLineNum, limit));
+            log.warn("trying fetch remote part log: {}", taskInstance.getLogPath());
+            return remoteLogClient.getPartLog(taskInstance, skipLineNum, limit);
         }
     }
 
@@ -63,48 +69,32 @@ public class LogClientDelegate {
      * @return A byte array containing the complete log content.
      */
     public byte[] getWholeLogBytes(TaskInstance taskInstance) {
-        TaskInstanceLogFileDownloadResponse response = getLocalWholeLog(taskInstance);
+        checkArgs(taskInstance);
+        checkNodeExists(taskInstance);
+        TaskInstanceLogFileDownloadResponse response = localLogClient.getWholeLog(taskInstance);
         if (response.getCode() == 0) {
             return response.getLogBytes();
         } else {
-            log.warn("Failed to get local whole log, trying remote: {}", response.getMessage());
-            return getRemoteWholeLog(taskInstance.getLogPath());
+            log.warn("trying fetch remote whole log: {}", taskInstance.getLogPath());
+            return remoteLogClient.getWholeLog(taskInstance);
         }
     }
 
-    private byte[] getRemoteWholeLog(String logPath) {
-        return LogUtils.getFileContentBytesFromRemote(logPath);
+    private static void checkArgs(TaskInstance taskInstance) {
+        if (taskInstance == null) {
+            throw new IllegalArgumentException("canFetchLog task instance is null");
+        }
     }
 
-    private TaskInstanceLogFileDownloadResponse getLocalWholeLog(TaskInstance taskInstance) {
-        TaskInstanceLogFileDownloadRequest request = buildLogFileDownloadRequest(taskInstance);
-        return getProxyLogService(taskInstance).getTaskInstanceWholeLogFileBytes(request);
-    }
-
-    private TaskInstanceLogPageQueryResponse getLocalPartLog(TaskInstance taskInstance, int skipLineNum, int limit) {
-        TaskInstanceLogPageQueryRequest request = buildLogPageQueryRequest(taskInstance, skipLineNum, limit);
-        return getProxyLogService(taskInstance).pageQueryTaskInstanceLog(request);
-    }
-
-    private TaskInstanceLogFileDownloadRequest buildLogFileDownloadRequest(TaskInstance taskInstance) {
-        return new TaskInstanceLogFileDownloadRequest(
-                taskInstance.getId(),
-                taskInstance.getLogPath());
-    }
-
-    private TaskInstanceLogPageQueryRequest buildLogPageQueryRequest(TaskInstance taskInstance, int skipLineNum,
-                                                                     int limit) {
-        return TaskInstanceLogPageQueryRequest.builder()
-                .taskInstanceId(taskInstance.getId())
-                .taskInstanceLogAbsolutePath(taskInstance.getLogPath())
-                .skipLineNum(skipLineNum)
-                .limit(limit)
-                .build();
-    }
-
-    private ILogService getProxyLogService(TaskInstance taskInstance) {
-        return Clients
-                .withService(ILogService.class)
-                .withHost(taskInstance.getHost());
+    private void checkNodeExists(TaskInstance taskInstance) {
+        RegistryNodeType nodeType;
+        if (TaskTypeUtils.isLogicTask(taskInstance.getTaskType())) {
+            nodeType = RegistryNodeType.MASTER;
+        } else {
+            nodeType = RegistryNodeType.WORKER;
+        }
+        if (!registryClient.checkNodeExists(taskInstance.getHost(), nodeType)) {
+            throw new IllegalArgumentException("canFetchLog node " + taskInstance.getHost() + " is not exists");
+        }
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/RemoteLogClient.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/RemoteLogClient.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.executor.logging;
+
+import org.apache.dolphinscheduler.common.utils.LogUtils;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RemoteLogClient {
+
+    /**
+     * Retrieves the entire log content for a given task instance.
+     * This method is used when it is necessary to obtain all the log information for a task instance.
+     * 
+     * @param taskInstance The task instance object, containing information such as the task ID and log path.
+     * @return Returns the log content in byte array format.
+     */
+    public byte[] getWholeLog(TaskInstance taskInstance) {
+        return LogUtils.getFileContentBytesFromRemote(taskInstance.getLogPath());
+    }
+
+    /**
+     * Retrieves part of the log content for a given task instance, based on the specified line number and the number of lines to read.
+     * This method is used when it is necessary to browse a portion of the log content, allowing for skipping a certain number of lines and limiting the number of lines read.
+     * 
+     * @param taskInstance The task instance object, containing information such as the task ID and log path.
+     * @param skipLineNum The number of lines to skip, starting from the beginning of the log.
+     * @param limit The maximum number of lines to read.
+     * @return Returns the specified part of the log content in string format.
+     */
+    public String getPartLog(TaskInstance taskInstance, int skipLineNum, int limit) {
+        // todo We can optimize requests by the actual range, reducing disk usage and network traffic.
+        return LogUtils.rollViewLogLines(
+                LogUtils.readPartFileContentFromRemote(taskInstance.getLogPath(), skipLineNum, limit));
+    }
+
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -22,6 +22,7 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.executor.logging.LogClientDelegate;
 import org.apache.dolphinscheduler.api.service.LoggerService;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.utils.Result;
@@ -34,12 +35,6 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
-import org.apache.dolphinscheduler.extract.base.client.Clients;
-import org.apache.dolphinscheduler.extract.common.ILogService;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -72,6 +67,9 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
 
     @Autowired
     private TaskDefinitionMapper taskDefinitionMapper;
+
+    @Autowired
+    private LogClientDelegate logClientDelegate;
 
     /**
      * view log
@@ -203,17 +201,7 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
         }
 
         try {
-            TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
-                    .taskInstanceId(taskInstance.getId())
-                    .taskInstanceLogAbsolutePath(logPath)
-                    .skipLineNum(skipLineNum)
-                    .limit(limit)
-                    .build();
-            final TaskInstanceLogPageQueryResponse response = Clients
-                    .withService(ILogService.class)
-                    .withHost(taskInstance.getHost())
-                    .pageQueryTaskInstanceLog(request);
-            String logContent = response.getLogContent();
+            String logContent = logClientDelegate.getPartLogString(taskInstance, skipLineNum, limit);
             if (logContent != null) {
                 sb.append(logContent);
             }
@@ -241,14 +229,7 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
         byte[] logBytes;
 
         try {
-            final TaskInstanceLogFileDownloadRequest request = new TaskInstanceLogFileDownloadRequest(
-                    taskInstance.getId(),
-                    logPath);
-            final TaskInstanceLogFileDownloadResponse response = Clients
-                    .withService(ILogService.class)
-                    .withHost(taskInstance.getHost())
-                    .getTaskInstanceWholeLogFileBytes(request);
-            logBytes = response.getLogBytes();
+            logBytes = logClientDelegate.getWholeLogBytes(taskInstance);
             return Bytes.concat(head, logBytes);
         } catch (Exception ex) {
             log.error("Download TaskInstance: {} Log Error", taskInstance.getName(), ex);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClientTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClientTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.executor.logging;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.extract.base.config.NettyServerConfig;
+import org.apache.dolphinscheduler.extract.base.server.SpringServerMethodInvokerDiscovery;
+import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class LocalLogClientTest {
+
+    @InjectMocks
+    private LocalLogClient localLogClient;
+
+    private SpringServerMethodInvokerDiscovery springServerMethodInvokerDiscovery;
+
+    private int nettyServerPort = 18080;
+
+    @BeforeEach
+    public void setUp() {
+        try (ServerSocket s = new ServerSocket(0)) {
+            nettyServerPort = s.getLocalPort();
+        } catch (IOException e) {
+            return;
+        }
+
+        springServerMethodInvokerDiscovery = new SpringServerMethodInvokerDiscovery(
+                NettyServerConfig.builder().serverName("TestLogServer").listenPort(nettyServerPort).build());
+        springServerMethodInvokerDiscovery.start();
+        springServerMethodInvokerDiscovery.registerServerMethodInvokerProvider(new ILogService() {
+
+            @Override
+            public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest taskInstanceLogFileDownloadRequest) {
+                if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 1) {
+                    return new TaskInstanceLogFileDownloadResponse(new byte[0], LogResponseStatus.SUCCESS, "");
+                } else if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 10) {
+                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), LogResponseStatus.SUCCESS,
+                            "");
+                }
+
+                throw new ServiceException("download error");
+            }
+
+            @Override
+            public TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest) {
+                if (taskInstanceLogPageQueryRequest.getTaskInstanceId() != null) {
+                    if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 100) {
+                        throw new ServiceException("query log error");
+                    } else if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 10) {
+                        return new TaskInstanceLogPageQueryResponse("Partial log content", LogResponseStatus.SUCCESS,
+                                "");
+                    }
+                }
+
+                return new TaskInstanceLogPageQueryResponse();
+            }
+
+            @Override
+            public void removeTaskInstanceLog(String taskInstanceLogAbsolutePath) {
+
+            }
+        });
+        springServerMethodInvokerDiscovery.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (springServerMethodInvokerDiscovery != null) {
+            springServerMethodInvokerDiscovery.close();
+        }
+    }
+
+    @Test
+    public void testGetWholeLogSuccess() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setHost("127.0.0.1:" + nettyServerPort);
+        taskInstance.setId(1);
+        taskInstance.setLogPath("/path/to/log");
+
+        TaskInstanceLogFileDownloadResponse actualResponse = localLogClient.getWholeLog(taskInstance);
+
+        assertNotNull(actualResponse);
+        assertArrayEquals("".getBytes(), actualResponse.getLogBytes());
+    }
+
+    @Test
+    public void testGetPartLogSuccess() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(10);
+        taskInstance.setHost("127.0.0.1:" + nettyServerPort);
+        taskInstance.setLogPath("/path/to/log");
+
+        TaskInstanceLogPageQueryResponse actualResponse = localLogClient.getPartLog(taskInstance, 0, 10);
+
+        assertNotNull(actualResponse);
+        assertEquals("Partial log content", actualResponse.getLogContent());
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegateTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegateTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.executor.logging;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+import org.apache.dolphinscheduler.registry.api.RegistryClient;
+import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class LogClientDelegateTest {
+
+    @Mock
+    private LocalLogClient localLogClient;
+
+    @Mock
+    private RemoteLogClient remoteLogClient;
+
+    @Mock
+    private RegistryClient registryClient;
+
+    @InjectMocks
+    private LogClientDelegate logClientDelegate;
+
+    @Test
+    public void testGetPartLogStringTaskInstanceNullThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> logClientDelegate.getPartLogString(null, 0, 10));
+    }
+
+    @Test
+    public void testGetPartLogStringNodeExistsLocalSuccess() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType("SHELL");
+        when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(true);
+        when(localLogClient.getPartLog(taskInstance, 0, 10))
+                .thenReturn(new TaskInstanceLogPageQueryResponse("logContent", LogResponseStatus.SUCCESS, ""));
+        String result = logClientDelegate.getPartLogString(taskInstance, 0, 10);
+        assertEquals("logContent", result);
+    }
+
+    @Test
+    public void testGetPartLogStringNodeExistsLocalFailure() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType("SHELL");
+
+        when(registryClient.checkNodeExists("localhost", RegistryNodeType.WORKER)).thenReturn(true);
+        when(localLogClient.getPartLog(taskInstance, 0, 10)).thenReturn(
+                new TaskInstanceLogPageQueryResponse(null, LogResponseStatus.ERROR, "error"));
+        when(remoteLogClient.getPartLog(taskInstance, 0, 10)).thenReturn("remoteLogContent");
+
+        String result = logClientDelegate.getPartLogString(taskInstance, 0, 10);
+        assertEquals("remoteLogContent", result);
+    }
+
+    @Test
+    public void testGetPartLogStringNodeNotExists() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType("SHELL");
+
+        when(registryClient.checkNodeExists("localhost", RegistryNodeType.WORKER)).thenReturn(false);
+        when(remoteLogClient.getPartLog(taskInstance, 0, 10)).thenReturn("remoteLogContent");
+
+        String result = logClientDelegate.getPartLogString(taskInstance, 0, 10);
+        assertEquals("remoteLogContent", result);
+    }
+
+    @Test
+    public void testGetWholeLogBytesTaskInstanceNullThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> logClientDelegate.getWholeLogBytes(null));
+    }
+
+    @Test
+    public void testGetWholeLogBytesNodeExistsLocalSuccess() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType("SWITCH");
+
+        when(registryClient.checkNodeExists("localhost", RegistryNodeType.MASTER)).thenReturn(true);
+        when(localLogClient.getWholeLog(taskInstance)).thenReturn(
+                new TaskInstanceLogFileDownloadResponse("logBytes".getBytes(), LogResponseStatus.SUCCESS, null));
+
+        byte[] result = logClientDelegate.getWholeLogBytes(taskInstance);
+        assertArrayEquals("logBytes".getBytes(), result);
+    }
+
+    @Test
+    public void testGetWholeLogBytesNodeExistsLocalFailure() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType("SWITCH");
+
+        when(registryClient.checkNodeExists("localhost", RegistryNodeType.MASTER)).thenReturn(true);
+        when(localLogClient.getWholeLog(taskInstance)).thenReturn(
+                new TaskInstanceLogFileDownloadResponse(null, LogResponseStatus.ERROR, "error"));
+        when(remoteLogClient.getWholeLog(taskInstance)).thenReturn("remoteLogBytes".getBytes());
+
+        byte[] result = logClientDelegate.getWholeLogBytes(taskInstance);
+        assertArrayEquals("remoteLogBytes".getBytes(), result);
+    }
+
+    @Test
+    public void testGetWholeLogBytesNodeNotExists() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType("SWITCH");
+
+        when(registryClient.checkNodeExists("localhost", RegistryNodeType.MASTER)).thenReturn(false);
+        when(remoteLogClient.getWholeLog(taskInstance)).thenReturn("remoteLogBytes".getBytes());
+
+        byte[] result = logClientDelegate.getWholeLogBytes(taskInstance);
+        assertArrayEquals("remoteLogBytes".getBytes(), result);
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
@@ -44,6 +44,7 @@ import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.extract.base.config.NettyServerConfig;
 import org.apache.dolphinscheduler.extract.base.server.SpringServerMethodInvokerDiscovery;
 import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -113,9 +114,9 @@ public class LoggerServiceTest {
             @Override
             public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest taskInstanceLogFileDownloadRequest) {
                 if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 1) {
-                    return new TaskInstanceLogFileDownloadResponse(new byte[0], 0, "");
+                    return new TaskInstanceLogFileDownloadResponse(new byte[0], LogResponseStatus.SUCCESS, "");
                 } else if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 10) {
-                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), 0, "");
+                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), LogResponseStatus.SUCCESS, "");
                 }
 
                 throw new ServiceException("download error");
@@ -127,7 +128,7 @@ public class LoggerServiceTest {
                     if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 100) {
                         throw new ServiceException("query log error");
                     } else if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 10) {
-                        return new TaskInstanceLogPageQueryResponse("log content", 0, "");
+                        return new TaskInstanceLogPageQueryResponse("log content", LogResponseStatus.SUCCESS, "");
                     }
                 }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import org.apache.dolphinscheduler.api.AssertionsHelper;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.executor.logging.LogClientDelegate;
 import org.apache.dolphinscheduler.api.service.impl.LoggerServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
@@ -88,12 +89,16 @@ public class LoggerServiceTest {
     @Mock
     private TaskDefinitionMapper taskDefinitionMapper;
 
+    @Mock
+    private LogClientDelegate logClientDelegate;
+
     private SpringServerMethodInvokerDiscovery springServerMethodInvokerDiscovery;
 
     private int nettyServerPort = 18080;
 
     @BeforeEach
     public void setUp() {
+        logger.info(logClientDelegate.toString());
         try (ServerSocket s = new ServerSocket(0)) {
             nettyServerPort = s.getLocalPort();
         } catch (IOException e) {
@@ -108,9 +113,9 @@ public class LoggerServiceTest {
             @Override
             public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest taskInstanceLogFileDownloadRequest) {
                 if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 1) {
-                    return new TaskInstanceLogFileDownloadResponse(new byte[0]);
+                    return new TaskInstanceLogFileDownloadResponse(new byte[0], 0, "");
                 } else if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 10) {
-                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes());
+                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), 0, "");
                 }
 
                 throw new ServiceException("download error");
@@ -122,7 +127,7 @@ public class LoggerServiceTest {
                     if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 100) {
                         throw new ServiceException("query log error");
                     } else if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 10) {
-                        return new TaskInstanceLogPageQueryResponse("log content");
+                        return new TaskInstanceLogPageQueryResponse("log content", 0, "");
                     }
                 }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
@@ -116,7 +116,8 @@ public class LoggerServiceTest {
                 if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 1) {
                     return new TaskInstanceLogFileDownloadResponse(new byte[0], LogResponseStatus.SUCCESS, "");
                 } else if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 10) {
-                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), LogResponseStatus.SUCCESS, "");
+                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), LogResponseStatus.SUCCESS,
+                            "");
                 }
 
                 throw new ServiceException("download error");

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
@@ -22,6 +22,8 @@ import static org.apache.dolphinscheduler.api.AssertionsHelper.assertThrowsServi
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.DOWNLOAD_LOG;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.VIEW_LOG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -41,24 +43,12 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
-import org.apache.dolphinscheduler.extract.base.config.NettyServerConfig;
-import org.apache.dolphinscheduler.extract.base.server.SpringServerMethodInvokerDiscovery;
-import org.apache.dolphinscheduler.extract.common.ILogService;
-import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -93,63 +83,7 @@ public class LoggerServiceTest {
     @Mock
     private LogClientDelegate logClientDelegate;
 
-    private SpringServerMethodInvokerDiscovery springServerMethodInvokerDiscovery;
-
-    private int nettyServerPort = 18080;
-
-    @BeforeEach
-    public void setUp() {
-        logger.info(logClientDelegate.toString());
-        try (ServerSocket s = new ServerSocket(0)) {
-            nettyServerPort = s.getLocalPort();
-        } catch (IOException e) {
-            return;
-        }
-
-        springServerMethodInvokerDiscovery = new SpringServerMethodInvokerDiscovery(
-                NettyServerConfig.builder().serverName("TestLogServer").listenPort(nettyServerPort).build());
-        springServerMethodInvokerDiscovery.start();
-        springServerMethodInvokerDiscovery.registerServerMethodInvokerProvider(new ILogService() {
-
-            @Override
-            public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest taskInstanceLogFileDownloadRequest) {
-                if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 1) {
-                    return new TaskInstanceLogFileDownloadResponse(new byte[0], LogResponseStatus.SUCCESS, "");
-                } else if (taskInstanceLogFileDownloadRequest.getTaskInstanceId() == 10) {
-                    return new TaskInstanceLogFileDownloadResponse("log content".getBytes(), LogResponseStatus.SUCCESS,
-                            "");
-                }
-
-                throw new ServiceException("download error");
-            }
-
-            @Override
-            public TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest) {
-                if (taskInstanceLogPageQueryRequest.getTaskInstanceId() != null) {
-                    if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 100) {
-                        throw new ServiceException("query log error");
-                    } else if (taskInstanceLogPageQueryRequest.getTaskInstanceId() == 10) {
-                        return new TaskInstanceLogPageQueryResponse("log content", LogResponseStatus.SUCCESS, "");
-                    }
-                }
-
-                return new TaskInstanceLogPageQueryResponse();
-            }
-
-            @Override
-            public void removeTaskInstanceLog(String taskInstanceLogAbsolutePath) {
-
-            }
-        });
-        springServerMethodInvokerDiscovery.start();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        if (springServerMethodInvokerDiscovery != null) {
-            springServerMethodInvokerDiscovery.close();
-        }
-    }
+    private final int nettyServerPort = 18080;
 
     @Test
     public void testQueryLog() {
@@ -244,8 +178,10 @@ public class LoggerServiceTest {
                 () -> loggerService.queryLog(loginUser, 1, 1, 1));
 
         // SUCCESS
+        when(logClientDelegate.getWholeLogBytes(any())).thenReturn(new byte[0]);
         doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, taskInstance.getProjectCode(),
                 DOWNLOAD_LOG);
+        when(logClientDelegate.getWholeLogBytes(any())).thenReturn(new byte[0]);
         byte[] logBytes = loggerService.getLogBytes(loginUser, 1);
         Assertions.assertEquals(42, logBytes.length - String.valueOf(nettyServerPort).length());
     }
@@ -285,11 +221,16 @@ public class LoggerServiceTest {
         taskDefinition.setProjectCode(1);
         taskInstance.setId(10);
         when(taskInstanceDao.queryById(10)).thenReturn(taskInstance);
+
+        when(logClientDelegate.getPartLogString(any(), anyInt(), anyInt())).thenReturn("log content");
+
         String result = loggerService.queryLog(loginUser, projectCode, 10, 1, 1);
         assertEquals("log content", result);
 
         taskInstance.setId(100);
         when(taskInstanceDao.queryById(100)).thenReturn(taskInstance);
+        doThrow(new ServiceException("query log error")).when(logClientDelegate).getPartLogString(any(), anyInt(),
+                anyInt());
         assertThrowsServiceException(Status.QUERY_TASK_INSTANCE_LOG_ERROR,
                 () -> loggerService.queryLog(loginUser, projectCode, 10, 1, 1));
     }
@@ -321,6 +262,7 @@ public class LoggerServiceTest {
 
         when(taskInstanceDao.queryById(1)).thenReturn(taskInstance);
         when(taskDefinitionMapper.queryByCode(taskInstance.getTaskCode())).thenReturn(taskDefinition);
+        when(logClientDelegate.getWholeLogBytes(any())).thenReturn(new byte[0]);
         assertDoesNotThrow(() -> loggerService.getLogBytes(loginUser, projectCode, 1));
 
         taskDefinition.setProjectCode(2L);
@@ -330,6 +272,7 @@ public class LoggerServiceTest {
         taskDefinition.setProjectCode(1L);
         taskInstance.setId(100);
         when(taskInstanceDao.queryById(100)).thenReturn(taskInstance);
+        doThrow(new ServiceException("download error")).when(logClientDelegate).getWholeLogBytes(any());
         assertThrowsServiceException(Status.DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR,
                 () -> loggerService.getLogBytes(loginUser, projectCode, 100));
     }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -17,9 +17,11 @@
 
 package org.apache.dolphinscheduler.extract.common.service.impl;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -44,8 +46,8 @@ public class LogServiceImpl implements ILogService {
                     .getFileContentBytesFromLocal(taskInstanceLogFileDownloadRequest.getTaskInstanceLogAbsolutePath());
             taskInstanceLogFileDownloadResponse.setLogBytes(bytes);
         } catch (Exception e) {
-            taskInstanceLogFileDownloadResponse.setCode(1);
-            taskInstanceLogFileDownloadResponse.setMessage(e.getMessage());
+            taskInstanceLogFileDownloadResponse.setCode(LogResponseStatus.ERROR);
+            taskInstanceLogFileDownloadResponse.setMessage(ExceptionUtils.getRootCauseMessage(e));
         }
         return taskInstanceLogFileDownloadResponse;
     }
@@ -68,8 +70,8 @@ public class LogServiceImpl implements ILogService {
                     taskInstanceLogPageQueryRequest.getLimit());
             taskInstanceLogPageQueryResponse.setLogContent(LogUtils.rollViewLogLines(lines));
         } catch (Exception e) {
-            taskInstanceLogPageQueryResponse.setCode(1);
-            taskInstanceLogPageQueryResponse.setMessage(e.getMessage());
+            taskInstanceLogPageQueryResponse.setCode(LogResponseStatus.ERROR);
+            taskInstanceLogPageQueryResponse.setMessage(ExceptionUtils.getMessage(e));
         }
         return taskInstanceLogPageQueryResponse;
     }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.extract.common.service.impl;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.extract.common.ILogService;
@@ -26,6 +25,8 @@ import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFil
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.List;
 

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.extract.common.service.impl;
+
+import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.common.utils.LogUtils;
+import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import java.util.List;
+
+public class LogServiceImpl implements ILogService {
+
+    /**
+     * Downloads the entire log file for a task instance.
+     *
+     * @param taskInstanceLogFileDownloadRequest Request object containing the path to the task instance log file.
+     * @return Response object containing the log file content in byte array form.
+     */
+    @Override
+    public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest taskInstanceLogFileDownloadRequest) {
+        final TaskInstanceLogFileDownloadResponse taskInstanceLogFileDownloadResponse =
+                new TaskInstanceLogFileDownloadResponse();
+        try {
+            byte[] bytes = LogUtils
+                    .getFileContentBytesFromLocal(taskInstanceLogFileDownloadRequest.getTaskInstanceLogAbsolutePath());
+            taskInstanceLogFileDownloadResponse.setLogBytes(bytes);
+        } catch (Exception e) {
+            taskInstanceLogFileDownloadResponse.setCode(1);
+            taskInstanceLogFileDownloadResponse.setMessage(e.getMessage());
+        }
+        return taskInstanceLogFileDownloadResponse;
+    }
+
+    /**
+     * Performs paginated queries on task instance logs.
+     *
+     * @param taskInstanceLogPageQueryRequest Request object containing the path to the task instance log file, the number of lines to skip, and the maximum number of lines to read.
+     * @return Response object containing the log content.
+     */
+    @Override
+    public TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest) {
+        final TaskInstanceLogPageQueryResponse taskInstanceLogPageQueryResponse =
+                new TaskInstanceLogPageQueryResponse();
+        List<String> lines;
+        try {
+            lines = LogUtils.readPartFileContentFromLocal(
+                    taskInstanceLogPageQueryRequest.getTaskInstanceLogAbsolutePath(),
+                    taskInstanceLogPageQueryRequest.getSkipLineNum(),
+                    taskInstanceLogPageQueryRequest.getLimit());
+            taskInstanceLogPageQueryResponse.setLogContent(LogUtils.rollViewLogLines(lines));
+        } catch (Exception e) {
+            taskInstanceLogPageQueryResponse.setCode(1);
+            taskInstanceLogPageQueryResponse.setMessage(e.getMessage());
+        }
+        return taskInstanceLogPageQueryResponse;
+    }
+
+    @Override
+    public void removeTaskInstanceLog(String taskInstanceLogAbsolutePath) {
+        FileUtils.deleteFile(taskInstanceLogAbsolutePath);
+    }
+
+}

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/LogResponseStatus.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/LogResponseStatus.java
@@ -1,0 +1,18 @@
+package org.apache.dolphinscheduler.extract.common.transportor;
+
+public enum LogResponseStatus {
+    /**
+     * Success status code.
+     */
+    SUCCESS,
+
+    /**
+     * General error status code.
+     */
+    ERROR,
+
+    /**
+     * Log file not found status code.
+     */
+    LOG_FILE_NOT_FOUND,
+}

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/LogResponseStatus.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/LogResponseStatus.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.extract.common.transportor;
 
 public enum LogResponseStatus {

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileDownloadResponse.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileDownloadResponse.java
@@ -28,4 +28,8 @@ public class TaskInstanceLogFileDownloadResponse {
 
     private byte[] logBytes;
 
+    private int code = 0;
+
+    private String message;
+
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileDownloadResponse.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileDownloadResponse.java
@@ -28,7 +28,7 @@ public class TaskInstanceLogFileDownloadResponse {
 
     private byte[] logBytes;
 
-    private int code = 0;
+    private LogResponseStatus code = LogResponseStatus.SUCCESS;
 
     private String message;
 

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogPageQueryResponse.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogPageQueryResponse.java
@@ -28,4 +28,8 @@ public class TaskInstanceLogPageQueryResponse {
 
     private String logContent;
 
+    private int code = 0;
+
+    private String message;
+
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogPageQueryResponse.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogPageQueryResponse.java
@@ -28,7 +28,7 @@ public class TaskInstanceLogPageQueryResponse {
 
     private String logContent;
 
-    private int code = 0;
+    private LogResponseStatus code = LogResponseStatus.SUCCESS;
 
     private String message;
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/MasterLogServiceImpl.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/MasterLogServiceImpl.java
@@ -17,15 +17,8 @@
 
 package org.apache.dolphinscheduler.server.master.rpc;
 
-import org.apache.dolphinscheduler.common.utils.FileUtils;
-import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.extract.common.ILogService;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
-
-import java.util.List;
+import org.apache.dolphinscheduler.extract.common.service.impl.LogServiceImpl;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,30 +26,6 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class MasterLogServiceImpl implements ILogService {
+public class MasterLogServiceImpl extends LogServiceImpl implements ILogService {
 
-    @Override
-    public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest logicTaskInstanceLogFileDownloadRequest) {
-        byte[] bytes =
-                LogUtils.getFileContentBytes(logicTaskInstanceLogFileDownloadRequest.getTaskInstanceLogAbsolutePath());
-        // todo: if file not exists, return error result
-        return new TaskInstanceLogFileDownloadResponse(bytes);
-    }
-
-    @Override
-    public TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest) {
-
-        List<String> lines = LogUtils.readPartFileContent(
-                taskInstanceLogPageQueryRequest.getTaskInstanceLogAbsolutePath(),
-                taskInstanceLogPageQueryRequest.getSkipLineNum(),
-                taskInstanceLogPageQueryRequest.getLimit());
-
-        String logContent = LogUtils.rollViewLogLines(lines);
-        return new TaskInstanceLogPageQueryResponse(logContent);
-    }
-
-    @Override
-    public void removeTaskInstanceLog(String taskInstanceLogAbsolutePath) {
-        FileUtils.deleteFile(taskInstanceLogAbsolutePath);
-    }
 }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/rpc/WorkerLogServiceImpl.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/rpc/WorkerLogServiceImpl.java
@@ -17,15 +17,8 @@
 
 package org.apache.dolphinscheduler.server.worker.rpc;
 
-import org.apache.dolphinscheduler.common.utils.FileUtils;
-import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.extract.common.ILogService;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
-import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
-
-import java.util.List;
+import org.apache.dolphinscheduler.extract.common.service.impl.LogServiceImpl;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,29 +26,6 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class WorkerLogServiceImpl implements ILogService {
+public class WorkerLogServiceImpl extends LogServiceImpl implements ILogService {
 
-    @Override
-    public TaskInstanceLogFileDownloadResponse getTaskInstanceWholeLogFileBytes(TaskInstanceLogFileDownloadRequest taskInstanceLogFileDownloadRequest) {
-        byte[] bytes = LogUtils
-                .getFileContentBytes(taskInstanceLogFileDownloadRequest.getTaskInstanceLogAbsolutePath());
-        // todo: if file not exists, return error result
-        return new TaskInstanceLogFileDownloadResponse(bytes);
-    }
-
-    @Override
-    public TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest) {
-        List<String> lines = LogUtils.readPartFileContent(
-                taskInstanceLogPageQueryRequest.getTaskInstanceLogAbsolutePath(),
-                taskInstanceLogPageQueryRequest.getSkipLineNum(),
-                taskInstanceLogPageQueryRequest.getLimit());
-
-        String logContent = LogUtils.rollViewLogLines(lines);
-        return new TaskInstanceLogPageQueryResponse(logContent);
-    }
-
-    @Override
-    public void removeTaskInstanceLog(String taskInstanceLogAbsolutePath) {
-        FileUtils.deleteFile(taskInstanceLogAbsolutePath);
-    }
 }


### PR DESCRIPTION
1.Pull local and remote task logs via the LogClientDelegate proxy. Fetch local logs first; if that fails, pull from the remote.
2.The logic in MasterLogServiceImpl and WorkerLogServiceImpl is the same. Abstract the shared logic into LoggerServiceImpl to maintain a single codebase.

close #15966 
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

