### PR TITLE
[Improvement-16994][TaskPlugin] support retry for every api call for serverless spark

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-aliyunserverlessspark/src/main/java/org/apache/dolphinscheduler/plugin/task/aliyunserverlessspark/AliyunServerlessSparkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-aliyunserverlessspark/src/main/java/org/apache/dolphinscheduler/plugin/task/aliyunserverlessspark/AliyunServerlessSparkTask.java
@@ -37,9 +37,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +54,6 @@ import com.aliyun.emr_serverless_spark20230808.models.StartJobRunRequest;
 import com.aliyun.emr_serverless_spark20230808.models.StartJobRunResponse;
 import com.aliyun.emr_serverless_spark20230808.models.Tag;
 import com.aliyun.teaopenapi.models.Config;
-import com.aliyun.teautil.models.RuntimeOptions;
 
 @Slf4j
 public class AliyunServerlessSparkTask extends AbstractRemoteTask {
@@ -126,60 +124,66 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
 
     @Override
     public void handle(TaskCallBack taskCallBack) throws TaskException {
-        try {
-            GetTemplateResponse getTemplateResponse = aliyunServerlessSparkClient.getTemplate(
-                    aliyunServerlessSparkParameters.getWorkspaceId(),
-                    buildGetTemplateRequest());
-
-            if (getTemplateResponse != null) {
-                templateConf = getTemplateResponse.getBody()
-                        .getData()
-                        .getSparkConf()
-                        .stream()
-                        .map(item -> "--conf " + item.getKey() + "=" + item.getValue())
-                        .collect(Collectors.joining(" "));
-
-                templateDisplayReleaseVersion = getTemplateResponse.getBody().getData().getDisplaySparkVersion();
-                templateFusion = getTemplateResponse.getBody().getData().getFusion();
+        GetTemplateResponse getTemplateResponse = RetryUtils.retryFunction(() -> {
+            try {
+                return aliyunServerlessSparkClient.getTemplate(
+                        aliyunServerlessSparkParameters.getWorkspaceId(),
+                        buildGetTemplateRequest());
+            } catch (Exception e) {
+                throw new TaskException("Failed to get template info", e);
             }
-        } catch (Exception e) {
-            throw new AliyunServerlessSparkTaskException("Failed to get serverless spark template!");
+        });
+
+        if (getTemplateResponse != null) {
+            templateConf = getTemplateResponse.getBody()
+                    .getData()
+                    .getSparkConf()
+                    .stream()
+                    .map(item -> "--conf " + item.getKey() + "=" + item.getValue())
+                    .collect(Collectors.joining(" "));
+
+            templateDisplayReleaseVersion = getTemplateResponse.getBody().getData().getDisplaySparkVersion();
+            templateFusion = getTemplateResponse.getBody().getData().getFusion();
         }
 
-        try {
-            StartJobRunRequest startJobRunRequest = buildStartJobRunRequest(aliyunServerlessSparkParameters);
-            RuntimeOptions runtime = new RuntimeOptions();
-            Map<String, String> headers = new HashMap<>();
-            StartJobRunResponse startJobRunResponse = aliyunServerlessSparkClient.startJobRunWithOptions(
-                    aliyunServerlessSparkParameters.getWorkspaceId(), startJobRunRequest, headers, runtime);
-            jobRunId = startJobRunResponse.getBody().getJobRunId();
-            setAppIds(jobRunId);
-            log.info("Successfully submitted serverless spark job, jobRunId - {}", jobRunId);
+        StartJobRunRequest startJobRunRequest = buildStartJobRunRequest(aliyunServerlessSparkParameters);
+        StartJobRunResponse startJobRunResponse = RetryUtils.retryFunction(() -> {
+            try {
+                return aliyunServerlessSparkClient.startJobRun(
+                        aliyunServerlessSparkParameters.getWorkspaceId(), startJobRunRequest);
+            } catch (Exception e) {
+                throw new AliyunServerlessSparkTaskException("Failed to start job run!");
+            }
+        });
 
-            while (!RunState.isFinal(currentState)) {
-                GetJobRunRequest getJobRunRequest = buildGetJobRunRequest();
+        jobRunId = startJobRunResponse.getBody().getJobRunId();
+        setAppIds(jobRunId);
+        log.info("Successfully submitted serverless spark job, jobRunId - {}", jobRunId);
 
-                GetJobRunResponse getJobRunResponse = RetryUtils.retryFunction(() -> {
-                    try {
-                        return aliyunServerlessSparkClient
-                                .getJobRun(aliyunServerlessSparkParameters.getWorkspaceId(), jobRunId,
-                                        getJobRunRequest);
-                    } catch (Exception e) {
-                        throw new AliyunServerlessSparkTaskException("Failed to get job run!", e);
-                    }
-                }, new RetryUtils.RetryPolicy(10, 1000L));
+        while (!RunState.isFinal(currentState)) {
+            GetJobRunRequest getJobRunRequest = buildGetJobRunRequest();
 
-                currentState = RunState.valueOf(getJobRunResponse.getBody().getJobRun().getState());
-                log.info("job - {} state - {}", jobRunId, currentState);
+            GetJobRunResponse getJobRunResponse = RetryUtils.retryFunction(() -> {
+                try {
+                    return aliyunServerlessSparkClient
+                            .getJobRun(aliyunServerlessSparkParameters.getWorkspaceId(), jobRunId,
+                                    getJobRunRequest);
+                } catch (Exception e) {
+                    throw new AliyunServerlessSparkTaskException("Failed to get job run!", e);
+                }
+            }, new RetryUtils.RetryPolicy(10, 1000L));
+
+            currentState = RunState.valueOf(getJobRunResponse.getBody().getJobRun().getState());
+            log.info("job - {} state - {}", jobRunId, currentState);
+
+            try {
                 Thread.sleep(10 * 1000L);
+            } catch (InterruptedException e) {
+                break;
             }
-
-            setExitStatusCode(mapFinalStateToExitCode(currentState));
-
-        } catch (Exception e) {
-            log.error("Serverless spark job failed!", e);
-            throw new AliyunServerlessSparkTaskException("Serverless spark job failed!");
         }
+
+        setExitStatusCode(mapFinalStateToExitCode(currentState));
     }
 
     @Override
@@ -211,12 +215,16 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
     @Override
     public void cancelApplication() throws TaskException {
         CancelJobRunRequest cancelJobRunRequest = buildCancelJobRunRequest();
-        try {
-            aliyunServerlessSparkClient.cancelJobRun(aliyunServerlessSparkParameters.getWorkspaceId(), jobRunId,
-                    cancelJobRunRequest);
-        } catch (Exception e) {
-            log.error("Failed to cancel serverless spark job run", e);
-        }
+        RetryUtils.retryFunction(
+                () -> {
+                    try {
+                        return aliyunServerlessSparkClient.cancelJobRun(
+                                aliyunServerlessSparkParameters.getWorkspaceId(), jobRunId,
+                                cancelJobRunRequest);
+                    } catch (Exception e) {
+                        throw new AliyunServerlessSparkTaskException("Failed to cancel job run!");
+                    }
+                });
     }
 
     @Override
@@ -244,6 +252,7 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
         }
 
         StartJobRunRequest startJobRunRequest = new StartJobRunRequest();
+        startJobRunRequest.setClientToken(genereteClientToken());
         startJobRunRequest.setRegionId(regionId);
         startJobRunRequest.setResourceQueueId(aliyunServerlessSparkParameters.getResourceQueueId());
         startJobRunRequest.setCodeType(aliyunServerlessSparkParameters.getCodeType());
@@ -296,10 +305,15 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
     protected GetTemplateRequest buildGetTemplateRequest() {
         GetTemplateRequest getTemplateRequest = new GetTemplateRequest();
 
-        if (aliyunServerlessSparkParameters.getTemplateId() != null) {
+        if (aliyunServerlessSparkParameters.getTemplateId() != null
+                && !aliyunServerlessSparkParameters.getTemplateId().isEmpty()) {
             getTemplateRequest.setTemplateBizId(aliyunServerlessSparkParameters.getTemplateId());
         }
 
         return getTemplateRequest;
+    }
+
+    protected String genereteClientToken() {
+        return taskExecutionContext.getTaskInstanceId() + "-" + UUID.randomUUID();
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-aliyunserverlessspark/src/main/java/org/apache/dolphinscheduler/plugin/task/aliyunserverlessspark/AliyunServerlessSparkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-aliyunserverlessspark/src/main/java/org/apache/dolphinscheduler/plugin/task/aliyunserverlessspark/AliyunServerlessSparkTask.java
@@ -84,6 +84,8 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
 
     private String endpoint;
 
+    private RetryUtils.RetryPolicy retryPolicy = new RetryUtils.RetryPolicy(10, 1000L);
+
     protected AliyunServerlessSparkTask(TaskExecutionContext taskExecutionContext) {
         super(taskExecutionContext);
         this.taskExecutionContext = taskExecutionContext;
@@ -132,7 +134,7 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
             } catch (Exception e) {
                 throw new TaskException("Failed to get template info", e);
             }
-        });
+        }, retryPolicy);
 
         if (getTemplateResponse != null) {
             templateConf = getTemplateResponse.getBody()
@@ -154,7 +156,7 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
             } catch (Exception e) {
                 throw new AliyunServerlessSparkTaskException("Failed to start job run!");
             }
-        });
+        }, retryPolicy);
 
         jobRunId = startJobRunResponse.getBody().getJobRunId();
         setAppIds(jobRunId);
@@ -171,7 +173,7 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
                 } catch (Exception e) {
                     throw new AliyunServerlessSparkTaskException("Failed to get job run!", e);
                 }
-            }, new RetryUtils.RetryPolicy(10, 1000L));
+            }, retryPolicy);
 
             currentState = RunState.valueOf(getJobRunResponse.getBody().getJobRun().getState());
             log.info("job - {} state - {}", jobRunId, currentState);
@@ -224,7 +226,7 @@ public class AliyunServerlessSparkTask extends AbstractRemoteTask {
                     } catch (Exception e) {
                         throw new AliyunServerlessSparkTaskException("Failed to cancel job run!");
                     }
-                });
+                }, retryPolicy);
     }
 
     @Override

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-aliyunserverlessspark/src/test/java/org/apache/dolphinscheduler/plugin/task/aliyunserverlessspark/AliyunServerlessSparkTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-aliyunserverlessspark/src/test/java/org/apache/dolphinscheduler/plugin/task/aliyunserverlessspark/AliyunServerlessSparkTaskTest.java
@@ -164,7 +164,7 @@ public class AliyunServerlessSparkTaskTest {
         doReturn(startJobRunResponseBody).when(mockStartJobRunResponse).getBody();
         Assertions.assertDoesNotThrow(
                 () -> doReturn(mockStartJobRunResponse).when(mockAliyunServerlessSparkClient)
-                        .startJobRunWithOptions(any(), any(), any(), any()));
+                        .startJobRun(any(), any()));
 
         doReturn(mockGetJobRunRequest).when(aliyunServerlessSparkTask).buildGetJobRunRequest();
         GetJobRunResponseBody getJobRunResponseBody = new GetJobRunResponseBody();


### PR DESCRIPTION
support retry for every api call for EMR Serverless Spark, will improve the robustness of this task plugin against some temporarily malfunction of remote service

part of #16994 