### PR TITLE
[Fix-17527][registry-api] Fix Master Worker API startup fails to clean failover finished nodes due to invalid ZooKeeper path

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/RegistryClient.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/RegistryClient.java
@@ -243,12 +243,13 @@ public class RegistryClient {
         }
         for (final String failoverFinishedNode : failoverFinishedNodes) {
             try {
-                final String failoverFinishTime = registry.get(failoverFinishedNode);
+                final String failoverFinishedNodePath = RegistryNodeType.FAILOVER_FINISH_NODES.getRegistryPath() + Constants.SINGLE_SLASH + failoverFinishedNode;
+                final String failoverFinishTime = registry.get(failoverFinishedNodePath);
                 if (System.currentTimeMillis() - Long.parseLong(failoverFinishTime) > TimeUnit.DAYS.toMillis(7)) {
-                    registry.delete(failoverFinishedNode);
+                    registry.delete(failoverFinishedNodePath);
                     log.info(
                             "Clear the failover finished node: {} which failover time is before the current time minus 1 week",
-                            failoverFinishedNode);
+                            failoverFinishedNodePath);
                 }
             } catch (Exception ex) {
                 log.error("Failed to clean the failoverFinishedNode: {}", failoverFinishedNode, ex);

--- a/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/RegistryClient.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/RegistryClient.java
@@ -242,8 +242,8 @@ public class RegistryClient {
             return;
         }
         for (final String failoverFinishedNode : failoverFinishedNodes) {
+            final String failoverFinishedNodePath = RegistryNodeType.FAILOVER_FINISH_NODES.getRegistryPath() + Constants.SINGLE_SLASH + failoverFinishedNode;
             try {
-                final String failoverFinishedNodePath = RegistryNodeType.FAILOVER_FINISH_NODES.getRegistryPath() + Constants.SINGLE_SLASH + failoverFinishedNode;
                 final String failoverFinishTime = registry.get(failoverFinishedNodePath);
                 if (System.currentTimeMillis() - Long.parseLong(failoverFinishTime) > TimeUnit.DAYS.toMillis(7)) {
                     registry.delete(failoverFinishedNodePath);
@@ -252,7 +252,7 @@ public class RegistryClient {
                             failoverFinishedNodePath);
                 }
             } catch (Exception ex) {
-                log.error("Failed to clean the failoverFinishedNode: {}", failoverFinishedNode, ex);
+                log.error("Failed to clean the failoverFinishedNode: {}", failoverFinishedNodePath, ex);
             }
         }
     }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/RegistryClient.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-api/src/main/java/org/apache/dolphinscheduler/registry/api/RegistryClient.java
@@ -242,7 +242,8 @@ public class RegistryClient {
             return;
         }
         for (final String failoverFinishedNode : failoverFinishedNodes) {
-            final String failoverFinishedNodePath = RegistryNodeType.FAILOVER_FINISH_NODES.getRegistryPath() + Constants.SINGLE_SLASH + failoverFinishedNode;
+            final String failoverFinishedNodePath = RegistryNodeType.FAILOVER_FINISH_NODES.getRegistryPath()
+                    + Constants.SINGLE_SLASH + failoverFinishedNode;
             try {
                 final String failoverFinishTime = registry.get(failoverFinishedNodePath);
                 if (System.currentTimeMillis() - Long.parseLong(failoverFinishTime) > TimeUnit.DAYS.toMillis(7)) {


### PR DESCRIPTION
Master Worker API startup fails to clean failover finished nodes due to invalid ZooKeeper path

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #17527

Fix Master Worker API startup fails to clean failover finished nodes due to invalid ZooKeeper path.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
- *Modified org.apache.dolphinscheduler.registry.api.RegistryClient*

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)