### PR TITLE
[Fix-17688][Storage-OSS] Fix resource validation error and duplicate folder…

### DIFF
--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
@@ -255,6 +255,10 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
                 .withPrefix(ossResourceAbsolutePath);
 
         ListObjectsV2Result listObjectsV2Result = ossClient.listObjectsV2(listObjectsV2Request);
+
+        // Collect common prefixes (directories)
+        Set<String> commonPrefixSet = new HashSet<>(listObjectsV2Result.getCommonPrefixes());
+
         List<StorageEntity> storageEntities = new ArrayList<>();
         storageEntities.addAll(listObjectsV2Result.getCommonPrefixes()
                 .stream()
@@ -262,7 +266,10 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
                 .collect(Collectors.toList()));
         storageEntities.addAll(
                 listObjectsV2Result.getObjectSummaries().stream()
-                        .filter(s3ObjectSummary -> !s3ObjectSummary.getKey().equals(resourceAbsolutePath))
+                        // Filter out the current directory itself
+                        .filter(s3ObjectSummary -> !s3ObjectSummary.getKey().equals(ossResourceAbsolutePath))
+                        // Filter out directory marker objects that are already in commonPrefixes
+                        .filter(s3ObjectSummary -> !commonPrefixSet.contains(s3ObjectSummary.getKey()))
                         .map(this::transformOSSObjectToStorageEntity)
                         .collect(Collectors.toList()));
 
@@ -363,11 +370,13 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
         StorageEntity entity = new StorageEntity();
         entity.setFileName(new File(absolutePath).getName());
         entity.setFullName(absolutePath);
+        entity.setPfullName(resourceMetaData.getResourceParentAbsolutePath());
         entity.setDirectory(resourceMetaData.isDirectory());
         entity.setType(resourceMetaData.getResourceType());
         entity.setSize(0L);
         entity.setCreateTime(null);
         entity.setUpdateTime(null);
+        entity.setRelativePath(resourceMetaData.getResourceRelativePath());
         return entity;
     }
 


### PR DESCRIPTION

1. Add missing pfullName and relativePath fields in transformCommonPrefixToStorageEntity()
   - This fixes resource validation error when selecting OSS resources in task editing page
   - Align with transformOSSObjectToStorageEntity() method implementation

2. Add deduplication filters in listStorageEntity()
   - Filter out the current directory itself to prevent self-reference
   - Filter out directory marker objects that are already in CommonPrefixes
   - This prevents duplicate folder entries in resource list

Root cause:
- Aliyun OSS creates directory marker objects (empty objects with key ending with '/')
- OSS API returns the same directory in both CommonPrefixes and ObjectSummaries
- Without deduplication, folders appear multiple times in the resource tree

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17688

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
