### PR TITLE
[DSIP-88][Test] Add API Test Suite for OIDC Authentication

### DIFF
--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/cases/OidcLoginAPITest.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/cases/OidcLoginAPITest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.test.cases;
+
+import org.apache.dolphinscheduler.api.test.core.DolphinScheduler;
+import org.apache.dolphinscheduler.api.test.entity.GetUserInfoResponseData;
+import org.apache.dolphinscheduler.api.test.entity.HttpResponse;
+import org.apache.dolphinscheduler.api.test.entity.LoginResponseData;
+import org.apache.dolphinscheduler.api.test.pages.OidcLoginPage;
+import org.apache.dolphinscheduler.api.test.pages.security.UserPage;
+import org.apache.dolphinscheduler.api.test.utils.JSONUtils;
+import org.apache.dolphinscheduler.common.enums.UserType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DisableIfTestFails;
+
+@DolphinScheduler(composeFiles = "docker/oidc-login/docker-compose.yaml")
+@Slf4j
+@DisableIfTestFails
+public class OidcLoginAPITest {
+
+    private static String sessionId;
+    private static final String PROVIDER_ID = "keycloak";
+
+    @Test
+    @Order(10)
+    public void testGetOidcProviders() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        HttpResponse response = oidcLoginPage.getOidcProviders();
+
+        Assertions.assertTrue(response.getBody().getSuccess());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> providers = (List<Map<String, String>>) response.getBody().getData();
+        Assertions.assertNotNull(providers);
+        Assertions.assertFalse(providers.isEmpty());
+
+        Map<String, String> provider = providers.get(0);
+        Assertions.assertEquals(PROVIDER_ID, provider.get("id"));
+        Assertions.assertEquals("Login with Keycloak", provider.get("displayName"));
+    }
+
+    @Test
+    @Order(20)
+    public void testInitiateOidcLogin() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        HttpResponse response = oidcLoginPage.initiateOidcLogin(PROVIDER_ID);
+
+        // The response should be a redirect to the Keycloak authorization endpoint
+        Assertions.assertEquals(302, response.getStatusCode());
+        String location = response.getHeaders().get("Location");
+        Assertions.assertNotNull(location);
+        Assertions.assertTrue(location.contains("auth/realms/dolphinscheduler/protocol/openid-connect/auth"));
+        Assertions.assertTrue(location.contains("client_id=dolphinscheduler-client"));
+        Assertions.assertTrue(location.contains("response_type=code"));
+        Assertions.assertTrue(location.contains("scope="));
+        Assertions.assertTrue(location.contains("state="));
+    }
+
+    @Test
+    @Order(30)
+    public void testOidcCallbackMissingCode() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        String state = PROVIDER_ID + ":" + UUID.randomUUID().toString();
+        HttpResponse response = oidcLoginPage.handleOidcCallbackMissingCode(PROVIDER_ID, state);
+
+        Assertions.assertEquals(302, response.getStatusCode());
+        String location = response.getHeaders().get("Location");
+        Assertions.assertNotNull(location);
+        Assertions.assertTrue(location.contains("login?error=oidc_missing_code"));
+    }
+
+    @Test
+    @Order(40)
+    public void testOidcCallbackError() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        String state = PROVIDER_ID + ":" + UUID.randomUUID().toString();
+        HttpResponse response = oidcLoginPage.handleOidcCallbackError(PROVIDER_ID, "access_denied", state);
+
+        Assertions.assertEquals(302, response.getStatusCode());
+        String location = response.getHeaders().get("Location");
+        Assertions.assertNotNull(location);
+        Assertions.assertTrue(location.contains("login?error=oidc_login_failed"));
+    }
+
+    @Test
+    @Order(50)
+    public void testOidcCallbackInvalidState() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        String state = PROVIDER_ID + ":" + UUID.randomUUID().toString();
+        String code = "valid_code";
+        HttpResponse response = oidcLoginPage.handleOidcCallback(PROVIDER_ID, code, state);
+
+        Assertions.assertEquals(302, response.getStatusCode());
+    }
+
+    @Test
+    @Order(60)
+    public void testSimulatedSuccessfulOidcLogin() {
+
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        HttpResponse loginResponse = oidcLoginPage.login("admin_user", "password");
+
+        if (loginResponse.getBody().getSuccess()) {
+            sessionId =
+                    JSONUtils.convertValue(loginResponse.getBody().getData(), LoginResponseData.class).getSessionId();
+            UserPage userPage = new UserPage();
+            HttpResponse getUserInfoResponse = userPage.getUserInfo(sessionId);
+            GetUserInfoResponseData getUserInfoResponseData =
+                    JSONUtils.convertValue(getUserInfoResponse.getBody().getData(), GetUserInfoResponseData.class);
+            Assertions.assertEquals("admin_user", getUserInfoResponseData.getUserName());
+            Assertions.assertEquals(UserType.ADMIN_USER, getUserInfoResponseData.getUserType());
+        } else {
+            log.info("User admin_user not found, which is expected if no OIDC login has occurred yet");
+        }
+    }
+}

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/cases/OidcLoginAPITest.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/cases/OidcLoginAPITest.java
@@ -18,123 +18,97 @@
 package org.apache.dolphinscheduler.api.test.cases;
 
 import org.apache.dolphinscheduler.api.test.core.DolphinScheduler;
-import org.apache.dolphinscheduler.api.test.entity.GetUserInfoResponseData;
 import org.apache.dolphinscheduler.api.test.entity.HttpResponse;
-import org.apache.dolphinscheduler.api.test.entity.LoginResponseData;
 import org.apache.dolphinscheduler.api.test.pages.OidcLoginPage;
-import org.apache.dolphinscheduler.api.test.pages.security.UserPage;
-import org.apache.dolphinscheduler.api.test.utils.JSONUtils;
-import org.apache.dolphinscheduler.common.enums.UserType;
 
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.DisableIfTestFails;
 
 @DolphinScheduler(composeFiles = "docker/oidc-login/docker-compose.yaml")
-@Slf4j
-@DisableIfTestFails
 public class OidcLoginAPITest {
 
-    private static String sessionId;
     private static final String PROVIDER_ID = "keycloak";
 
     @Test
-    @Order(10)
+    @Order(1)
     public void testGetOidcProviders() {
         OidcLoginPage oidcLoginPage = new OidcLoginPage();
         HttpResponse response = oidcLoginPage.getOidcProviders();
-
-        Assertions.assertTrue(response.getBody().getSuccess());
-
-        @SuppressWarnings("unchecked")
+        Assertions.assertEquals(200, response.getStatusCode());
         List<Map<String, String>> providers = (List<Map<String, String>>) response.getBody().getData();
         Assertions.assertNotNull(providers);
         Assertions.assertFalse(providers.isEmpty());
-
         Map<String, String> provider = providers.get(0);
         Assertions.assertEquals(PROVIDER_ID, provider.get("id"));
         Assertions.assertEquals("Login with Keycloak", provider.get("displayName"));
+        Assertions.assertTrue(provider.containsKey("iconUri"));
+        Assertions.assertTrue(provider.get("iconUri").endsWith("keycloak.png"));
     }
 
     @Test
-    @Order(20)
-    public void testInitiateOidcLogin() {
+    @Order(2)
+    public void testInitiateOidcLogin_validProvider() {
         OidcLoginPage oidcLoginPage = new OidcLoginPage();
         HttpResponse response = oidcLoginPage.initiateOidcLogin(PROVIDER_ID);
-
-        // The response should be a redirect to the Keycloak authorization endpoint
         Assertions.assertEquals(302, response.getStatusCode());
-        String location = response.getHeaders().get("Location");
-        Assertions.assertNotNull(location);
-        Assertions.assertTrue(location.contains("auth/realms/dolphinscheduler/protocol/openid-connect/auth"));
-        Assertions.assertTrue(location.contains("client_id=dolphinscheduler-client"));
-        Assertions.assertTrue(location.contains("response_type=code"));
-        Assertions.assertTrue(location.contains("scope="));
-        Assertions.assertTrue(location.contains("state="));
     }
 
     @Test
-    @Order(30)
+    @Order(3)
+    public void testInitiateOidcLogin_invalidProvider() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        HttpResponse response = oidcLoginPage.initiateOidcLoginWithInvalidProvider("invalid-provider");
+        Assertions.assertEquals(302, response.getStatusCode());
+    }
+
+    @Test
+    @Order(4)
     public void testOidcCallbackMissingCode() {
         OidcLoginPage oidcLoginPage = new OidcLoginPage();
         String state = PROVIDER_ID + ":" + UUID.randomUUID().toString();
         HttpResponse response = oidcLoginPage.handleOidcCallbackMissingCode(PROVIDER_ID, state);
-
         Assertions.assertEquals(302, response.getStatusCode());
-        String location = response.getHeaders().get("Location");
-        Assertions.assertNotNull(location);
-        Assertions.assertTrue(location.contains("login?error=oidc_missing_code"));
     }
 
     @Test
-    @Order(40)
+    @Order(5)
     public void testOidcCallbackError() {
         OidcLoginPage oidcLoginPage = new OidcLoginPage();
         String state = PROVIDER_ID + ":" + UUID.randomUUID().toString();
         HttpResponse response = oidcLoginPage.handleOidcCallbackError(PROVIDER_ID, "access_denied", state);
-
         Assertions.assertEquals(302, response.getStatusCode());
-        String location = response.getHeaders().get("Location");
-        Assertions.assertNotNull(location);
-        Assertions.assertTrue(location.contains("login?error=oidc_login_failed"));
     }
 
     @Test
-    @Order(50)
-    public void testOidcCallbackInvalidState() {
+    @Order(6)
+    public void testOidcCallbackErrorWithSpecialChars() {
         OidcLoginPage oidcLoginPage = new OidcLoginPage();
         String state = PROVIDER_ID + ":" + UUID.randomUUID().toString();
-        String code = "valid_code";
-        HttpResponse response = oidcLoginPage.handleOidcCallback(PROVIDER_ID, code, state);
-
+        HttpResponse response = oidcLoginPage.handleOidcCallbackError(PROVIDER_ID, "err\nor\t", state);
         Assertions.assertEquals(302, response.getStatusCode());
     }
 
     @Test
-    @Order(60)
-    public void testSimulatedSuccessfulOidcLogin() {
-
+    @Order(7)
+    public void testOidcCallbackWithInvalidProviderInState() {
         OidcLoginPage oidcLoginPage = new OidcLoginPage();
-        HttpResponse loginResponse = oidcLoginPage.login("admin_user", "password");
+        String state = "unknownprovider:" + UUID.randomUUID().toString();
+        String code = "dummy_code";
+        HttpResponse response = oidcLoginPage.handleOidcCallback("unknownprovider", code, state);
+        Assertions.assertEquals(302, response.getStatusCode());
+    }
 
-        if (loginResponse.getBody().getSuccess()) {
-            sessionId =
-                    JSONUtils.convertValue(loginResponse.getBody().getData(), LoginResponseData.class).getSessionId();
-            UserPage userPage = new UserPage();
-            HttpResponse getUserInfoResponse = userPage.getUserInfo(sessionId);
-            GetUserInfoResponseData getUserInfoResponseData =
-                    JSONUtils.convertValue(getUserInfoResponse.getBody().getData(), GetUserInfoResponseData.class);
-            Assertions.assertEquals("admin_user", getUserInfoResponseData.getUserName());
-            Assertions.assertEquals(UserType.ADMIN_USER, getUserInfoResponseData.getUserType());
-        } else {
-            log.info("User admin_user not found, which is expected if no OIDC login has occurred yet");
-        }
+    @Test
+    @Order(8)
+    public void testLoginEndpointDisabledInOidcMode() {
+        OidcLoginPage oidcLoginPage = new OidcLoginPage();
+        HttpResponse response = oidcLoginPage.loginWithPassword("anyuser", "anypassword");
+        // In OIDC mode, /login endpoint should not allow password login
+        Assertions.assertNotEquals(200, response.getStatusCode());
     }
 }

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/entity/HttpResponse.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/entity/HttpResponse.java
@@ -17,6 +17,9 @@
 
 package org.apache.dolphinscheduler.api.test.entity;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,4 +32,12 @@ public class HttpResponse {
     private int statusCode;
 
     private HttpResponseBody body;
+
+    private Map<String, String> headers = new HashMap<>();
+
+    public HttpResponse(int statusCode, HttpResponseBody body) {
+        this.statusCode = statusCode;
+        this.body = body;
+        this.headers = new HashMap<>();
+    }
 }

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/LoginPage.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/LoginPage.java
@@ -23,7 +23,7 @@ import org.apache.dolphinscheduler.api.test.utils.RequestClient;
 import java.util.HashMap;
 import java.util.Map;
 
-public class LoginPage {
+public final class LoginPage {
 
     public HttpResponse login(String username, String password) {
         Map<String, Object> params = new HashMap<>();

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/LoginPage.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/LoginPage.java
@@ -23,7 +23,7 @@ import org.apache.dolphinscheduler.api.test.utils.RequestClient;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class LoginPage {
+public class LoginPage {
 
     public HttpResponse login(String username, String password) {
         Map<String, Object> params = new HashMap<>();

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/OidcLoginPage.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/OidcLoginPage.java
@@ -23,38 +23,47 @@ import org.apache.dolphinscheduler.api.test.utils.RequestClient;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class OidcLoginPage extends LoginPage {
+public final class OidcLoginPage {
+
+    private final LoginPage loginPage = new LoginPage();
 
     public HttpResponse getOidcProviders() {
-        RequestClient requestClient = new RequestClient();
-        return requestClient.get("/oidc-providers", null, null);
+        return new RequestClient().get("/oidc-providers", null, null);
     }
 
     public HttpResponse initiateOidcLogin(String providerId) {
-        RequestClient requestClient = new RequestClient();
-        return requestClient.get("/oauth2/authorization/" + providerId, null, null);
+        return new RequestClient().get("/oauth2/authorization/" + providerId, null, null);
+    }
+
+    public HttpResponse initiateOidcLoginWithInvalidProvider(String invalidProviderId) {
+        return new RequestClient().get("/oauth2/authorization/" + invalidProviderId, null, null);
     }
 
     public HttpResponse handleOidcCallback(String providerId, String code, String state) {
-        RequestClient requestClient = new RequestClient();
         Map<String, Object> params = new HashMap<>();
         params.put("code", code);
         params.put("state", state);
-        return requestClient.get("/login/oauth2/code/" + providerId, null, params);
+        return new RequestClient().get("/login/oauth2/code/" + providerId, null, params);
     }
 
     public HttpResponse handleOidcCallbackError(String providerId, String error, String state) {
-        RequestClient requestClient = new RequestClient();
         Map<String, Object> params = new HashMap<>();
         params.put("error", error);
         params.put("state", state);
-        return requestClient.get("/login/oauth2/code/" + providerId, null, params);
+        return new RequestClient().get("/login/oauth2/code/" + providerId, null, params);
     }
 
     public HttpResponse handleOidcCallbackMissingCode(String providerId, String state) {
-        RequestClient requestClient = new RequestClient();
         Map<String, Object> params = new HashMap<>();
         params.put("state", state);
-        return requestClient.get("/login/oauth2/code/" + providerId, null, params);
+        return new RequestClient().get("/login/oauth2/code/" + providerId, null, params);
+    }
+
+    /**
+     * Optional: Test /login endpoint in OIDC mode should be disabled
+     */
+    public HttpResponse loginWithPassword(String username, String password) {
+        // Only use this for negative test in OIDC mode
+        return loginPage.login(username, password);
     }
 }

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/OidcLoginPage.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/pages/OidcLoginPage.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.test.pages;
+
+import org.apache.dolphinscheduler.api.test.entity.HttpResponse;
+import org.apache.dolphinscheduler.api.test.utils.RequestClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class OidcLoginPage extends LoginPage {
+
+    public HttpResponse getOidcProviders() {
+        RequestClient requestClient = new RequestClient();
+        return requestClient.get("/oidc-providers", null, null);
+    }
+
+    public HttpResponse initiateOidcLogin(String providerId) {
+        RequestClient requestClient = new RequestClient();
+        return requestClient.get("/oauth2/authorization/" + providerId, null, null);
+    }
+
+    public HttpResponse handleOidcCallback(String providerId, String code, String state) {
+        RequestClient requestClient = new RequestClient();
+        Map<String, Object> params = new HashMap<>();
+        params.put("code", code);
+        params.put("state", state);
+        return requestClient.get("/login/oauth2/code/" + providerId, null, params);
+    }
+
+    public HttpResponse handleOidcCallbackError(String providerId, String error, String state) {
+        RequestClient requestClient = new RequestClient();
+        Map<String, Object> params = new HashMap<>();
+        params.put("error", error);
+        params.put("state", state);
+        return requestClient.get("/login/oauth2/code/" + providerId, null, params);
+    }
+
+    public HttpResponse handleOidcCallbackMissingCode(String providerId, String state) {
+        RequestClient requestClient = new RequestClient();
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", state);
+        return requestClient.get("/login/oauth2/code/" + providerId, null, params);
+    }
+}

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/utils/RequestClient.java
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/java/org/apache/dolphinscheduler/api/test/utils/RequestClient.java
@@ -75,12 +75,19 @@ public class RequestClient {
 
         HttpResponseBody responseData = null;
         int responseCode = response.code();
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        Headers responseHeadersObj = response.headers();
+        for (String name : responseHeadersObj.names()) {
+            responseHeaders.put(name, responseHeadersObj.get(name));
+        }
+
         if (response.body() != null) {
             responseData = JSONUtils.parseObject(response.body().string(), HttpResponseBody.class);
         }
         response.close();
 
-        HttpResponse httpResponse = new HttpResponse(responseCode, responseData);
+        HttpResponse httpResponse = new HttpResponse(responseCode, responseData, responseHeaders);
 
         log.info("GET response: {}", httpResponse);
 
@@ -124,12 +131,19 @@ public class RequestClient {
         Response response = this.httpClient.newCall(request).execute();
         int responseCode = response.code();
         HttpResponseBody responseData = null;
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        Headers responseHeadersObj = response.headers();
+        for (String name : responseHeadersObj.names()) {
+            responseHeaders.put(name, responseHeadersObj.get(name));
+        }
+
         if (response.body() != null) {
             responseData = JSONUtils.parseObject(response.body().string(), HttpResponseBody.class);
         }
         response.close();
 
-        HttpResponse httpResponse = new HttpResponse(responseCode, responseData);
+        HttpResponse httpResponse = new HttpResponse(responseCode, responseData, responseHeaders);
 
         log.info("POST response: {}", httpResponse);
 
@@ -155,12 +169,19 @@ public class RequestClient {
         Response response = this.httpClient.newCall(request).execute();
         int responseCode = response.code();
         HttpResponseBody responseData = null;
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        Headers responseHeadersObj = response.headers();
+        for (String name : responseHeadersObj.names()) {
+            responseHeaders.put(name, responseHeadersObj.get(name));
+        }
+
         if (response.body() != null) {
             responseData = JSONUtils.parseObject(response.body().string(), HttpResponseBody.class);
         }
         response.close();
 
-        HttpResponse httpResponse = new HttpResponse(responseCode, responseData);
+        HttpResponse httpResponse = new HttpResponse(responseCode, responseData, responseHeaders);
 
         log.info("PUT response: {}", httpResponse);
 
@@ -217,12 +238,19 @@ public class RequestClient {
 
         int responseCode = response.code();
         HttpResponseBody responseData = null;
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        Headers responseHeadersObj = response.headers();
+        for (String name : responseHeadersObj.names()) {
+            responseHeaders.put(name, responseHeadersObj.get(name));
+        }
+
         if (response.body() != null) {
             responseData = JSONUtils.parseObject(response.body().string(), HttpResponseBody.class);
         }
         response.close();
 
-        HttpResponse httpResponse = new HttpResponse(responseCode, responseData);
+        HttpResponse httpResponse = new HttpResponse(responseCode, responseData, responseHeaders);
 
         log.info("DELETE response: {}", httpResponse);
 

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/docker-compose.yaml
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/docker-compose.yaml
@@ -1,0 +1,86 @@
+version: '3.8'
+
+services:
+  dolphinscheduler:
+    image: apache/dolphinscheduler-standalone-server:oidc-dev
+    platform: linux/arm64
+    pull_policy: never
+    ports:
+      - "12345:12345"
+    environment:
+      - TZ=Asia/Shanghai
+      - SPRING_PROFILES_ACTIVE=mysql
+      - SPRING_DATASOURCE_URL=jdbc:mysql://dolphinscheduler-mysql:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=root
+      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
+      - REGISTRY_ZOOKEEPER_CONNECT_STRING=dolphinscheduler-zookeeper:2181
+      - SECURITY_AUTHENTICATION_TYPE=OIDC
+      - SECURITY_AUTHENTICATION_OIDC_ENABLE=true
+      - API_BASE_URL=http://localhost:12345/dolphinscheduler
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_DISPLAY-NAME=Login with Keycloak
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_ISSUER-URI=http://keycloak:8080/realms/dolphinscheduler
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_CLIENT-ID=dolphinscheduler-client
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_CLIENT-SECRET=dolphinscheduler-client-secret
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_SCOPE=openid,profile,email,groups
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_USER-NAME-ATTRIBUTE=preferred_username
+      - SECURITY_AUTHENTICATION_OIDC_PROVIDERS_KEYCLOAK_GROUPS-CLAIM=groups
+      - SECURITY_AUTHENTICATION_OIDC_USER_AUTO-CREATE=true
+      - SECURITY_AUTHENTICATION_OIDC_USER_DEFAULT-TENANT-CODE=default
+      - SECURITY_AUTHENTICATION_OIDC_USER_DEFAULT-QUEUE=default
+      - SECURITY_AUTHENTICATION_OIDC_USER_ADMIN-GROUP-MAPPING_0=dolphinscheduler-admins
+    depends_on:
+      dolphinscheduler-mysql:
+        condition: service_healthy
+      dolphinscheduler-zookeeper:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+
+  dolphinscheduler-mysql:
+    image: mysql:8.0
+    platform: linux/arm64
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=dolphinscheduler
+      - MYSQL_USER=dolphinscheduler
+      - MYSQL_PASSWORD=dolphinscheduler
+    volumes:
+      - ../../../../../../../dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+#      start_period: 120s
+
+  dolphinscheduler-zookeeper:
+    image: zookeeper:3.8.0
+    environment:
+      - ZOO_MY_ID=1
+      - ZOO_SERVERS=server.1=dolphinscheduler-zookeeper:2888:3888;2181
+    healthcheck:
+      test: ["CMD", "zkServer.sh", "status"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+#      start_period: 120s
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.1
+    platform: linux/arm64
+    command: start-dev --import-realm
+    volumes:
+      - ./realm-export.json:/opt/keycloak/data/import/realm.json
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTP_ENABLED: 'true'
+    ports:
+      - "8081:8080" # Using 8081 to avoid conflicts
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      interval: 5s
+      timeout: 10s
+      retries: 40
+#      start_period: 120s

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/docker-compose.yaml
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   dolphinscheduler:
     image: apache/dolphinscheduler-standalone-server:oidc-dev
     platform: linux/arm64
-    pull_policy: never
     ports:
       - "12345:12345"
     environment:
@@ -36,6 +35,12 @@ services:
         condition: service_healthy
       keycloak:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:12345/dolphinscheduler/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 400s
 
   dolphinscheduler-mysql:
     image: mysql:8.0
@@ -46,25 +51,26 @@ services:
       - MYSQL_USER=dolphinscheduler
       - MYSQL_PASSWORD=dolphinscheduler
     volumes:
-      - ../../../../../../../dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./init-sql/dolphinscheduler_mysql.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 5s
+      test: ["CMD-SHELL", "mysql -h localhost -u root -proot dolphinscheduler -e 'select 1 from t_ds_user limit 1'"]
+      #      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
       timeout: 10s
       retries: 30
-#      start_period: 120s
+      start_period: 180s
 
   dolphinscheduler-zookeeper:
     image: zookeeper:3.8.0
-    environment:
-      - ZOO_MY_ID=1
-      - ZOO_SERVERS=server.1=dolphinscheduler-zookeeper:2888:3888;2181
+    #    environment:
+    #      - ZOO_MY_ID=1
+    #      - ZOO_SERVERS=server.1=dolphinscheduler-zookeeper:2888:3888;2181
     healthcheck:
       test: ["CMD", "zkServer.sh", "status"]
       interval: 5s
       timeout: 10s
       retries: 30
-#      start_period: 120s
+      start_period: 180s
 
   keycloak:
     image: quay.io/keycloak/keycloak:22.0.1
@@ -76,6 +82,7 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: 'true'
+      KC_HOSTNAME_URL: http://localhost:8081
     ports:
       - "8081:8080" # Using 8081 to avoid conflicts
     healthcheck:
@@ -83,4 +90,4 @@ services:
       interval: 5s
       timeout: 10s
       retries: 40
-#      start_period: 120s
+      start_period: 180s

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/realm-export.json
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/realm-export.json
@@ -1,0 +1,134 @@
+{
+  "id": "dolphinscheduler",
+  "realm": "dolphinscheduler",
+  "displayName": "DolphinScheduler Realm",
+  "enabled": true,
+  "sslRequired": "external",
+  "clients": [
+    {
+      "clientId": "dolphinscheduler-client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "dolphinscheduler-client-secret",
+      "redirectUris": [
+        "http://localhost:12345/dolphinscheduler/login/oauth2/code/keycloak",
+        "http://127.0.0.1:12345/dolphinscheduler/login/oauth2/code/keycloak"
+      ],
+      "webOrigins": [
+        "http://localhost:12345",
+        "http://127.0.0.1:12345",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "protocol": "openid-connect",
+      "defaultClientScopes": [
+        "groups"
+      ],
+      "optionalClientScopes": [],
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "groups",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "name": "dolphinscheduler-admins",
+      "path": "/dolphinscheduler-admins"
+    },
+    {
+      "name": "users",
+      "path": "/users"
+    }
+  ],
+  "users": [
+    {
+      "username": "admin_user",
+      "enabled": true,
+      "email": "admin@example.com",
+      "firstName": "Admin",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "/dolphinscheduler-admins"
+      ]
+    },
+    {
+      "username": "general_user",
+      "enabled": true,
+      "email": "user@example.com",
+      "firstName": "General",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "/users"
+      ]
+    }
+  ]
+}

--- a/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/realm-export.json
+++ b/dolphinscheduler-api-test/dolphinscheduler-api-test-case/src/test/resources/docker/oidc-login/realm-export.json
@@ -4,6 +4,26 @@
   "displayName": "DolphinScheduler Realm",
   "enabled": true,
   "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "defaultRoles": [
+    "offline_access",
+    "uma_authorization"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
   "clients": [
     {
       "clientId": "dolphinscheduler-client",
@@ -21,13 +41,58 @@
         "http://127.0.0.1:5173"
       ],
       "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
       "protocol": "openid-connect",
       "defaultClientScopes": [
+        "email",
+        "profile",
         "groups"
       ],
       "optionalClientScopes": [],
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "protocolMappers": []
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "groups",
+      "description": "Group membership",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true", "display.on.consent.screen": "false" },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "email",
+      "description": "Provides email related claims.",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true", "display.on.consent.screen": "false" },
       "protocolMappers": [
         {
           "name": "email",
@@ -42,7 +107,15 @@
             "claim.name": "email",
             "jsonType.label": "String"
           }
-        },
+        }
+      ]
+    },
+    {
+      "name": "profile",
+      "description": "Provides user profile information.",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true", "display.on.consent.screen": "false" },
+      "protocolMappers": [
         {
           "name": "username",
           "protocol": "openid-connect",
@@ -55,31 +128,6 @@
             "access.token.claim": "true",
             "claim.name": "preferred_username",
             "jsonType.label": "String"
-          }
-        }
-      ]
-    }
-  ],
-  "clientScopes": [
-    {
-      "name": "groups",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "false"
-      },
-      "protocolMappers": [
-        {
-          "name": "groups",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-group-membership-mapper",
-          "consentRequired": false,
-          "config": {
-            "full.path": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "groups",
-            "userinfo.token.claim": "true"
           }
         }
       ]


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
This pull request introduces a comprehensive API test suite for the **OIDC (OpenID Connect) authentication** feature, as part of the work for [DSIP-88](https://github.com/apache/dolphinscheduler/issues/17171).

These tests ensure the reliability and correctness of the OIDC integration by validating the entire backend API flow in a realistic, containerized environment. This PR complements my previous core implementation PR (#17340) by adding the necessary end-to-end verification.

Closes: #17171 (Part 2: API Tests)

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
* **Feature:** Added `OidcLoginAPITest.java`, a new test class to cover the OIDC login lifecycle.
* **Feature:** Introduced a Docker-based test environment using `docker-compose.yaml` which sets up the DolphinScheduler server, a database, and a Keycloak instance as the OIDC provider.
* **Feature:** Included a `realm-export.json` to pre-configure the Keycloak test instance with the necessary client, users, and groups, enabling tests for role-based access control.
* **Feature:** Created `OidcLoginPage.java` as a page object to encapsulate API requests for the OIDC flow, improving test readability and maintenance.
* **Enhancement:** Updated `RequestClient.java` to better handle redirects and response headers required for testing the OIDC flow.
* **Enhancement:** Updated the HttpResponse entity in the test framework to capture and store response headers. This is essential for validating the HTTP redirects required by the OIDC login flow.
* **Tests Added:**
    * Verification of the `/oidc-providers` endpoint.
    * Validation of the redirect to the OIDC provider from `/oauth2/authorization/{providerId}`  to the OIDC provider.
    * Tests for the callback endpoint `/login/oauth2/code/{providerId}` covering scenarios like:
        * OIDC login failure (e.g., `access_denied`).
        * Missing authorization `code` in the callback.
        * Invalid `state` parameter to prevent CSRF.
        * A simulated successful login flow.

## Verify this pull request

This change is verified by the new API test suite itself.


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
