### PR TITLE
[Fix-17831] Fix incorrect parallelism num when complement data in parallel excution mode

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/workflow/BackfillWorkflowExecutorDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/workflow/BackfillWorkflowExecutorDelegate.java
@@ -35,6 +35,7 @@ import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -95,15 +96,39 @@ public class BackfillWorkflowExecutorDelegate implements IExecutorDelegate<Backf
             expectedParallelismNumber = listDate.size();
         }
 
-        log.info("In parallel mode, current expectedParallelismNumber:{}", expectedParallelismNumber);
+        log.info("In parallel mode, current expectedParallelismNumber: {}", expectedParallelismNumber);
         final List<Integer> workflowInstanceIdList = Lists.newArrayList();
-        for (List<ZonedDateTime> stringDate : Lists.partition(listDate, expectedParallelismNumber)) {
+        for (List<ZonedDateTime> stringDate : splitDateTime(listDate, expectedParallelismNumber)) {
             final Integer workflowInstanceId = doBackfillWorkflow(
                     backfillWorkflowDTO,
                     stringDate.stream().map(DateUtils::dateToString).collect(Collectors.toList()));
             workflowInstanceIdList.add(workflowInstanceId);
         }
         return workflowInstanceIdList;
+    }
+
+    /**
+     * split date time list into n parts, the last part may be larger if not divisible
+     */
+    private List<List<ZonedDateTime>> splitDateTime(List<ZonedDateTime> dateTimeList, int numParts) {
+        List<List<ZonedDateTime>> result = new ArrayList<>();
+        int n = dateTimeList.size();
+
+        int baseSize = n / numParts;
+        int remainder = n % numParts;
+
+        int start = 0;
+        for (int i = 0; i < numParts; i++) {
+            int currentSize = baseSize;
+            if (i == numParts - 1) {
+                currentSize += remainder;
+            }
+            List<ZonedDateTime> part = dateTimeList.subList(start, start + currentSize);
+            result.add(part);
+            start += currentSize;
+        }
+
+        return result;
     }
 
     private Integer doBackfillWorkflow(final BackfillWorkflowDTO backfillWorkflowDTO,


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

fix #17831 

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
