### PR TITLE
[Fix-17239][Dependent] Dependent check get wrong result in manual running execution type

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
@@ -17,21 +17,19 @@
 
 package org.apache.dolphinscheduler.dao.mapper;
 
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
-
 import org.apache.ibatis.annotations.Param;
 
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 /**
  * workflow instance mapper interface
@@ -65,6 +63,7 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      */
     List<WorkflowInstance> queryMainWorkflowByHostAndStatus(@Param("host") String host,
                                                             @Param("states") int[] stateArray);
+
     /**
      * query workflow instance host by stateArray
      *
@@ -108,15 +107,15 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
     /**
      * workflow instance page
      *
-     * @param page                  page
-     * @param projectCode           projectCode
+     * @param page                   page
+     * @param projectCode            projectCode
      * @param workflowDefinitionCode workflowDefinitionCode
-     * @param searchVal             searchVal
-     * @param executorName          executorName
-     * @param statusArray           statusArray
-     * @param host                  host
-     * @param startTime             startTime
-     * @param endTime               endTime
+     * @param searchVal              searchVal
+     * @param executorName           executorName
+     * @param statusArray            statusArray
+     * @param host                   host
+     * @param startTime              startTime
+     * @param endTime                endTime
      * @return workflow instance page
      */
     IPage<WorkflowInstance> queryWorkflowInstanceListPaging(Page<WorkflowInstance> page,
@@ -143,9 +142,9 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * Update the workflow instance state from originState to destState
      */
     int updateWorkflowInstanceState(
-                                    @Param("workflowInstanceId") Integer workflowInstanceId,
-                                    @Param("originState") WorkflowExecutionStatus originState,
-                                    @Param("targetState") WorkflowExecutionStatus targetState);
+            @Param("workflowInstanceId") Integer workflowInstanceId,
+            @Param("originState") WorkflowExecutionStatus originState,
+            @Param("targetState") WorkflowExecutionStatus targetState);
 
     /**
      * update workflow instance by tenantCode
@@ -178,15 +177,15 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * @return ExecuteStatusCount list
      */
     List<WorkflowInstanceStatusCountDto> countWorkflowInstanceStateByProjectCodes(
-                                                                                  @Param("startTime") Date startTime,
-                                                                                  @Param("endTime") Date endTime,
-                                                                                  @Param("projectCodes") Collection<Long> projectCodes);
+            @Param("startTime") Date startTime,
+            @Param("endTime") Date endTime,
+            @Param("projectCodes") Collection<Long> projectCodes);
 
     /**
      * query workflow instance by workflowDefinitionCode
      *
      * @param workflowDefinitionCode workflowDefinitionCode
-     * @param size                  size
+     * @param size                   size
      * @return workflow instance list
      */
     List<WorkflowInstance> queryByWorkflowDefinitionCode(@Param("workflowDefinitionCode") Long workflowDefinitionCode,
@@ -196,10 +195,10 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * query last scheduler workflow instance
      *
      * @param workflowDefinitionCode definitionCode
-     * @param taskDefinitionCode    definitionCode
-     * @param startTime             startTime
-     * @param endTime               endTime
-     * @param testFlag              testFlag
+     * @param taskDefinitionCode     definitionCode
+     * @param startTime              startTime
+     * @param endTime                endTime
+     * @param testFlag               testFlag
      * @return workflow instance
      */
     WorkflowInstance queryLastSchedulerWorkflow(@Param("workflowDefinitionCode") Long workflowDefinitionCode,
@@ -212,10 +211,10 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * query last manual workflow instance
      *
      * @param workflowDefinitionCode workflowDefinitionCode
-     * @param taskCode       taskCode
-     * @param startTime      startTime
-     * @param endTime        endTime
-     * @param testFlag       testFlag
+     * @param taskCode               taskCode
+     * @param startTime              startTime
+     * @param endTime                endTime
+     * @param testFlag               testFlag
      * @return workflow instance
      */
     WorkflowInstance queryLastManualWorkflow(@Param("workflowDefinitionCode") Long workflowDefinitionCode,
@@ -223,6 +222,11 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
                                              @Param("startTime") Date startTime,
                                              @Param("endTime") Date endTime,
                                              @Param("testFlag") int testFlag);
+
+    WorkflowInstance queryLastRunningWorkflow(@Param("workflowDefinitionCode") Long workflowDefinitionCode,
+                                              @Param("startTime") Date startTime,
+                                              @Param("endTime") Date endTime,
+                                              @Param("states") int[] stateArray);
 
     /**
      * query first schedule workflow instance
@@ -261,7 +265,7 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * query workflow instance by workflowDefinitionCode and stateArray
      *
      * @param workflowDefinitionCode workflowDefinitionCode
-     * @param states                states array
+     * @param states                 states array
      * @return workflow instance list
      */
 
@@ -275,12 +279,12 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
     /**
      * Filter workflow instance
      *
-     * @param page                  page
+     * @param page                   page
      * @param workflowDefinitionCode workflowDefinitionCode
-     * @param name                  name
-     * @param host                  host
-     * @param startTime             startTime
-     * @param endTime               endTime
+     * @param name                   name
+     * @param host                   host
+     * @param startTime              startTime
+     * @param endTime                endTime
      * @return workflow instance IPage
      */
     IPage<WorkflowInstance> queryWorkflowInstanceListV2Paging(Page<WorkflowInstance> page,
@@ -306,12 +310,12 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * @return ExecuteStatusCount list
      */
     List<ExecuteStatusCount> countInstanceStateV2(
-                                                  @Param("startTime") Date startTime,
-                                                  @Param("endTime") Date endTime,
-                                                  @Param("projectCode") Long projectCode,
-                                                  @Param("workflowCode") Long workflowCode,
-                                                  @Param("model") Integer model,
-                                                  @Param("projectIds") Set<Integer> projectIds);
+            @Param("startTime") Date startTime,
+            @Param("endTime") Date endTime,
+            @Param("projectCode") Long projectCode,
+            @Param("workflowCode") Long workflowCode,
+            @Param("model") Integer model,
+            @Param("projectIds") Set<Integer> projectIds);
 
     /**
      * query process list by triggerCode

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
@@ -17,19 +17,21 @@
 
 package org.apache.dolphinscheduler.dao.mapper;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.ExecuteStatusCount;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
+
 import org.apache.ibatis.annotations.Param;
 
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 /**
  * workflow instance mapper interface
@@ -142,9 +144,9 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * Update the workflow instance state from originState to destState
      */
     int updateWorkflowInstanceState(
-            @Param("workflowInstanceId") Integer workflowInstanceId,
-            @Param("originState") WorkflowExecutionStatus originState,
-            @Param("targetState") WorkflowExecutionStatus targetState);
+                                    @Param("workflowInstanceId") Integer workflowInstanceId,
+                                    @Param("originState") WorkflowExecutionStatus originState,
+                                    @Param("targetState") WorkflowExecutionStatus targetState);
 
     /**
      * update workflow instance by tenantCode
@@ -177,9 +179,9 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * @return ExecuteStatusCount list
      */
     List<WorkflowInstanceStatusCountDto> countWorkflowInstanceStateByProjectCodes(
-            @Param("startTime") Date startTime,
-            @Param("endTime") Date endTime,
-            @Param("projectCodes") Collection<Long> projectCodes);
+                                                                                  @Param("startTime") Date startTime,
+                                                                                  @Param("endTime") Date endTime,
+                                                                                  @Param("projectCodes") Collection<Long> projectCodes);
 
     /**
      * query workflow instance by workflowDefinitionCode
@@ -310,12 +312,12 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
      * @return ExecuteStatusCount list
      */
     List<ExecuteStatusCount> countInstanceStateV2(
-            @Param("startTime") Date startTime,
-            @Param("endTime") Date endTime,
-            @Param("projectCode") Long projectCode,
-            @Param("workflowCode") Long workflowCode,
-            @Param("model") Integer model,
-            @Param("projectIds") Set<Integer> projectIds);
+                                                  @Param("startTime") Date startTime,
+                                                  @Param("endTime") Date endTime,
+                                                  @Param("projectCode") Long projectCode,
+                                                  @Param("workflowCode") Long workflowCode,
+                                                  @Param("model") Integer model,
+                                                  @Param("projectIds") Set<Integer> projectIds);
 
     /**
      * query process list by triggerCode

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/WorkflowInstanceDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/WorkflowInstanceDao.java
@@ -68,6 +68,8 @@ public interface WorkflowInstanceDao extends IDao<WorkflowInstance> {
     WorkflowInstance queryLastManualWorkflowInterval(Long definitionCode, Long taskCode, DateInterval dateInterval,
                                                      int testFlag);
 
+    WorkflowInstance queryLastRunningWorkflowInterval(Long definitionCode, DateInterval dateInterval);
+
     /**
      * query first schedule workflow instance
      *

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
@@ -120,6 +120,16 @@ public class WorkflowInstanceDaoImpl extends BaseDao<WorkflowInstance, WorkflowI
                 testFlag);
     }
 
+    @Override
+    public WorkflowInstance queryLastRunningWorkflowInterval(Long definitionCode, DateInterval dateInterval) {
+        int[] runningStateArray = new int[]{WorkflowExecutionStatus.SUBMITTED_SUCCESS.ordinal(),
+                WorkflowExecutionStatus.RUNNING_EXECUTION.ordinal(),
+                WorkflowExecutionStatus.READY_PAUSE.ordinal(),
+                WorkflowExecutionStatus.READY_STOP.ordinal()};
+        return mybatisMapper.queryLastRunningWorkflow(definitionCode, dateInterval.getStartTime(),
+                dateInterval.getEndTime(), runningStateArray);
+    }
+
     /**
      * query first schedule process instance
      *

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.xml
@@ -249,6 +249,24 @@
         order by t1.end_time desc limit 1
     </select>
 
+    <select id="queryLastRunningWorkflow" resultType="org.apache.dolphinscheduler.dao.entity.WorkflowInstance">
+        select
+        <include refid="baseSql"/>
+        from t_ds_workflow_instance
+        where workflow_definition_code=#{workflowDefinitionCode}
+        <if test="states !=null and states.length != 0">
+            and state in
+            <foreach collection="states" item="i" index="index" open="(" separator="," close=")">
+                #{i}
+            </foreach>
+        </if>
+        <if test="startTime!=null and endTime != null ">
+            and ((schedule_time <![CDATA[ >= ]]> #{startTime} and schedule_time <![CDATA[ <= ]]> #{endTime})
+            or (start_time <![CDATA[ >= ]]> #{startTime} and start_time <![CDATA[ <= ]]> #{endTime}))
+        </if>
+        order by start_time desc limit 1
+    </select>
+
     <select id="queryFirstScheduleWorkflowInstance" resultType="org.apache.dolphinscheduler.dao.entity.WorkflowInstance">
         select
         <include refid="baseSql"/>

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/DependentExecute.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/DependentExecute.java
@@ -325,6 +325,10 @@ public class DependentExecute {
      */
     private WorkflowInstance findLastWorkflowInterval(Long definitionCode, Long taskCode, DateInterval dateInterval,
                                                       int testFlag) {
+        WorkflowInstance runningWorkflow = workflowInstanceDao.queryLastRunningWorkflowInterval(definitionCode, dateInterval);
+        if (runningWorkflow != null) {
+            return runningWorkflow;
+        }
 
         WorkflowInstance lastSchedulerWorkflowInstance =
                 workflowInstanceDao.queryLastSchedulerWorkflowInterval(definitionCode, taskCode, dateInterval,

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/DependentExecute.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/DependentExecute.java
@@ -155,7 +155,7 @@ public class DependentExecute {
         DependResult result = DependResult.FAILED;
         for (DateInterval dateInterval : dateIntervals) {
             WorkflowInstance workflowInstance =
-                    findLastWorkflowInterval(dependentItem.getDefinitionCode(), dependentItem.getDepTaskCode(),
+                    findDependentWorkflowCandidate(dependentItem.getDefinitionCode(), dependentItem.getDepTaskCode(),
                             dateInterval, testFlag);
             if (workflowInstance == null) {
                 return DependResult.WAITING;
@@ -314,17 +314,19 @@ public class DependentExecute {
     }
 
     /**
-     * find the last one workflow instance that :
-     * 1. manual run and finish between the interval
-     * 2. schedule run and schedule time between the interval
+     * find the last one workflow instance that:
+     * 1. running workflow instance in the date interval
+     * 2. manual run and finish between the interval
+     * 3. schedule run and schedule time between the interval
      *
      * @param definitionCode definition code
      * @param taskCode task code
      * @param dateInterval   date interval
      * @return workflowInstance
      */
-    private WorkflowInstance findLastWorkflowInterval(Long definitionCode, Long taskCode, DateInterval dateInterval,
-                                                      int testFlag) {
+    private WorkflowInstance findDependentWorkflowCandidate(Long definitionCode, Long taskCode,
+                                                            DateInterval dateInterval,
+                                                            int testFlag) {
         WorkflowInstance runningWorkflow =
                 workflowInstanceDao.queryLastRunningWorkflowInterval(definitionCode, dateInterval);
         if (runningWorkflow != null) {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/DependentExecute.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/DependentExecute.java
@@ -325,7 +325,8 @@ public class DependentExecute {
      */
     private WorkflowInstance findLastWorkflowInterval(Long definitionCode, Long taskCode, DateInterval dateInterval,
                                                       int testFlag) {
-        WorkflowInstance runningWorkflow = workflowInstanceDao.queryLastRunningWorkflowInterval(definitionCode, dateInterval);
+        WorkflowInstance runningWorkflow =
+                workflowInstanceDao.queryLastRunningWorkflowInterval(definitionCode, dateInterval);
         if (runningWorkflow != null) {
             return runningWorkflow;
         }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #17239

![f8wVnu6cmNOiUsP.png](https://cdn.sa.net/2025/06/04/f8wVnu6cmNOiUsP.png)

## Brief change log

This logic exists in the old version, but it is missing in the new version.
https://github.com/apache/dolphinscheduler/blob/2a22b960580c907f67128a294df2b10b4380312a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/DependentExecute.java#L230-L235

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
