### PR TITLE
[Fix-17864] [ApiServer] Remove STOP state for task instance from ui

### DIFF
--- a/dolphinscheduler-ui/src/common/common.ts
+++ b/dolphinscheduler-ui/src/common/common.ts
@@ -215,14 +215,6 @@ export const tasksState = (t: any): ITaskStateConfig => ({
     isSpin: false,
     classNames: 'pause'
   },
-  STOP: {
-    id: 5,
-    desc: `${t('project.workflow.stop')}`,
-    color: '#e90101',
-    icon: StopOutlined,
-    isSpin: false,
-    classNames: 'stop'
-  },
   FAILURE: {
     id: 6,
     desc: `${t('project.workflow.failed')}`,

--- a/dolphinscheduler-ui/src/common/types.ts
+++ b/dolphinscheduler-ui/src/common/types.ts
@@ -20,7 +20,6 @@ export type ITaskState =
   | 'SUBMITTED_SUCCESS'
   | 'RUNNING_EXECUTION'
   | 'PAUSE'
-  | 'STOP'
   | 'FAILURE'
   | 'SUCCESS'
   | 'NEED_FAULT_TOLERANCE'


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17864 

## Brief change log

Remove STOP state for task instance from ui

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
