### PR TITLE
[Fix-17805][ApiServer]Get the datasource password from the database when testing the connection to an existing datasource.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
@@ -44,6 +44,7 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.BaseDataSourceParamDTO;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.CommonUtils;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
+import org.apache.dolphinscheduler.plugin.datasource.api.utils.PasswordUtils;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbType;
@@ -214,6 +215,11 @@ public class DataSourceController extends BaseController {
     public Result<Boolean> connectDataSource(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                              @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "dataSourceParam") @RequestBody String jsonStr) {
         BaseDataSourceParamDTO dataSourceParam = DataSourceUtils.buildDatasourceParam(jsonStr);
+        if (dataSourceParam.getId() != null
+                && dataSourceParam.getPassword().equals(dataSourceService.getHiddenPassword())) {
+            String passwordInDb = dataSourceService.queryDataSourceRealPassword(dataSourceParam.getId(), loginUser);
+            dataSourceParam.setPassword(PasswordUtils.decodePassword(passwordInDb));
+        }
         DataSourceUtils.checkDatasourceParam(dataSourceParam);
         ConnectionParam connectionParams = DataSourceUtils.buildConnectionParams(dataSourceParam);
         dataSourceService.checkConnection(dataSourceParam.getType(), connectionParams);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
@@ -51,12 +51,27 @@ public interface DataSourceService {
     DataSource updateDataSource(User loginUser, BaseDataSourceParamDTO dataSourceParam);
 
     /**
-     * updateWorkflowInstance datasource
+     * query datasource with hidden password
      *
      * @param id datasource id
      * @return data source detail
      */
     BaseDataSourceParamDTO queryDataSource(int id, User loginUser);
+
+    /**
+     * get hidden password (resolve the security hotspot)
+     *
+     * @return hidden password
+     */
+    String getHiddenPassword();
+
+    /**
+     * query datasource real password
+     *
+     * @param id datasource id
+     * @return data source detail
+     */
+    String queryDataSourceRealPassword(int id, User loginUser);
 
     /**
      * query datasource list by keyword

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -189,7 +189,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     }
 
     /**
-     * updateWorkflowInstance datasource
+     * query datasource with hidden password
      *
      * @param id datasource id
      * @return data source detail
@@ -216,6 +216,30 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
         baseDataSourceParamDTO.setPassword(getHiddenPassword());
 
         return baseDataSourceParamDTO;
+    }
+
+    /**
+     * query datasource real password
+     *
+     * @param id datasource id
+     * @return data source detail
+     */
+    @Override
+    public String queryDataSourceRealPassword(int id, User loginUser) {
+        DataSource dataSource = dataSourceMapper.selectById(id);
+        if (dataSource == null) {
+            log.error("Datasource does not exist, id:{}.", id);
+            throw new ServiceException(Status.RESOURCE_NOT_EXIST);
+        }
+
+        if (!canOperatorPermissions(loginUser, new Object[]{dataSource.getId()}, AuthorizationType.DATASOURCE,
+                ApiFuncIdentificationConstant.DATASOURCE)) {
+            throw new ServiceException(Status.USER_NO_OPERATION_PERM);
+        }
+
+        ConnectionParam connectionParam =
+                DataSourceUtils.buildConnectionParams(dataSource.getType(), dataSource.getConnectionParams());
+        return connectionParam.getPassword();
     }
 
     /**
@@ -268,7 +292,8 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
      *
      * @return hidden password
      */
-    private String getHiddenPassword() {
+    @Override
+    public String getHiddenPassword() {
         return Constants.XXXXXX;
     }
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17805 

## Brief change log

Get the datasource password from the database when testing the connection to an existing datasource.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
