### PR TITLE
[Doc-17211] Update links in Chinese Quick Start guide to point to Chinese versions

### DIFF
--- a/docs/docs/en/guide/start/quick-start.md
+++ b/docs/docs/en/guide/start/quick-start.md
@@ -17,8 +17,8 @@ provide both video and text in this tutorial, you can choose the way you prefer
 You have to install and start dolphinscheduler first before go ahead. For beginners, we recommend setting up
 DolphinScheduler with the official Docker image or with the standalone server.
 
-* [standalone server](https://dolphinscheduler.apache.org/en-us/docs/3.1.3/guide/installation/standalone)
-* [docker](https://dolphinscheduler.apache.org/en-us/docs/3.1.3/guide/start/docker)
+* [standalone server](../installation/standalone.md)
+* [docker](./docker.md)
 
 ### Build Your First Workflow
 

--- a/docs/docs/zh/guide/start/quick-start.md
+++ b/docs/docs/zh/guide/start/quick-start.md
@@ -13,8 +13,8 @@
 
 在继续之前，您必须先安装并启动 dolphinscheduler。 对于初学者，我们建议设置 dolphionscheduler 与官方 Docker image 或 standalone server。
 
-* [standalone server](https://dolphinscheduler.apache.org/zh-cn/docs/3.1.3/guide/installation/standalone)
-* [docker](https://dolphinscheduler.apache.org/zh-cn/docs/3.1.3/guide/start/docker)
+* [standalone server](../installation/standalone.md)
+* [docker](./docker.md)
 
 ### 构建您的第一个工作流程
 

--- a/docs/docs/zh/guide/start/quick-start.md
+++ b/docs/docs/zh/guide/start/quick-start.md
@@ -13,8 +13,8 @@
 
 在继续之前，您必须先安装并启动 dolphinscheduler。 对于初学者，我们建议设置 dolphionscheduler 与官方 Docker image 或 standalone server。
 
-* [standalone server](https://dolphinscheduler.apache.org/en-us/docs/3.1.3/guide/installation/standalone)
-* [docker](https://dolphinscheduler.apache.org/en-us/docs/3.1.3/guide/start/docker)
+* [standalone server](https://dolphinscheduler.apache.org/zh-cn/docs/3.1.3/guide/installation/standalone)
+* [docker](https://dolphinscheduler.apache.org/zh-cn/docs/3.1.3/guide/start/docker)
 
 ### 构建您的第一个工作流程
 


### PR DESCRIPTION
## Purpose of this Pull Request

The Chinese "Quick Start" guide contained incorrect hyperlinks for "standalone server" and "docker" setup instructions, which pointed to English documentation pages instead of their Chinese counterparts. This could be confusing for Chinese-speaking users.

This PR updates these links to direct to the correct Chinese documentation, improving the usability and accuracy of the guide for Chinese users.

close #17211

## Brief Change Log

* In the Chinese "Quick Start" documentation file (`docs/docs/zh/guide/start/quick-start.md`), updated the hyperlinks in the "standalone server" and "docker" sections by changing "en-us" to "zh-cn" within the URLs.
* These links now point to their respective Chinese-language documentation pages.

## Verification

* This is a documentation update only.
* The corrected links have been manually checked to ensure they lead to the appropriate Chinese documentation pages and that the pages are accessible.