### PR TITLE
[Fix-17579][Workflow] fix view variable error after setting startup parameters for workflow instance

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -25,6 +25,7 @@ import static org.apache.dolphinscheduler.common.constants.Constants.GLOBAL_PARA
 import static org.apache.dolphinscheduler.common.constants.Constants.LOCAL_PARAMS;
 import static org.apache.dolphinscheduler.common.constants.Constants.TASK_LIST;
 import static org.apache.dolphinscheduler.common.constants.Constants.WORKFLOW_INSTANCE_STATE;
+import static org.apache.dolphinscheduler.common.utils.JSONUtils.parseObject;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager.checkTaskParameters;
 
 import org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant;
@@ -79,6 +80,7 @@ import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceMapDao;
 import org.apache.dolphinscheduler.dao.utils.WorkflowUtils;
+import org.apache.dolphinscheduler.extract.master.command.ICommandParam;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
@@ -663,13 +665,12 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
             return result;
         }
 
-        //
-        Map<String, String> commandParamMap = JSONUtils.toMap(workflowInstance.getCommandParam());
-        String timezoneId = null;
-        if (commandParamMap == null || StringUtils.isBlank(commandParamMap.get(Constants.SCHEDULE_TIMEZONE))) {
+        String timezoneId;
+        final ICommandParam commandParam = parseObject(workflowInstance.getCommandParam(), ICommandParam.class);
+        if (commandParam == null || StringUtils.isBlank(commandParam.getTimeZone())) {
             timezoneId = loginUser.getTimeZone();
         } else {
-            timezoneId = commandParamMap.get(Constants.SCHEDULE_TIMEZONE);
+            timezoneId = commandParam.getTimeZone();
         }
 
         setWorkflowInstance(workflowInstance, scheduleTime, globalParams, timeout, timezoneId);
@@ -873,11 +874,12 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
             return result;
         }
 
-        Map<String, String> commandParam = JSONUtils.toMap(workflowInstance.getCommandParam());
         String timezone = null;
-        if (commandParam != null) {
-            timezone = commandParam.get(Constants.SCHEDULE_TIMEZONE);
+        final ICommandParam commandParam = parseObject(workflowInstance.getCommandParam(), ICommandParam.class);
+        if (commandParam != null && StringUtils.isBlank(commandParam.getTimeZone())) {
+            timezone = commandParam.getTimeZone();
         }
+
         Map<String, String> timeParams = BusinessTimeUtils
                 .getBusinessTime(workflowInstance.getCmdTypeIfComplement(),
                         workflowInstance.getScheduleTime(), timezone);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -667,7 +667,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         String timezoneId;
         final ICommandParam commandParam = parseObject(workflowInstance.getCommandParam(), ICommandParam.class);
-        if (commandParam == null || StringUtils.isBlank(commandParam.getTimeZone())) {
+        if (commandParam == null || StringUtils.isEmpty(commandParam.getTimeZone())) {
             timezoneId = loginUser.getTimeZone();
         } else {
             timezoneId = commandParam.getTimeZone();
@@ -876,7 +876,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         String timezone = null;
         final ICommandParam commandParam = parseObject(workflowInstance.getCommandParam(), ICommandParam.class);
-        if (commandParam != null && StringUtils.isBlank(commandParam.getTimeZone())) {
+        if (commandParam != null && StringUtils.isNotEmpty(commandParam.getTimeZone())) {
             timezone = commandParam.getTimeZone();
         }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -647,6 +647,21 @@ public class WorkflowInstanceServiceTest {
                             taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", true, "", "", 0);
             Assertions.assertEquals(Status.SUCCESS, processInstanceFinishRes.get(Constants.STATUS));
 
+            final RunWorkflowCommandParam runWorkflowCommandParam = RunWorkflowCommandParam.builder()
+                    .commandParams(Lists.newArrayList(Property.builder()
+                            .prop("name")
+                            .direct(Direct.IN)
+                            .type(DataType.VARCHAR)
+                            .value("commandParam")
+                            .build()))
+                    .timeZone("Asia/Shanghai")
+                    .build();
+            workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
+            Map<String, Object> processInstanceFinishRes2 =
+                    workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
+                            taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", true, "", "", 0);
+            Assertions.assertEquals(Status.SUCCESS, processInstanceFinishRes2.get(Constants.STATUS));
+
             // success
             when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
             putMsg(result, Status.SUCCESS, projectCode);
@@ -811,15 +826,31 @@ public class WorkflowInstanceServiceTest {
                         .type(DataType.VARCHAR)
                         .value("commandParam")
                         .build()))
+                .timeZone("Asia/Shanghai")
                 .build();
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setCommandType(CommandType.SCHEDULER);
         workflowInstance.setScheduleTime(new Date());
-        workflowInstance.setGlobalParams("");
         workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
+
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
         Map<String, Object> successRes = workflowInstanceService.viewVariables(1L, 1);
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+
+        final RunWorkflowCommandParam commandParamWithEmptyTimeZone = RunWorkflowCommandParam.builder()
+                .commandParams(Lists.newArrayList(Property.builder()
+                        .prop("name")
+                        .direct(Direct.IN)
+                        .type(DataType.VARCHAR)
+                        .value("commandParam")
+                        .build()))
+                .build();
+        workflowInstance.setCommandType(CommandType.SCHEDULER);
+        workflowInstance.setScheduleTime(new Date());
+        workflowInstance.setCommandParam(JSONUtils.toJsonString(commandParamWithEmptyTimeZone));
+        Map<String, Object> successRes2 = workflowInstanceService.viewVariables(1L, 1);
+        Assertions.assertEquals(Status.SUCCESS, successRes2.get(Constants.STATUS));
+
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -67,9 +67,13 @@ import org.apache.dolphinscheduler.dao.repository.TaskInstanceContextDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceMapDao;
+import org.apache.dolphinscheduler.extract.master.command.RunWorkflowCommandParam;
 import org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager;
+import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DependResult;
+import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.service.expand.CuringParamsService;
 import org.apache.dolphinscheduler.service.model.TaskNode;
 import org.apache.dolphinscheduler.service.process.ProcessService;
@@ -796,6 +800,26 @@ public class WorkflowInstanceServiceTest {
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
         Map<String, Object> processNotExist = workflowInstanceService.viewVariables(1L, 1);
         Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, processNotExist.get(Constants.STATUS));
+    }
+
+    @Test
+    public void testViewVariablesWithStartingParam() {
+        final RunWorkflowCommandParam runWorkflowCommandParam = RunWorkflowCommandParam.builder()
+                .commandParams(Lists.newArrayList(Property.builder()
+                        .prop("name")
+                        .direct(Direct.IN)
+                        .type(DataType.VARCHAR)
+                        .value("commandParam")
+                        .build()))
+                .build();
+        WorkflowInstance workflowInstance = getProcessInstance();
+        workflowInstance.setCommandType(CommandType.SCHEDULER);
+        workflowInstance.setScheduleTime(new Date());
+        workflowInstance.setGlobalParams("");
+        workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
+        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
+        Map<String, Object> successRes = workflowInstanceService.viewVariables(1L, 1);
+        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
     }
 
     /**


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close https://github.com/apache/dolphinscheduler/issues/17579
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.



This change added tests and can be verified as follows:
ut: `org.apache.dolphinscheduler.api.service.WorkflowInstanceServiceTest#testViewVariablesWithStartingParam`

The variables of workflow instance can be viewed normally
<img width="1628" height="355" alt="截屏2025-10-16 14 22 06" src="https://github.com/user-attachments/assets/78fa7f00-942e-4f68-8327-b52c95602264" />


<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
