### PR TITLE
[Fix-17625][Dolphinscheduler on K8S]fix dolphinscheduler can't reconnect zookeeper when PodIP change 

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -958,7 +958,7 @@
             </activation>
             <properties>
                 <zookeeper.version>3.8.0</zookeeper.version>
-                <curator.version>5.3.0</curator.version>
+                <curator.version>5.5.0</curator.version>
             </properties>
         </profile>
         <profile>

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -243,10 +243,10 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-text 1.4: https://github.com/apache/commons-text, Apache 2.0
     cron-utils 9.1.6: https://mvnrepository.com/artifact/com.cronutils/cron-utils/9.1.6, Apache 2.0
     commons-lang3 3.12.0: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.12.0, Apache 2.0
-    curator-client 5.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-client/5.3.0, Apache 2.0
-    curator-framework 5.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-framework/5.3.0, Apache 2.0
-    curator-recipes 5.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-recipes/5.3.0, Apache 2.0
-    curator-test 5.3.0: https://mvnrepository.com/artifact/org.apache.curator/curator-test/5.3.0, Apache 2.0
+    curator-client 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-client/5.5.0, Apache 2.0
+    curator-framework 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-framework/5.5.0, Apache 2.0
+    curator-recipes 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-recipes/5.5.0, Apache 2.0
+    curator-test 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-test/5.5.0, Apache 2.0
     druid 1.2.20: https://mvnrepository.com/artifact/com.alibaba/druid/1.2.20, Apache 2.0
     metrics-core 4.2.11: https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core, Apache 2.0
     error_prone_annotations 2.1.3 https://mvnrepository.com/artifact/com.google.errorprone/error_prone_annotations/2.1.3, Apache 2.0

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -49,9 +49,9 @@ commons-math3-3.1.1.jar
 commons-net-3.6.jar
 commons-text-1.4.jar
 cron-utils-9.1.6.jar
-curator-client-5.3.0.jar
-curator-framework-5.3.0.jar
-curator-recipes-5.3.0.jar
+curator-client-5.5.0.jar
+curator-framework-5.5.0.jar
+curator-recipes-5.5.0.jar
 datasync-2.17.282.jar
 dnsjava-2.1.7.jar
 druid-1.2.20.jar


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

- Fixes [Issue #17265](https://github.com/apache/dolphinscheduler/issues/17265): DolphinScheduler on K8S can't reconnect to ZooKeeper when PodIP changes

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

1. **dolphinscheduler-bom/pom.xml**: Updated curator version from 5.3.0 to 5.5.0
2. **dolphinscheduler-dist/release-docs/LICENSE**: Updated curator dependency version information
3. **tools/dependencies/known-dependencies.txt**: Updated curator jar file versions

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
