### PR TITLE
[Fix-17688] Resource validation error and duplicate folders when using Aliyun OSS storage

### DIFF
--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
@@ -267,9 +267,9 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
         storageEntities.addAll(
                 listObjectsV2Result.getObjectSummaries().stream()
                         // Filter out the current directory itself
-                        .filter(s3ObjectSummary -> !s3ObjectSummary.getKey().equals(ossResourceAbsolutePath))
+                        .filter(ossObjectSummary -> !ossObjectSummary.getKey().equals(ossResourceAbsolutePath))
                         // Filter out directory marker objects that are already in commonPrefixes
-                        .filter(s3ObjectSummary -> !commonPrefixSet.contains(s3ObjectSummary.getKey()))
+                        .filter(ossObjectSummary -> !commonPrefixSet.contains(ossObjectSummary.getKey()))
                         .map(this::transformOSSObjectToStorageEntity)
                         .collect(Collectors.toList()));
 

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-oss/src/main/java/org/apache/dolphinscheduler/plugin/storage/oss/OssStorageOperator.java
@@ -255,6 +255,10 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
                 .withPrefix(ossResourceAbsolutePath);
 
         ListObjectsV2Result listObjectsV2Result = ossClient.listObjectsV2(listObjectsV2Request);
+
+        // Collect common prefixes (directories)
+        Set<String> commonPrefixSet = new HashSet<>(listObjectsV2Result.getCommonPrefixes());
+
         List<StorageEntity> storageEntities = new ArrayList<>();
         storageEntities.addAll(listObjectsV2Result.getCommonPrefixes()
                 .stream()
@@ -262,7 +266,10 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
                 .collect(Collectors.toList()));
         storageEntities.addAll(
                 listObjectsV2Result.getObjectSummaries().stream()
-                        .filter(s3ObjectSummary -> !s3ObjectSummary.getKey().equals(resourceAbsolutePath))
+                        // Filter out the current directory itself
+                        .filter(s3ObjectSummary -> !s3ObjectSummary.getKey().equals(ossResourceAbsolutePath))
+                        // Filter out directory marker objects that are already in commonPrefixes
+                        .filter(s3ObjectSummary -> !commonPrefixSet.contains(s3ObjectSummary.getKey()))
                         .map(this::transformOSSObjectToStorageEntity)
                         .collect(Collectors.toList()));
 
@@ -363,11 +370,13 @@ public class OssStorageOperator extends AbstractStorageOperator implements Close
         StorageEntity entity = new StorageEntity();
         entity.setFileName(new File(absolutePath).getName());
         entity.setFullName(absolutePath);
+        entity.setPfullName(resourceMetaData.getResourceParentAbsolutePath());
         entity.setDirectory(resourceMetaData.isDirectory());
         entity.setType(resourceMetaData.getResourceType());
         entity.setSize(0L);
         entity.setCreateTime(null);
         entity.setUpdateTime(null);
+        entity.setRelativePath(resourceMetaData.getResourceRelativePath());
         return entity;
     }
 


### PR DESCRIPTION
… OSS storage

- add missing pfullName and relativePath fields in transformCommonPrefixToStorageEntity()
- add deduplication filters in listStorageEntity() to filter duplicate directories
- filter out current directory itself to prevent self-reference
- filter out directory marker objects already in CommonPrefixes

This closes #17688

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
