### PR TITLE
[Improvement-17646][JdbcRegistry] Using transaction in JdbcRegistryDataManager

### DIFF
--- a/docs/docs/en/guide/installation/registry-plugins/jdbc.md
+++ b/docs/docs/en/guide/installation/registry-plugins/jdbc.md
@@ -38,19 +38,13 @@ registry:
   heartbeat-refresh-interval: 3s
   # Once the client's heartbeat is not refresh in this time, the server will consider the client is offline.
   session-timeout: 60s
-  # The hikari configuration, default will use the same datasource pool as DolphinScheduler.
-  hikari-config:
-    jdbc-url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler
-    username: root
-    password: root
-    maximum-pool-size: 5
-    connection-timeout: 9000
-    idle-timeout: 600000
 ```
 
-## Use different database configuration for jdbc registry center
+## Set DataSource for worker
 
-You need to set the registry properties in master/worker/api's application.yml
+Since worker server doesn't contain datasource, so you need to config datasource for worker.
+
+You need to set the registry hikari-config properties at worker's application.yml
 
 ### Use Mysql as registry center
 

--- a/docs/docs/zh/guide/installation/registry-plugins/jdbc.md
+++ b/docs/docs/zh/guide/installation/registry-plugins/jdbc.md
@@ -32,19 +32,11 @@ registry:
   heartbeat-refresh-interval: 3s
   # Once the client's heartbeat is not refresh in this time, the server will consider the client is offline.
   session-timeout: 60s
-  # The hikari configuration, default will use the same datasource pool as DolphinScheduler.
-  hikari-config:
-    jdbc-url: jdbc:mysql://127.0.0.1:3306/dolphinscheduler
-    username: root
-    password: root
-    maximum-pool-size: 5
-    connection-timeout: 9000
-    idle-timeout: 600000
 ```
 
-## 对 JDBC 注册中心使用不同的数据库配置
+## 为 worker 配置数据源
 
-需要在 master/worker/api 的 application.yml 中设置属性
+由于Worker服务默认不包含数据源，因此你需要在 worker 的 application.yml 中为注册中心设置数据源属性
 
 ### 使用 MySQL 作为注册中心
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryAutoConfiguration.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryAutoConfiguration.java
@@ -17,10 +17,6 @@
 
 package org.apache.dolphinscheduler.plugin.registry.jdbc;
 
-import org.apache.dolphinscheduler.plugin.registry.jdbc.mapper.JdbcRegistryClientHeartbeatMapper;
-import org.apache.dolphinscheduler.plugin.registry.jdbc.mapper.JdbcRegistryDataChangeEventMapper;
-import org.apache.dolphinscheduler.plugin.registry.jdbc.mapper.JdbcRegistryDataMapper;
-import org.apache.dolphinscheduler.plugin.registry.jdbc.mapper.JdbcRegistryLockMapper;
 import org.apache.dolphinscheduler.plugin.registry.jdbc.repository.JdbcRegistryClientRepository;
 import org.apache.dolphinscheduler.plugin.registry.jdbc.repository.JdbcRegistryDataChangeEventRepository;
 import org.apache.dolphinscheduler.plugin.registry.jdbc.repository.JdbcRegistryDataRepository;
@@ -29,6 +25,8 @@ import org.apache.dolphinscheduler.plugin.registry.jdbc.server.IJdbcRegistryServ
 import org.apache.dolphinscheduler.plugin.registry.jdbc.server.JdbcRegistryServer;
 
 import org.apache.ibatis.session.SqlSessionFactory;
+
+import javax.sql.DataSource;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +38,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.baomidou.mybatisplus.autoconfigure.MybatisPlusAutoConfiguration;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
@@ -62,13 +63,15 @@ public class JdbcRegistryAutoConfiguration {
                                                   JdbcRegistryLockRepository jdbcRegistryLockRepository,
                                                   JdbcRegistryClientRepository jdbcRegistryClientRepository,
                                                   JdbcRegistryDataChangeEventRepository jdbcRegistryDataChangeEventRepository,
-                                                  JdbcRegistryProperties jdbcRegistryProperties) {
+                                                  JdbcRegistryProperties jdbcRegistryProperties,
+                                                  TransactionTemplate jdbcTransactionTemplate) {
         return new JdbcRegistryServer(
                 jdbcRegistryDataRepository,
                 jdbcRegistryLockRepository,
                 jdbcRegistryClientRepository,
                 jdbcRegistryDataChangeEventRepository,
-                jdbcRegistryProperties);
+                jdbcRegistryProperties,
+                jdbcTransactionTemplate);
     }
 
     @Bean
@@ -81,42 +84,38 @@ public class JdbcRegistryAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SqlSessionFactory sqlSessionFactory(JdbcRegistryProperties jdbcRegistryProperties) throws Exception {
-        log.info("Initialize jdbcRegistrySqlSessionFactory");
+    public DataSource jdbcRegistryDataSource(JdbcRegistryProperties jdbcRegistryProperties) {
+        return new HikariDataSource(jdbcRegistryProperties.getHikariConfig());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PlatformTransactionManager jdbcRegistryTransactionManager(DataSource jdbcRegistryDataSource) {
+        DataSourceTransactionManager transactionManager = new DataSourceTransactionManager();
+        transactionManager.setDataSource(jdbcRegistryDataSource);
+        return transactionManager;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TransactionTemplate jdbcTransactionTemplate(PlatformTransactionManager jdbcRegistryTransactionManager) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate();
+        transactionTemplate.setTransactionManager(jdbcRegistryTransactionManager);
+        return transactionTemplate;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SqlSessionFactory jdbcRegistrySqlSessionFactory(DataSource jdbcRegistryDataSource) throws Exception {
         MybatisSqlSessionFactoryBean sqlSessionFactoryBean = new MybatisSqlSessionFactoryBean();
-        sqlSessionFactoryBean.setDataSource(new HikariDataSource(jdbcRegistryProperties.getHikariConfig()));
+        sqlSessionFactoryBean.setDataSource(jdbcRegistryDataSource);
         return sqlSessionFactoryBean.getObject();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory jdbcRegistrySqlSessionFactory) {
-        log.info("Initialize jdbcRegistrySqlSessionTemplate");
+    public SqlSessionTemplate jdbcRegistrySqlSessionTemplate(SqlSessionFactory jdbcRegistrySqlSessionFactory) {
         return new SqlSessionTemplate(jdbcRegistrySqlSessionFactory);
-    }
-
-    @Bean
-    public JdbcRegistryDataMapper jdbcRegistryDataMapper(SqlSessionTemplate jdbcRegistrySqlSessionTemplate) {
-        jdbcRegistrySqlSessionTemplate.getConfiguration().addMapper(JdbcRegistryDataMapper.class);
-        return jdbcRegistrySqlSessionTemplate.getMapper(JdbcRegistryDataMapper.class);
-    }
-
-    @Bean
-    public JdbcRegistryLockMapper jdbcRegistryLockMapper(SqlSessionTemplate jdbcRegistrySqlSessionTemplate) {
-        jdbcRegistrySqlSessionTemplate.getConfiguration().addMapper(JdbcRegistryLockMapper.class);
-        return jdbcRegistrySqlSessionTemplate.getMapper(JdbcRegistryLockMapper.class);
-    }
-
-    @Bean
-    public JdbcRegistryDataChangeEventMapper jdbcRegistryDataChangeEventMapper(SqlSessionTemplate jdbcRegistrySqlSessionTemplate) {
-        jdbcRegistrySqlSessionTemplate.getConfiguration().addMapper(JdbcRegistryDataChangeEventMapper.class);
-        return jdbcRegistrySqlSessionTemplate.getMapper(JdbcRegistryDataChangeEventMapper.class);
-    }
-
-    @Bean
-    public JdbcRegistryClientHeartbeatMapper jdbcRegistryClientHeartbeatMapper(SqlSessionTemplate jdbcRegistrySqlSessionTemplate) {
-        jdbcRegistrySqlSessionTemplate.getConfiguration().addMapper(JdbcRegistryClientHeartbeatMapper.class);
-        return jdbcRegistrySqlSessionTemplate.getMapper(JdbcRegistryClientHeartbeatMapper.class);
     }
 
 }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryProperties.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryProperties.java
@@ -65,13 +65,13 @@ public class JdbcRegistryProperties implements Validator {
         JdbcRegistryProperties jdbcRegistryProperties = (JdbcRegistryProperties) target;
         if (jdbcRegistryProperties.getHeartbeatRefreshInterval().compareTo(MIN_HEARTBEAT_REFRESH_INTERVAL) < 0) {
             errors.rejectValue("heartbeatRefreshInterval", "heartbeatRefreshInterval",
-                    "heartbeatRefreshInterval must be greater than 1s");
+                    "registry.heartbeatRefreshInterval must be greater than 1s");
         }
 
         if (jdbcRegistryProperties.getSessionTimeout().toMillis() < 3
                 * jdbcRegistryProperties.getHeartbeatRefreshInterval().toMillis()) {
             errors.rejectValue("sessionTimeout", "sessionTimeout",
-                    "sessionTimeout must be greater than 3 * heartbeatRefreshInterval");
+                    "registry.sessionTimeout must be greater than 3 * heartbeatRefreshInterval");
         }
         if (StringUtils.isEmpty(jdbcRegistryClientName)) {
             jdbcRegistryClientName = NetUtils.getHost() + ":" + serverPort;
@@ -86,7 +86,6 @@ public class JdbcRegistryProperties implements Validator {
                         "\n  jdbcRegistryClientName -> " + jdbcRegistryClientName +
                         "\n  heartbeatRefreshInterval -> " + heartbeatRefreshInterval +
                         "\n  sessionTimeout -> " + sessionTimeout +
-                        "\n  hikariConfig -> " + hikariConfig +
                         "\n****************************JdbcRegistryProperties**************************************";
         log.info(config);
     }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryDataManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryDataManager.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.transaction.support.TransactionTemplate;
+
 import com.google.common.collect.Lists;
 
 @Slf4j
@@ -57,23 +59,27 @@ public class JdbcRegistryDataManager
 
     private final JdbcRegistryDataChangeEventRepository jdbcRegistryDataChangeEventRepository;
 
+    private final TransactionTemplate jdbcRegistryTransactionTemplate;
+
     private final List<RegistryRowChangeListener<JdbcRegistryDataDTO>> registryRowChangeListeners;
 
     private long lastDetectedJdbcRegistryDataChangeEventId = -1;
 
     public JdbcRegistryDataManager(JdbcRegistryProperties registryProperties,
                                    JdbcRegistryDataRepository jdbcRegistryDataRepository,
-                                   JdbcRegistryDataChangeEventRepository jdbcRegistryDataChangeEventRepository) {
+                                   JdbcRegistryDataChangeEventRepository jdbcRegistryDataChangeEventRepository,
+                                   TransactionTemplate jdbcRegistryTransactionTemplate) {
         this.registryProperties = registryProperties;
         this.jdbcRegistryDataChangeEventRepository = jdbcRegistryDataChangeEventRepository;
         this.jdbcRegistryDataRepository = jdbcRegistryDataRepository;
+        this.jdbcRegistryTransactionTemplate = jdbcRegistryTransactionTemplate;
         this.registryRowChangeListeners = new CopyOnWriteArrayList<>();
-        this.lastDetectedJdbcRegistryDataChangeEventId =
-                jdbcRegistryDataChangeEventRepository.getMaxJdbcRegistryDataChangeEventId();
     }
 
     @Override
     public void start() {
+        this.lastDetectedJdbcRegistryDataChangeEventId =
+                jdbcRegistryDataChangeEventRepository.getMaxJdbcRegistryDataChangeEventId();
         JdbcRegistryThreadFactory.getDefaultSchedulerThreadExecutor().scheduleWithFixedDelay(
                 this::detectJdbcRegistryDataChangeEvent,
                 registryProperties.getHeartbeatRefreshInterval().toMillis(),
@@ -162,67 +168,73 @@ public class JdbcRegistryDataManager
         checkNotNull(key);
         checkNotNull(dataType);
 
-        Optional<JdbcRegistryDataDTO> jdbcRegistryDataOptional = jdbcRegistryDataRepository.selectByKey(key);
-        if (jdbcRegistryDataOptional.isPresent()) {
-            JdbcRegistryDataDTO jdbcRegistryData = jdbcRegistryDataOptional.get();
-            if (!dataType.name().equals(jdbcRegistryData.getDataType())) {
-                throw new UnsupportedOperationException("The data type: " + jdbcRegistryData.getDataType()
-                        + " of the key: " + key + " cannot be updated");
-            }
+        final Optional<JdbcRegistryDataDTO> jdbcRegistryDataOptional = jdbcRegistryDataRepository.selectByKey(key);
 
-            if (DataType.EPHEMERAL.name().equals(jdbcRegistryData.getDataType())) {
-                if (!jdbcRegistryData.getClientId().equals(clientId)) {
-                    throw new UnsupportedOperationException(
-                            "The EPHEMERAL data: " + key + " can only be updated by its owner: "
-                                    + jdbcRegistryData.getClientId() + " but not: " + clientId);
+        jdbcRegistryTransactionTemplate.execute(status -> {
+            if (jdbcRegistryDataOptional.isPresent()) {
+                JdbcRegistryDataDTO jdbcRegistryData = jdbcRegistryDataOptional.get();
+                if (!dataType.name().equals(jdbcRegistryData.getDataType())) {
+                    throw new UnsupportedOperationException("The data type: " + jdbcRegistryData.getDataType()
+                            + " of the key: " + key + " cannot be updated");
                 }
+
+                if (DataType.EPHEMERAL.name().equals(jdbcRegistryData.getDataType())) {
+                    if (!jdbcRegistryData.getClientId().equals(clientId)) {
+                        throw new UnsupportedOperationException(
+                                "The EPHEMERAL data: " + key + " can only be updated by its owner: "
+                                        + jdbcRegistryData.getClientId() + " but not: " + clientId);
+                    }
+                }
+
+                jdbcRegistryData.setDataValue(value);
+                jdbcRegistryData.setLastUpdateTime(new Date());
+                jdbcRegistryDataRepository.updateById(jdbcRegistryData);
+
+                JdbcRegistryDataChangeEventDTO jdbcRegistryDataChangeEvent = JdbcRegistryDataChangeEventDTO.builder()
+                        .jdbcRegistryData(jdbcRegistryData)
+                        .eventType(JdbcRegistryDataChangeEventDTO.EventType.UPDATE)
+                        .createTime(new Date())
+                        .build();
+                jdbcRegistryDataChangeEventRepository.insert(jdbcRegistryDataChangeEvent);
+            } else {
+                JdbcRegistryDataDTO jdbcRegistryDataDTO = JdbcRegistryDataDTO.builder()
+                        .clientId(clientId)
+                        .dataKey(key)
+                        .dataValue(value)
+                        .dataType(dataType.name())
+                        .createTime(new Date())
+                        .lastUpdateTime(new Date())
+                        .build();
+                jdbcRegistryDataRepository.insert(jdbcRegistryDataDTO);
+                JdbcRegistryDataChangeEventDTO registryDataChangeEvent = JdbcRegistryDataChangeEventDTO.builder()
+                        .jdbcRegistryData(jdbcRegistryDataDTO)
+                        .eventType(JdbcRegistryDataChangeEventDTO.EventType.ADD)
+                        .createTime(new Date())
+                        .build();
+                jdbcRegistryDataChangeEventRepository.insert(registryDataChangeEvent);
             }
-
-            jdbcRegistryData.setDataValue(value);
-            jdbcRegistryData.setLastUpdateTime(new Date());
-            jdbcRegistryDataRepository.updateById(jdbcRegistryData);
-
-            JdbcRegistryDataChangeEventDTO jdbcRegistryDataChangeEvent = JdbcRegistryDataChangeEventDTO.builder()
-                    .jdbcRegistryData(jdbcRegistryData)
-                    .eventType(JdbcRegistryDataChangeEventDTO.EventType.UPDATE)
-                    .createTime(new Date())
-                    .build();
-            jdbcRegistryDataChangeEventRepository.insert(jdbcRegistryDataChangeEvent);
-        } else {
-            JdbcRegistryDataDTO jdbcRegistryDataDTO = JdbcRegistryDataDTO.builder()
-                    .clientId(clientId)
-                    .dataKey(key)
-                    .dataValue(value)
-                    .dataType(dataType.name())
-                    .createTime(new Date())
-                    .lastUpdateTime(new Date())
-                    .build();
-            jdbcRegistryDataRepository.insert(jdbcRegistryDataDTO);
-            JdbcRegistryDataChangeEventDTO registryDataChangeEvent = JdbcRegistryDataChangeEventDTO.builder()
-                    .jdbcRegistryData(jdbcRegistryDataDTO)
-                    .eventType(JdbcRegistryDataChangeEventDTO.EventType.ADD)
-                    .createTime(new Date())
-                    .build();
-            jdbcRegistryDataChangeEventRepository.insert(registryDataChangeEvent);
-        }
+            return null;
+        });
 
     }
 
     @Override
     public void deleteJdbcRegistryDataByKey(String key) {
         checkNotNull(key);
-        // todo: this is not atomic, need to be improved
         Optional<JdbcRegistryDataDTO> jdbcRegistryDataOptional = jdbcRegistryDataRepository.selectByKey(key);
         if (!jdbcRegistryDataOptional.isPresent()) {
             return;
         }
-        jdbcRegistryDataRepository.deleteByKey(key);
-        final JdbcRegistryDataChangeEventDTO registryDataChangeEvent = JdbcRegistryDataChangeEventDTO.builder()
-                .jdbcRegistryData(jdbcRegistryDataOptional.get())
-                .eventType(JdbcRegistryDataChangeEventDTO.EventType.DELETE)
-                .createTime(new Date())
-                .build();
-        jdbcRegistryDataChangeEventRepository.insert(registryDataChangeEvent);
+        jdbcRegistryTransactionTemplate.execute(status -> {
+            jdbcRegistryDataRepository.deleteByKey(key);
+            final JdbcRegistryDataChangeEventDTO registryDataChangeEvent = JdbcRegistryDataChangeEventDTO.builder()
+                    .jdbcRegistryData(jdbcRegistryDataOptional.get())
+                    .eventType(JdbcRegistryDataChangeEventDTO.EventType.DELETE)
+                    .createTime(new Date())
+                    .build();
+            jdbcRegistryDataChangeEventRepository.insert(registryDataChangeEvent);
+            return null;
+        });
     }
 
     private void doTriggerJdbcRegistryDataAddedListener(List<JdbcRegistryDataDTO> valuesToAdd) {

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryLockManager.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryLockManager.java
@@ -79,7 +79,7 @@ public class JdbcRegistryLockManager implements IJdbcRegistryLockManager {
                 // The lock is already exist, wait it release.
                 continue;
             }
-            log.debug("Acquire the lock {} failed try again", lockKey);
+            log.debug("{} acquire the lock {} failed try again", lockOwner, lockKey);
             // acquire failed, wait and try again
             ThreadUtils.sleep(jdbcRegistryProperties.getHeartbeatRefreshInterval().toMillis());
         }
@@ -123,7 +123,7 @@ public class JdbcRegistryLockManager implements IJdbcRegistryLockManager {
                 // The lock is already exist, wait it release.
                 continue;
             }
-            log.debug("Acquire the lock {} failed try again", lockKey);
+            log.debug("{} acquire the lock {} failed try again", lockOwner, lockKey);
             // acquire failed, wait and try again
             ThreadUtils.sleep(jdbcRegistryProperties.getHeartbeatRefreshInterval().toMillis());
         }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryServer.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryServer.java
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.transaction.support.TransactionTemplate;
+
 import com.google.common.collect.Lists;
 
 /**
@@ -84,13 +86,15 @@ public class JdbcRegistryServer implements IJdbcRegistryServer {
                               JdbcRegistryLockRepository jdbcRegistryLockRepository,
                               JdbcRegistryClientRepository jdbcRegistryClientRepository,
                               JdbcRegistryDataChangeEventRepository jdbcRegistryDataChangeEventRepository,
-                              JdbcRegistryProperties jdbcRegistryProperties) {
+                              JdbcRegistryProperties jdbcRegistryProperties,
+                              TransactionTemplate transactionTemplate) {
         this.jdbcRegistryDataRepository = checkNotNull(jdbcRegistryDataRepository);
         this.jdbcRegistryLockRepository = checkNotNull(jdbcRegistryLockRepository);
         this.jdbcRegistryClientRepository = checkNotNull(jdbcRegistryClientRepository);
         this.jdbcRegistryProperties = checkNotNull(jdbcRegistryProperties);
         this.jdbcRegistryDataManager = new JdbcRegistryDataManager(
-                jdbcRegistryProperties, jdbcRegistryDataRepository, jdbcRegistryDataChangeEventRepository);
+                jdbcRegistryProperties, jdbcRegistryDataRepository, jdbcRegistryDataChangeEventRepository,
+                transactionTemplate);
         this.jdbcRegistryLockManager = new JdbcRegistryLockManager(
                 jdbcRegistryProperties, jdbcRegistryLockRepository);
         this.jdbcRegistryServerState = JdbcRegistryServerState.INIT;


### PR DESCRIPTION
## Purpose of the pull request

close #17646 

## Brief change log

- Use the default datasource as jdbc registry, since there are no performance issues here
- Use transaction to make sure jdbc registry data incorrect
- Update the document we only need to set the registry datasource for worker.

## Verify this pull request

Verity by UT

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
