### PR TITLE
[Improvement-17699][GrpcTask] Support cancel gRPC task

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/main/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/main/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTask.java
@@ -86,8 +86,8 @@ public class GrpcTask extends AbstractTask {
 
             // Attach a cancellable gRPC Context to support external cancellation.
             // This context propagates cancellation signals to the underlying RPC call.
-            this.cancellableContext = (Context.CancellableContext) Context.current().withCancellation().attach();
-            Context previous = this.cancellableContext;
+            this.cancellableContext = Context.current().withCancellation();
+            Context previous = this.cancellableContext.attach();
 
             try {
                 GrpcDynamicService stubService = new GrpcDynamicService(channel, fileDesc);
@@ -105,9 +105,8 @@ public class GrpcTask extends AbstractTask {
             if (statusre.getStatus().getCode() == Status.Code.CANCELLED) {
                 setExitStatusCode(TaskConstants.EXIT_CODE_KILL);
             } else {
-                setExitStatusCode(TaskConstants.EXIT_CODE_FAILURE);
+                validateResponse(statusre.getStatus());
             }
-            validateResponse(statusre.getStatus());
         } catch (Exception e) {
             setExitStatusCode(TaskConstants.EXIT_CODE_FAILURE);
             throw new GrpcTaskException("gRPC handle exception:", e);
@@ -120,13 +119,14 @@ public class GrpcTask extends AbstractTask {
     }
 
     @Override
-    public void cancel() {
+    public void cancel() throws TaskException {
         // Read volatile reference once for thread safety (avoid repeated reads under race conditions)
         Context.CancellableContext ctx = this.cancellableContext;
 
         if (ctx != null && !ctx.isCancelled()) {
             try {
-                log.info("Canceling gRPC task: method={}", grpcParameters.getMethodName());
+                log.info("Canceling gRPC task: method={}",
+                        grpcParameters != null ? grpcParameters.getMethodName() : "unknown");
 
                 // Trigger gRPC cancellation by canceling the context.
                 // This interrupts the ongoing RPC and causes stubService.call() to throw CANCELLED.

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/main/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/main/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTask.java
@@ -37,6 +37,7 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;
 
+import io.grpc.Context;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -47,6 +48,7 @@ public class GrpcTask extends AbstractTask {
 
     private GrpcParameters grpcParameters;
     private TaskExecutionContext taskExecutionContext;
+    private volatile Context.CancellableContext cancellableContext;
 
     /**
      * constructor
@@ -71,36 +73,87 @@ public class GrpcTask extends AbstractTask {
 
     @Override
     public void handle(TaskCallBack taskCallBack) throws TaskException {
+        ManagedChannel channel = null;
         try {
-            ManagedChannel channel;
             if (grpcParameters.getChannelCredentialType() == GrpcCredentialType.TLS_DEFAULT) {
                 TlsChannelCredentials creds = (TlsChannelCredentials) TlsChannelCredentials.create();
                 channel = GrpcDynamicService.ChannelFactory.createChannel(grpcParameters.getUrl(), creds);
             } else {
                 channel = GrpcDynamicService.ChannelFactory.createChannel(grpcParameters.getUrl());
             }
+
             Descriptors.FileDescriptor fileDesc =
                     JSONDescriptorHelper.fileDescFromJSON(grpcParameters.getGrpcServiceDefinitionJSON());
-            GrpcDynamicService stubService = new GrpcDynamicService(channel, fileDesc);
-            DynamicMessage message = stubService.call(grpcParameters.getMethodName(), grpcParameters.getMessage(),
-                    grpcParameters.getConnectTimeoutMs());
-            Printer printer = JsonFormat.printer().omittingInsignificantWhitespace();
-            addDefaultOutput(printer.print(message));
-        } catch (StatusRuntimeException statusre) {
-            validateResponse(statusre.getStatus());
-            return;
-        } catch (Exception e) {
-            throw new GrpcTaskException("gRPC handle exception:", e);
+
+            // → Attach a cancellable gRPC Context to support external cancellation.
+            // This context propagates cancellation signals to the underlying RPC call.
+            this.cancellableContext = (Context.CancellableContext) Context.current().withCancellation().attach();
+            Context previous = this.cancellableContext;
+
+            try {
+                GrpcDynamicService stubService = new GrpcDynamicService(channel, fileDesc);
+
+                // → Perform the actual blocking gRPC call.
+                // If cancel() is invoked concurrently, this call will throw StatusRuntimeException(CANCELLED).
+                DynamicMessage message = stubService.call(
+                        grpcParameters.getMethodName(),
+                        grpcParameters.getMessage(),
+                        grpcParameters.getConnectTimeoutMs());
+
+                // → Format and store the response as task output
+                Printer printer = JsonFormat.printer().omittingInsignificantWhitespace();
+                addDefaultOutput(printer.print(message));
+                validateResponse(Status.OK);
+            } finally {
+                // → Detach the cancellable context to restore the previous context and avoid leaks
+                this.cancellableContext.detach(previous);
+                this.cancellableContext = null; // Clear reference for GC and idempotent cancel
+            }
+        } catch (StatusRuntimeException ex) {
+            validateResponse(ex.getStatus());
+        } catch (Exception ex) {
+            setExitStatusCode(TaskConstants.EXIT_CODE_FAILURE);
+            throw new GrpcTaskException("gRPC handle exception", ex);
+        } finally {
+            // → Gracefully shut down the gRPC channel to release network resources
+            if (channel != null) {
+                channel.shutdown();
+            }
         }
-        validateResponse(Status.OK);
     }
 
     @Override
-    public void cancel() throws TaskException {
-        // Do nothing when task to be canceled
+    public void cancel() {
+        // → Read volatile reference once for thread safety (avoid repeated reads under race conditions)
+        Context.CancellableContext ctx = this.cancellableContext;
+
+        if (ctx != null && !ctx.isCancelled()) {
+            try {
+                log.debug("Canceling gRPC task: method={}", grpcParameters.getMethodName());
+
+                // → Trigger gRPC cancellation by canceling the context.
+                // This interrupts the ongoing RPC and causes stubService.call() to throw CANCELLED.
+                ctx.cancel(new TaskException("gRPC task was canceled by user"));
+
+                // → Record user intent: task was explicitly killed, not failed
+                setExitStatusCode(TaskConstants.EXIT_CODE_KILL);
+                log.debug("gRPC task was successfully canceled");
+            } catch (Exception ex) {
+                log.warn("Failed to cancel gRPC context", ex);
+                throw new TaskException("Cancel gRPC task failed", ex);
+            }
+        } else {
+            // → No active context: task may not have started, already finished, or already canceled
+            log.debug("gRPC task cancel requested, but no active cancellable context.");
+        }
     }
 
     private void validateResponse(Status statusCode) {
+        if (exitStatusCode == TaskConstants.EXIT_CODE_KILL) {
+            log.info("this gRPC task has been killed");
+            return;
+        }
+
         switch (grpcParameters.getGrpcCheckCondition()) {
             case STATUS_CODE_DEFAULT:
                 if (!statusCode.isOk()) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/main/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/main/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTask.java
@@ -81,41 +81,38 @@ public class GrpcTask extends AbstractTask {
             } else {
                 channel = GrpcDynamicService.ChannelFactory.createChannel(grpcParameters.getUrl());
             }
-
             Descriptors.FileDescriptor fileDesc =
                     JSONDescriptorHelper.fileDescFromJSON(grpcParameters.getGrpcServiceDefinitionJSON());
 
-            // → Attach a cancellable gRPC Context to support external cancellation.
+            // Attach a cancellable gRPC Context to support external cancellation.
             // This context propagates cancellation signals to the underlying RPC call.
             this.cancellableContext = (Context.CancellableContext) Context.current().withCancellation().attach();
             Context previous = this.cancellableContext;
 
             try {
                 GrpcDynamicService stubService = new GrpcDynamicService(channel, fileDesc);
-
-                // → Perform the actual blocking gRPC call.
-                // If cancel() is invoked concurrently, this call will throw StatusRuntimeException(CANCELLED).
-                DynamicMessage message = stubService.call(
-                        grpcParameters.getMethodName(),
-                        grpcParameters.getMessage(),
+                DynamicMessage message = stubService.call(grpcParameters.getMethodName(), grpcParameters.getMessage(),
                         grpcParameters.getConnectTimeoutMs());
-
-                // → Format and store the response as task output
                 Printer printer = JsonFormat.printer().omittingInsignificantWhitespace();
                 addDefaultOutput(printer.print(message));
                 validateResponse(Status.OK);
             } finally {
-                // → Detach the cancellable context to restore the previous context and avoid leaks
+                // Detach the cancellable context to restore the previous context and avoid leaks
                 this.cancellableContext.detach(previous);
-                this.cancellableContext = null; // Clear reference for GC and idempotent cancel
+                this.cancellableContext = null;
             }
-        } catch (StatusRuntimeException ex) {
-            validateResponse(ex.getStatus());
-        } catch (Exception ex) {
+        } catch (StatusRuntimeException statusre) {
+            if (statusre.getStatus().getCode() == Status.Code.CANCELLED) {
+                setExitStatusCode(TaskConstants.EXIT_CODE_KILL);
+            } else {
+                setExitStatusCode(TaskConstants.EXIT_CODE_FAILURE);
+            }
+            validateResponse(statusre.getStatus());
+        } catch (Exception e) {
             setExitStatusCode(TaskConstants.EXIT_CODE_FAILURE);
-            throw new GrpcTaskException("gRPC handle exception", ex);
+            throw new GrpcTaskException("gRPC handle exception:", e);
         } finally {
-            // → Gracefully shut down the gRPC channel to release network resources
+            // Gracefully shut down the gRPC channel to release network resources
             if (channel != null) {
                 channel.shutdown();
             }
@@ -124,36 +121,31 @@ public class GrpcTask extends AbstractTask {
 
     @Override
     public void cancel() {
-        // → Read volatile reference once for thread safety (avoid repeated reads under race conditions)
+        // Read volatile reference once for thread safety (avoid repeated reads under race conditions)
         Context.CancellableContext ctx = this.cancellableContext;
 
         if (ctx != null && !ctx.isCancelled()) {
             try {
-                log.debug("Canceling gRPC task: method={}", grpcParameters.getMethodName());
+                log.info("Canceling gRPC task: method={}", grpcParameters.getMethodName());
 
-                // → Trigger gRPC cancellation by canceling the context.
+                // Trigger gRPC cancellation by canceling the context.
                 // This interrupts the ongoing RPC and causes stubService.call() to throw CANCELLED.
                 ctx.cancel(new TaskException("gRPC task was canceled by user"));
 
-                // → Record user intent: task was explicitly killed, not failed
+                // Record user intent: task was explicitly killed, not failed
                 setExitStatusCode(TaskConstants.EXIT_CODE_KILL);
-                log.debug("gRPC task was successfully canceled");
+                log.info("gRPC task was successfully canceled");
             } catch (Exception ex) {
-                log.warn("Failed to cancel gRPC context", ex);
+                log.error("Failed to cancel gRPC context", ex);
                 throw new TaskException("Cancel gRPC task failed", ex);
             }
         } else {
-            // → No active context: task may not have started, already finished, or already canceled
-            log.debug("gRPC task cancel requested, but no active cancellable context.");
+            // No active context: task may not have started, already finished, or already canceled
+            log.warn("gRPC task cancel requested, but no active cancellable context.");
         }
     }
 
     private void validateResponse(Status statusCode) {
-        if (exitStatusCode == TaskConstants.EXIT_CODE_KILL) {
-            log.info("this gRPC task has been killed");
-            return;
-        }
-
         switch (grpcParameters.getGrpcCheckCondition()) {
             case STATUS_CODE_DEFAULT:
                 if (!statusCode.isOk()) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/test/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-grpc/src/test/java/org/apache/dolphinscheduler/plugin/task/grpc/GrpcTaskTest.java
@@ -20,8 +20,16 @@ package org.apache.dolphinscheduler.plugin.task.grpc;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EXIT_CODE_FAILURE;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.EXIT_CODE_SUCCESS;
 import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
+import org.apache.dolphinscheduler.plugin.task.api.TaskException;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
@@ -35,6 +43,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +67,7 @@ import org.springframework.core.io.ClassPathResource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.grpc.Context;
 import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
@@ -221,6 +233,233 @@ public class GrpcTaskTest {
             resultStringBuilder.setLength(resultStringBuilder.length() - 1);
         }
         return resultStringBuilder.toString();
+    }
+
+    @Test
+    void cancel_shouldCancelContextAndSetKillCode_whenActiveAndNotCancelled() throws Exception {
+        GrpcTask grpcTaskOK = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        // Set grpcParameters for logging
+        GrpcParameters params = new GrpcParameters();
+        params.setMethodName("TestMethod");
+        setPrivateField(grpcTaskOK, "grpcParameters", params);
+
+        // Mock active, not-cancelled context
+        Context.CancellableContext mockCtx = mock(Context.CancellableContext.class);
+        when(mockCtx.isCancelled()).thenReturn(false);
+        setPrivateField(grpcTaskOK, "cancellableContext", mockCtx);
+
+        // Act
+        grpcTaskOK.cancel();
+
+        // Assert
+        verify(mockCtx).cancel(argThat(e -> e instanceof TaskException &&
+                "gRPC task was canceled by user".equals(e.getMessage())));
+        Assertions.assertEquals(TaskConstants.EXIT_CODE_KILL, grpcTaskOK.getExitStatusCode());
+    }
+
+    @Test
+    void cancel_shouldDoNothing_whenCancellableContextIsNull() throws Exception {
+        GrpcTask grpcTaskOK = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        setPrivateField(grpcTaskOK, "cancellableContext", null);
+
+        Assertions.assertDoesNotThrow(grpcTaskOK::cancel);
+        Assertions.assertNotEquals(TaskConstants.EXIT_CODE_KILL, grpcTaskOK.getExitStatusCode());
+    }
+
+    @Test
+    void cancel_shouldDoNothing_whenContextAlreadyCancelled() throws Exception {
+        GrpcTask grpcTaskOK = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        Context.CancellableContext mockCtx = mock(Context.CancellableContext.class);
+        when(mockCtx.isCancelled()).thenReturn(true);
+        setPrivateField(grpcTaskOK, "cancellableContext", mockCtx);
+
+        grpcTaskOK.cancel();
+
+        verify(mockCtx, never()).cancel(any());
+        Assertions.assertNotEquals(TaskConstants.EXIT_CODE_KILL, grpcTaskOK.getExitStatusCode());
+    }
+
+    @Test
+    void cancel_shouldThrowTaskException_whenCtxCancelThrows() throws Exception {
+        GrpcTask grpcTaskOK = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        GrpcParameters params = new GrpcParameters();
+        params.setMethodName("TestMethod");
+        setPrivateField(grpcTaskOK, "grpcParameters", params);
+
+        Context.CancellableContext mockCtx = mock(Context.CancellableContext.class);
+        when(mockCtx.isCancelled()).thenReturn(false);
+        doThrow(new RuntimeException("gRPC internal error"))
+                .when(mockCtx).cancel(any(TaskException.class));
+        setPrivateField(grpcTaskOK, "cancellableContext", mockCtx);
+
+        // Act & Assert
+        TaskException thrown = Assertions.assertThrows(TaskException.class, grpcTaskOK::cancel);
+        Assertions.assertTrue(thrown.getMessage().contains("Cancel gRPC task failed"));
+        Assertions.assertNotNull(thrown.getCause());
+        Assertions.assertEquals("gRPC internal error", thrown.getCause().getMessage());
+
+        // Exit code should NOT be set to KILL because cancellation failed
+        Assertions.assertNotEquals(TaskConstants.EXIT_CODE_KILL, grpcTaskOK.getExitStatusCode());
+    }
+
+    @Test
+    void validateResponse_shouldSetSuccessForOK_whenCheckConditionIsDefault() throws Exception {
+        GrpcTask task = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        // Setup grpcParameters
+        GrpcParameters params = new GrpcParameters();
+        params.setGrpcCheckCondition(GrpcCheckCondition.STATUS_CODE_DEFAULT);
+        params.setUrl("test-url");
+        params.setMethodName("TestMethod");
+        setPrivateField(task, "grpcParameters", params);
+
+        // Call private method via reflection
+        invokePrivateMethod(task, "validateResponse", new Class[]{Status.class}, Status.OK);
+
+        // Assert exit code is SUCCESS
+        Assertions.assertEquals(TaskConstants.EXIT_CODE_SUCCESS, getPrivateField(task, "exitStatusCode"));
+    }
+
+    @Test
+    void validateResponse_shouldSetFailureForNonOK_whenCheckConditionIsDefault() throws Exception {
+        GrpcTask task = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        GrpcParameters params = new GrpcParameters();
+        params.setGrpcCheckCondition(GrpcCheckCondition.STATUS_CODE_DEFAULT);
+        params.setUrl("test-url");
+        params.setMethodName("TestMethod");
+        setPrivateField(task, "grpcParameters", params);
+
+        invokePrivateMethod(task, "validateResponse", new Class[]{Status.class}, Status.NOT_FOUND);
+
+        Assertions.assertEquals(TaskConstants.EXIT_CODE_FAILURE, getPrivateField(task, "exitStatusCode"));
+    }
+
+    @Test
+    void validateResponse_shouldSetSuccessForMatchingCustomCode() throws Exception {
+        GrpcTask task = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        GrpcParameters params = new GrpcParameters();
+        params.setGrpcCheckCondition(GrpcCheckCondition.STATUS_CODE_CUSTOM);
+        params.setCondition("UNIMPLEMENTED"); // matches Status.UNIMPLEMENTED
+        params.setUrl("test-url");
+        params.setMethodName("TestMethod");
+        setPrivateField(task, "grpcParameters", params);
+
+        invokePrivateMethod(task, "validateResponse", new Class[]{Status.class}, Status.UNIMPLEMENTED);
+
+        Assertions.assertEquals(TaskConstants.EXIT_CODE_SUCCESS, getPrivateField(task, "exitStatusCode"));
+    }
+
+    @Test
+    void validateResponse_shouldSetFailureForMismatchedCustomCode() throws Exception {
+        GrpcTask task = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        GrpcParameters params = new GrpcParameters();
+        params.setGrpcCheckCondition(GrpcCheckCondition.STATUS_CODE_CUSTOM);
+        params.setCondition("NOT_FOUND");
+        params.setUrl("test-url");
+        params.setMethodName("TestMethod");
+        setPrivateField(task, "grpcParameters", params);
+
+        invokePrivateMethod(task, "validateResponse", new Class[]{Status.class}, Status.UNIMPLEMENTED);
+
+        Assertions.assertEquals(TaskConstants.EXIT_CODE_FAILURE, getPrivateField(task, "exitStatusCode"));
+    }
+
+    @Test
+    void validateResponse_shouldThrowGrpcTaskException_forInvalidCustomCondition() throws IOException {
+        GrpcTask task = generateGrpcTask("TaskTester/TestOK", "{\"username\":\"test username\"}",
+                GrpcCheckCondition.STATUS_CODE_DEFAULT, "OK");
+
+        GrpcParameters params = new GrpcParameters();
+        params.setGrpcCheckCondition(GrpcCheckCondition.STATUS_CODE_CUSTOM);
+        params.setCondition("INVALID_CODE"); // not a valid Status.Code
+        params.setUrl("test-url");
+        params.setMethodName("TestMethod");
+        setPrivateField(task, "grpcParameters", params);
+
+        GrpcTaskException exception = Assertions.assertThrows(GrpcTaskException.class, () -> {
+            invokePrivateMethod(task, "validateResponse", new Class[]{Status.class}, Status.OK);
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("grpc unrecogenized condition INVALID_CODE"));
+    }
+
+    /**
+     * Gets the value of a private field from the target object, searching up the inheritance hierarchy.
+     */
+    private Object getPrivateField(Object target, String fieldName) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field.get(target);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to get field '" + fieldName + "' from " + target.getClass(), e);
+            }
+        }
+        throw new RuntimeException("Field '" + fieldName + "' not found in class hierarchy of " + target.getClass());
+    }
+
+    /**
+     * Sets a private field on the target object, searching up the inheritance hierarchy.
+     */
+    private void setPrivateField(Object target, String fieldName, Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to set field '" + fieldName + "' on " + target.getClass(), e);
+            }
+        }
+        throw new RuntimeException("Field '" + fieldName + "' not found in class hierarchy of " + target.getClass());
+    }
+
+    /**
+     * Invokes a private method with given arguments.
+     * If the method throws an exception, it is rethrown as-is (unchecked) or wrapped in RuntimeException if checked.
+     */
+    private void invokePrivateMethod(Object target, String methodName, Class<?>[] paramTypes, Object... args) {
+        try {
+            Method method = target.getClass().getDeclaredMethod(methodName, paramTypes);
+            method.setAccessible(true);
+            method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            // Unwrap the actual exception thrown by the target method
+            Throwable cause = e.getTargetException();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            } else {
+                // For checked exceptions (should not happen in your case, but safe)
+                throw new RuntimeException("Checked exception thrown in private method: " + cause.getMessage(), cause);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException("Reflection setup failed for method: " + methodName, e);
+        }
     }
 
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17699 

## Brief change log

When we kill (manual or timeout) the gRPC task, we should call ctx.cancel method to cancel the gRPC task

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
