### PR TITLE
[Fix-17771][ApiServer]update TaskCode references within the task parameters when importing tasks such as ConditionTask and SwitchTask

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -116,6 +116,7 @@ import org.apache.dolphinscheduler.plugin.task.api.model.ConditionDependentTaskM
 import org.apache.dolphinscheduler.plugin.task.api.model.DependentItem;
 import org.apache.dolphinscheduler.plugin.task.api.model.DependentTaskModel;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+import org.apache.dolphinscheduler.plugin.task.api.model.SwitchResultVo;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.ConditionsParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.DependentParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
@@ -1513,6 +1514,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             return false;
         }
 
+        // Updates task code references in all SWITCH-type tasks within the given list
+        if (!updateSwitchTaskReferences(taskDefinitionLogList, taskCodeMap, result)) {
+            return false;
+        }
+
         int insert = taskDefinitionMapper.batchInsert(taskDefinitionLogList);
         int logInsert = taskDefinitionLogMapper.batchInsert(taskDefinitionLogList);
         if ((logInsert & insert) == 0) {
@@ -1683,6 +1689,70 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     .collect(Collectors.toList());
             result.setFailedNode(updatedFailed);
         }
+    }
+
+    /**
+     * Updates task code references in all SWITCH-type tasks within the given list.
+     * Specifically replaces:
+     *   - {@code nextBranch} at the top level of SwitchParameters
+     *   - {@code nextNode} in the default branch (switchResult.nextNode)
+     *   - {@code nextNode} in each conditional branch (switchResult.dependTaskList[*].nextNode)
+     * using the provided mapping from old task codes to new ones.
+     *
+     * @param taskDefinitionLogList list of task definition logs to process
+     * @param taskCodeMap           mapping from old task code to new task code
+     * @param result                result context for error reporting
+     * @return {@code true} if all SWITCH tasks were processed successfully;
+     *         {@code false} if any task parameter failed to parse (error already set in {@code result})
+     */
+    private boolean updateSwitchTaskReferences(
+                                               List<TaskDefinitionLog> taskDefinitionLogList,
+                                               Map<Long, Long> taskCodeMap,
+                                               Map<String, Object> result) {
+
+        for (TaskDefinitionLog taskDefinitionLog : taskDefinitionLogList) {
+            if (!"SWITCH".equals(taskDefinitionLog.getTaskType())) {
+                continue;
+            }
+
+            SwitchParameters switchParams = JSONUtils.parseObject(
+                    taskDefinitionLog.getTaskParams(),
+                    new TypeReference<SwitchParameters>() {
+                    });
+
+            if (switchParams == null) {
+                log.warn("Failed to parse taskParams for SWITCH task: {}", taskDefinitionLog.getTaskParams());
+                putMsg(result, Status.DATA_IS_NOT_VALID, "taskParams");
+                return false;
+            }
+
+            // Update top-level nextBranch
+            if (switchParams.getNextBranch() != null && taskCodeMap.containsKey(switchParams.getNextBranch())) {
+                switchParams.setNextBranch(taskCodeMap.get(switchParams.getNextBranch()));
+            }
+
+            // Update switchResult block
+            SwitchParameters.SwitchResult switchResult = switchParams.getSwitchResult();
+            if (switchResult != null) {
+                // Default branch
+                if (switchResult.getNextNode() != null && taskCodeMap.containsKey(switchResult.getNextNode())) {
+                    switchResult.setNextNode(taskCodeMap.get(switchResult.getNextNode()));
+                }
+
+                // Conditional branches
+                if (CollectionUtils.isNotEmpty(switchResult.getDependTaskList())) {
+                    for (SwitchResultVo vo : switchResult.getDependTaskList()) {
+                        if (vo != null && vo.getNextNode() != null && taskCodeMap.containsKey(vo.getNextNode())) {
+                            vo.setNextNode(taskCodeMap.get(vo.getNextNode()));
+                        }
+                    }
+                }
+            }
+
+            // Persist changes
+            taskDefinitionLog.setTaskParams(JSONUtils.toJsonString(switchParams));
+        }
+        return true;
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -111,9 +111,12 @@ import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.utils.WorkerGroupUtils;
 import org.apache.dolphinscheduler.plugin.task.api.enums.SqlType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskTimeoutStrategy;
+import org.apache.dolphinscheduler.plugin.task.api.model.ConditionDependentItem;
+import org.apache.dolphinscheduler.plugin.task.api.model.ConditionDependentTaskModel;
 import org.apache.dolphinscheduler.plugin.task.api.model.DependentItem;
 import org.apache.dolphinscheduler.plugin.task.api.model.DependentTaskModel;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.ConditionsParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.DependentParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SwitchParameters;
@@ -166,6 +169,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -1503,6 +1507,12 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
             taskDefinitionLogList.add(taskDefinitionLog);
         }
+
+        // Updates task code references in all CONDITIONS-type tasks within the given list
+        if (!updateConditionTaskReferences(taskDefinitionLogList, taskCodeMap, result)) {
+            return false;
+        }
+
         int insert = taskDefinitionMapper.batchInsert(taskDefinitionLogList);
         int logInsert = taskDefinitionLogMapper.batchInsert(taskDefinitionLogList);
         if ((logInsert & insert) == 0) {
@@ -1580,6 +1590,99 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         log.info("Import workflow definition complete, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                 workflowDefinition.getCode());
         return true;
+    }
+
+    /**
+     * Updates task code references in all CONDITIONS-type tasks within the given list.
+     * Specifically replaces:
+     *   - {@code depTaskCode} in each {@code ConditionDependentItem}
+     *   - node IDs in {@code successNode} and {@code failedNode}
+     * using the provided mapping from old task codes to new ones.
+     * <p>
+     * Unmapped codes are left unchanged. The updated parameters are serialized back
+     * into the {@code taskParams} field of each matching task log.
+     *
+     * @param taskDefinitionLogList list of task definition logs to process
+     * @param taskCodeMap           mapping from old task code to new task code (non-null)
+     * @param result                result context for error reporting
+     * @return {@code true} if all CONDITIONS tasks were processed successfully;
+     *         {@code false} if any task parameter failed to parse (error already set in {@code result})
+     */
+    private boolean updateConditionTaskReferences(
+                                                  List<TaskDefinitionLog> taskDefinitionLogList,
+                                                  Map<Long, Long> taskCodeMap,
+                                                  Map<String, Object> result) {
+
+        for (TaskDefinitionLog taskLog : taskDefinitionLogList) {
+            if (!"CONDITIONS".equals(taskLog.getTaskType())) {
+                continue;
+            }
+
+            ConditionsParameters params = JSONUtils.parseObject(
+                    taskLog.getTaskParams(),
+                    new TypeReference<ConditionsParameters>() {
+                    });
+
+            if (params == null) {
+                log.warn("Failed to parse taskParams for CONDITIONS task: {}", taskLog.getTaskParams());
+                putMsg(result, Status.DATA_IS_NOT_VALID, "taskParams");
+                return false;
+            }
+
+            updateDependenceTaskCodes(params, taskCodeMap);
+            updateConditionResultNodes(params, taskCodeMap);
+
+            taskLog.setTaskParams(JSONUtils.toJsonString(params));
+        }
+        return true;
+    }
+
+    /**
+     * Replaces {@code depTaskCode} in all dependent items using the given code mapping.
+     */
+    private void updateDependenceTaskCodes(ConditionsParameters params, Map<Long, Long> taskCodeMap) {
+        ConditionsParameters.ConditionDependency dependence = params.getDependence();
+        if (dependence == null || CollectionUtils.isEmpty(dependence.getDependTaskList())) {
+            return;
+        }
+
+        for (ConditionDependentTaskModel dependTask : dependence.getDependTaskList()) {
+            if (CollectionUtils.isEmpty(dependTask.getDependItemList())) {
+                continue;
+            }
+            for (ConditionDependentItem item : dependTask.getDependItemList()) {
+                Long oldCode = item.getDepTaskCode();
+                if (taskCodeMap.containsKey(oldCode)) {
+                    item.setDepTaskCode(taskCodeMap.get(oldCode));
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces node IDs in {@code successNode} and {@code failedNode} lists using the given mapping.
+     */
+    private void updateConditionResultNodes(ConditionsParameters params, Map<Long, Long> taskCodeMap) {
+        ConditionsParameters.ConditionResult result = params.getConditionResult();
+        if (result == null) {
+            return;
+        }
+
+        // Update success branch
+        if (CollectionUtils.isNotEmpty(result.getSuccessNode())) {
+            List<Long> updatedSuccess = result.getSuccessNode().stream()
+                    .map(code -> taskCodeMap.getOrDefault(code, code))
+                    .collect(Collectors.toList());
+            result.setSuccessNode(updatedSuccess);
+        }
+
+        // Update failure branch
+        if (CollectionUtils.isNotEmpty(result.getFailedNode())) {
+            List<Long> updatedFailed = result.getFailedNode().stream()
+                    .map(code -> taskCodeMap.getOrDefault(code, code))
+                    .collect(Collectors.toList());
+            result.setFailedNode(updatedFailed);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17771 

## Brief change log

update TaskCode references within the task parameters when importing tasks such as ConditionTask and SwitchTask


## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
