### PR TITLE
[Chore][Master] Rename methods in StateAction for better readability.

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class TaskDispatchLifecycleEventHandler extends AbstractTaskLifecycleEven
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskDispatchLifecycleEvent event) {
-        taskStateAction.dispatchEventAction(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onDispatchEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchedLifecycleEventHandler.java
@@ -48,7 +48,7 @@ public class TaskDispatchedLifecycleEventHandler
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        taskStateAction.dispatchedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskDispatchedEvent);
+        taskStateAction.onDispatchedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskDispatchedEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailedLifecycleEventHandler.java
@@ -43,7 +43,7 @@ public class TaskFailedLifecycleEventHandler extends AbstractTaskLifecycleEventH
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskFailedLifecycleEvent event) {
-        taskStateAction.failedEventAction(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailoverLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailoverLifecycleEventHandler.java
@@ -34,7 +34,7 @@ public class TaskFailoverLifecycleEventHandler extends AbstractTaskLifecycleEven
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        taskStateAction.failoverEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskFailoverEvent);
+        taskStateAction.onFailoverEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKillLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKillLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class TaskKillLifecycleEventHandler extends AbstractTaskLifecycleEventHan
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskKillLifecycleEvent taskKillEvent) {
-        taskStateAction.killEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKillEvent);
+        taskStateAction.onKillEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKillEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKilledLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKilledLifecycleEventHandler.java
@@ -43,7 +43,7 @@ public class TaskKilledLifecycleEventHandler extends AbstractTaskLifecycleEventH
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskKilledLifecycleEvent taskKilledEvent) {
-        taskStateAction.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        taskStateAction.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPauseLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPauseLifecycleEventHandler.java
@@ -34,7 +34,7 @@ public class TaskPauseLifecycleEventHandler extends AbstractTaskLifecycleEventHa
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskPauseLifecycleEvent taskPauseEvent) {
-        taskStateAction.pauseEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPauseEvent);
+        taskStateAction.onPauseEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPauseEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPausedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPausedLifecycleEventHandler.java
@@ -43,7 +43,7 @@ public class TaskPausedLifecycleEventHandler extends AbstractTaskLifecycleEventH
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskPausedLifecycleEvent event) {
-        taskStateAction.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRetryLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRetryLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class TaskRetryLifecycleEventHandler extends AbstractTaskLifecycleEventHa
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskRetryLifecycleEvent taskRetryLifecycleEvent) {
-        taskStateAction.retryEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskRetryLifecycleEvent);
+        taskStateAction.onRetryEvent(workflowExecutionRunnable, taskExecutionRunnable, taskRetryLifecycleEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRunningLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRunningLifecycleEventHandler.java
@@ -46,7 +46,7 @@ public class TaskRunningLifecycleEventHandler extends AbstractTaskLifecycleEvent
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskRunningLifecycleEvent taskRunningEvent) {
-        taskStateAction.startedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskRunningEvent);
+        taskStateAction.onStartedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskRunningEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRuntimeContextChangedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRuntimeContextChangedLifecycleEventHandler.java
@@ -48,7 +48,7 @@ public class TaskRuntimeContextChangedLifecycleEventHandler
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskRuntimeContextChangedEvent event) {
-        taskStateAction.runtimeContextChangedEventAction(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onRuntimeContextChangedEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
 
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskStartLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskStartLifecycleEventHandler.java
@@ -53,7 +53,7 @@ public class TaskStartLifecycleEventHandler extends AbstractTaskLifecycleEventHa
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskStartLifecycleEvent event) {
-        taskStateAction.startEventAction(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onStartEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskSuccessLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskSuccessLifecycleEventHandler.java
@@ -43,7 +43,7 @@ public class TaskSuccessLifecycleEventHandler extends AbstractTaskLifecycleEvent
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final ITaskExecutionRunnable taskExecutionRunnable,
                        final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        taskStateAction.succeedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
+        taskStateAction.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
                 taskExecutionRunnable,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/AbstractTaskStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/AbstractTaskStateAction.java
@@ -98,9 +98,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
         taskInstance.setState(DISPATCH);
         taskInstance.setHost(taskDispatchedEvent.getExecutorHost());
@@ -108,9 +108,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void runtimeContextChangedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                                 final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent) {
+    public void onRuntimeContextChangedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                             final ITaskExecutionRunnable taskExecutionRunnable,
+                                             final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent) {
         final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
         if (StringUtils.isNotEmpty(taskRuntimeContextChangedEvent.getRuntimeContext())) {
             taskInstance.setAppLink(taskRuntimeContextChangedEvent.getRuntimeContext());
@@ -128,9 +128,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
         persistentTaskInstancePausedEventToDB(taskExecutionRunnable, taskPausedEvent);
         taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainPause(taskExecutionRunnable);
@@ -145,9 +145,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskInstanceKillEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskInstanceKillEvent) {
         releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
         persistentTaskInstanceKilledEventToDB(taskExecutionRunnable, taskInstanceKillEvent);
         taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainKill(taskExecutionRunnable);
@@ -164,9 +164,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
         persistentTaskInstanceFailedEventToDB(taskExecutionRunnable, taskFailedEvent);
 
@@ -194,9 +194,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
         persistentTaskInstanceSuccessEventToDB(taskExecutionRunnable, taskSuccessEvent);
         mergeTaskVarPoolToWorkflow(workflowExecutionRunnable, taskExecutionRunnable);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/ITaskStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/ITaskStateAction.java
@@ -55,105 +55,105 @@ public interface ITaskStateAction {
      * Perform the necessary actions when the task in a certain state receive a {@link TaskStartLifecycleEvent}.
      * <p> This method is called when you want to start a task.
      */
-    void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                          final ITaskExecutionRunnable taskExecutionRunnable,
-                          final TaskStartLifecycleEvent taskStartEvent);
+    void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                      final ITaskExecutionRunnable taskExecutionRunnable,
+                      final TaskStartLifecycleEvent taskStartEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskRunningLifecycleEvent}.
      * <p> This method is called when the master receive task running event from executor.
      */
-    void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
-                            final TaskRunningLifecycleEvent taskRunningEvent);
+    void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                        final ITaskExecutionRunnable taskExecutionRunnable,
+                        final TaskRunningLifecycleEvent taskRunningEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskRuntimeContextChangedEvent}.
      * <p> This method is called when the master receive task runtime context changed event from executor.
      */
-    void runtimeContextChangedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                          final ITaskExecutionRunnable taskExecutionRunnable,
-                                          final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent);
+    void onRuntimeContextChangedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                      final ITaskExecutionRunnable taskExecutionRunnable,
+                                      final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskRetryLifecycleEvent}.
      * <p> This method is called when the task need to retry.
      */
-    void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                          final ITaskExecutionRunnable taskExecutionRunnable,
-                          final TaskRetryLifecycleEvent taskRetryEvent);
+    void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                      final ITaskExecutionRunnable taskExecutionRunnable,
+                      final TaskRetryLifecycleEvent taskRetryEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskDispatchLifecycleEvent}.
      * <p> This method is called when you want to dispatch a task.
      */
-    void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
-                             final TaskDispatchLifecycleEvent taskDispatchEvent);
+    void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                         final ITaskExecutionRunnable taskExecutionRunnable,
+                         final TaskDispatchLifecycleEvent taskDispatchEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskDispatchedLifecycleEvent}.
      * <p> This method is called when the task has been dispatched to executor.
      */
-    void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
-                               final TaskDispatchedLifecycleEvent taskDispatchedEvent);
+    void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                           final ITaskExecutionRunnable taskExecutionRunnable,
+                           final TaskDispatchedLifecycleEvent taskDispatchedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskPauseLifecycleEvent}.
      * <p> This method is called when you want to pause a task.
      */
-    void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                          final ITaskExecutionRunnable taskExecutionRunnable,
-                          final TaskPauseLifecycleEvent taskPauseEvent);
+    void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                      final ITaskExecutionRunnable taskExecutionRunnable,
+                      final TaskPauseLifecycleEvent taskPauseEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskPausedLifecycleEvent}.
      * <p> This method is called when the task has been paused.
      */
-    void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                           final ITaskExecutionRunnable taskExecutionRunnable,
-                           final TaskPausedLifecycleEvent taskPausedEvent);
+    void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final TaskPausedLifecycleEvent taskPausedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskKillLifecycleEvent}.
      * <p> This method is called when you want to kill a task.
      */
-    void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                         final ITaskExecutionRunnable taskExecutionRunnable,
-                         final TaskKillLifecycleEvent taskKillEvent);
+    void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                     final ITaskExecutionRunnable taskExecutionRunnable,
+                     final TaskKillLifecycleEvent taskKillEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskKilledLifecycleEvent}.
      * <p> This method is called when the task has been killed.
      */
-    void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                           final ITaskExecutionRunnable taskExecutionRunnable,
-                           final TaskKilledLifecycleEvent taskKilledEvent);
+    void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final TaskKilledLifecycleEvent taskKilledEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskFailedLifecycleEvent}.
      * <p> This method is called when the task has been failed.
      */
-    void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                           final ITaskExecutionRunnable taskExecutionRunnable,
-                           final TaskFailedLifecycleEvent taskFailedEvent);
+    void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final TaskFailedLifecycleEvent taskFailedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskSuccessLifecycleEvent}.
      * <p> This method is called when the task has been success.
      */
-    void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
-                            final TaskSuccessLifecycleEvent taskSuccessEvent);
+    void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                        final ITaskExecutionRunnable taskExecutionRunnable,
+                        final TaskSuccessLifecycleEvent taskSuccessEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskFailoverLifecycleEvent}.
      * <p> This method is called when the task need to failover.
      */
-    void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
-                             final TaskFailoverLifecycleEvent taskFailoverEvent);
+    void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                         final ITaskExecutionRunnable taskExecutionRunnable,
+                         final TaskFailoverLifecycleEvent taskFailoverEvent);
 
     /**
      * Get the {@link TaskExecutionStatus} that this action match.

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskDispatchStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskDispatchStateAction.java
@@ -47,97 +47,97 @@ public class TaskDispatchStateAction extends AbstractTaskStateAction {
     private TaskExecutorClient taskExecutorClient;
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutionRunnable.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecutionRunnable));
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         persistentTaskInstanceStartedEventToDB(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutorClient.pause(taskExecutionRunnable);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutorClient.kill(taskExecutionRunnable);
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent event) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent event) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, event);
+        super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.failedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.succeedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
+        super.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         super.failoverTask(taskExecutionRunnable);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailoverStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailoverStateAction.java
@@ -46,97 +46,97 @@ import org.springframework.stereotype.Component;
 public class TaskFailoverStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskStartEvent);
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -47,9 +47,9 @@ import org.springframework.stereotype.Component;
 public class TaskFailureStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         final TaskFailedLifecycleEvent taskFailedEvent = TaskFailedLifecycleEvent.builder()
                 .taskExecutionRunnable(taskExecutionRunnable)
@@ -59,17 +59,17 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
         // check the retry times
@@ -84,29 +84,29 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // When the failed task is awaiting retry, we can mark it as 'paused' to ignore the retry event.
         if (isTaskRetrying(taskExecutionRunnable)) {
-            super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
+            super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable,
                     TaskPausedLifecycleEvent.of(taskExecutionRunnable));
             return;
         }
@@ -114,28 +114,28 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
         if (isTaskRetrying(taskExecutionRunnable)) {
-            super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+            super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
             return;
         }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // When the failed task is awaiting retry, we can mark it as 'killed' to ignore the retry event.
         if (isTaskRetrying(taskExecutionRunnable)) {
-            super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable,
+            super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable,
                     TaskKilledLifecycleEvent.of(taskExecutionRunnable));
             return;
         }
@@ -143,40 +143,40 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
         if (isTaskRetrying(taskExecutionRunnable)) {
-            super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+            super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
             return;
         }
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.failedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskKillStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskKillStateAction.java
@@ -42,98 +42,98 @@ import org.springframework.stereotype.Component;
 public class TaskKillStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainKill(taskExecutionRunnable);
         publishWorkflowInstanceTopologyLogicalTransitionEvent(taskExecutionRunnable);
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskPauseStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskPauseStateAction.java
@@ -42,98 +42,98 @@ import org.springframework.stereotype.Component;
 public class TaskPauseStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainPause(taskExecutionRunnable);
         publishWorkflowInstanceTopologyLogicalTransitionEvent(taskExecutionRunnable);
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskRunningStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskRunningStateAction.java
@@ -42,97 +42,97 @@ import org.springframework.stereotype.Component;
 public class TaskRunningStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutionRunnable.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecutionRunnable));
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         persistentTaskInstanceStartedEventToDB(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutorClient.pause(taskExecutionRunnable);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         taskExecutorClient.kill(taskExecutionRunnable);
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.failedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.succeedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
+        super.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         // regenerate a failover task instance
         super.failoverTask(taskExecutionRunnable);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSubmittedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSubmittedStateAction.java
@@ -58,9 +58,9 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
     private TaskInstanceDao taskInstanceDao;
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
 
         if (workflowExecutionRunnable.isWorkflowReadyPause()) {
@@ -77,25 +77,25 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
         long remainTimeMills = DateUtils.getRemainTime(
@@ -114,17 +114,17 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.dispatchedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskDispatchedEvent);
+        super.onDispatchedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         if (workerGroupDispatcherCoordinator.removeTask(taskExecutionRunnable)) {
             log.info("Success pause task: {} before dispatch", taskExecutionRunnable.getName());
@@ -138,17 +138,17 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.pausedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         if (workerGroupDispatcherCoordinator.removeTask(taskExecutionRunnable)) {
             log.info("Success kill task[id={}] before dispatch", taskExecutionRunnable.getId());
@@ -162,33 +162,33 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.killedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.failedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSuccessStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSuccessStateAction.java
@@ -46,102 +46,102 @@ import org.springframework.stereotype.Component;
 public class TaskSuccessStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskStartLifecycleEvent taskStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskStartLifecycleEvent taskStartEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         final TaskSuccessLifecycleEvent taskSuccessLifecycleEvent = TaskSuccessLifecycleEvent.builder()
                 .taskExecutionRunnable(taskExecutionRunnable)
                 .varPool(VarPoolUtils.deserializeVarPool(taskExecutionRunnable.getTaskInstance().getVarPool()))
                 .endTime(taskExecutionRunnable.getTaskInstance().getEndTime())
                 .build();
-        super.succeedEventAction(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessLifecycleEvent);
+        super.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessLifecycleEvent);
     }
 
     @Override
-    public void startedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskRunningLifecycleEvent taskRunningEvent) {
+    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskRunningLifecycleEvent taskRunningEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
     }
 
     @Override
-    public void retryEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskRetryLifecycleEvent taskRetryEvent) {
+    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskRetryLifecycleEvent taskRetryEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
     }
 
     @Override
-    public void dispatchEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskDispatchLifecycleEvent taskDispatchEvent) {
+    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskDispatchLifecycleEvent taskDispatchEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
     }
 
     @Override
-    public void dispatchedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
-                                      final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
+    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                  final ITaskExecutionRunnable taskExecutionRunnable,
+                                  final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final ITaskExecutionRunnable taskExecutionRunnable,
-                                 final TaskPauseLifecycleEvent taskPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final ITaskExecutionRunnable taskExecutionRunnable,
+                             final TaskPauseLifecycleEvent taskPauseEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskPausedLifecycleEvent taskPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskPausedLifecycleEvent taskPausedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
     }
 
     @Override
-    public void killEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
-                                final TaskKillLifecycleEvent taskKillEvent) {
+    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final ITaskExecutionRunnable taskExecutionRunnable,
+                            final TaskKillLifecycleEvent taskKillEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
     }
 
     @Override
-    public void killedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskKilledLifecycleEvent taskKilledEvent) {
+    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskKilledLifecycleEvent taskKilledEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
-                                  final TaskFailedLifecycleEvent taskFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final ITaskExecutionRunnable taskExecutionRunnable,
+                              final TaskFailedLifecycleEvent taskFailedEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final ITaskExecutionRunnable taskExecutionRunnable,
-                                   final TaskSuccessLifecycleEvent taskSuccessEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final ITaskExecutionRunnable taskExecutionRunnable,
+                               final TaskSuccessLifecycleEvent taskSuccessEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
     }
 
     @Override
-    public void failoverEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final ITaskExecutionRunnable taskExecutionRunnable,
-                                    final TaskFailoverLifecycleEvent taskFailoverEvent) {
+    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final TaskFailoverLifecycleEvent taskFailoverEvent) {
         throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
         logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFailedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFailedLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class WorkflowFailedLifecycleEventHandler
     public void handle(final IWorkflowStateAction workflowStateAction,
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        workflowStateAction.failedEventAction(workflowExecutionRunnable, workflowFailedEvent);
+        workflowStateAction.onFailedEvent(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFinalizeLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFinalizeLifecycleEventHandler.java
@@ -51,7 +51,7 @@ public class WorkflowFinalizeLifecycleEventHandler
     public void handle(final IWorkflowStateAction workflowStateAction,
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        workflowStateAction.finalizeEventAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        workflowStateAction.onFinalizeEvent(workflowExecutionRunnable, workflowFinalizeEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPauseLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPauseLifecycleEventHandler.java
@@ -38,7 +38,7 @@ public class WorkflowPauseLifecycleEventHandler
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowPauseLifecycleEvent pauseEvent) {
 
-        workflowStateAction.pauseEventAction(workflowExecutionRunnable, pauseEvent);
+        workflowStateAction.onPauseEvent(workflowExecutionRunnable, pauseEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPausedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPausedLifecycleEventHandler.java
@@ -34,7 +34,7 @@ public class WorkflowPausedLifecycleEventHandler
     public void handle(final IWorkflowStateAction workflowStateAction,
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        workflowStateAction.pausedEventAction(workflowExecutionRunnable, workflowPausedEvent);
+        workflowStateAction.onPausedEvent(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStartLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStartLifecycleEventHandler.java
@@ -38,7 +38,7 @@ public class WorkflowStartLifecycleEventHandler
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowStartLifecycleEvent workflowStartEvent) {
 
-        workflowStateAction.startEventAction(workflowExecutionRunnable, workflowStartEvent);
+        workflowStateAction.onStartEvent(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStopLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStopLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class WorkflowStopLifecycleEventHandler
     public void handle(final IWorkflowStateAction workflowStateAction,
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowStopLifecycleEvent event) {
-        workflowStateAction.stopEventAction(workflowExecutionRunnable, event);
+        workflowStateAction.onStopEvent(workflowExecutionRunnable, event);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStoppedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStoppedLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class WorkflowStoppedLifecycleEventHandler
     public void handle(final IWorkflowStateAction workflowStateAction,
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        workflowStateAction.stoppedEventAction(workflowExecutionRunnable, workflowStoppedEvent);
+        workflowStateAction.onStoppedEvent(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowSucceedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowSucceedLifecycleEventHandler.java
@@ -37,7 +37,7 @@ public class WorkflowSucceedLifecycleEventHandler
     public void handle(final IWorkflowStateAction workflowStateAction,
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        workflowStateAction.succeedEventAction(workflowExecutionRunnable, workflowSucceedEvent);
+        workflowStateAction.onSucceedEvent(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEventHandler.java
@@ -35,7 +35,7 @@ public class WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEventHandle
                        final IWorkflowExecutionRunnable workflowExecutionRunnable,
                        final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
 
-        workflowStateAction.topologyLogicalTransitionEventAction(
+        workflowStateAction.onTopologyLogicalTransitionEvent(
                 workflowExecutionRunnable,
                 workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/IWorkflowStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/IWorkflowStateAction.java
@@ -49,56 +49,56 @@ public interface IWorkflowStateAction {
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowStartLifecycleEvent}.
      */
-    void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                          final WorkflowStartLifecycleEvent workflowStartEvent);
+    void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                      final WorkflowStartLifecycleEvent workflowStartEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent}.
      */
-    void topologyLogicalTransitionEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                              final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent);
+    void onTopologyLogicalTransitionEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                          final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowPauseLifecycleEvent}.
      */
-    void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                          final WorkflowPauseLifecycleEvent workflowPauseEvent);
+    void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                      final WorkflowPauseLifecycleEvent workflowPauseEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowPausedLifecycleEvent}.
      */
-    void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                           final WorkflowPausedLifecycleEvent workflowPausedEvent);
+    void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final WorkflowPausedLifecycleEvent workflowPausedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowStopLifecycleEvent}.
      */
-    void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                         final WorkflowStopLifecycleEvent workflowStopEvent);
+    void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                     final WorkflowStopLifecycleEvent workflowStopEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowStoppedLifecycleEvent}.
      */
-    void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final WorkflowStoppedLifecycleEvent workflowStoppedEvent);
+    void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                        final WorkflowStoppedLifecycleEvent workflowStoppedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowSucceedLifecycleEvent}.
      */
-    void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final WorkflowSucceedLifecycleEvent workflowSucceedEvent);
+    void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                        final WorkflowSucceedLifecycleEvent workflowSucceedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowFailedLifecycleEvent}.
      */
-    void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                           final WorkflowFailedLifecycleEvent workflowFailedEvent);
+    void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final WorkflowFailedLifecycleEvent workflowFailedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowFinalizeLifecycleEvent}.
      */
-    void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent);
+    void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                         final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent);
 
     /**
      * Get the {@link WorkflowExecutionStatus} that this action match.

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailedStateAction.java
@@ -38,65 +38,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowFailedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.finalizeEventAction(workflowExecutionRunnable);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailoverStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailoverStateAction.java
@@ -41,65 +41,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowFailoverStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowPausedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowPausedStateAction.java
@@ -38,65 +38,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowPausedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.finalizeEventAction(workflowExecutionRunnable);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyPauseStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyPauseStateAction.java
@@ -40,8 +40,8 @@ import org.springframework.stereotype.Component;
 public class WorkflowReadyPauseStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         final IWorkflowExecutionGraph workflowExecutionGraph =
                 workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
@@ -49,59 +49,59 @@ public class WorkflowReadyPauseStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecutionRunnable,
                 workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecutionRunnable());
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.PAUSE);
 
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.SUCCESS);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.FAILURE);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyStopStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyStopStateAction.java
@@ -40,8 +40,8 @@ import org.springframework.stereotype.Component;
 public class WorkflowReadyStopStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         final IWorkflowExecutionGraph workflowExecutionGraph =
                 workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
@@ -49,58 +49,58 @@ public class WorkflowReadyStopStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecutionRunnable,
                 workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecutionRunnable());
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.killActiveTask(workflowExecutionRunnable);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.STOP);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.SUCCESS);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.FAILURE);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowRunningStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowRunningStateAction.java
@@ -40,8 +40,8 @@ import org.springframework.stereotype.Component;
 public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         final IWorkflowExecutionGraph workflowExecutionGraph =
                 workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
@@ -49,47 +49,47 @@ public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecutionRunnable,
                 workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecutionRunnable());
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.transformWorkflowInstanceState(workflowExecutionRunnable, WorkflowExecutionStatus.READY_PAUSE);
         super.pauseActiveTask(workflowExecutionRunnable);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.transformWorkflowInstanceState(workflowExecutionRunnable, WorkflowExecutionStatus.READY_STOP);
         super.killActiveTask(workflowExecutionRunnable);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
         if (!workflowExecutionGraph.isAllTaskExecutionRunnableChainSuccess()) {
@@ -100,8 +100,8 @@ public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    public void failedEventAction(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
         if (!workflowExecutionGraph.isExistFailureTaskExecutionRunnableChain()) {
@@ -113,8 +113,8 @@ public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSerialWaitStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSerialWaitStateAction.java
@@ -42,65 +42,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowSerialWaitStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowStoppedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowStoppedStateAction.java
@@ -38,65 +38,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowStoppedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.finalizeEventAction(workflowExecutionRunnable);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSubmittedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSubmittedStateAction.java
@@ -41,65 +41,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowSubmittedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSuccessStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSuccessStateAction.java
@@ -38,65 +38,65 @@ import org.springframework.stereotype.Component;
 public class WorkflowSuccessStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void startEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowStartLifecycleEvent workflowStartEvent) {
+    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowStartLifecycleEvent workflowStartEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
     }
 
     @Override
-    public void topologyLogicalTransitionEventAction(
-                                                     final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                     final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
+    public void onTopologyLogicalTransitionEvent(
+                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void pauseEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                 final WorkflowPauseLifecycleEvent workflowPauseEvent) {
+    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                             final WorkflowPauseLifecycleEvent workflowPauseEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
     }
 
     @Override
-    public void pausedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowPausedLifecycleEvent workflowPausedEvent) {
+    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowPausedLifecycleEvent workflowPausedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
     }
 
     @Override
-    public void stopEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final WorkflowStopLifecycleEvent workflowStopEvent) {
+    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                            final WorkflowStopLifecycleEvent workflowStopEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
     }
 
     @Override
-    public void stoppedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
+    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
     }
 
     @Override
-    public void succeedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                   final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
+    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                               final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
     }
 
     @Override
-    public void failedEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final WorkflowFailedLifecycleEvent workflowFailedEvent) {
+    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              final WorkflowFailedLifecycleEvent workflowFailedEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
     }
 
     @Override
-    public void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                    final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
+    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
         throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
         super.finalizeEventAction(workflowExecutionRunnable);
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Rename methods in TaskStateActions and WorkflowStateActions for better readability.

## Brief change log

Rename methods `xxxEventAction`  to `onXxxEvent` in TaskStateActions and WorkflowStateActions for better readability.

close #17377

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.
