### PR TITLE
[Chore] Prevent NPE when handling zk connection events

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java
@@ -34,7 +34,7 @@ public class ZookeeperTreeCacheListenerAdapter implements TreeCacheListener {
 
     private final SubscribeListener listener;
 
-    private final EnumSet<TreeCacheEvent.Type> NODE_CHANGE_EVENTS =
+    private static final EnumSet<TreeCacheEvent.Type> NODE_CHANGE_EVENTS =
             EnumSet.of(TreeCacheEvent.Type.NODE_REMOVED,
                     TreeCacheEvent.Type.NODE_UPDATED,
                     TreeCacheEvent.Type.NODE_ADDED);

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java
@@ -39,6 +39,11 @@ public class ZookeeperTreeCacheListenerAdapter implements TreeCacheListener {
 
     @Override
     public void childEvent(final CuratorFramework curatorFramework, final TreeCacheEvent event) {
+        // When the event type is INITIALIZED or CONNECTION_SUSPENDED or CONNECTION_LOST or CONNECTION_RECONNECTED, the
+        // data in the event is null by default
+        if (event.getData() == null) {
+            return;
+        }
         final String eventPath = event.getData().getPath();
         switch (listener.getSubscribeScope()) {
             case PATH_ONLY:

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java
@@ -26,11 +26,18 @@ import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
 import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 
+import java.util.EnumSet;
+
 public class ZookeeperTreeCacheListenerAdapter implements TreeCacheListener {
 
     private final String watchedPath;
 
     private final SubscribeListener listener;
+
+    private final EnumSet<TreeCacheEvent.Type> NODE_CHANGE_EVENTS =
+            EnumSet.of(TreeCacheEvent.Type.NODE_REMOVED,
+                    TreeCacheEvent.Type.NODE_UPDATED,
+                    TreeCacheEvent.Type.NODE_ADDED);
 
     public ZookeeperTreeCacheListenerAdapter(final String watchedPath, final SubscribeListener listener) {
         this.listener = listener;
@@ -41,7 +48,7 @@ public class ZookeeperTreeCacheListenerAdapter implements TreeCacheListener {
     public void childEvent(final CuratorFramework curatorFramework, final TreeCacheEvent event) {
         // When the event type is INITIALIZED or CONNECTION_SUSPENDED or CONNECTION_LOST or CONNECTION_RECONNECTED, the
         // data in the event is null by default
-        if (event.getData() == null) {
+        if (!isNodeChangeEvent(event)) {
             return;
         }
         final String eventPath = event.getData().getPath();
@@ -62,6 +69,10 @@ public class ZookeeperTreeCacheListenerAdapter implements TreeCacheListener {
             default:
                 throw new RegistryException("Unknown event scope: " + listener.getSubscribeScope());
         }
+    }
+
+    private boolean isNodeChangeEvent(TreeCacheEvent event) {
+        return NODE_CHANGE_EVENTS.contains(event.getType());
     }
 
     private Event convertToEvent(TreeCacheEvent event, String watchedPath) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
An NPE error is thrown when starting the master.
```
[WI-0][TI-0] - 2025-09-21 03:24:47.217 INFO  [Master-Server] o.a.d.s.m.c.ClusterManager:[93] - Initialized WorkerClusters: [ ]
[WI-0][TI-0] - 2025-09-21 03:24:47.218 ERROR [Curator-TreeCache-0] o.a.c.f.r.c.TreeCache:[828] -
java.lang.NullPointerException: null
        at org.apache.dolphinscheduler.plugin.registry.zookeeper.ZookeeperTreeCacheListenerAdapter.childEvent(ZookeeperTreeCacheListenerAdapter.java:42)
        at org.apache.curator.framework.recipes.cache.TreeCache.lambda$callListeners$1(TreeCache.java:811)
        at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92)
        at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89)
        at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89)
        at org.apache.curator.framework.recipes.cache.TreeCache.callListeners(TreeCache.java:807)
        at org.apache.curator.framework.recipes.cache.TreeCache.access$1900(TreeCache.java:79)
        at org.apache.curator.framework.recipes.cache.TreeCache$2.run(TreeCache.java:909)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
[WI-0][TI-0] - 2025-09-21 03:24:47.219 INFO  [Curator-TreeCache-0] o.a.d.s.m.c.AbstractClusterSubscribeListener:[41] - Server MasterServerMetadata(super=BaseServerMetadata(processId=46421, serverStartupTime=1758396285183, address=10.1.2.10:5678, cpuUsage=0.435457953936797, memoryUsage=0.6507625579833984, serverStatus=NORMAL)) added
[WI-0][TI-0] - 2025-09-21 03:24:47.219 ERROR [Curator-TreeCache-0] o.a.c.f.r.c.TreeCache:[828] -
java.lang.NullPointerException: null
        at org.apache.dolphinscheduler.plugin.registry.zookeeper.ZookeeperTreeCacheListenerAdapter.childEvent(ZookeeperTreeCacheListenerAdapter.java:42)
        at org.apache.curator.framework.recipes.cache.TreeCache.lambda$callListeners$1(TreeCache.java:811)
        at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92)
        at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89)
        at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89)
        at org.apache.curator.framework.recipes.cache.TreeCache.callListeners(TreeCache.java:807)
        at org.apache.curator.framework.recipes.cache.TreeCache.access$1900(TreeCache.java:79)
        at org.apache.curator.framework.recipes.cache.TreeCache$2.run(TreeCache.java:909)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
[WI-0][TI-0] - 2025-09-21 03:24:47.288 INFO  [Master-Server] o.a.d.s.m.c.ClusterManager:[59] - ClusterManager started...
[WI-0][TI-0] - 2025-09-21 03:24:47.290 INFO  [Master-Server] o.a.d.s.m.c.ClusterStateMonitors:[46] - ClusterStateMonitors started...
[WI-0][TI-0] - 2025-09-21 03:24:47.513 INFO  [Master-Server] o.a.d.s.m.e.WorkflowEventBusFireWorkers:[71] - WorkflowEventBusFireWorkers s
```
First, let me explain why NPE is thrown. From the source code of curator below, you can see that when the event is of the following four types(INITIALIZED or CONNECTION_SUSPENDED or CONNECTION_LOST or CONNECTION_RECONNECTED), the data in event is null by default. Dolphin does not handle the null value of data, so npe is thrown https://github.com/apache/dolphinscheduler/blob/b5e73983933f054d738ddb8d48d5818254bd369b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-zookeeper/src/main/java/org/apache/dolphinscheduler/plugin/registry/zookeeper/ZookeeperTreeCacheListenerAdapter.java#L42

<img width="969" height="214" alt="截屏2025-09-21 03 36 50" src="https://github.com/user-attachments/assets/e70c12c0-788b-407e-84ad-c6d76eb910b9" />
<img width="716" height="106" alt="截屏2025-09-21 03 36 38" src="https://github.com/user-attachments/assets/985cedf5-b8a5-4ecc-847f-d1b7b68cc36a" />

Curator only logs the error message, so the NPE doesn’t break master startup; nevertheless, we should still eliminate the misleading stack-trace to avoid confusing users.

<img width="796" height="279" alt="截屏2025-09-21 03 35 06" src="https://github.com/user-attachments/assets/746f8016-228f-4244-a290-56592179698b" />
<img width="806" height="452" alt="截屏2025-09-21 03 34 50" src="https://github.com/user-attachments/assets/5ff9a146-619a-43da-8db6-d8698f836652" />




<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
