### PR TITLE
[DSIP-88][UI] Implement Frontend for OIDC Authentication

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/login.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/login.ts
@@ -22,6 +22,6 @@ export default {
   userPassword: 'Password',
   userPassword_tips: 'Please enter your password',
   login: 'Login',
-  loginWithOAuth2: 'login with OAuth2',
+  loginWithOAuth2: 'Login with OAuth2',
   ssoLogin: 'SSO Login'
 }

--- a/dolphinscheduler-ui/src/service/modules/login/index.ts
+++ b/dolphinscheduler-ui/src/service/modules/login/index.ts
@@ -40,6 +40,13 @@ export function getOauth2Provider(): any {
   })
 }
 
+export function getOidcProviders(): any {
+  return axios({
+    url: '/oidc-providers',
+    method: 'get'
+  })
+}
+
 export function clearCookie(): any {
   return axios({
     url: '/cookies',

--- a/dolphinscheduler-ui/src/service/modules/login/types.ts
+++ b/dolphinscheduler-ui/src/service/modules/login/types.ts
@@ -33,4 +33,10 @@ interface OAuth2Provider {
   iconUri: string
 }
 
-export { LoginReq, LoginRes, OAuth2Provider }
+interface OidcProvider {
+  id: string
+  displayName: string
+  iconUri?: string
+}
+
+export { LoginReq, LoginRes, OAuth2Provider, OidcProvider }

--- a/dolphinscheduler-ui/src/views/login/index.module.scss
+++ b/dolphinscheduler-ui/src/views/login/index.module.scss
@@ -60,3 +60,40 @@
     }
   }
 }
+
+.oidc-provider-link {
+  text-decoration: none;
+  width: 100%;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.oidc-provider-btn {
+  font-weight: 350 !important;
+  color: #24292e !important;
+
+  background-color: #f6f8fa;
+  border-radius: 6px;
+  height: 40px;
+
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    transform: translate(1px, -1px);
+    box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.oidc-btn-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.oidc-btn-icon {
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  object-fit: contain;
+}

--- a/dolphinscheduler-ui/src/views/login/index.tsx
+++ b/dolphinscheduler-ui/src/views/login/index.tsx
@@ -41,7 +41,7 @@ import { useLocalesStore } from '@/store/locales/locales'
 import { useThemeStore } from '@/store/theme/theme'
 import cookies from 'js-cookie'
 import { ssoLoginUrl } from '@/service/modules/login'
-import type { OAuth2Provider } from '@/service/modules/login/types'
+import type { OAuth2Provider, OidcProvider } from '@/service/modules/login/types'
 
 const login = defineComponent({
   name: 'login',
@@ -52,7 +52,9 @@ const login = defineComponent({
     const {
       handleLogin,
       handleGetOAuth2Provider,
+      handleGetOidcProviders,
       oauth2Providers,
+      oidcProviders,
       gotoOAuth2Page,
       handleRedirect
     } = useLogin(state)
@@ -86,6 +88,7 @@ const login = defineComponent({
     })
 
     handleGetOAuth2Provider()
+    handleGetOidcProviders()
     return {
       t,
       handleChange,
@@ -94,7 +97,8 @@ const login = defineComponent({
       localesStore,
       trim,
       oauth2Providers,
-      gotoOAuth2Page
+      oidcProviders,
+      gotoOAuth2Page,
     }
   },
   render() {
@@ -183,7 +187,7 @@ const login = defineComponent({
               </NButton>
             </a>
           </div>
-          {this.oauth2Providers.length > 0 && (
+          {(this.oauth2Providers.length > 0 || this.oidcProviders.length > 0) && (
             <NDivider>{this.t('login.loginWithOAuth2')}</NDivider>
           )}
 
@@ -197,6 +201,19 @@ const login = defineComponent({
                 <NButton onClick={() => this.gotoOAuth2Page(e)}>
                   {e.provider}
                 </NButton>
+              )
+            })}
+            {this.oidcProviders?.map((e: OidcProvider) => {
+              const authUrl = `/dolphinscheduler/oauth2/authorization/${e.id}`
+              return (
+                  <a href={authUrl} class={styles['oidc-provider-link']}>
+                    <NButton block class={styles['oidc-provider-btn']}>
+                      <div class={styles['oidc-btn-content']}>
+                        {e.iconUri && <img src={e.iconUri} class={styles['oidc-btn-icon']} />}
+                        <span>{e.displayName}</span>
+                      </div>
+                    </NButton>
+                  </a>
               )
             })}
           </NSpace>

--- a/dolphinscheduler-ui/src/views/login/use-login.ts
+++ b/dolphinscheduler-ui/src/views/login/use-login.ts
@@ -16,11 +16,11 @@
  */
 
 import { useRouter, useRoute } from 'vue-router'
-import { clearCookie, getOauth2Provider, login } from '@/service/modules/login'
+import { clearCookie, getOauth2Provider, getOidcProviders, login } from '@/service/modules/login'
 import { getUserInfo } from '@/service/modules/users'
 import { useUserStore } from '@/store/user/user'
 import type { Router } from 'vue-router'
-import type { LoginRes, OAuth2Provider } from '@/service/modules/login/types'
+import type { LoginRes, OAuth2Provider, OidcProvider } from '@/service/modules/login/types'
 import type { UserInfoRes } from '@/service/modules/users/types'
 import { useRouteStore } from '@/store/route/route'
 import { useTimezoneStore } from '@/store/timezone/timezone'
@@ -66,7 +66,14 @@ export function useLogin(state: any) {
     })
   }
 
+  const handleGetOidcProviders = () => {
+    getOidcProviders().then((res: Array<OidcProvider> | []) => {
+      oidcProviders.value = res
+    })
+  }
+
   const oauth2Providers = ref<Array<OAuth2Provider> | []>([])
+  const oidcProviders = ref<Array<OidcProvider> | []>([])
 
   const gotoOAuth2Page = async (oauth2Provider: OAuth2Provider) => {
     await clearCookie()
@@ -77,19 +84,21 @@ export function useLogin(state: any) {
 
   const handleRedirect = async () => {
     const authType = route.query.authType
-    if (authType && authType === 'oauth2') {
-      const sessionId = route.query.sessionId
-      if (sessionId) {
-        cookies.set('sessionId', String(sessionId), { path: '/' })
-        const userInfoRes: UserInfoRes = await getUserInfo()
-        await userStore.setUserInfo(userInfoRes)
-        const timezone = userInfoRes.timeZone ? userInfoRes.timeZone : 'UTC'
-        await timezoneStore.setTimezone(timezone)
-        router.push('home')
-      }
-      const error = route.query.error
-      if (error) {
-        window.$message.error(error)
+    if (authType) {
+      if (authType === 'oauth2' || authType === 'oidc') {
+        const sessionId = route.query.sessionId
+        if (sessionId) {
+          cookies.set('sessionId', String(sessionId), { path: '/' })
+          const userInfoRes: UserInfoRes = await getUserInfo()
+          await userStore.setUserInfo(userInfoRes)
+          const timezone = userInfoRes.timeZone ? userInfoRes.timeZone : 'UTC'
+          await timezoneStore.setTimezone(timezone)
+          router.push('home')
+        }
+        const error = route.query.error
+        if (error) {
+          window.$message.error(String(error))
+        }
       }
     }
   }
@@ -97,8 +106,10 @@ export function useLogin(state: any) {
   return {
     handleLogin,
     handleGetOAuth2Provider,
+    handleGetOidcProviders,
     gotoOAuth2Page,
     oauth2Providers,
+    oidcProviders,
     handleRedirect
   }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
This pull request introduces the complete user interface for the **OIDC (OpenID Connect) authentication** feature, as part of [DSIP-88](https://github.com/apache/dolphinscheduler/issues/17171) as mentioned in [[TOC] DSIP Collection](https://github.com/apache/dolphinscheduler/issues/14102).

This change enables users to log in via configured external identity providers (like Keycloak, Okta, etc.) by dynamically rendering SSO buttons on the login page. It provides the final user-facing piece for a seamless OIDC integration, making DolphinScheduler more accessible for enterprise environments.

Closes: #17171 (Part 3: Frontend)

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
This PR implements the end-to-end frontend logic for OIDC authentication, broken down as follows:

- **API Service Integration:**
    - A new service function `getOidcProviders` has been added in `dolphinscheduler-ui/src/service/modules/login/index.ts` to fetch the list of configured OIDC providers from the `/oidc-providers` backend endpoint.
    - The `OidcProvider` interface was added to `dolphinscheduler-ui/src/service/modules/login/types.ts` to ensure type-safe handling of the API response, including the optional `iconUri`.

- **Login Page Logic:**
    - The core logic in the `use-login.ts` hook has been updated. On component mount, it now calls the new service to fetch the OIDC providers.
    - A `handleRedirect` function has been implemented to process the callback from the IdP. It checks the URL for a `sessionId`, sets the session cookie, and fetches user info to complete the login process.

- **UI Rendering and Styling:**
    - The main login component, `dolphinscheduler-ui/src/views/login/index.tsx`, now dynamically renders a styled button for each OIDC provider returned from the API.
    - New styles have been added to `dolphinscheduler-ui/src/views/login/index.module.scss` to create visually distinct and professional buttons for each provider, complete with logos and interactive hover effects (lift and shadow).

- **Internationalization (i18n):**
    - A minor change in `dolphinscheduler-ui/src/locales/en_US/login.ts` file for text displayed as a divider above the SSO buttons.


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This change does not add new automated tests but can be verified through manual testing of the complete user flow.

**Steps to Verify:**

1.  Ensure the backend is running with at least one OIDC provider configured in `application.yaml`. The configuration should include an `icon-uri` pointing to a valid image path (e.g., `/images/providers-icon/keycloak.svg`).
2.  Start the `dolphinscheduler-ui` service.
3.  Navigate to the login page. You should see the new, styled OIDC provider button(s) rendered below the main login form.
4.  Click on an OIDC provider button. You should be correctly redirected to the external identity provider's login page.
5.  Authenticate successfully with the external provider.
6.  After authentication, you should be redirected back to the DolphinScheduler dashboard, fully logged in.


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
