### PR TITLE
[Fix-17520][TaskExecutor] fix not clear task exec path when set development.state=false in common.properties

### DIFF
--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -81,7 +81,7 @@ dolphin.scheduler.network.interface.restrict=docker0
 # network IP gets priority, default: inner outer
 #dolphin.scheduler.network.priority.strategy=default
 
-# development state
+# development state. it may delete task exec path when task finished, or keep it for debug reason in development
 development.state=false
 
 # If the shell process is still active after this timeout value (in seconds), then will use kill -9 to kill it

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/LogicTaskExecutor.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/LogicTaskExecutor.java
@@ -78,6 +78,11 @@ public class LogicTaskExecutor extends AbstractTaskExecutor {
     }
 
     @Override
+    public void finalizeTask() {
+        // do nothing for now
+    }
+
+    @Override
     public String toString() {
         return "LogicTaskExecutor{" +
                 "id=" + taskExecutionContext.getTaskInstanceId() +

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/ITaskExecutor.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/ITaskExecutor.java
@@ -70,6 +70,11 @@ public interface ITaskExecutor extends ITaskExecutorStateTracker {
     void kill();
 
     /**
+     * finalize the task executor.
+     */
+    void finalizeTask();
+
+    /**
      * Get the EventBus belongs to the task executor.
      */
     TaskExecutorEventBus getTaskExecutorEventBus();

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/container/AbstractTaskExecutorContainer.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/container/AbstractTaskExecutorContainer.java
@@ -19,8 +19,11 @@ package org.apache.dolphinscheduler.task.executor.container;
 
 import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
 
+import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.log.remote.RemoteLogUtils;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
+import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.exceptions.TaskExecutorRuntimeException;
@@ -98,6 +101,7 @@ public abstract class AbstractTaskExecutorContainer implements ITaskExecutorCont
         }
         log.info(FINALIZE_SESSION_MARKER, FINALIZE_SESSION_MARKER.toString());
         pushTaskExecutorLogToRemote(taskExecutor);
+        deleteExecPathIfProduction(taskExecutor);
     }
 
     @Override
@@ -142,6 +146,28 @@ public abstract class AbstractTaskExecutorContainer implements ITaskExecutorCont
             }
         } catch (Exception ex) {
             log.error("Send task log {} to remote storage failed", taskExecutionContext.getLogPath(), ex);
+        }
+    }
+
+    /**
+     * Delete task exec Directory if set development.state=false in common.properties explicit
+     * otherwise keep it for debug reason.
+     */
+    private void deleteExecPathIfProduction(ITaskExecutor taskExecutor) {
+        boolean isDev = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
+        if (!isDev) {
+            try {
+                final TaskExecutionContext ctx = taskExecutor.getTaskExecutionContext();
+                final String execPath = (ctx != null ? ctx.getExecutePath() : "");
+                if (!"".equals(execPath)) {
+                    FileUtils.deleteFile(execPath);
+                    log.info("Deleted task exec directory: {}", execPath);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to delete task exec directory in prod mode.", e);
+            }
+        } else {
+            log.debug("Development mode is on, skip deleting executePath for debug reason");
         }
     }
 

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/container/AbstractTaskExecutorContainer.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/container/AbstractTaskExecutorContainer.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.task.executor.container;
 
 import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.log.remote.RemoteLogUtils;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
@@ -158,8 +159,8 @@ public abstract class AbstractTaskExecutorContainer implements ITaskExecutorCont
         if (!isDev) {
             try {
                 final TaskExecutionContext ctx = taskExecutor.getTaskExecutionContext();
-                final String execPath = (ctx != null ? ctx.getExecutePath() : "");
-                if (!"".equals(execPath)) {
+                final String execPath = ctx.getExecutePath();
+                if (StringUtils.isNotEmpty(execPath)) {
                     FileUtils.deleteFile(execPath);
                     log.info("Deleted task exec directory: {}", execPath);
                 }

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/container/AbstractTaskExecutorContainer.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/container/AbstractTaskExecutorContainer.java
@@ -19,12 +19,8 @@ package org.apache.dolphinscheduler.task.executor.container;
 
 import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.log.remote.RemoteLogUtils;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
-import org.apache.dolphinscheduler.common.utils.FileUtils;
-import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.exceptions.TaskExecutorRuntimeException;
@@ -102,7 +98,8 @@ public abstract class AbstractTaskExecutorContainer implements ITaskExecutorCont
         }
         log.info(FINALIZE_SESSION_MARKER, FINALIZE_SESSION_MARKER.toString());
         pushTaskExecutorLogToRemote(taskExecutor);
-        deleteExecPathIfProduction(taskExecutor);
+        // [Fix-17520]
+        taskExecutor.finalizeTask();
     }
 
     @Override
@@ -147,28 +144,6 @@ public abstract class AbstractTaskExecutorContainer implements ITaskExecutorCont
             }
         } catch (Exception ex) {
             log.error("Send task log {} to remote storage failed", taskExecutionContext.getLogPath(), ex);
-        }
-    }
-
-    /**
-     * Delete task exec Directory if set development.state=false in common.properties explicit
-     * otherwise keep it for debug reason.
-     */
-    private void deleteExecPathIfProduction(ITaskExecutor taskExecutor) {
-        boolean isDev = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
-        if (!isDev) {
-            try {
-                final TaskExecutionContext ctx = taskExecutor.getTaskExecutionContext();
-                final String execPath = ctx.getExecutePath();
-                if (StringUtils.isNotEmpty(execPath)) {
-                    FileUtils.deleteFile(execPath);
-                    log.info("Deleted task exec directory: {}", execPath);
-                }
-            } catch (Exception e) {
-                log.warn("Failed to delete task exec directory in prod mode.", e);
-            }
-        } else {
-            log.debug("Development mode is on, skip deleting executePath for debug reason");
         }
     }
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
@@ -105,6 +105,12 @@ public class PhysicalTaskExecutor extends AbstractTaskExecutor {
     }
 
     @Override
+    public void finalizeTask() {
+        TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
+    }
+
+
+    @Override
     protected void initializeTaskContext() {
         super.initializeTaskContext();
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
@@ -109,7 +109,6 @@ public class PhysicalTaskExecutor extends AbstractTaskExecutor {
         TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
     }
 
-
     @Override
     protected void initializeTaskContext() {
         super.initializeTaskContext();

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
@@ -17,7 +17,9 @@
 
 package org.apache.dolphinscheduler.server.worker.executor;
 
+import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTask;
 import org.apache.dolphinscheduler.plugin.task.api.TaskCallBack;
@@ -106,7 +108,14 @@ public class PhysicalTaskExecutor extends AbstractTaskExecutor {
 
     @Override
     public void finalizeTask() {
-        TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
+        clearTaskInstanceWorkingDirectoryIfNeeded();
+    }
+
+    private void clearTaskInstanceWorkingDirectoryIfNeeded() {
+        boolean isDevelopment = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
+        if (!isDevelopment) {
+            TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
+        }
     }
 
     @Override

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
@@ -111,7 +111,7 @@ public class TaskExecutionContextUtils {
         return resourceContext;
     }
 
-    public static void clearTaskInstanceWorkingDirectory (TaskExecutionContext taskExecutionContext) {
+    public static void clearTaskInstanceWorkingDirectory(TaskExecutionContext taskExecutionContext) {
         boolean isDevelopment = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
         if (!isDevelopment) {
             try {

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
@@ -17,9 +17,7 @@
 
 package org.apache.dolphinscheduler.server.worker.utils;
 
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
-import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.storage.api.ResourceMetadata;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
 import org.apache.dolphinscheduler.plugin.task.api.TaskChannel;
@@ -112,19 +110,14 @@ public class TaskExecutionContextUtils {
     }
 
     public static void clearTaskInstanceWorkingDirectory(TaskExecutionContext taskExecutionContext) {
-        boolean isDevelopment = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
-        if (!isDevelopment) {
-            try {
-                final String execPath = taskExecutionContext.getExecutePath();
-                if (StringUtils.isNotEmpty(execPath)) {
-                    FileUtils.deleteFile(execPath);
-                    log.info("Deleted task exec directory: {}", execPath);
-                }
-            } catch (Exception e) {
-                log.warn("Failed to delete task exec directory in prod mode.", e);
+        final String execPath = taskExecutionContext.getExecutePath();
+        try {
+            if (StringUtils.isNotEmpty(execPath)) {
+                FileUtils.deleteFile(execPath);
+                log.info("Deleted task exec directory: {}", execPath);
             }
-        } else {
-            log.debug("Development mode is on, skip deleting executePath for debug reason");
+        } catch (Exception e) {
+            log.warn("Failed to delete task exec directory.", e);
         }
     }
 

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtils.java
@@ -17,7 +17,9 @@
 
 package org.apache.dolphinscheduler.server.worker.utils;
 
+import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.storage.api.ResourceMetadata;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
 import org.apache.dolphinscheduler.plugin.task.api.TaskChannel;
@@ -29,6 +31,7 @@ import org.apache.dolphinscheduler.plugin.task.api.resource.ResourceContext;
 import org.apache.dolphinscheduler.server.worker.metrics.WorkerServerMetrics;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -106,6 +109,23 @@ public class TaskExecutionContextUtils {
             resourceContext.addResourceItem(resourceItem);
         }
         return resourceContext;
+    }
+
+    public static void clearTaskInstanceWorkingDirectory (TaskExecutionContext taskExecutionContext) {
+        boolean isDevelopment = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
+        if (!isDevelopment) {
+            try {
+                final String execPath = taskExecutionContext.getExecutePath();
+                if (StringUtils.isNotEmpty(execPath)) {
+                    FileUtils.deleteFile(execPath);
+                    log.info("Deleted task exec directory: {}", execPath);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to delete task exec directory in prod mode.", e);
+            }
+        } else {
+            log.debug("Development mode is on, skip deleting executePath for debug reason");
+        }
     }
 
 }

--- a/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
+++ b/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.worker.utils;
 
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 
@@ -59,8 +58,6 @@ class TaskExecutionContextUtilsTest {
 
     @Test
     void clearTaskInstanceWorkingDirectory() throws IOException {
-        System.getProperties().setProperty(Constants.DEVELOPMENT_STATE, "false");
-
         TaskExecutionContext taskExecutionContext = new TaskExecutionContext();
         taskExecutionContext.setTaskInstanceId(1);
 
@@ -69,8 +66,12 @@ class TaskExecutionContextUtilsTest {
                 FileUtils.getTaskInstanceWorkingDirectory(taskExecutionContext.getTaskInstanceId());
         Files.createFile(Paths.get(taskWorkingDirectory, "1.sh"));
 
-        // Test if set development.state=false, will delete the working directory
+        // Test delete the working directory
         TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
         Assertions.assertFalse(Files.exists(Paths.get(taskWorkingDirectory)));
+
+        // Test do nothing if working directory is empty
+        TaskExecutionContext emptyExecPathContext = new TaskExecutionContext();
+        TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(emptyExecPathContext);
     }
 }

--- a/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
+++ b/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
@@ -68,7 +68,7 @@ class TaskExecutionContextUtilsTest {
         String taskWorkingDirectory =
                 FileUtils.getTaskInstanceWorkingDirectory(taskExecutionContext.getTaskInstanceId());
         Files.createFile(Paths.get(taskWorkingDirectory, "1.sh"));
-        
+
         // Test if set development.state=false, will delete the working directory
         TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
         Assertions.assertFalse(Files.exists(Paths.get(taskWorkingDirectory)));

--- a/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
+++ b/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskExecutionContextUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.server.worker.utils;
 
+import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 
@@ -54,5 +55,22 @@ class TaskExecutionContextUtilsTest {
         } finally {
             FileUtils.deleteFile(taskWorkingDirectory);
         }
+    }
+
+    @Test
+    void clearTaskInstanceWorkingDirectory() throws IOException {
+        System.getProperties().setProperty(Constants.DEVELOPMENT_STATE, "false");
+
+        TaskExecutionContext taskExecutionContext = new TaskExecutionContext();
+        taskExecutionContext.setTaskInstanceId(1);
+
+        TaskExecutionContextUtils.createTaskInstanceWorkingDirectory(taskExecutionContext);
+        String taskWorkingDirectory =
+                FileUtils.getTaskInstanceWorkingDirectory(taskExecutionContext.getTaskInstanceId());
+        Files.createFile(Paths.get(taskWorkingDirectory, "1.sh"));
+        
+        // Test if set development.state=false, will delete the working directory
+        TaskExecutionContextUtils.clearTaskInstanceWorkingDirectory(taskExecutionContext);
+        Assertions.assertFalse(Files.exists(Paths.get(taskWorkingDirectory)));
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

close #17520

## Brief change log

fix bug with modifing AbstractTaskExecutorContainer.handle() after task exec finished

## Verify this pull request

This pull request is code cleanup without any test coverage.

(or)

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
