### PR TITLE
[Fix-17299][alert] upgrade to poi 5.4.1

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/ExcelUtils.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/ExcelUtils.java
@@ -119,7 +119,6 @@ public final class ExcelUtils {
 
             // setting file output
             wb.write(fos);
-            wb.dispose();
         } catch (Exception e) {
             throw new AlertEmailException("generate excel error", e);
         }

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -62,7 +62,7 @@
         <dameng-jdbc.version>8.1.2.79</dameng-jdbc.version>
         <ngdbc.version>2.4.51</ngdbc.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <poi.version>4.1.2</poi.version>
+        <poi.version>5.4.1</poi.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <activation.version>1.1</activation.version>
         <javax-mail>1.6.2</javax-mail>

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -70,7 +70,7 @@
         <postgresql.version>42.4.1</postgresql.version>
         <hive-jdbc.version>2.3.9</hive-jdbc.version>
         <kyuubi-jdbc.version>1.7.0</kyuubi-jdbc.version>
-        <commons-io.version>2.11.0</commons-io.version>
+        <commons-io.version>2.19.0</commons-io.version>
         <oshi-core.version>6.1.1</oshi-core.version>
         <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
         <databend-jdbc.version>0.0.7</databend-jdbc.version>

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -41,7 +41,7 @@
         <io.grpc.version>1.41.0</io.grpc.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-logging.version>1.1.1</commons-logging.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
         <commons-httpclient>3.0.1</commons-httpclient>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-configuration.version>1.10</commons-configuration.version>

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -46,7 +46,7 @@
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-email.version>1.5</commons-email.version>
-        <commons-collections4.version>4.5</commons-collections4.version>
+        <commons-collections4.version>4.5.0</commons-collections4.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <jackson.version>2.13.4</jackson.version>

--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -46,7 +46,7 @@
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-email.version>1.5</commons-email.version>
-        <commons-collections4.version>4.3</commons-collections4.version>
+        <commons-collections4.version>4.5</commons-collections4.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <jackson.version>2.13.4</jackson.version>
@@ -82,8 +82,8 @@
         <reflections.version>0.10.2</reflections.version>
         <py4j.version>0.10.9</py4j.version>
         <jsr305.version>3.0.0</jsr305.version>
-        <commons-compress.version>1.21</commons-compress.version>
-        <commons-math3.version>3.1.1</commons-math3.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
+        <commons-math3.version>3.6.1</commons-math3.version>
         <error_prone_annotations.version>2.5.1</error_prone_annotations.version>
         <hibernate-validator.version>6.2.2.Final</hibernate-validator.version>
         <aws-sdk.version>1.12.300</aws-sdk.version>

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -232,13 +232,13 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-beanutils 1.9.4 https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils/1.9.4, Apache 2.0
     commons-cli 1.2: https://mvnrepository.com/artifact/commons-cli/commons-cli/1.2, Apache 2.0
     commons-codec 1.11: https://mvnrepository.com/artifact/commons-codec/commons-codec/1.11, Apache 2.0
-    commons-collections4 4.3: https://mvnrepository.com/artifact/org.apache.commons/commons-collections4/4.3, Apache 2.0
-    commons-compress 1.21: https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.21, Apache 2.0
+    commons-collections4 4.5: https://mvnrepository.com/artifact/org.apache.commons/commons-collections4/4.5, Apache 2.0
+    commons-compress 1.27.1: https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.27.1, Apache 2.0
     commons-configuration2 2.1.1: https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2/2.1.1, Apache 2.0
     commons-daemon 1.0.13: https://github.com/apache/commons-daemon, Apache 2.0
     commons-io 2.19.0: https://github.com/apache/commons-io, Apache 2.0
     commons-logging 1.1.1: https://github.com/apache/commons-logging, Apache 2.0
-    commons-math3 3.1.1: https://mvnrepository.com/artifact/org.apache.commons/commons-math3/3.1.1, Apache 2.0
+    commons-math3 3.6.1: https://mvnrepository.com/artifact/org.apache.commons/commons-math3/3.6.1, Apache 2.0
     commons-net 3.6: https://github.com/apache/commons-net, Apache 2.0
     commons-text 1.4: https://github.com/apache/commons-text, Apache 2.0
     cron-utils 9.1.6: https://mvnrepository.com/artifact/com.cronutils/cron-utils/9.1.6, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -232,7 +232,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-beanutils 1.9.4 https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils/1.9.4, Apache 2.0
     commons-cli 1.2: https://mvnrepository.com/artifact/commons-cli/commons-cli/1.2, Apache 2.0
     commons-codec 1.11: https://mvnrepository.com/artifact/commons-codec/commons-codec/1.11, Apache 2.0
-    commons-collections4 4.5: https://mvnrepository.com/artifact/org.apache.commons/commons-collections4/4.5, Apache 2.0
+    commons-collections4 4.5.0: https://mvnrepository.com/artifact/org.apache.commons/commons-collections4/4.5.0, Apache 2.0
     commons-compress 1.27.1: https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.27.1, Apache 2.0
     commons-configuration2 2.1.1: https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2/2.1.1, Apache 2.0
     commons-daemon 1.0.13: https://github.com/apache/commons-daemon, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -242,7 +242,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-net 3.6: https://github.com/apache/commons-net, Apache 2.0
     commons-text 1.4: https://github.com/apache/commons-text, Apache 2.0
     cron-utils 9.1.6: https://mvnrepository.com/artifact/com.cronutils/cron-utils/9.1.6, Apache 2.0
-    commons-lang3 3.12.0: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.12.0, Apache 2.0
+    commons-lang3 3.17.0: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.17.0, Apache 2.0
     curator-client 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-client/5.5.0, Apache 2.0
     curator-framework 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-framework/5.5.0, Apache 2.0
     curator-recipes 5.5.0: https://mvnrepository.com/artifact/org.apache.curator/curator-recipes/5.5.0, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -236,7 +236,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-compress 1.21: https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.21, Apache 2.0
     commons-configuration2 2.1.1: https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2/2.1.1, Apache 2.0
     commons-daemon 1.0.13: https://github.com/apache/commons-daemon, Apache 2.0
-    commons-io 2.11.0: https://github.com/apache/commons-io, Apache 2.0
+    commons-io 2.19.0: https://github.com/apache/commons-io, Apache 2.0
     commons-logging 1.1.1: https://github.com/apache/commons-logging, Apache 2.0
     commons-math3 3.1.1: https://mvnrepository.com/artifact/org.apache.commons/commons-math3/3.1.1, Apache 2.0
     commons-net 3.6: https://github.com/apache/commons-net, Apache 2.0

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -38,14 +38,14 @@ commons-beanutils-1.9.4.jar
 commons-cli-1.2.jar
 commons-codec-1.11.jar
 commons-collections-3.2.2.jar
-commons-collections4-4.3.jar
+commons-collections4-4.5.jar
 commons-compiler-3.1.7.jar
-commons-compress-1.21.jar
+commons-compress-1.27.1.jar
 commons-configuration2-2.1.1.jar
 commons-io-2.19.0.jar
 commons-lang3-3.12.0.jar
 commons-logging-1.1.1.jar
-commons-math3-3.1.1.jar
+commons-math3-3.6.1.jar
 commons-net-3.6.jar
 commons-text-1.4.jar
 cron-utils-9.1.6.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -43,7 +43,7 @@ commons-compiler-3.1.7.jar
 commons-compress-1.27.1.jar
 commons-configuration2-2.1.1.jar
 commons-io-2.19.0.jar
-commons-lang3-3.12.0.jar
+commons-lang3-3.17.0.jar
 commons-logging-1.1.1.jar
 commons-math3-3.6.1.jar
 commons-net-3.6.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -42,7 +42,7 @@ commons-collections4-4.3.jar
 commons-compiler-3.1.7.jar
 commons-compress-1.21.jar
 commons-configuration2-2.1.1.jar
-commons-io-2.11.0.jar
+commons-io-2.19.0.jar
 commons-lang3-3.12.0.jar
 commons-logging-1.1.1.jar
 commons-math3-3.1.1.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -38,7 +38,7 @@ commons-beanutils-1.9.4.jar
 commons-cli-1.2.jar
 commons-codec-1.11.jar
 commons-collections-3.2.2.jar
-commons-collections4-4.5.jar
+commons-collections4-4.5.0.jar
 commons-compiler-3.1.7.jar
 commons-compress-1.27.1.jar
 commons-configuration2-2.1.1.jar


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #17299 - security issues

also need to upgrade commons-io because POI needs a newer version and upgrading resolves CVE-2024-47554

when working on this, I had to upgrade a few other jar versions because POI or its dependencies needs newer versions of those jars

POI 5.4.1 no longer requires SXSSFWorkbook to be disposed - close is enough

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
