### PR TITLE
[Doc-17327] add helm section in development documentation in both Chinese and English 

### DIFF
--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -54,7 +54,6 @@ pre-commit install
 
 Now, every time you commit your code, `pre-commit` will automatically run `Spotless` to check the code style and formatting.
 
-
 ### Helm Template Guidelines
 
 After modifying files related to Helm templates, you can use the following command to debug the Helm templates:
@@ -68,7 +67,6 @@ Once the Helm templates are debugged and verified, use the following command to 
 ```shell
 ./mvnw validate -P helm-doc -pl :dolphinscheduler
 ```
-
 
 ## Docker image build
 

--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -54,6 +54,22 @@ pre-commit install
 
 Now, every time you commit your code, `pre-commit` will automatically run `Spotless` to check the code style and formatting.
 
+
+### Helm Template Guidelines
+
+After modifying files related to Helm templates, you can use the following command to debug the Helm templates:
+
+```shell
+helm template ./deploy/kubernetes/dolphinscheduler --debug 
+```
+
+Once the Helm templates are debugged and verified, use the following command to automatically update the README.md file (manually updating may likely result in incorrect formatting):
+
+```shell
+./mvnw validate -P helm-doc -pl :dolphinscheduler
+```
+
+
 ## Docker image build
 
 DolphinScheduler will release new Docker images after it released, you could find them in [Docker Hub](https://hub.docker.com/search?q=DolphinScheduler).

--- a/docs/docs/zh/contribute/development-environment-setup.md
+++ b/docs/docs/zh/contribute/development-environment-setup.md
@@ -51,7 +51,6 @@ pre-commit install
 
 现在，每次您提交代码时，`pre-commit`都会自动运行`Spotless`来检查代码风格和格式。
 
-
 ### Helm 模板规范
 
 当您修改了Helm模板相关的文件后， 可以使用如下命令来调试 Helm 模板：

--- a/docs/docs/zh/contribute/development-environment-setup.md
+++ b/docs/docs/zh/contribute/development-environment-setup.md
@@ -51,6 +51,21 @@ pre-commit install
 
 现在，每次您提交代码时，`pre-commit`都会自动运行`Spotless`来检查代码风格和格式。
 
+
+### Helm 模板规范
+
+当您修改了Helm模板相关的文件后， 可以使用如下命令来调试 Helm 模板：
+
+```shell
+helm template ./deploy/kubernetes/dolphinscheduler --debug 
+```
+
+Helm模板调试通过之后，需要使用如下命令来自动更新README.md文件（手动更新很可能格式不符合要求）：
+
+```shell
+./mvnw validate -P helm-doc -pl :dolphinscheduler
+```
+
 ## Docker镜像构建
 
 DolphinScheduler 每次发版都会同时发布 Docker 镜像，你可以在 [Docker Hub](https://hub.docker.com/search?q=DolphinScheduler) 中找到这些镜像


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->


## Purpose of the pull request

close https://github.com/apache/dolphinscheduler/issues/17327


## Brief change log

add helm section in development documentation in both Chinese and English 


## Verify this pull request

This pull request is code cleanup without any test coverage.

This change is a documentation improvement that can be verified by:

Reviewing the enhanced overview sections in both language versions for clarity and accuracy
Ensuring the documentation follows the project's documentation standards
Confirming that the modified content provides better guidance for users in both Chinese and English
