### PR TITLE
[Fix-17297][YARN-QUEUE-MANAGE]Fix creation time should not be changed when modifying data

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/QueueServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/QueueServiceImpl.java
@@ -192,6 +192,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
         }
 
         Queue updateQueue = new Queue(id, queueName, queue);
+        updateQueue.setCreateTime(null);
         Queue existsQueue = queueMapper.selectById(id);
         updateQueueValid(existsQueue, updateQueue);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/QueueServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/QueueServiceTest.java
@@ -186,6 +186,8 @@ public class QueueServiceTest {
         // success
         when(userMapper.existUser(Mockito.anyString())).thenReturn(false);
         assertDoesNotThrow(() -> queueService.updateQueue(getLoginUser(), 1, NOT_EXISTS, NOT_EXISTS));
+        Queue queue = queueService.updateQueue(getLoginUser(), 1, NOT_EXISTS, NOT_EXISTS);
+        Assertions.assertNull(queue.getCreateTime());
 
         // success update with same queue name
         when(queueMapper.existQueue(NOT_EXISTS_FINAL, null)).thenReturn(false);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close #17297 

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
