### PR TITLE
[Doc-17574] Add timezone configuration notice for MySQL datasource

### DIFF
--- a/docs/docs/en/guide/installation/datasource-setting.md
+++ b/docs/docs/en/guide/installation/datasource-setting.md
@@ -75,13 +75,19 @@ pg_ctl reload
 
 Then, set the database configurations by exporting the following environment variables, change {user} and {password} to what you set in the previous step.
 
+> **⚠️ Timezone Configuration Notice**
+> 
+> Avoid using ambiguous timezone identifiers like `CST`, which may cause scheduling time errors.
+> 
+> Use explicit timezone like: `serverTimezone=Asia/Shanghai`
+
 For MySQL:
 
 ```shell
 # for mysql
 export DATABASE=${DATABASE:-mysql}
 export SPRING_PROFILES_ACTIVE=${DATABASE}
-export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
+export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone={your_timezone}"
 export SPRING_DATASOURCE_USERNAME={user}
 export SPRING_DATASOURCE_PASSWORD={password}
 ```

--- a/docs/docs/en/guide/installation/datasource-setting.md
+++ b/docs/docs/en/guide/installation/datasource-setting.md
@@ -76,9 +76,9 @@ pg_ctl reload
 Then, set the database configurations by exporting the following environment variables, change {user} and {password} to what you set in the previous step.
 
 > **⚠️ Timezone Configuration Notice**
-> 
+>
 > Avoid using ambiguous timezone identifiers like `CST`, which may cause scheduling time errors.
-> 
+>
 > Use explicit timezone like: `serverTimezone=Asia/Shanghai`
 
 For MySQL:

--- a/docs/docs/zh/guide/installation/datasource-setting.md
+++ b/docs/docs/zh/guide/installation/datasource-setting.md
@@ -74,13 +74,19 @@ pg_ctl reload
 
 然后设置以下环境变量，将username和password改成你在上一步中设置的用户名{user}和密码{password}
 
+> **⚠️ 时区配置提醒**
+> 
+> 避免使用 `CST` 等模糊时区标识符，可能造成调度时间错误。
+> 
+> 推荐使用明确的时区，如：`serverTimezone=Asia/Shanghai`
+
 对于 MySQL：
 
 ```shell
 # for mysql
 export DATABASE=${DATABASE:-mysql}
 export SPRING_PROFILES_ACTIVE=${DATABASE}
-export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
+export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/dolphinscheduler?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone={your_timezone}"
 export SPRING_DATASOURCE_USERNAME={user}
 export SPRING_DATASOURCE_PASSWORD={password}
 ```

--- a/docs/docs/zh/guide/installation/datasource-setting.md
+++ b/docs/docs/zh/guide/installation/datasource-setting.md
@@ -75,9 +75,9 @@ pg_ctl reload
 然后设置以下环境变量，将username和password改成你在上一步中设置的用户名{user}和密码{password}
 
 > **⚠️ 时区配置提醒**
-> 
+>
 > 避免使用 `CST` 等模糊时区标识符，可能造成调度时间错误。
-> 
+>
 > 推荐使用明确的时区，如：`serverTimezone=Asia/Shanghai`
 
 对于 MySQL：


### PR DESCRIPTION
### Description:
  This PR adds timezone configuration warnings for MySQL datasource setup to prevent scheduling errors caused by ambiguous timezone identifiers like 'CST'.

### Changes Made:
  - ✅ Updated JDBC connection strings to use placeholder {your_timezone} instead of hardcoded timezone values
  - ✅ Added clear warning about avoiding ambiguous timezone identifiers (CST)
  - ✅ Added timezone configuration notice in both Chinese and English documentation

### Files Modified:
  - docs/docs/zh/guide/installation/datasource-setting.md
  - docs/docs/en/guide/installation/datasource-setting.md

### Problem Solved:
  This documentation improvement directly addresses GitHub issue #17574 regarding CST timezone scheduling problems by providing clear guidance and warnings about timezone configuration.

close #17574

### Key Benefits:
  - Prevents scheduling time calculation errors caused by timezone ambiguity
