### PR TITLE
[Fix-17520][TaskExecutor] Clear the task execution file and dircetory when development.state is set to false in common.properties

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -505,7 +505,7 @@ public enum Status {
     DELETE_CLUSTER_RELATED_NAMESPACE_EXISTS(120034, "this cluster has been used in namespace,so you can't delete it.",
             "该集群已经被命名空间使用，所以不能删除该集群信息"),
 
-    TASK_GROUP_NAME_EXSIT(130001, "this task group name is repeated in a project", "该任务组名称在一个项目中已经使用"),
+    TASK_GROUP_NAME_EXIST(130001, "this task group name is repeated in a project", "该任务组名称在一个项目中已经使用"),
     TASK_GROUP_SIZE_ERROR(130002, "task group size error", "任务组大小应该为大于1的整数"),
     TASK_GROUP_STATUS_ERROR(130003, "task group status error", "任务组已经被关闭"),
     TASK_GROUP_FULL(130004, "task group is full", "任务组已经满了"),

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
@@ -112,7 +112,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         TaskGroup taskGroup1 = taskGroupMapper.queryByName(loginUser.getId(), name);
         if (taskGroup1 != null) {
             log.warn("Task group with the same name already exists, taskGroupName:{}.", taskGroup1.getName());
-            putMsg(result, Status.TASK_GROUP_NAME_EXSIT);
+            putMsg(result, Status.TASK_GROUP_NAME_EXIST);
             return result;
         }
         Date now = new Date();
@@ -178,7 +178,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
 
         if (exists > 0) {
             log.error("Task group with the same name already exists.");
-            putMsg(result, Status.TASK_GROUP_NAME_EXSIT);
+            putMsg(result, Status.TASK_GROUP_NAME_EXIST);
             return result;
         }
         if (taskGroup.getStatus() != Flag.YES) {

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtils.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtils.java
@@ -17,17 +17,26 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.api.utils;
 
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
+import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_STORAGE_TYPE;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.HADOOP_SECURITY_AUTHENTICATION;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.JAVA_SECURITY_KRB5_CONF;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.JAVA_SECURITY_KRB5_CONF_PATH;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.KERBEROS;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.LOGIN_USER_KEY_TAB_PATH;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.LOGIN_USER_KEY_TAB_USERNAME;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.RESOURCE_UPLOAD_PATH;
+
 import org.apache.dolphinscheduler.common.enums.StorageType;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 
-import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_STORAGE_TYPE;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.*;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * common utils
@@ -106,4 +115,26 @@ public class CommonUtils {
         return false;
     }
 
+    /**
+     * @param tenantCode tenant code
+     * @return file directory of tenants on hdfs
+     */
+    public static String getHdfsTenantDir(String tenantCode) {
+        return String.format("%s/%s", getHdfsDataBasePath(), tenantCode);
+    }
+
+    /**
+     * get data hdfs path
+     *
+     * @return data hdfs path
+     */
+    public static String getHdfsDataBasePath() {
+        String resourceUploadPath = PropertyUtils.getString(RESOURCE_UPLOAD_PATH, "/dolphinscheduler");
+        if ("/".equals(resourceUploadPath)) {
+            // if basepath is configured to /, the generated url may be //default/resources (with extra leading /)
+            return "";
+        } else {
+            return resourceUploadPath;
+        }
+    }
 }

--- a/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtils.java
+++ b/dolphinscheduler-datasource-plugin/dolphinscheduler-datasource-api/src/main/java/org/apache/dolphinscheduler/plugin/datasource/api/utils/CommonUtils.java
@@ -17,27 +17,17 @@
 
 package org.apache.dolphinscheduler.plugin.datasource.api.utils;
 
-import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_STORAGE_TYPE;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.HADOOP_SECURITY_AUTHENTICATION;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.HADOOP_SECURITY_AUTHENTICATION_STARTUP_STATE;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.JAVA_SECURITY_KRB5_CONF;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.JAVA_SECURITY_KRB5_CONF_PATH;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.KERBEROS;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.LOGIN_USER_KEY_TAB_PATH;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.LOGIN_USER_KEY_TAB_USERNAME;
-import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.RESOURCE_UPLOAD_PATH;
-
-import org.apache.dolphinscheduler.common.constants.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.common.enums.StorageType;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 
-import lombok.extern.slf4j.Slf4j;
+import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_STORAGE_TYPE;
+import static org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants.*;
 
 /**
  * common utils
@@ -47,15 +37,6 @@ public class CommonUtils {
 
     private CommonUtils() {
         throw new UnsupportedOperationException("Construct CommonUtils");
-    }
-
-    private static final boolean IS_DEVELOP_MODE = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
-
-    /**
-     * @return is develop mode
-     */
-    public static boolean isDevelopMode() {
-        return IS_DEVELOP_MODE;
     }
 
     /**
@@ -125,26 +106,4 @@ public class CommonUtils {
         return false;
     }
 
-    /**
-     * @param tenantCode tenant code
-     * @return file directory of tenants on hdfs
-     */
-    public static String getHdfsTenantDir(String tenantCode) {
-        return String.format("%s/%s", getHdfsDataBasePath(), tenantCode);
-    }
-
-    /**
-     * get data hdfs path
-     *
-     * @return data hdfs path
-     */
-    public static String getHdfsDataBasePath() {
-        String resourceUploadPath = PropertyUtils.getString(RESOURCE_UPLOAD_PATH, "/dolphinscheduler");
-        if ("/".equals(resourceUploadPath)) {
-            // if basepath is configured to /, the generated url may be //default/resources (with extra leading /)
-            return "";
-        } else {
-            return resourceUploadPath;
-        }
-    }
 }

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/listener/TaskExecutorLifecycleEventListener.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/listener/TaskExecutorLifecycleEventListener.java
@@ -24,6 +24,18 @@ import org.apache.dolphinscheduler.task.executor.ITaskExecutorRepository;
 import org.apache.dolphinscheduler.task.executor.container.ITaskExecutorContainer;
 import org.apache.dolphinscheduler.task.executor.container.ITaskExecutorContainerProvider;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
+import org.apache.dolphinscheduler.task.executor.events.IReportableTaskExecutorLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.ITaskExecutorLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorDispatchedLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorFailedLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorFinalizeLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorKillLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorKilledLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorPauseLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorPausedLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorStartedLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.TaskExecutorSuccessLifecycleEvent;
 import org.apache.dolphinscheduler.task.executor.exceptions.TaskExecutorNotFoundException;
 import org.apache.dolphinscheduler.task.executor.utils.CommonUtils;
 

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/listener/TaskExecutorLifecycleEventListener.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/listener/TaskExecutorLifecycleEventListener.java
@@ -17,8 +17,6 @@
 
 package org.apache.dolphinscheduler.task.executor.listener;
 
-import com.google.common.base.Strings;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.log.TaskInstanceLogHeader;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
@@ -26,7 +24,6 @@ import org.apache.dolphinscheduler.task.executor.ITaskExecutorRepository;
 import org.apache.dolphinscheduler.task.executor.container.ITaskExecutorContainer;
 import org.apache.dolphinscheduler.task.executor.container.ITaskExecutorContainerProvider;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
-import org.apache.dolphinscheduler.task.executor.events.*;
 import org.apache.dolphinscheduler.task.executor.exceptions.TaskExecutorNotFoundException;
 import org.apache.dolphinscheduler.task.executor.utils.CommonUtils;
 
@@ -34,6 +31,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.google.common.base.Strings;
 
 @Slf4j
 public class TaskExecutorLifecycleEventListener implements ITaskExecutorLifecycleEventListener {

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/listener/TaskExecutorLifecycleEventListener.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/listener/TaskExecutorLifecycleEventListener.java
@@ -17,27 +17,23 @@
 
 package org.apache.dolphinscheduler.task.executor.listener;
 
+import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.log.TaskInstanceLogHeader;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutorRepository;
 import org.apache.dolphinscheduler.task.executor.container.ITaskExecutorContainer;
 import org.apache.dolphinscheduler.task.executor.container.ITaskExecutorContainerProvider;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
-import org.apache.dolphinscheduler.task.executor.events.IReportableTaskExecutorLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.ITaskExecutorLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorDispatchedLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorFailedLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorFinalizeLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorKillLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorKilledLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorPauseLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorPausedLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorStartedLifecycleEvent;
-import org.apache.dolphinscheduler.task.executor.events.TaskExecutorSuccessLifecycleEvent;
+import org.apache.dolphinscheduler.task.executor.events.*;
 import org.apache.dolphinscheduler.task.executor.exceptions.TaskExecutorNotFoundException;
+import org.apache.dolphinscheduler.task.executor.utils.CommonUtils;
 
-import lombok.extern.slf4j.Slf4j;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 
 @Slf4j
 public class TaskExecutorLifecycleEventListener implements ITaskExecutorLifecycleEventListener {
@@ -106,8 +102,9 @@ public class TaskExecutorLifecycleEventListener implements ITaskExecutorLifecycl
     @Override
     public void onTaskExecutorFinalizeLifecycleEvent(final TaskExecutorFinalizeLifecycleEvent event) {
         TaskInstanceLogHeader.printFinalizeTaskHeader();
-        final ITaskExecutor taskExecutor = getTaskExecutor(event);
 
+        final ITaskExecutor taskExecutor = getTaskExecutor(event);
+        clearTaskExecPathIfNeeded(taskExecutor.getTaskExecutionContext());
         taskExecutorRepository.remove(taskExecutor.getId());
 
         final ITaskExecutorContainer executorContainer = taskExecutorContainerDelegator.getExecutorContainer();
@@ -121,6 +118,61 @@ public class TaskExecutorLifecycleEventListener implements ITaskExecutorLifecycl
     private ITaskExecutor getTaskExecutor(final ITaskExecutorLifecycleEvent taskExecutorLifecycleEvent) {
         return taskExecutorRepository.get(taskExecutorLifecycleEvent.getTaskInstanceId()).orElseThrow(
                 () -> new TaskExecutorNotFoundException(taskExecutorLifecycleEvent.getTaskInstanceId()));
+    }
+
+    /**
+     * Clears the local execution path directory for a task if needed.
+     * Skips in develop mode, validates path safety, and handles deletion errors gracefully.
+     *
+     * @param taskExecutionContext context containing task execution details, nullable
+     */
+    private void clearTaskExecPathIfNeeded(TaskExecutionContext taskExecutionContext) {
+        if (taskExecutionContext == null) {
+            log.warn("TaskExecutionContext is null, cannot clear execution path");
+            return;
+        }
+
+        String execLocalPath = taskExecutionContext.getExecutePath();
+
+        // Skip cleanup in development mode to preserve files for debugging
+        if (CommonUtils.isDevelopMode()) {
+            log.info("Running in develop mode, skip clearing path: {}", execLocalPath);
+            return;
+        }
+
+        log.info("Clearing task execution path: {}", execLocalPath);
+
+        if (Strings.isNullOrEmpty(execLocalPath)) {
+            log.warn("Execution path is null or empty for task: {}", taskExecutionContext.getTaskName());
+            return;
+        }
+
+        File execFile = new File(execLocalPath);
+        Path path;
+
+        try {
+            // Resolve the canonical path (follow symlinks, remove ../)
+            path = execFile.toPath().toRealPath();
+            // Prevent deletion of root directories (e.g., "/", "C:\") to avoid system damage
+            if (path.getRoot().equals(path)) {
+                log.warn("Refusing to delete root directory: {}", path);
+                return;
+            }
+
+            // Only attempt deletion if the path is an existing directory
+            if (path.toFile().isDirectory()) {
+                org.apache.commons.io.FileUtils.deleteDirectory(execFile);
+                log.info("Successfully cleared task execution path: {}", execLocalPath);
+            } else {
+                log.debug("Path is not a directory or does not exist: {}", execLocalPath);
+            }
+        } catch (NoSuchFileException ex) {
+            log.warn("Path does not exist or already deleted: {}", execLocalPath, ex);
+        } catch (IOException ex) {
+            log.error("Failed to delete task execution path: {}", execLocalPath, ex);
+        } catch (SecurityException ex) {
+            log.error("Permission denied when accessing or deleting path: {}", execLocalPath, ex);
+        }
     }
 
 }

--- a/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/utils/CommonUtils.java
+++ b/dolphinscheduler-task-executor/src/main/java/org/apache/dolphinscheduler/task/executor/utils/CommonUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.task.executor.utils;
+
+import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+
+/**
+ * Common utility methods for the application.
+ */
+public final class CommonUtils {
+
+    /**
+     * Indicates whether the application is running in development mode.
+     * Configured via property key: {@link Constants#DEVELOPMENT_STATE}.
+     * Defaults to {@code true} if not set.
+     */
+    private static final boolean DEVELOP_MODE = PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true);
+
+    private CommonUtils() {
+        throw new UnsupportedOperationException("Utility class should not be instantiated");
+    }
+
+    /**
+     * Checks whether the application is running in development mode.
+     *
+     * @return {@code true} if in development mode, {@code false} otherwise
+     */
+    public static boolean isDevelopMode() {
+        return DEVELOP_MODE;
+    }
+}

--- a/dolphinscheduler-task-executor/src/test/java/org/apache/dolphinscheduler/task/executor/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-task-executor/src/test/java/org/apache/dolphinscheduler/task/executor/utils/CommonUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.task.executor.utils;
 
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/dolphinscheduler-task-executor/src/test/java/org/apache/dolphinscheduler/task/executor/utils/CommonUtilsTest.java
+++ b/dolphinscheduler-task-executor/src/test/java/org/apache/dolphinscheduler/task/executor/utils/CommonUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.task.executor.utils;
+
+import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class CommonUtilsTest {
+
+    @BeforeEach
+    public void setUp() {
+        // Setup code if needed
+    }
+
+    @Test
+    public void isDevelopMode_DevelopmentStateTrue_ReturnsTrue() {
+        try (MockedStatic<PropertyUtils> mockedPropertyUtils = Mockito.mockStatic(PropertyUtils.class)) {
+            mockedPropertyUtils.when(() -> PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true))
+                    .thenReturn(true);
+            Assertions.assertTrue(CommonUtils.isDevelopMode());
+        }
+    }
+
+    @Test
+    public void isDevelopMode_DevelopmentStateFalse_ReturnsFalse() {
+        try (MockedStatic<PropertyUtils> mockedPropertyUtils = Mockito.mockStatic(PropertyUtils.class)) {
+            mockedPropertyUtils.when(() -> PropertyUtils.getBoolean(Constants.DEVELOPMENT_STATE, true))
+                    .thenReturn(false);
+            Assertions.assertFalse(CommonUtils.isDevelopMode());
+        }
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close #17520

## Brief change log

add clearTaskExecPathIfNeeded logic in TaskExecutorLifecycleEventListener

## Verify this pull request

This change added tests and can be verified as follows:

I have conducted thorough testing in my own environment, and the logs are as follows.

(1) in /worker-server/conf/common.properties: development.state=false 

2025-09-18 11:25:43.258 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-48] - 🐬 Finalize Task Instance
2025-09-18 11:25:43.258 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-48] - Clearing task execution path: /data01/dolphinscheduler/exec/process/3077
2025-09-18 11:25:43.271 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-48] - Successfully cleared task execution path: /data01/dolphinscheduler/exec/process/3077
2025-09-18 11:25:43.271 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-48] - FINALIZE_SESSION

(2) in /worker-server/conf/common.properties: development.state=true 

2025-09-18 11:30:12.159 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-22] - 🐬 Finalize Task Instance
2025-09-18 11:30:12.160 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-22] - Running in develop mode, skip clearing path: /data01/dolphinscheduler/exec/process/3078
2025-09-18 11:30:12.160 INFO  [PhysicalTaskExecutorEventBusCoordinator-eventbus-coordinator-worker-22] - FINALIZE_SESSION


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
