### PR TITLE
[Fix-17534][Service/Master] Add global parameters and varpool from current workflow instance and add them to start params list of the trigger request of a sub workflow

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
@@ -17,9 +17,9 @@
 
 package org.apache.dolphinscheduler.server.master.engine.executor.plugin.subworkflow;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
+import static java.util.Arrays.asList;
+import static org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils.deserializeVarPool;
+
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
@@ -46,7 +46,8 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkf
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
-import org.springframework.context.ApplicationContext;
+
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -54,8 +55,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
-import static org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils.deserializeVarPool;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.ApplicationContext;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 @Slf4j
 public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameters> {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
@@ -17,9 +17,9 @@
 
 package org.apache.dolphinscheduler.server.master.engine.executor.plugin.subworkflow;
 
-import static java.util.Arrays.asList;
-import static org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils.deserializeVarPool;
-
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
@@ -46,8 +46,7 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkf
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
-
-import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.context.ApplicationContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,11 +54,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.context.ApplicationContext;
-
-import com.fasterxml.jackson.core.type.TypeReference;
+import static java.util.Arrays.asList;
+import static org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils.deserializeVarPool;
 
 @Slf4j
 public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameters> {
@@ -235,9 +231,9 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
                 JSONUtils.parseObject(workflowInstance.getCommandParam(), ICommandParam.class);
 
         final List<Property> paramList = mergeParams(asList(
+                new ArrayList<>(deserializeVarPool(workflowInstance.getGlobalParams())),
                 commandParam.getCommandParams(),
-                new ArrayList<>(deserializeVarPool(workflowInstance.getVarPool())),
-                new ArrayList<>(deserializeVarPool(workflowInstance.getGlobalParams()))));
+                new ArrayList<>(deserializeVarPool(workflowInstance.getVarPool()))));
 
         final WorkflowManualTriggerRequest workflowManualTriggerRequest = WorkflowManualTriggerRequest.builder()
                 .userId(taskExecutionContext.getExecutorId())

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
@@ -17,6 +17,9 @@
 
 package org.apache.dolphinscheduler.server.master.engine.executor.plugin.subworkflow;
 
+import static java.util.Arrays.asList;
+import static org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils.deserializeVarPool;
+
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
@@ -35,6 +38,7 @@ import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowI
 import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowManualTriggerRequest;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SubWorkflowParameters;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.AbstractLogicTask;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
@@ -42,6 +46,14 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkf
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -222,6 +234,11 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
         final ICommandParam commandParam =
                 JSONUtils.parseObject(workflowInstance.getCommandParam(), ICommandParam.class);
 
+        final List<Property> paramList = mergeParams(asList(
+                commandParam.getCommandParams(),
+                new ArrayList<>(deserializeVarPool(workflowInstance.getVarPool())),
+                new ArrayList<>(deserializeVarPool(workflowInstance.getGlobalParams()))));
+
         final WorkflowManualTriggerRequest workflowManualTriggerRequest = WorkflowManualTriggerRequest.builder()
                 .userId(taskExecutionContext.getExecutorId())
                 .workflowDefinitionCode(subWorkflowDefinition.getCode())
@@ -233,14 +250,32 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
                 .workerGroup(workflowInstance.getWorkerGroup())
                 .tenantCode(workflowInstance.getTenantCode())
                 .environmentCode(workflowInstance.getEnvironmentCode())
-                // todo: transport varpool and local params
-                .startParamList(commandParam.getCommandParams())
+                .startParamList(paramList)
                 .dryRun(Flag.of(workflowInstance.getDryRun()))
                 .build();
         final Integer subWorkflowInstanceId = applicationContext
                 .getBean(SubWorkflowControlClient.class)
                 .triggerSubWorkflow(workflowManualTriggerRequest);
         return SubWorkflowLogicTaskRuntimeContext.of(subWorkflowInstanceId);
+    }
+
+    private List<Property> mergeParams(List<List<Property>> params) {
+        if (CollectionUtils.isEmpty(params)) {
+            return Collections.emptyList();
+        }
+        if (params.size() == 1) {
+            return params.get(0);
+        }
+        Map<String, Property> result = new HashMap<>();
+        for (List<Property> param : params) {
+            if (CollectionUtils.isEmpty(param)) {
+                continue;
+            }
+            for (Property property : param) {
+                result.put(property.getProp(), property);
+            }
+        }
+        return new ArrayList<>(result.values());
     }
 
     private void upsertSubWorkflowRelation() {

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/SubWorkflowInstanceGlobalParamsInheritanceTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/SubWorkflowInstanceGlobalParamsInheritanceTestCase.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.master.integration.cases;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.apache.dolphinscheduler.common.enums.Flag;
+import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
+import org.apache.dolphinscheduler.extract.master.command.RunWorkflowCommandParam;
+import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+import org.apache.dolphinscheduler.server.master.AbstractMasterIntegrationTestCase;
+import org.apache.dolphinscheduler.server.master.integration.WorkflowOperator;
+import org.apache.dolphinscheduler.server.master.integration.WorkflowTestCaseContext;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The integration test for validating sub workflow instances inherit global params from all parent flows.
+ * Global params are asserted in each sub workflow instance and the fake_task in the sub-sub-workflow is used to verify the global params.
+ */
+class SubWorkflowInstanceGlobalParamsInheritanceTestCase extends AbstractMasterIntegrationTestCase {
+
+    @Test
+    @DisplayName("Test subflows inherit global params from all parent flows")
+    void testSubflowInheritsGlobalParamsFromParentFlows_with_oneSuccessTask() {
+        final String yaml = "/it/start/workflow_with_sub_workflows_with_global_params.yaml";
+        final WorkflowTestCaseContext context = workflowTestCaseContextFactory.initializeContextFromYaml(yaml);
+        final WorkflowDefinition parentWorkflow = context.getOneWorkflow();
+
+        final WorkflowOperator.WorkflowTriggerDTO workflowTriggerDTO = WorkflowOperator.WorkflowTriggerDTO.builder()
+                .workflowDefinition(parentWorkflow)
+                .runWorkflowCommandParam(new RunWorkflowCommandParam())
+                .build();
+        final Integer workflowInstanceId = workflowOperator.manualTriggerWorkflow(workflowTriggerDTO);
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    Assertions
+                            .assertThat(repository.queryWorkflowInstance(workflowInstanceId))
+                            .matches(workflowInstance -> workflowInstance.getState() == WorkflowExecutionStatus.SUCCESS)
+                            .matches(workflowInstance -> workflowInstance.getIsSubWorkflow() == Flag.NO);
+
+                    final List<WorkflowInstance> subWorkflowInstance =
+                            repository.queryWorkflowInstance(context.getWorkflows().get(1));
+                    Assertions
+                            .assertThat(subWorkflowInstance)
+                            .hasSize(1)
+                            .satisfiesExactly(workflowInstance -> {
+                                assertThat(workflowInstance.getState()).isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                                assertThat(workflowInstance.getIsSubWorkflow()).isEqualTo(Flag.YES);
+
+                                Assertions
+                                        .assertThat(
+                                                JSONUtils.toList(workflowInstance.getGlobalParams(), Property.class))
+                                        .hasSize(1)
+                                        .anySatisfy(property -> {
+                                            assertThat(property.getProp()).isEqualTo("parentWorkflowParam");
+                                            assertThat(property.getValue()).isEqualTo("parentWorkflowParamValue");
+                                        });
+                            });
+
+                    final List<WorkflowInstance> subSubWorkflowInstance =
+                            repository.queryWorkflowInstance(context.getWorkflows().get(2));
+                    Assertions
+                            .assertThat(subSubWorkflowInstance)
+                            .hasSize(1)
+                            .satisfiesExactly(workflowInstance -> {
+                                assertThat(workflowInstance.getState()).isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                                assertThat(workflowInstance.getIsSubWorkflow()).isEqualTo(Flag.YES);
+
+                                Assertions
+                                        .assertThat(
+                                                JSONUtils.toList(workflowInstance.getGlobalParams(), Property.class))
+                                        .hasSize(2)
+                                        .anySatisfy(property -> {
+                                            assertThat(property.getProp()).isEqualTo("parentWorkflowParam");
+                                            assertThat(property.getValue()).isEqualTo("parentWorkflowParamValue");
+                                        })
+                                        .anySatisfy(property -> {
+                                            assertThat(property.getProp()).isEqualTo("subWorkflowParam");
+                                            assertThat(property.getValue()).isEqualTo("subWorkflowParamValue");
+                                        });
+                            });
+
+                    Assertions
+                            .assertThat(repository.queryTaskInstance(subSubWorkflowInstance.get(0).getId()))
+                            .satisfiesExactly(taskInstance -> {
+                                assertThat(taskInstance.getName()).isEqualTo("fake_task");
+                                assertThat(taskInstance.getState()).isEqualTo(TaskExecutionStatus.SUCCESS);
+                            });
+                });
+
+        masterContainer.assertAllResourceReleased();
+    }
+
+}

--- a/dolphinscheduler-master/src/test/resources/it/start/workflow_with_sub_workflows_with_global_params.yaml
+++ b/dolphinscheduler-master/src/test/resources/it/start/workflow_with_sub_workflows_with_global_params.yaml
@@ -1,0 +1,135 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project:
+  name: MasterIntegrationTest
+  code: 1
+  description: This is a fake project
+  userId: 1
+  userName: admin
+  createTime: 2024-08-12 00:00:00
+  updateTime: 2021-08-12 00:00:00
+
+workflows:
+  - name: workflow_with_sub_workflow
+    code: 1
+    version: 1
+    projectCode: 1
+    description: This is a fake workflow with single subflow task
+    releaseState: ONLINE
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    userId: 1
+    globalParams: >
+      [{
+        "prop": "parentWorkflowParam",
+        "value": "parentWorkflowParamValue",
+        "direct": "IN",
+        "type":"VARCHAR"
+      }]
+    executionType: PARALLEL
+  - name: subworkflow_with_another_subworkflow
+    code: 2
+    version: 1
+    projectCode: 1
+    description: This is a fake sub workflow with another single subflow task
+    releaseState: ONLINE
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    userId: 1
+    executionType: PARALLEL
+  - name: subworkflow_with_single_task
+    code: 3
+    version: 1
+    projectCode: 1
+    description: This is a fake sub sub workflow with single task
+    releaseState: ONLINE
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    userId: 1
+    globalParams: >
+      [{
+        "prop": "subWorkflowParam",
+        "value": "subWorkflowParamValue",
+        "direct": "IN",
+        "type":"VARCHAR"
+      }]
+    executionType: PARALLEL
+
+tasks:
+  - name: sub_workflow_task
+    code: 1
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":2}'
+    workerGroup: default
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    taskExecuteType: BATCH
+  - name: sub_sub_workflow_task
+    code: 2
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: SUB_WORKFLOW
+    taskParams: '{"localParams":[],"resourceList":[],"workflowDefinitionCode":3}'
+    workerGroup: default
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    taskExecuteType: BATCH
+  - name: fake_task
+    code: 3
+    version: 1
+    projectCode: 1
+    userId: 1
+    taskType: LogicFakeTask
+    taskParams: '{"localParams":null,"varPool":[],"shellScript":  "if [ \"${parentWorkflowParam}\" != \"parentWorkflowParamValue\" ]; then\n  exit 1\nelif [ \"${subWorkflowParam}\" != \"subWorkflowParamValue\" ]; then\n  exit 1\nelse\n  exit 0\nfi"}'
+    workerGroup: default
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2021-08-12 00:00:00
+    taskExecuteType: BATCH
+
+taskRelations:
+  - projectCode: 1
+    workflowDefinitionCode: 1
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 1
+    postTaskVersion: 1
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2024-08-12 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 2
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 2
+    postTaskVersion: 1
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2024-08-12 00:00:00
+  - projectCode: 1
+    workflowDefinitionCode: 3
+    workflowDefinitionVersion: 1
+    preTaskCode: 0
+    preTaskVersion: 0
+    postTaskCode: 3
+    postTaskVersion: 1
+    createTime: 2024-08-12 00:00:00
+    updateTime: 2024-08-12 00:00:00


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Close [#17534](https://github.com/apache/dolphinscheduler/issues/17534)

## Brief change log

When triggering a sub workflow, lookup all global parameters from the current, and any parent workflow instances and pass them along in the start param list of the trigger request of the sub workflow

## Verify this pull request

This change added tests and can be verified as follows:
- *Added a new integration test for validating the fixed behaviour*
- *Manually verified the change by using the test-case mentioned in issue [#17534](https://github.com/apache/dolphinscheduler/issues/17534)*

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

This is my very first pull-request, so bear with me on this one. :-)

A colleague of mine opened the original issue. This PR fixes these erroneous workflows for us, but I'm not entirely sure if this is the correct approach taken. I'll try and follow-up to make sure this PR meets all coding conventions and fulfills all requirements. I'll do my best on taking the time on improving the implementation on any pointers/advice given, if the implementation in the PR is not entirely correct or does not cover all use-cases, but I can't make any promises there.

Thank you for reviewing.