### PR TITLE
[Fix-13635] Fix process instance state is ready stop and never changed to stop

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/WorkflowStateEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/event/WorkflowStateEventHandler.java
@@ -48,7 +48,6 @@ public class WorkflowStateEventHandler implements StateEventHandler {
             if (processDefinition.getExecutionType().typeIsSerialWait() || processDefinition.getExecutionType()
                     .typeIsSerialPriority()) {
                 workflowExecuteRunnable.endProcess();
-                return true;
             }
             workflowExecuteRunnable.updateProcessInstanceState(workflowStateEvent);
             return true;


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Related issue: https://github.com/apache/dolphinscheduler/issues/13635

Fix process instance state is ready stop and never changed to stop,

When process execution type is SERIAL_WAIT or SERIAL_PRIORITY, workflow stop event handler still hive to updateProcessInstanceState after this "endProcess()".
