### PR TITLE
[Fix-17350] Fix issues of sub-workflow failover from different master server

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
@@ -94,8 +94,12 @@ public enum WorkflowExecutionStatus {
                 || this == SERIAL_WAIT;
     }
 
-    public boolean canFailover() {
-        return Arrays.stream(NEED_FAILOVER_STATES).anyMatch(x -> x == this.getCode());
+    /**
+     * status can be take over on sub-workflow
+     * @return bool
+     */
+    public boolean canTakeover() {
+        return Arrays.stream(NEED_FAILOVER_STATES).anyMatch(x -> x == this.getCode()) || this == FAILOVER;
     }
 
     public boolean canDirectPauseInDB() {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
@@ -99,7 +99,14 @@ public enum WorkflowExecutionStatus {
      * @return bool
      */
     public boolean canTakeover() {
-        return Arrays.stream(NEED_FAILOVER_STATES).anyMatch(x -> x == this.getCode()) || this == FAILOVER;
+        return this == RUNNING_EXECUTION
+                || this == READY_PAUSE
+                || this == PAUSE
+                || this == READY_STOP
+                || this == STOP
+                || this == FAILURE
+                || this == SUCCESS
+                || this == FAILOVER;
     }
 
     public boolean canDirectPauseInDB() {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/enums/WorkflowExecutionStatus.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.common.enums;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.java
@@ -57,16 +57,6 @@ public interface WorkflowInstanceMapper extends BaseMapper<WorkflowInstance> {
                                                 @Param("states") int[] stateArray);
 
     /**
-     * query workflow instance by host and stateArray which is not sub workflow
-     *
-     * @param host       host
-     * @param stateArray stateArray
-     * @return workflow instance list
-     */
-    List<WorkflowInstance> queryMainWorkflowByHostAndStatus(@Param("host") String host,
-                                                            @Param("states") int[] stateArray);
-
-    /**
      * query workflow instance host by stateArray
      *
      * @param stateArray

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
@@ -176,7 +176,7 @@ public class WorkflowInstanceDaoImpl extends BaseDao<WorkflowInstance, WorkflowI
 
     @Override
     public List<WorkflowInstance> queryNeedFailoverWorkflowInstances(String masterAddress) {
-        return mybatisMapper.queryMainWorkflowByHostAndStatus(masterAddress,
+        return mybatisMapper.queryByHostAndStatus(masterAddress,
                 WorkflowExecutionStatus.getNeedFailoverWorkflowInstanceState());
     }
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/WorkflowInstanceMapper.xml
@@ -50,22 +50,6 @@
         </if>
         order by id asc
     </select>
-    <select id="queryMainWorkflowByHostAndStatus" resultType="org.apache.dolphinscheduler.dao.entity.WorkflowInstance">
-        select
-        <include refid="baseSql"/>
-        from t_ds_workflow_instance
-        where is_sub_workflow=0
-        <if test="host != null and host != ''">
-            and host=#{host}
-        </if>
-        <if test="states != null and states.length != 0">
-            and state in
-            <foreach collection="states" item="i" open="(" close=")" separator=",">
-                #{i}
-            </foreach>
-        </if>
-        order by id asc
-    </select>
     <select id="queryNeedFailoverWorkflowInstanceHost" resultType="String">
         select distinct host
         from t_ds_workflow_instance

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
@@ -40,7 +40,6 @@ import org.apache.dolphinscheduler.server.master.engine.executor.plugin.Abstract
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
 import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
-import org.apache.dolphinscheduler.server.master.failover.WorkflowFailover;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
 
@@ -168,9 +167,9 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
         final WorkflowInstance subWorkflowInstance = workflowInstanceDao.queryById(
                 subWorkflowLogicTaskRuntimeContext.getSubWorkflowInstanceId());
 
-        if (subWorkflowInstance != null && subWorkflowInstance.getState().canFailover()) {
-            // Only handle sub-workflow's fail-over in SubWorkflowLogicTask's fail-over
-            applicationContext.getBean(WorkflowFailover.class).failoverWorkflow(subWorkflowInstance);
+        if (subWorkflowInstance != null && subWorkflowInstance.getState().canTakeover()) {
+            // Here we only need to take over the runtime context of sub-workflow,
+            // the sub-workflow will be failover by master-server when needed.
             return subWorkflowLogicTaskRuntimeContext;
         }
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -856,7 +856,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .address(subWorkflowInstance.getHost())
                 .build();
 
-        // first start sub-workflow to simulate the normal parent workflow
+        // first start sub-workflow to simulate the normal child workflow
         systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
 
         final String subMasterFailoverNodePath = RegistryUtils.getFailoveredNodePath(

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -21,9 +21,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import org.apache.dolphinscheduler.common.enums.Flag;
+import org.apache.dolphinscheduler.common.enums.ServerStatus;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.extract.base.client.Clients;
 import org.apache.dolphinscheduler.extract.master.IWorkflowControlClient;
 import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowInstanceStopRequest;
@@ -31,16 +33,21 @@ import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowI
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.registry.api.utils.RegistryUtils;
 import org.apache.dolphinscheduler.server.master.AbstractMasterIntegrationTestCase;
+import org.apache.dolphinscheduler.server.master.cluster.MasterServerMetadata;
 import org.apache.dolphinscheduler.server.master.engine.system.SystemEventBus;
 import org.apache.dolphinscheduler.server.master.engine.system.event.GlobalMasterFailoverEvent;
+import org.apache.dolphinscheduler.server.master.engine.system.event.MasterFailoverEvent;
+import org.apache.dolphinscheduler.server.master.failover.FailoverCoordinator;
 import org.apache.dolphinscheduler.server.master.integration.WorkflowTestCaseContext;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.Duration;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import org.h2.util.Task;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -48,6 +55,9 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
     @Autowired
     private SystemEventBus systemEventBus;
+
+    @Autowired
+    FailoverCoordinator failoverCoordinator;
 
     @Test
     public void testGlobalFailover_runningWorkflow_withSubmittedTasks() {
@@ -671,6 +681,528 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         assertThat(repository.queryAllTaskInstance()).hasSize(4);
+
+        masterContainer.assertAllResourceReleased();
+
+    }
+
+
+    @Test
+    public void testMasterFailover_runningWorkflow_takeOverSubWorkflowOnParentHealthy() {
+        final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running")).findFirst()
+                .orElse(null);
+        final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running")).findFirst().orElse(null);
+
+
+        final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
+        final WorkflowInstance subWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running-20250424180000000")).findFirst().orElse(null);
+
+
+        assertThat(mainWorkflow).isNotNull();
+        assertThat(subWorkflow).isNotNull();
+        assertThat(mainWorkflowInstance).isNotNull();
+        assertThat(subWorkflowInstance).isNotNull();
+
+
+
+        MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(mainWorkflowInstance.getHost())
+                .build();
+        MasterServerMetadata masterServerSub = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(subWorkflowInstance.getHost())
+                .build();
+
+
+
+
+        // first start workflow to simulate the normal parent workflow
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
+
+        final String mainMasterFailoverNodePath = RegistryUtils.getFailoveredNodePath(
+                masterServerMain.getAddress(),
+                masterServerMain.getServerStartupTime(),
+                masterServerMain.getProcessId());
+        // wait failover main-workflow
+        await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> {
+                    assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
+                });
+        // wait main-workflow started
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(mainWorkflow))
+                            .hasSize(1)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
+                            });
+                });
+
+        // wait sub-workflow-task started
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(mainWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.RUNNING_EXECUTION);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("sub_workflow_task");
+                            });
+                });
+
+
+        // failover sub-workflow
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryAllWorkflowInstance())
+                            .hasSize(2)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(mainWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.SUCCESS);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("sub_workflow_task");
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(subWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.SUCCESS);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("fake_task_A");
+                            });
+                });
+
+        assertThat(repository.queryAllTaskInstance()).hasSize(4);
+
+        masterContainer.assertAllResourceReleased();
+
+    }
+
+
+    @Test
+    public void testMasterFailover_runningWorkflow_takeOverSubWorkflowOnChildHealthy() {
+        final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running")).findFirst()
+                .orElse(null);
+        final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running")).findFirst().orElse(null);
+
+
+        final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
+        final WorkflowInstance subWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running-20250424180000000")).findFirst().orElse(null);
+
+
+        assertThat(mainWorkflow).isNotNull();
+        assertThat(subWorkflow).isNotNull();
+        assertThat(mainWorkflowInstance).isNotNull();
+        assertThat(subWorkflowInstance).isNotNull();
+
+
+
+        MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(mainWorkflowInstance.getHost())
+                .build();
+        MasterServerMetadata masterServerSub = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(subWorkflowInstance.getHost())
+                .build();
+
+        // first start sub-workflow to simulate the normal parent workflow
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
+
+        final String subMasterFailoverNodePath = RegistryUtils.getFailoveredNodePath(
+                masterServerSub.getAddress(),
+                masterServerSub.getServerStartupTime(),
+                masterServerSub.getProcessId());
+        // wait failover sub-workflow
+        await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> {
+                    assertThat(registryClient.exists(subMasterFailoverNodePath)).isTrue();
+                });
+        // wait sub-workflow started
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(subWorkflow))
+                            .hasSize(1)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
+                            });
+                });
+
+
+        // failover main-workflow
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryAllWorkflowInstance())
+                            .hasSize(2)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(mainWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.SUCCESS);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("sub_workflow_task");
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryTaskInstance(subWorkflow))
+                            .hasSize(2)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                                : TaskExecutionStatus.SUCCESS);
+                                assertThat(taskInstance.getName())
+                                        .isEqualTo("fake_task_A");
+                            });
+                });
+
+        assertThat(repository.queryAllTaskInstance()).hasSize(4);
+
+        masterContainer.assertAllResourceReleased();
+
+    }
+
+
+    @Test
+    public void testMasterFailover_runningWorkflow_takeOverSubWorkflowOnChildNotHealthy() {
+        final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflows")).findFirst()
+                .orElse(null);
+        final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow")).findFirst().orElse(null);
+
+
+        final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
+        final WorkflowInstance submittedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst().orElse(null);
+
+        final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst().orElse(null);
+
+        final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst().orElse(null);
+
+
+        assertThat(mainWorkflow).isNotNull();
+        assertThat(subWorkflow).isNotNull();
+        assertThat(mainWorkflowInstance).isNotNull();
+        assertThat(submittedSubWorkflowInstance).isNotNull();
+        assertThat(stopppedSubWorkflowInstance).isNotNull();
+        assertThat(pausedSubWorkflowInstance).isNotNull();
+
+
+
+        MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(mainWorkflowInstance.getHost())
+                .build();
+        MasterServerMetadata masterServerSub = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(submittedSubWorkflowInstance.getHost())
+                .build();
+
+
+
+
+        // first start workflow to simulate the normal parent workflow
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
+
+        final String mainMasterFailoverNodePath = RegistryUtils.getFailoveredNodePath(
+                masterServerMain.getAddress(),
+                masterServerMain.getServerStartupTime(),
+                masterServerMain.getProcessId());
+        // wait failover main-workflow
+        await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> {
+                    assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
+                });
+        // wait main-workflow started
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(mainWorkflow))
+                            .hasSize(1)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryAllWorkflowInstance())
+                            .hasSize(7)
+                            .filteredOn(workflowInstance -> workflowInstance.getId() > 4)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                            });
+                });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryAllTaskInstance())
+                            .hasSize(9)
+                            .filteredOn(taskInstance -> taskInstance.getId() > 4)
+                            .anySatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(TaskExecutionStatus.SUCCESS);
+                            });
+                });
+
+        masterContainer.assertAllResourceReleased();
+
+    }
+
+
+    @Test
+    public void testMasterFailover_readyStopWorkflow_takeOverSubWorkflowOnChildNotHealthy() {
+        final String yaml = "/it/failover/readyStop_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflows")).findFirst()
+                .orElse(null);
+        final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow")).findFirst().orElse(null);
+
+
+        final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
+        final WorkflowInstance submittedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst().orElse(null);
+
+        final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst().orElse(null);
+
+        final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst().orElse(null);
+
+
+        assertThat(mainWorkflow).isNotNull();
+        assertThat(subWorkflow).isNotNull();
+        assertThat(mainWorkflowInstance).isNotNull();
+        assertThat(submittedSubWorkflowInstance).isNotNull();
+        assertThat(stopppedSubWorkflowInstance).isNotNull();
+        assertThat(pausedSubWorkflowInstance).isNotNull();
+
+
+
+        MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(mainWorkflowInstance.getHost())
+                .build();
+        MasterServerMetadata masterServerSub = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(submittedSubWorkflowInstance.getHost())
+                .build();
+
+
+
+
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
+
+        final String mainMasterFailoverNodePath = RegistryUtils.getFailoveredNodePath(
+                masterServerMain.getAddress(),
+                masterServerMain.getServerStartupTime(),
+                masterServerMain.getProcessId());
+        // wait failover main-workflow
+        await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> {
+                    assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
+                });
+        // wait main-workflow stop
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(mainWorkflow))
+                            .hasSize(1)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.STOP);
+                            });
+                });
+
+        assertThat(repository.queryAllWorkflowInstance().size()).isEqualTo(4);
+        assertThat(repository.queryAllTaskInstance())
+                .hasSize(6)
+                .filteredOn(taskInstance -> taskInstance.getId() > 4)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(TaskExecutionStatus.KILL);
+                });
+
+        masterContainer.assertAllResourceReleased();
+
+    }
+
+    @Test
+    public void testMasterFailover_readyPauseWorkflow_takeOverSubWorkflowOnChildNotHealthy() {
+        final String yaml = "/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflows")).findFirst()
+                .orElse(null);
+        final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow")).findFirst().orElse(null);
+
+
+        final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
+        final WorkflowInstance submittedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst().orElse(null);
+
+        final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst().orElse(null);
+
+        final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
+                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst().orElse(null);
+
+
+        assertThat(mainWorkflow).isNotNull();
+        assertThat(subWorkflow).isNotNull();
+        assertThat(mainWorkflowInstance).isNotNull();
+        assertThat(submittedSubWorkflowInstance).isNotNull();
+        assertThat(stopppedSubWorkflowInstance).isNotNull();
+        assertThat(pausedSubWorkflowInstance).isNotNull();
+
+
+
+        MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(mainWorkflowInstance.getHost())
+                .build();
+        MasterServerMetadata masterServerSub = MasterServerMetadata.builder()
+                .cpuUsage(0.2)
+                .memoryUsage(0.4)
+                .serverStatus(ServerStatus.NORMAL)
+                .address(submittedSubWorkflowInstance.getHost())
+                .build();
+
+
+
+
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
+        systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
+
+        final String mainMasterFailoverNodePath = RegistryUtils.getFailoveredNodePath(
+                masterServerMain.getAddress(),
+                masterServerMain.getServerStartupTime(),
+                masterServerMain.getProcessId());
+        // wait failover main-workflow
+        await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> {
+                    assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
+                });
+        // wait main-workflow stop
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(mainWorkflow))
+                            .hasSize(1)
+                            .anySatisfy(workflowInstance -> {
+                                assertThat(workflowInstance.getState())
+                                        .isEqualTo(WorkflowExecutionStatus.PAUSE);
+                            });
+                });
+
+        assertThat(repository.queryAllWorkflowInstance().size()).isEqualTo(4);
+        assertThat(repository.queryAllTaskInstance())
+                .hasSize(6)
+                .filteredOn(taskInstance -> taskInstance.getId() > 4)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(TaskExecutionStatus.PAUSE);
+                });
 
         masterContainer.assertAllResourceReleased();
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -43,11 +43,9 @@ import org.apache.dolphinscheduler.server.master.integration.WorkflowTestCaseCon
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.Duration;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import org.h2.util.Task;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -686,7 +684,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
     }
 
-
     @Test
     public void testMasterFailover_runningWorkflow_takeOverSubWorkflowOnParentHealthy() {
         final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml";
@@ -697,20 +694,19 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
                 .filter(workflow -> workflow.getName().equals("sub_workflow_running")).findFirst().orElse(null);
 
-
         final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running-20250424180000000")).findFirst()
+                .filter(workflow -> workflow.getName()
+                        .equals("workflow_with_one_sub_workflow_running-20250424180000000"))
+                .findFirst()
                 .orElse(null);
         final WorkflowInstance subWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_running-20250424180000000")).findFirst().orElse(null);
-
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
 
         assertThat(mainWorkflow).isNotNull();
         assertThat(subWorkflow).isNotNull();
         assertThat(mainWorkflowInstance).isNotNull();
         assertThat(subWorkflowInstance).isNotNull();
-
-
 
         MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
                 .cpuUsage(0.2)
@@ -724,9 +720,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .serverStatus(ServerStatus.NORMAL)
                 .address(subWorkflowInstance.getHost())
                 .build();
-
-
-
 
         // first start workflow to simulate the normal parent workflow
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
@@ -767,7 +760,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                                         .isEqualTo("sub_workflow_task");
                             });
                 });
-
 
         // failover sub-workflow
         systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
@@ -817,7 +809,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
     }
 
-
     @Test
     public void testMasterFailover_runningWorkflow_takeOverSubWorkflowOnChildHealthy() {
         final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml";
@@ -828,20 +819,19 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
                 .filter(workflow -> workflow.getName().equals("sub_workflow_running")).findFirst().orElse(null);
 
-
         final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflow_running-20250424180000000")).findFirst()
+                .filter(workflow -> workflow.getName()
+                        .equals("workflow_with_one_sub_workflow_running-20250424180000000"))
+                .findFirst()
                 .orElse(null);
         final WorkflowInstance subWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_running-20250424180000000")).findFirst().orElse(null);
-
+                .filter(workflow -> workflow.getName().equals("sub_workflow_running-20250424180000000")).findFirst()
+                .orElse(null);
 
         assertThat(mainWorkflow).isNotNull();
         assertThat(subWorkflow).isNotNull();
         assertThat(mainWorkflowInstance).isNotNull();
         assertThat(subWorkflowInstance).isNotNull();
-
-
 
         MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
                 .cpuUsage(0.2)
@@ -880,7 +870,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                                         .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
                             });
                 });
-
 
         // failover main-workflow
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
@@ -930,7 +919,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
     }
 
-
     @Test
     public void testMasterFailover_runningWorkflow_takeOverSubWorkflowOnChildNotHealthy() {
         final String yaml = "/it/failover/running_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
@@ -941,19 +929,21 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
                 .filter(workflow -> workflow.getName().equals("sub_workflow")).findFirst().orElse(null);
 
-
         final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000")).findFirst()
+                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000"))
+                .findFirst()
                 .orElse(null);
         final WorkflowInstance submittedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst().orElse(null);
+                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst()
+                .orElse(null);
 
         final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst().orElse(null);
+                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst()
+                .orElse(null);
 
         final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst().orElse(null);
-
+                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst()
+                .orElse(null);
 
         assertThat(mainWorkflow).isNotNull();
         assertThat(subWorkflow).isNotNull();
@@ -961,8 +951,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         assertThat(submittedSubWorkflowInstance).isNotNull();
         assertThat(stopppedSubWorkflowInstance).isNotNull();
         assertThat(pausedSubWorkflowInstance).isNotNull();
-
-
 
         MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
                 .cpuUsage(0.2)
@@ -976,9 +964,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .serverStatus(ServerStatus.NORMAL)
                 .address(submittedSubWorkflowInstance.getHost())
                 .build();
-
-
-
 
         // first start workflow to simulate the normal parent workflow
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
@@ -1033,7 +1018,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
     }
 
-
     @Test
     public void testMasterFailover_readyStopWorkflow_takeOverSubWorkflowOnChildNotHealthy() {
         final String yaml = "/it/failover/readyStop_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
@@ -1044,19 +1028,21 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
                 .filter(workflow -> workflow.getName().equals("sub_workflow")).findFirst().orElse(null);
 
-
         final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000")).findFirst()
+                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000"))
+                .findFirst()
                 .orElse(null);
         final WorkflowInstance submittedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst().orElse(null);
+                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst()
+                .orElse(null);
 
         final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst().orElse(null);
+                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst()
+                .orElse(null);
 
         final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst().orElse(null);
-
+                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst()
+                .orElse(null);
 
         assertThat(mainWorkflow).isNotNull();
         assertThat(subWorkflow).isNotNull();
@@ -1064,8 +1050,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         assertThat(submittedSubWorkflowInstance).isNotNull();
         assertThat(stopppedSubWorkflowInstance).isNotNull();
         assertThat(pausedSubWorkflowInstance).isNotNull();
-
-
 
         MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
                 .cpuUsage(0.2)
@@ -1079,9 +1063,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .serverStatus(ServerStatus.NORMAL)
                 .address(submittedSubWorkflowInstance.getHost())
                 .build();
-
-
-
 
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
         systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
@@ -1123,7 +1104,8 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
     @Test
     public void testMasterFailover_readyPauseWorkflow_takeOverSubWorkflowOnChildNotHealthy() {
-        final String yaml = "/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
+        final String yaml =
+                "/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml";
         final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
         final WorkflowDefinition mainWorkflow = context.getWorkflows().stream()
                 .filter(workflow -> workflow.getName().equals("workflow_with_one_sub_workflows")).findFirst()
@@ -1131,19 +1113,21 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         final WorkflowDefinition subWorkflow = context.getWorkflows().stream()
                 .filter(workflow -> workflow.getName().equals("sub_workflow")).findFirst().orElse(null);
 
-
         final WorkflowInstance mainWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000")).findFirst()
+                .filter(workflow -> workflow.getName().equals("workflow_with_sub_workflow_running-20250424180000000"))
+                .findFirst()
                 .orElse(null);
         final WorkflowInstance submittedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst().orElse(null);
+                .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst()
+                .orElse(null);
 
         final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst().orElse(null);
+                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst()
+                .orElse(null);
 
         final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst().orElse(null);
-
+                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst()
+                .orElse(null);
 
         assertThat(mainWorkflow).isNotNull();
         assertThat(subWorkflow).isNotNull();
@@ -1151,8 +1135,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         assertThat(submittedSubWorkflowInstance).isNotNull();
         assertThat(stopppedSubWorkflowInstance).isNotNull();
         assertThat(pausedSubWorkflowInstance).isNotNull();
-
-
 
         MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
                 .cpuUsage(0.2)
@@ -1166,9 +1148,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .serverStatus(ServerStatus.NORMAL)
                 .address(submittedSubWorkflowInstance.getHost())
                 .build();
-
-
-
 
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
         systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -640,7 +640,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         systemEventBus.publish(GlobalMasterFailoverEvent.of(new Date()));
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(5))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -640,7 +640,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         systemEventBus.publish(GlobalMasterFailoverEvent.of(new Date()));
 
         await()
-                .atMost(Duration.ofMinutes(5))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
@@ -651,7 +651,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(mainWorkflow))
                             .hasSize(2)
@@ -665,7 +665,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(subWorkflow))
                             .hasSize(2)
@@ -730,13 +730,13 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(3))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow started
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
@@ -748,7 +748,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         // wait sub-workflow-task started
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(mainWorkflow))
                             .hasSize(2)
@@ -765,7 +765,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
@@ -776,7 +776,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(mainWorkflow))
                             .hasSize(2)
@@ -790,7 +790,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(subWorkflow))
                             .hasSize(2)
@@ -855,13 +855,13 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerSub.getProcessId());
         // wait failover sub-workflow
         await()
-                .atMost(Duration.ofMinutes(3))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(subMasterFailoverNodePath)).isTrue();
                 });
         // wait sub-workflow started
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(subWorkflow))
                             .hasSize(1)
@@ -875,7 +875,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
@@ -886,7 +886,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(mainWorkflow))
                             .hasSize(2)
@@ -900,7 +900,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(subWorkflow))
                             .hasSize(2)
@@ -974,13 +974,13 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(3))
+                .atMost(Duration.ofMinutes(5))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow started
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
@@ -991,7 +991,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(7)
@@ -1003,7 +1003,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 });
 
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllTaskInstance())
                             .hasSize(9)
@@ -1073,13 +1073,13 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(3))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow stop
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
@@ -1158,13 +1158,13 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(3))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow stop
         await()
-                .atMost(Duration.ofMinutes(1))
+                .atMost(Duration.ofMinutes(8))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -640,12 +640,12 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         systemEventBus.publish(GlobalMasterFailoverEvent.of(new Date()));
 
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
-                            .anySatisfy(workflowInstance -> {
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.SUCCESS);
                             });
@@ -653,7 +653,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         assertThat(repository.queryTaskInstance(mainWorkflow))
                 .hasSize(2)
-                .anySatisfy(taskInstance -> {
+                .allSatisfy(taskInstance -> {
                     assertThat(taskInstance.getState())
                             .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
                                     : TaskExecutionStatus.SUCCESS);
@@ -664,7 +664,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         assertThat(repository.queryTaskInstance(subWorkflow))
                 .hasSize(2)
-                .anySatisfy(taskInstance -> {
+                .allSatisfy(taskInstance -> {
                     assertThat(taskInstance.getState())
                             .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
                                     : TaskExecutionStatus.SUCCESS);
@@ -724,19 +724,19 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow started
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
-                            .anySatisfy(workflowInstance -> {
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
                             });
@@ -744,12 +744,12 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         // wait sub-workflow-task started
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(mainWorkflow))
                             .hasSize(2)
-                            .anySatisfy(taskInstance -> {
+                            .allSatisfy(taskInstance -> {
                                 assertThat(taskInstance.getState())
                                         .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
                                                 : TaskExecutionStatus.RUNNING_EXECUTION);
@@ -762,12 +762,12 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         systemEventBus.publish(MasterFailoverEvent.of(masterServerSub, new Date(), 0));
 
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
-                            .anySatisfy(workflowInstance -> {
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.SUCCESS);
                             });
@@ -775,7 +775,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         assertThat(repository.queryTaskInstance(mainWorkflow))
                 .hasSize(2)
-                .anySatisfy(taskInstance -> {
+                .allSatisfy(taskInstance -> {
                     assertThat(taskInstance.getState())
                             .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
                                     : TaskExecutionStatus.SUCCESS);
@@ -785,7 +785,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         assertThat(repository.queryTaskInstance(subWorkflow))
                 .hasSize(2)
-                .anySatisfy(taskInstance -> {
+                .allSatisfy(taskInstance -> {
                     assertThat(taskInstance.getState())
                             .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
                                     : TaskExecutionStatus.SUCCESS);
@@ -845,34 +845,22 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerSub.getProcessId());
         // wait failover sub-workflow
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(subMasterFailoverNodePath)).isTrue();
-                });
-        // wait sub-workflow started
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .pollInterval(Duration.ofMillis(500))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryWorkflowInstance(subWorkflow))
-                            .hasSize(1)
-                            .anySatisfy(workflowInstance -> {
-                                assertThat(workflowInstance.getState())
-                                        .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
-                            });
                 });
 
         // failover main-workflow
         systemEventBus.publish(MasterFailoverEvent.of(masterServerMain, new Date(), 0));
 
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
-                            .anySatisfy(workflowInstance -> {
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.SUCCESS);
                             });
@@ -880,7 +868,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         assertThat(repository.queryAllTaskInstance()).filteredOn(
                 taskInstance -> taskInstance.getId() > 2 && taskInstance.getState() == TaskExecutionStatus.SUCCESS)
-                .hasSize(4);
+                .hasSize(2);
 
         masterContainer.assertAllResourceReleased();
     }
@@ -903,20 +891,10 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .filter(workflow -> workflow.getName().equals("sub_workflow_submitted-20250424180000000")).findFirst()
                 .orElse(null);
 
-        final WorkflowInstance stopppedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_stopped-20250424180000000")).findFirst()
-                .orElse(null);
-
-        final WorkflowInstance pausedSubWorkflowInstance = context.getWorkflowInstances().stream()
-                .filter(workflow -> workflow.getName().equals("sub_workflow_paused-20250424180000000")).findFirst()
-                .orElse(null);
-
         assertThat(mainWorkflow).isNotNull();
         assertThat(subWorkflow).isNotNull();
         assertThat(mainWorkflowInstance).isNotNull();
         assertThat(submittedSubWorkflowInstance).isNotNull();
-        assertThat(stopppedSubWorkflowInstance).isNotNull();
-        assertThat(pausedSubWorkflowInstance).isNotNull();
 
         MasterServerMetadata masterServerMain = MasterServerMetadata.builder()
                 .cpuUsage(0.2)
@@ -940,43 +918,42 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(5))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
-        // wait main-workflow started
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .pollInterval(Duration.ofMillis(500))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryWorkflowInstance(mainWorkflow))
-                            .hasSize(1)
-                            .anySatisfy(workflowInstance -> {
-                                assertThat(workflowInstance.getState())
-                                        .isEqualTo(WorkflowExecutionStatus.RUNNING_EXECUTION);
-                            });
-                });
 
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryWorkflowInstance(1).getState()).isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                });
+        await()
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
-                            .hasSize(7)
-                            .filteredOn(workflowInstance -> workflowInstance.getId() > 4)
-                            .anySatisfy(workflowInstance -> {
+                            .hasSize(3)
+                            .filteredOn(workflowInstance -> workflowInstance.getId() == 3)
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.SUCCESS);
                             });
                 });
 
-        assertThat(repository.queryAllTaskInstance())
-                .hasSize(9)
-                .filteredOn(taskInstance -> taskInstance.getId() > 4)
-                .anySatisfy(taskInstance -> {
-                    assertThat(taskInstance.getState())
-                            .isEqualTo(TaskExecutionStatus.SUCCESS);
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    assertThat(repository.queryAllTaskInstance())
+                            .hasSize(3)
+                            .filteredOn(taskInstance -> taskInstance.getId() > 1)
+                            .allSatisfy(taskInstance -> {
+                                assertThat(taskInstance.getState())
+                                        .isEqualTo(TaskExecutionStatus.SUCCESS);
+                            });
                 });
 
         masterContainer.assertAllResourceReleased();
@@ -1038,19 +1015,19 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow stop
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
-                            .anySatisfy(workflowInstance -> {
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.STOP);
                             });
@@ -1125,19 +1102,19 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 masterServerMain.getProcessId());
         // wait failover main-workflow
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow stop
         await()
-                .atMost(Duration.ofMinutes(8))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
-                            .anySatisfy(workflowInstance -> {
+                            .allSatisfy(workflowInstance -> {
                                 assertThat(workflowInstance.getState())
                                         .isEqualTo(WorkflowExecutionStatus.PAUSE);
                             });
@@ -1147,7 +1124,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         assertThat(repository.queryAllTaskInstance())
                 .hasSize(6)
                 .filteredOn(taskInstance -> taskInstance.getId() > 4)
-                .anySatisfy(taskInstance -> {
+                .allSatisfy(taskInstance -> {
                     assertThat(taskInstance.getState())
                             .isEqualTo(TaskExecutionStatus.PAUSE);
                 });

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -641,6 +641,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
@@ -650,32 +651,25 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                             });
                 });
 
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryTaskInstance(mainWorkflow))
-                            .hasSize(2)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
-                                                : TaskExecutionStatus.SUCCESS);
-                                assertThat(taskInstance.getName())
-                                        .isEqualTo("sub_workflow_task");
-                            });
+        assertThat(repository.queryTaskInstance(mainWorkflow))
+                .hasSize(2)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                    : TaskExecutionStatus.SUCCESS);
+                    assertThat(taskInstance.getName())
+                            .isEqualTo("sub_workflow_task");
                 });
 
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryTaskInstance(subWorkflow))
-                            .hasSize(2)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
-                                                : TaskExecutionStatus.SUCCESS);
-                                assertThat(taskInstance.getName())
-                                        .isEqualTo("fake_task_A");
-                            });
+
+        assertThat(repository.queryTaskInstance(subWorkflow))
+                .hasSize(2)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                    : TaskExecutionStatus.SUCCESS);
+                    assertThat(taskInstance.getName())
+                            .isEqualTo("fake_task_A");
                 });
 
         assertThat(repository.queryAllTaskInstance()).hasSize(4);
@@ -731,12 +725,14 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         // wait failover main-workflow
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow started
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
@@ -749,6 +745,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         // wait sub-workflow-task started
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryTaskInstance(mainWorkflow))
                             .hasSize(2)
@@ -766,6 +763,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
@@ -775,32 +773,24 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                             });
                 });
 
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryTaskInstance(mainWorkflow))
-                            .hasSize(2)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
-                                                : TaskExecutionStatus.SUCCESS);
-                                assertThat(taskInstance.getName())
-                                        .isEqualTo("sub_workflow_task");
-                            });
+        assertThat(repository.queryTaskInstance(mainWorkflow))
+                .hasSize(2)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                    : TaskExecutionStatus.SUCCESS);
+                    assertThat(taskInstance.getName())
+                            .isEqualTo("sub_workflow_task");
                 });
 
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryTaskInstance(subWorkflow))
-                            .hasSize(2)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
-                                                : TaskExecutionStatus.SUCCESS);
-                                assertThat(taskInstance.getName())
-                                        .isEqualTo("fake_task_A");
-                            });
+        assertThat(repository.queryTaskInstance(subWorkflow))
+                .hasSize(2)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
+                                    : TaskExecutionStatus.SUCCESS);
+                    assertThat(taskInstance.getName())
+                            .isEqualTo("fake_task_A");
                 });
 
         assertThat(repository.queryAllTaskInstance()).hasSize(4);
@@ -856,12 +846,14 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         // wait failover sub-workflow
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(subMasterFailoverNodePath)).isTrue();
                 });
         // wait sub-workflow started
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(subWorkflow))
                             .hasSize(1)
@@ -876,6 +868,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(2)
@@ -885,38 +878,11 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                             });
                 });
 
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryTaskInstance(mainWorkflow))
-                            .hasSize(2)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(taskInstance.getId() == 1 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
-                                                : TaskExecutionStatus.SUCCESS);
-                                assertThat(taskInstance.getName())
-                                        .isEqualTo("sub_workflow_task");
-                            });
-                });
-
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryTaskInstance(subWorkflow))
-                            .hasSize(2)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(taskInstance.getId() == 2 ? TaskExecutionStatus.NEED_FAULT_TOLERANCE
-                                                : TaskExecutionStatus.SUCCESS);
-                                assertThat(taskInstance.getName())
-                                        .isEqualTo("fake_task_A");
-                            });
-                });
-
-        assertThat(repository.queryAllTaskInstance()).hasSize(4);
+        assertThat(repository.queryAllTaskInstance()).filteredOn(
+                taskInstance -> taskInstance.getId() > 2 && taskInstance.getState() == TaskExecutionStatus.SUCCESS)
+                .hasSize(4);
 
         masterContainer.assertAllResourceReleased();
-
     }
 
     @Test
@@ -975,12 +941,14 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         // wait failover main-workflow
         await()
                 .atMost(Duration.ofMinutes(5))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow started
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
@@ -992,6 +960,7 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
 
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryAllWorkflowInstance())
                             .hasSize(7)
@@ -1002,16 +971,12 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                             });
                 });
 
-        await()
-                .atMost(Duration.ofMinutes(8))
-                .untilAsserted(() -> {
-                    assertThat(repository.queryAllTaskInstance())
-                            .hasSize(9)
-                            .filteredOn(taskInstance -> taskInstance.getId() > 4)
-                            .anySatisfy(taskInstance -> {
-                                assertThat(taskInstance.getState())
-                                        .isEqualTo(TaskExecutionStatus.SUCCESS);
-                            });
+        assertThat(repository.queryAllTaskInstance())
+                .hasSize(9)
+                .filteredOn(taskInstance -> taskInstance.getId() > 4)
+                .anySatisfy(taskInstance -> {
+                    assertThat(taskInstance.getState())
+                            .isEqualTo(TaskExecutionStatus.SUCCESS);
                 });
 
         masterContainer.assertAllResourceReleased();
@@ -1074,12 +1039,14 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         // wait failover main-workflow
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow stop
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)
@@ -1159,12 +1126,14 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
         // wait failover main-workflow
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(registryClient.exists(mainMasterFailoverNodePath)).isTrue();
                 });
         // wait main-workflow stop
         await()
                 .atMost(Duration.ofMinutes(8))
+                .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
                     assertThat(repository.queryWorkflowInstance(mainWorkflow))
                             .hasSize(1)

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowInstanceFailoverTestCase.java
@@ -661,7 +661,6 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                             .isEqualTo("sub_workflow_task");
                 });
 
-
         assertThat(repository.queryTaskInstance(subWorkflow))
                 .hasSize(2)
                 .allSatisfy(taskInstance -> {
@@ -928,7 +927,8 @@ public class WorkflowInstanceFailoverTestCase extends AbstractMasterIntegrationT
                 .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(500))
                 .untilAsserted(() -> {
-                    assertThat(repository.queryWorkflowInstance(1).getState()).isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                    assertThat(repository.queryWorkflowInstance(1).getState())
+                            .isEqualTo(WorkflowExecutionStatus.SUCCESS);
                 });
         await()
                 .atMost(Duration.ofMinutes(1))

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
@@ -1,0 +1,300 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2025-04-24 00:00:00
+  updateTime: 2025-04-24 00:00:00
+
+workflows:
+  - name: workflow_with_one_sub_workflows
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a workflow with sub workflow task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+  - name: sub_workflow
+    code: 2
+    version: 1
+    projectCode: 1
+    description: This is a workflow with a fake task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: sub_workflow_task_submitted
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_workflow_task_stopped
+    code: 2
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_workflow_task_paused
+    code: 3
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: fake_task_A
+    code: 4
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+
+
+workflowInstances:
+  - id: 1
+    name: workflow_with_sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_PAUSE
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 1.2.3.4:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 2
+    name: sub_workflow_submitted-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: SUBMITTED_SUCCESS
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 3
+    name: sub_workflow_stopped-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: STOP
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 4
+    name: sub_workflow_paused-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: PAUSE
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+
+
+taskInstances:
+  - id: 1
+    name: sub_workflow_task_submitted
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+  - id: 2
+    name: sub_workflow_task_stopped
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+  - id: 3
+    name: sub_workflow_task_paused
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 2
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 3
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 4
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyPause_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
@@ -58,6 +58,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: sub_workflow_task_stopped
     code: 2
     version: 1
@@ -69,6 +70,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: sub_workflow_task_paused
     code: 3
     version: 1
@@ -80,6 +82,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: fake_task_A
     code: 4
     version: 1
@@ -91,6 +94,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
 
 
 workflowInstances:
@@ -233,7 +237,7 @@ taskInstances:
     executorId: 1
     varPool: '[]'
     taskExecuteType: BATCH
-    appLink: '{"subWorkflowInstanceId":2}'
+    appLink: '{"subWorkflowInstanceId":3}'
     taskInstancePriority: MEDIUM
   - id: 3
     name: sub_workflow_task_paused
@@ -258,7 +262,7 @@ taskInstances:
     executorId: 1
     varPool: '[]'
     taskExecuteType: BATCH
-    appLink: '{"subWorkflowInstanceId":2}'
+    appLink: '{"subWorkflowInstanceId":4}'
     taskInstancePriority: MEDIUM
 
 taskRelations:

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
@@ -1,0 +1,300 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2025-04-24 00:00:00
+  updateTime: 2025-04-24 00:00:00
+
+workflows:
+  - name: workflow_with_one_sub_workflows
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a workflow with sub workflow task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+  - name: sub_workflow
+    code: 2
+    version: 1
+    projectCode: 1
+    description: This is a workflow with a fake task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: sub_workflow_task_submitted
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_workflow_task_stopped
+    code: 2
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_workflow_task_paused
+    code: 3
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: fake_task_A
+    code: 4
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+
+
+workflowInstances:
+  - id: 1
+    name: workflow_with_sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: READY_STOP
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 1.2.3.4:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 2
+    name: sub_workflow_submitted-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: SUBMITTED_SUCCESS
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 3
+    name: sub_workflow_stopped-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: STOP
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 4
+    name: sub_workflow_paused-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: PAUSE
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+
+
+taskInstances:
+  - id: 1
+    name: sub_workflow_task_submitted
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+  - id: 2
+    name: sub_workflow_task_stopped
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+  - id: 3
+    name: sub_workflow_task_paused
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 2
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 3
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 4
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00

--- a/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/readyStop_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
@@ -58,6 +58,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: sub_workflow_task_stopped
     code: 2
     version: 1
@@ -69,6 +70,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: sub_workflow_task_paused
     code: 3
     version: 1
@@ -80,6 +82,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: fake_task_A
     code: 4
     version: 1
@@ -91,6 +94,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
 
 
 workflowInstances:
@@ -233,7 +237,7 @@ taskInstances:
     executorId: 1
     varPool: '[]'
     taskExecuteType: BATCH
-    appLink: '{"subWorkflowInstanceId":2}'
+    appLink: '{"subWorkflowInstanceId":3}'
     taskInstancePriority: MEDIUM
   - id: 3
     name: sub_workflow_task_paused
@@ -258,7 +262,7 @@ taskInstances:
     executorId: 1
     varPool: '[]'
     taskExecuteType: BATCH
-    appLink: '{"subWorkflowInstanceId":2}'
+    appLink: '{"subWorkflowInstanceId":4}'
     taskInstancePriority: MEDIUM
 
 taskRelations:

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
@@ -1,0 +1,300 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2025-04-24 00:00:00
+  updateTime: 2025-04-24 00:00:00
+
+workflows:
+  - name: workflow_with_one_sub_workflows
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a workflow with sub workflow task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+  - name: sub_workflow
+    code: 2
+    version: 1
+    projectCode: 1
+    description: This is a workflow with a fake task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: sub_workflow_task_submitted
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_workflow_task_stopped
+    code: 2
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_workflow_task_paused
+    code: 3
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: fake_task_A
+    code: 4
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+
+
+workflowInstances:
+  - id: 1
+    name: workflow_with_sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 1.2.3.4:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 2
+    name: sub_workflow_submitted-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: SUBMITTED_SUCCESS
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 3
+    name: sub_workflow_stopped-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: STOP
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 4
+    name: sub_workflow_paused-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: PAUSE
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+
+
+taskInstances:
+  - id: 1
+    name: sub_workflow_task_submitted
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+  - id: 2
+    name: sub_workflow_task_stopped
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+  - id: 3
+    name: sub_workflow_task_paused
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 2
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 3
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 4
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_not_running_in_diff_master.yaml
@@ -58,28 +58,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
-  - name: sub_workflow_task_stopped
-    code: 2
-    version: 1
-    projectCode: 1
-    userId: 1
-    taskType: SUB_WORKFLOW
-    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
-    workerGroup: default
-    createTime: 2025-04-24 00:00:00
-    updateTime: 2025-04-24 00:00:00
-    taskExecuteType: BATCH
-  - name: sub_workflow_task_paused
-    code: 3
-    version: 1
-    projectCode: 1
-    userId: 1
-    taskType: SUB_WORKFLOW
-    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
-    workerGroup: default
-    createTime: 2025-04-24 00:00:00
-    updateTime: 2025-04-24 00:00:00
-    taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: fake_task_A
     code: 4
     version: 1
@@ -91,6 +70,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
 
 
 workflowInstances:
@@ -138,105 +118,11 @@ workflowInstances:
     globalParams: '[]'
     varPool: '[]'
     dryRun: 0
-  - id: 3
-    name: sub_workflow_stopped-20250424180000000
-    workflowDefinitionCode: 2
-    workflowDefinitionVersion: 1
-    projectCode: 1
-    state: STOP
-    recovery: NO
-    startTime: 2025-04-24 18:00:00
-    endTime: null
-    runTimes: 1
-    host: 5.6.7.8:5678
-    commandType: START_PROCESS
-    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-    taskDependType: TASK_POST
-    commandStartTime: 2025-04-24 18:00:00
-    isSubWorkflow: YES
-    executorId: 1
-    historyCmd: START_PROCESS
-    workerGroup: default
-    globalParams: '[]'
-    varPool: '[]'
-    dryRun: 0
-  - id: 4
-    name: sub_workflow_paused-20250424180000000
-    workflowDefinitionCode: 2
-    workflowDefinitionVersion: 1
-    projectCode: 1
-    state: PAUSE
-    recovery: NO
-    startTime: 2025-04-24 18:00:00
-    endTime: null
-    runTimes: 1
-    host: 5.6.7.8:5678
-    commandType: START_PROCESS
-    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
-    taskDependType: TASK_POST
-    commandStartTime: 2025-04-24 18:00:00
-    isSubWorkflow: YES
-    executorId: 1
-    historyCmd: START_PROCESS
-    workerGroup: default
-    globalParams: '[]'
-    varPool: '[]'
-    dryRun: 0
 
 
 taskInstances:
   - id: 1
     name: sub_workflow_task_submitted
-    taskType: SUB_WORKFLOW
-    workflowInstanceId: 1
-    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
-    projectCode: 1
-    taskCode: 1
-    taskDefinitionVersion: 1
-    state: RUNNING_EXECUTION
-    firstSubmitTime: 2025-04-24 18:00:00
-    submitTime: 2025-04-24 18:00:00
-    startTime: 2025-04-24 18:00:00
-    retryTimes: 0
-    host: 127.0.0.1:1234
-    maxRetryTimes: 0
-    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
-    flag: YES
-    retryInterval: 0
-    delayTime: 0
-    workerGroup: default
-    executorId: 1
-    varPool: '[]'
-    taskExecuteType: BATCH
-    appLink: '{"subWorkflowInstanceId":2}'
-    taskInstancePriority: MEDIUM
-  - id: 2
-    name: sub_workflow_task_stopped
-    taskType: SUB_WORKFLOW
-    workflowInstanceId: 1
-    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
-    projectCode: 1
-    taskCode: 1
-    taskDefinitionVersion: 1
-    state: RUNNING_EXECUTION
-    firstSubmitTime: 2025-04-24 18:00:00
-    submitTime: 2025-04-24 18:00:00
-    startTime: 2025-04-24 18:00:00
-    retryTimes: 0
-    host: 127.0.0.1:1234
-    maxRetryTimes: 0
-    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
-    flag: YES
-    retryInterval: 0
-    delayTime: 0
-    workerGroup: default
-    executorId: 1
-    varPool: '[]'
-    taskExecuteType: BATCH
-    appLink: '{"subWorkflowInstanceId":2}'
-    taskInstancePriority: MEDIUM
-  - id: 3
-    name: sub_workflow_task_paused
     taskType: SUB_WORKFLOW
     workflowInstanceId: 1
     workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
@@ -268,24 +154,6 @@ taskRelations:
     preTaskCode: 0
     preTaskVersion: 0
     postTaskCode: 1
-    postTaskVersion: 1
-    createTime: 2025-04-24 00:00:00
-    updateTime: 2025-04-24 00:00:00
-  - projectCode: 1
-    workflowDefinitionCode: 1
-    workflowDefinitionVersion: 1
-    preTaskCode: 0
-    preTaskVersion: 0
-    postTaskCode: 2
-    postTaskVersion: 1
-    createTime: 2025-04-24 00:00:00
-    updateTime: 2025-04-24 00:00:00
-  - projectCode: 1
-    workflowDefinitionCode: 1
-    workflowDefinitionVersion: 1
-    preTaskCode: 0
-    preTaskVersion: 0
-    postTaskCode: 3
     postTaskVersion: 1
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running.yaml
@@ -58,6 +58,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: fake_task_A
     code: 2
     version: 1
@@ -69,6 +70,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
 
 
 workflowInstances:
@@ -143,6 +145,7 @@ taskInstances:
     varPool: '[]'
     taskExecuteType: BATCH
     appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
   - id: 2
     name: fake_task_A
     taskType: LogicFakeTask
@@ -166,6 +169,7 @@ taskInstances:
     executorId: 1
     varPool: '[]'
     taskExecuteType: BATCH
+    taskInstancePriority: MEDIUM
 
 taskRelations:
   - projectCode: 1

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml
@@ -1,0 +1,188 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2025-04-24 00:00:00
+  updateTime: 2025-04-24 00:00:00
+
+workflows:
+  - name: workflow_with_one_sub_workflow_running
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a workflow with sub workflow task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+  - name: sub_workflow_running
+    code: 2
+    version: 1
+    projectCode: 1
+    description: This is a workflow with a fake task
+    releaseState: ONLINE
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    userId: 1
+    executionType: PARALLEL
+
+tasks:
+  - name: sub_workflow_task
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+  - name: fake_task_A
+    code: 2
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    workerGroup: default
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+    taskExecuteType: BATCH
+
+
+workflowInstances:
+  - id: 1
+    name: workflow_with_one_sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 1.2.3.4:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: NO
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+  - id: 2
+    name: sub_workflow_running-20250424180000000
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    projectCode: 1
+    state: RUNNING_EXECUTION
+    recovery: NO
+    startTime: 2025-04-24 18:00:00
+    endTime: null
+    runTimes: 1
+    host: 5.6.7.8:5678
+    commandType: START_PROCESS
+    commandParam: '{"commandType":"START_PROCESS","startNodes":[],"commandParams":[],"timeZone":"UTC"}'
+    taskDependType: TASK_POST
+    commandStartTime: 2025-04-24 18:00:00
+    isSubWorkflow: YES
+    executorId: 1
+    historyCmd: START_PROCESS
+    workerGroup: default
+    globalParams: '[]'
+    varPool: '[]'
+    dryRun: 0
+
+
+taskInstances:
+  - id: 1
+    name: sub_workflow_task
+    taskType: SUB_WORKFLOW
+    workflowInstanceId: 1
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 1
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"workflowDefinitionCode":1}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+    appLink: '{"subWorkflowInstanceId":2}'
+  - id: 2
+    name: fake_task_A
+    taskType: LogicFakeTask
+    workflowInstanceId: 2
+    workflowInstanceName: workflow_with_one_sub_workflow_running-20240816071251690
+    projectCode: 1
+    taskCode: 2
+    taskDefinitionVersion: 1
+    state: RUNNING_EXECUTION
+    firstSubmitTime: 2025-04-24 18:00:00
+    submitTime: 2025-04-24 18:00:00
+    startTime: 2025-04-24 18:00:00
+    retryTimes: 0
+    host: 127.0.0.1:1234
+    maxRetryTimes: 0
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":"ls ."}'
+    flag: YES
+    retryInterval: 0
+    delayTime: 0
+    workerGroup: default
+    executorId: 1
+    varPool: '[]'
+    taskExecuteType: BATCH
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 2
+    postTaskVersion: 1
+    createTime: 2025-04-24 00:00:00
+    updateTime: 2025-04-24 00:00:00

--- a/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/failover/running_workflowInstance_with_sub_workflow_task_running_in_diff_master.yaml
@@ -58,6 +58,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
   - name: fake_task_A
     code: 2
     version: 1
@@ -69,6 +70,7 @@ tasks:
     createTime: 2025-04-24 00:00:00
     updateTime: 2025-04-24 00:00:00
     taskExecuteType: BATCH
+    taskPriority: MEDIUM
 
 
 workflowInstances:
@@ -143,6 +145,7 @@ taskInstances:
     varPool: '[]'
     taskExecuteType: BATCH
     appLink: '{"subWorkflowInstanceId":2}'
+    taskInstancePriority: MEDIUM
   - id: 2
     name: fake_task_A
     taskType: LogicFakeTask
@@ -166,6 +169,7 @@ taskInstances:
     executorId: 1
     varPool: '[]'
     taskExecuteType: BATCH
+    taskInstancePriority: MEDIUM
 
 taskRelations:
   - projectCode: 1


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17350 .

## Brief change log

1. remove queryMainWorkflowByHostAndStatus
2. revert queryNeedFailoverWorkflowInstances, all workflow instances  still failover in FailoverCoordinator
3. SubWorkflowLogicTask only takeover old workflow-instance or trigger new workflow-instance

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
