### PR TITLE
[Improvement-17855] A dependent node should't depend on the workflow it is in

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -428,6 +428,10 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     .parseObject(taskDefinitionLog.getTaskParams(), DependentParameters.class)
                     .getDependence().getDependTaskList()) {
                 for (DependentItem dependentItem : dependentTaskModel.getDependItemList()) {
+                    // A Dependent node cannot rely on itself workflow
+                    if (dependentItem.getDefinitionCode() == workflowDefinitionCode) {
+                        throw new ServiceException(Status.WORKFLOW_NODE_HAS_CYCLE);
+                    }
                     WorkflowTaskLineage workflowTaskLineage = new WorkflowTaskLineage();
                     workflowTaskLineage.setWorkflowDefinitionCode(workflowDefinitionCode);
                     workflowTaskLineage.setWorkflowDefinitionVersion(workflowDefinitionVersion);


### PR DESCRIPTION

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
close https://github.com/apache/dolphinscheduler/issues/17873
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
