### PR TITLE
[Improvement-17708][API] Remove default value of `python-gateway.auth-token`

### DIFF
--- a/docs/docs/en/guide/upgrade/incompatible.md
+++ b/docs/docs/en/guide/upgrade/incompatible.md
@@ -36,4 +36,5 @@ This document records the incompatible updates between each version. You need to
 
 * Renamed the publicKey field to privateKey in the SSH connection parameters under the datasource configuration. ([#17666])(https://github.com/apache/dolphinscheduler/pull/17666)
 * Add table t_ds_serial_command. ([#17531])(https://github.com/apache/dolphinscheduler/pull/17531)
+* Remove the default value of `python-gateway.auth-token` at `api-server/application.yaml`. ([#17801])(https://github.com/apache/dolphinscheduler/pull/17801)
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/ApiConfig.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/ApiConfig.java
@@ -61,7 +61,7 @@ public class ApiConfig implements Validator {
     }
 
     private void validatePythonGateway(Errors errors) {
-        if (pythonGateway.isEnabled() && StringUtils.isNotEmpty(pythonGateway.getAuthToken())) {
+        if (pythonGateway.isEnabled() && StringUtils.isEmpty(pythonGateway.getAuthToken())) {
             errors.rejectValue("pythonGateway.auth-token", null, "should not be empty when enabled is true");
         }
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/ApiConfig.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/ApiConfig.java
@@ -17,12 +17,15 @@
 
 package org.apache.dolphinscheduler.api.configuration;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -53,7 +56,14 @@ public class ApiConfig implements Validator {
 
     @Override
     public void validate(Object target, Errors errors) {
+        validatePythonGateway(errors);
         printConfig();
+    }
+
+    private void validatePythonGateway(Errors errors) {
+        if (pythonGateway.isEnabled() && StringUtils.isNotEmpty(pythonGateway.getAuthToken())) {
+            errors.rejectValue("pythonGateway.auth-token", null, "should not be empty when enabled is true");
+        }
     }
 
     private void printConfig() {
@@ -76,12 +86,13 @@ public class ApiConfig implements Validator {
         private Map<String, Integer> customizeTenantQpsRate = new HashMap<>();
     }
 
+    @ToString(exclude = "authToken")
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PythonGatewayConfiguration {
 
-        private boolean enabled = true;
+        private boolean enabled = false;
         private String gatewayServerAddress = "0.0.0.0";
         private int gatewayServerPort = 25333;
         private String pythonAddress = "127.0.0.1";

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -154,9 +154,8 @@ api:
   python-gateway:
     # Weather enable python gateway server or not. The default value is false.
     enabled: false
-    # Authentication token for connection from python api to python gateway server. Should be changed the default value
-    # when you deploy in public network.
-    auth-token: jwUDzpLsNKEFER4*a8gruBH_GsAurNxU7A@Xc
+    # Authentication token for connection from python api to python gateway server. Should not be empty when enabled
+    auth-token:
     # The address of Python gateway server start. Set its value to `0.0.0.0` if your Python API run in different
     # between Python gateway server. It could be be specific to other address like `127.0.0.1` or `localhost`
     gateway-server-address: 0.0.0.0

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -249,11 +249,10 @@ api:
     #tenant1: 11
     #tenant2: 20
   python-gateway:
-    # Weather enable python gateway server or not. The default value is true.
-    enabled: true
-    # Authentication token for connection from python api to python gateway server. Should be changed the default value
-    # when you deploy in public network.
-    auth-token: jwUDzpLsNKEFER4*a8gruBH_GsAurNxU7A@Xc
+    # Weather enable python gateway server or not. The default value is false.
+    enabled: false
+    # Authentication token for connection from python api to python gateway server. Should not be empty when enabled
+    auth-token:
     # The address of Python gateway server start. Set its value to `0.0.0.0` if your Python API run in different
     # between Python gateway server. It could be be specific to other address like `127.0.0.1` or `localhost`
     gateway-server-address: 0.0.0.0


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17708

## Brief change log

- Remove the default value of `python-gateway.auth-token`
- Throw exception when `python-gateway.auth-token` is empty but python-gateway is enabled.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
