### PR TITLE
[Fix-17317][Task-API] Add kill yarn or k8s application after killing task

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/AbstractCommandExecutor.java
@@ -221,6 +221,9 @@ public abstract class AbstractCommandExecutor {
             log.error("Failed to kill process tree for task: {}, pid: {}",
                     taskRequest.getTaskAppId(), taskRequest.getProcessId());
         }
+
+        // Try to kill yarn or k8s application
+        ProcessUtils.cancelApplication(taskRequest);
     }
 
     private void collectPodLogIfNeeded() {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17317

add kill yarn or k8s application

## Brief change log

Add kill yarn or k8s application after killing task

