### PR TITLE
[Fix-17495] [Kubernetes] Fix configuration file mounting path issue

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
@@ -114,7 +114,7 @@ spec:
             - mountPath: "/opt/dolphinscheduler/logs"
               name: {{ include "dolphinscheduler.fullname" . }}-api
             - name: config-volume
-              mountPath: /opt/dolphinscheduler/conf/common.properties
+              mountPath: /opt/dolphinscheduler/api-server/conf/common.properties
               subPath: common.properties
             {{- if .Values.api.taskTypeFilter.enabled }}
             - name: config-volume

--- a/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
@@ -118,7 +118,7 @@ spec:
               subPath: application.yaml
             {{- end }}
             - name: config-volume
-              mountPath: /opt/dolphinscheduler/conf/common.properties
+              mountPath: /opt/dolphinscheduler/worker-server/conf/common.properties
               subPath: common.properties
             {{- include "dolphinscheduler.sharedStorage.volumeMount" . | nindent 12 }}
             {{- include "dolphinscheduler.fsFileResource.volumeMount" . | nindent 12 }}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close #17495

Fix the issue of incorrect mounting paths for Kubernetes 3.3.1 deployment dolphinscheduler-api and statefulset dolphinscheduler-worker resources
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
Fix the mismatch between the `common.properties` file and the mount path in the startup script configuration file
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
