### PR TITLE
[Chore] Fix ci cat server log failed in cluster-test

### DIFF
--- a/.github/workflows/cluster-test/mysql_with_mysql_registry/running_test.sh
+++ b/.github/workflows/cluster-test/mysql_with_mysql_registry/running_test.sh
@@ -46,22 +46,22 @@ do
 
   if [[ $i -eq $TIMEOUT ]];then
     if [[ $MASTER_HTTP_STATUS -ne 200 ]];then
-      cat ~/ds_test/master-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/master-server/logs/*.log
       cat ~/ds_test/master-server/logs/*.out
       echo "master start health check failed"
     fi
     if [[ $WORKER_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/worker-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/worker-server/logs/*.log
       cat ~/ds_test/worker-server/logs/*.out
       echo "worker start health check failed"
     fi
     if [[ $API_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/api-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/api-server/logs/*.log
       cat ~/ds_test/api-server/logs/*.out
       echo "api start health check failed"
     fi
     if [[ $ALERT_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/alert-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/alert-server/logs/*.log
       cat ~/ds_test/alert-server/logs/*.out
       echo "alert start health check failed"
     fi

--- a/.github/workflows/cluster-test/mysql_with_zookeeper_registry/running_test.sh
+++ b/.github/workflows/cluster-test/mysql_with_zookeeper_registry/running_test.sh
@@ -46,22 +46,22 @@ do
 
   if [[ $i -eq $TIMEOUT ]];then
     if [[ $MASTER_HTTP_STATUS -ne 200 ]];then
-      cat ~/ds_test/master-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/master-server/logs/*.log
       cat ~/ds_test/master-server/logs/*.out
       echo "master start health check failed"
     fi
     if [[ $WORKER_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/worker-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/worker-server/logs/*.log
       cat ~/ds_test/worker-server/logs/*.out
       echo "worker start health check failed"
     fi
     if [[ $API_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/api-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/api-server/logs/*.log
       cat ~/ds_test/api-server/logs/*.out
       echo "api start health check failed"
     fi
     if [[ $ALERT_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/alert-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/alert-server/logs/*.log
       cat ~/ds_test/alert-server/logs/*.out
       echo "alert start health check failed"
     fi

--- a/.github/workflows/cluster-test/postgresql_with_postgresql_registry/running_test.sh
+++ b/.github/workflows/cluster-test/postgresql_with_postgresql_registry/running_test.sh
@@ -46,22 +46,22 @@ do
 
   if [[ $i -eq $TIMEOUT ]];then
     if [[ $MASTER_HTTP_STATUS -ne 200 ]];then
-      cat ~/ds_test/master-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/master-server/logs/*.log
       cat ~/ds_test/master-server/logs/*.out
       echo "master start health check failed"
     fi
     if [[ $WORKER_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/worker-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/worker-server/logs/*.log
       cat ~/ds_test/worker-server/logs/*.out
       echo "worker start health check failed"
     fi
     if [[ $API_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/api-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/api-server/logs/*.log
       cat ~/ds_test/api-server/logs/*.out
       echo "api start health check failed"
     fi
     if [[ $ALERT_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/alert-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/alert-server/logs/*.log
       cat ~/ds_test/alert-server/logs/*.out
       echo "alert start health check failed"
     fi

--- a/.github/workflows/cluster-test/postgresql_with_zookeeper_registry/running_test.sh
+++ b/.github/workflows/cluster-test/postgresql_with_zookeeper_registry/running_test.sh
@@ -46,22 +46,22 @@ do
 
   if [[ $i -eq $TIMEOUT ]];then
     if [[ $MASTER_HTTP_STATUS -ne 200 ]];then
-      cat ~/ds_test/master-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/master-server/logs/*.log
       cat ~/ds_test/master-server/logs/*.out
       echo "master start health check failed"
     fi
     if [[ $WORKER_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/worker-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/worker-server/logs/*.log
       cat ~/ds_test/worker-server/logs/*.out
       echo "worker start health check failed"
     fi
     if [[ $API_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/api-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/api-server/logs/*.log
       cat ~/ds_test/api-server/logs/*.out
       echo "api start health check failed"
     fi
     if [[ $ALERT_HTTP_STATUS -ne 200 ]]; then
-      cat ~/ds_test/alert-server/logs/dolphinscheduler-master.log
+      cat ~/ds_test/alert-server/logs/*.log
       cat ~/ds_test/alert-server/logs/*.out
       echo "alert start health check failed"
     fi


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

When server is unhealthy, we will cat the server log, but the server log path is incorrect.
```log
+ cat /home/runner/ds_test/worker-server/logs/dolphinscheduler-master.log
cat: /home/runner/ds_test/worker-server/logs/dolphinscheduler-master.log: No such file or directory
```

## Brief change log

Change the log path when cat

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
