### PR TITLE
[Improvement-17169][service] unify preTasks and depList to predecessors in TaskNode, to avoid type conversion

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -1970,19 +1970,16 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return if graph has cycle flag
      */
     private boolean graphHasCycle(List<TaskNode> taskNodeResponseList) {
-        DAG<String, TaskNode, String> graph = new DAG<>();
+        DAG<Long, TaskNode, String> graph = new DAG<>();
         // Fill the vertices
         for (TaskNode taskNodeResponse : taskNodeResponseList) {
-            graph.addNode(Long.toString(taskNodeResponse.getCode()), taskNodeResponse);
+            graph.addNode(taskNodeResponse.getCode(), taskNodeResponse);
         }
         // Fill edge relations
         for (TaskNode taskNodeResponse : taskNodeResponseList) {
-            List<String> preTasks = JSONUtils.toList(taskNodeResponse.getPreTasks(), String.class);
-            if (CollectionUtils.isNotEmpty(preTasks)) {
-                for (String preTask : preTasks) {
-                    if (!graph.addEdge(preTask, Long.toString(taskNodeResponse.getCode()))) {
-                        return true;
-                    }
+            for (Long preTask : taskNodeResponse.getDepList()) {
+                if (!graph.addEdge(preTask, taskNodeResponse.getCode())) {
+                    return true;
                 }
             }
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -1977,7 +1977,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         }
         // Fill edge relations
         for (TaskNode taskNodeResponse : taskNodeResponseList) {
-            for (Long preTask : taskNodeResponse.getDepList()) {
+            for (Long preTask : taskNodeResponse.getPredecessors()) {
                 if (!graph.addEdge(preTask, taskNodeResponse.getCode())) {
                     return true;
                 }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/model/TaskNode.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/model/TaskNode.java
@@ -100,13 +100,6 @@ public class TaskNode {
     private String params;
 
     /**
-     * inner dependency information
-     */
-    @JsonDeserialize(using = JSONUtils.JsonDataDeserializer.class)
-    @JsonSerialize(using = JSONUtils.JsonDataSerializer.class)
-    private String preTasks;
-
-    /**
      * users store additional information
      */
     @JsonDeserialize(using = JSONUtils.JsonDataDeserializer.class)
@@ -200,15 +193,6 @@ public class TaskNode {
         this.params = params;
     }
 
-    public String getPreTasks() {
-        return preTasks;
-    }
-
-    public void setPreTasks(String preTasks) {
-        this.preTasks = preTasks;
-        this.depList = JSONUtils.toList(preTasks, Long.class);
-    }
-
     public String getExtras() {
         return extras;
     }
@@ -224,7 +208,6 @@ public class TaskNode {
     public void setDepList(List<Long> depList) {
         if (depList != null) {
             this.depList = depList;
-            this.preTasks = JSONUtils.toJsonString(depList);
         }
     }
 
@@ -265,7 +248,6 @@ public class TaskNode {
                 && Objects.equals(desc, taskNode.desc)
                 && Objects.equals(type, taskNode.type)
                 && Objects.equals(params, taskNode.params)
-                && Objects.equals(preTasks, taskNode.preTasks)
                 && Objects.equals(extras, taskNode.extras)
                 && Objects.equals(runFlag, taskNode.runFlag)
                 && Objects.equals(workerGroup, taskNode.workerGroup)
@@ -276,7 +258,7 @@ public class TaskNode {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, desc, type, params, preTasks, extras, depList, runFlag);
+        return Objects.hash(name, desc, type, params, extras, depList, runFlag);
     }
 
     public int getMaxRetryTimes() {
@@ -357,7 +339,6 @@ public class TaskNode {
                 + ", maxRetryTimes=" + maxRetryTimes
                 + ", retryInterval=" + retryInterval
                 + ", params='" + params + '\''
-                + ", preTasks='" + preTasks + '\''
                 + ", extras='" + extras + '\''
                 + ", depList=" + depList
                 + ", taskInstancePriority=" + taskInstancePriority

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/model/TaskNode.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/model/TaskNode.java
@@ -109,7 +109,7 @@ public class TaskNode {
     /**
      * node dependency list
      */
-    private List<Long> depList;
+    private List<Long> predecessors;
 
     /**
      * task instance priority
@@ -201,13 +201,13 @@ public class TaskNode {
         this.extras = extras;
     }
 
-    public List<Long> getDepList() {
-        return depList;
+    public List<Long> getPredecessors() {
+        return predecessors;
     }
 
-    public void setDepList(List<Long> depList) {
-        if (depList != null) {
-            this.depList = depList;
+    public void setPredecessors(List<Long> predecessors) {
+        if (predecessors != null) {
+            this.predecessors = predecessors;
         }
     }
 
@@ -252,13 +252,13 @@ public class TaskNode {
                 && Objects.equals(runFlag, taskNode.runFlag)
                 && Objects.equals(workerGroup, taskNode.workerGroup)
                 && Objects.equals(environmentCode, taskNode.environmentCode)
-                && CollectionUtils.isEqualCollection(depList, taskNode.depList)
+                && CollectionUtils.isEqualCollection(predecessors, taskNode.predecessors)
                 && Objects.equals(taskExecuteType, taskNode.taskExecuteType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, desc, type, params, extras, depList, runFlag);
+        return Objects.hash(name, desc, type, params, extras, predecessors, runFlag);
     }
 
     public int getMaxRetryTimes() {
@@ -340,7 +340,7 @@ public class TaskNode {
                 + ", retryInterval=" + retryInterval
                 + ", params='" + params + '\''
                 + ", extras='" + extras + '\''
-                + ", depList=" + depList
+                + ", depList=" + predecessors
                 + ", taskInstancePriority=" + taskInstancePriority
                 + ", workerGroup='" + workerGroup + '\''
                 + ", environmentCode=" + environmentCode

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -718,8 +718,8 @@ public class ProcessServiceImpl implements ProcessService {
                                 taskDefinitionLog.getTimeoutNotifyStrategy(),
                                 taskDefinitionLog.getTimeout())));
                 taskNode.setDelayTime(taskDefinitionLog.getDelayTime());
-                taskNode.setPreTasks(JSONUtils.toJsonString(code.getValue().stream().map(taskDefinitionLogMap::get)
-                        .map(TaskDefinition::getCode).collect(Collectors.toList())));
+                taskNode.setDepList(code.getValue().stream().map(taskDefinitionLogMap::get)
+                        .map(TaskDefinition::getCode).collect(Collectors.toList()));
                 taskNode.setTaskGroupId(taskDefinitionLog.getTaskGroupId());
                 taskNode.setTaskGroupPriority(taskDefinitionLog.getTaskGroupPriority());
                 taskNode.setCpuQuota(taskDefinitionLog.getCpuQuota());

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/process/ProcessServiceImpl.java
@@ -718,7 +718,7 @@ public class ProcessServiceImpl implements ProcessService {
                                 taskDefinitionLog.getTimeoutNotifyStrategy(),
                                 taskDefinitionLog.getTimeout())));
                 taskNode.setDelayTime(taskDefinitionLog.getDelayTime());
-                taskNode.setDepList(code.getValue().stream().map(taskDefinitionLogMap::get)
+                taskNode.setPredecessors(code.getValue().stream().map(taskDefinitionLogMap::get)
                         .map(TaskDefinition::getCode).collect(Collectors.toList()));
                 taskNode.setTaskGroupId(taskDefinitionLog.getTaskGroupId());
                 taskNode.setTaskGroupPriority(taskDefinitionLog.getTaskGroupPriority());


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #17169 , unify `depList` and `preTasks` to  `predecessors` in `TaskNode`, to avoid type conversion

## Brief change log


<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
