### PR TITLE
[Fix-17370] Fix worker server start failed when using hdfs storage type

### DIFF
--- a/dolphinscheduler-worker/pom.xml
+++ b/dolphinscheduler-worker/pom.xml
@@ -228,6 +228,11 @@
             <artifactId>zt-zip</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.hbase.thirdparty</groupId>
+            <artifactId>hbase-noop-htrace</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/dolphinscheduler-worker/pom.xml
+++ b/dolphinscheduler-worker/pom.xml
@@ -228,11 +228,6 @@
             <artifactId>zt-zip</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.hbase.thirdparty</groupId>
-            <artifactId>hbase-noop-htrace</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/script/install-plugins.sh
+++ b/script/install-plugins.sh
@@ -55,7 +55,7 @@ while read line; do
 
   if [ "$start_char" != "-" ] && [ "$start_char" != "#" ]; then
       echo "installing plugin: " $line
-      ${DOLPHINSCHEDULER_HOME}/mvnw dependency:get -DgroupId=org.apache.dolphinscheduler -DartifactId=${line} -Dversion=${version} -Ddest=${DOLPHINSCHEDULER_HOME}/plugins/${plugin_dir}
+      ${DOLPHINSCHEDULER_HOME}/mvnw dependency:get -DgroupId=org.apache.dolphinscheduler -DartifactId=${line} -Dversion=${version} -Dclassifier=shade -Ddest=${DOLPHINSCHEDULER_HOME}/plugins/${plugin_dir}
   fi
 
 done < ${DOLPHINSCHEDULER_HOME}/conf/plugins_config


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17370
close #17488

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
