### PR TITLE
[Improvement-17738][Dependency] Upgrade PostgreSQL JDBC Driver to fix CVE-2024-1597

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -69,7 +69,7 @@
         <activation.version>1.1</activation.version>
         <javax-mail>1.6.2</javax-mail>
         <guava.version>31.1-jre</guava.version>
-        <postgresql.version>42.4.1</postgresql.version>
+        <postgresql.version>42.4.4</postgresql.version>
         <hive-jdbc.version>2.3.9</hive-jdbc.version>
         <kyuubi-jdbc.version>1.7.0</kyuubi-jdbc.version>
         <commons-io.version>2.19.0</commons-io.version>

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -533,7 +533,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     jakarta.xml.bind-api 2.3.3: https://github.com/eclipse-ee4j/jaxb-api/blob/2.3.3/LICENSE.md, BSD 3-clause
     jsch 0.1.42: https://mvnrepository.com/artifact/com.jcraft/jsch/0.1.42, BSD
     leveldbjni-all 1.8: https://mvnrepository.com/artifact/org.fusesource.leveldbjni/leveldbjni-all/1.8, BSD 3-clause
-    postgresql 42.4.1: https://mvnrepository.com/artifact/org.postgresql/postgresql/42.4.1, BSD 2-clause
+    postgresql 42.4.4: https://mvnrepository.com/artifact/org.postgresql/postgresql/42.4.4, BSD 2-clause
     paranamer 2.3: https://mvnrepository.com/artifact/com.thoughtworks.paranamer/paranamer/2.3, BSD
     re2j 1.1: https://github.com/google/re2j/blob/re2j-1.1/LICENSE, BSD 3-clause
     stax2-api 4.2.1: https://mvnrepository.com/artifact/org.codehaus.woodstox/stax2-api/4.2.1, BSD

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -214,7 +214,7 @@ okio-3.6.0.jar
 okio-jvm-3.6.0.jar
 oshi-core-6.1.1.jar
 paranamer-2.3.jar
-postgresql-42.4.1.jar
+postgresql-42.4.4.jar
 profiles-2.17.282.jar
 protocol-core-2.17.282.jar
 py4j-0.10.9.jar


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close #17738 

## Brief change log
Upgrade PostgreSQL JDBC Driver from 42.4.1 to 42.4.4 to fix CVE-2024-1597 


## Verify this pull request
This pull request is already covered by existing tests, such as *(PostgreSQLDataSourceChannelFactoryTest、DataSourceServiceTest、PostgreSQLDataSourceChannelTest)*.


(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
