### PR TITLE
[Fix-17389] Fix JSONUtils to support nested JSON objects

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.TimeZone;
 
@@ -248,9 +249,20 @@ public final class JSONUtils {
      * @return json to map
      */
     public static Map<String, String> toMap(String json) {
-        return parseObject(json, new TypeReference<Map<String, String>>() {
+        Map<String, Object> map = parseObject(json, new TypeReference<Map<String, Object>>() {
         });
+
+        if (map == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            result.put(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+        return result;
     }
+
 
     /**
      * from the key-value generated json  to get the str value no matter the real type of value


### PR DESCRIPTION
This PR fixes JSONUtils.toMap to support nested JSON and non-string values.

Previously the method parsed Map<String, String> which caused failures when JSON values were objects or arrays.

Now it parses Map<String, Object> and safely converts values to string format while maintaining backward compatibility.

Fixes #17389


