### PR TITLE
[Fix-17495] Fix missing jar: temporary add storage jar to distribution

### DIFF
--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-storage-all</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/dolphinscheduler-standalone-server/pom.xml
+++ b/dolphinscheduler-standalone-server/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-storage-all</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/dolphinscheduler-worker/pom.xml
+++ b/dolphinscheduler-worker/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-storage-all</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
Fix: https://github.com/apache/dolphinscheduler/issues/17495

## Brief change log
I see Plugin Jar are move to `$DOLPHINSCHEDULER_HOME/plugins/$plugin`, but installing plugin is not ready for k8s helm.

Revert this after new plugin feature is ready.

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request


This pull request is code cleanup without any test coverage.


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
