### PR TITLE
[Fix-17912] Fix http plugin cannot send json nested types

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -42,7 +42,7 @@ public final class HttpSender {
 
     private Map<String, String> headerParams;
     private OkHttpRequestHeaderContentType contentType;
-    private Map<String, String> bodyParams;
+    private Map<String, Object> bodyParams;
     private HttpRequestMethod requestType;
     private int timeout;
     private String url;
@@ -69,7 +69,7 @@ public final class HttpSender {
 
         String bodyParamsString = paramsMap.get(HttpAlertConstants.NAME_BODY_PARAMS);
         if (StringUtils.isNotBlank(bodyParamsString)) {
-            bodyParams = JSONUtils.toMap(bodyParamsString);
+            bodyParams = JSONUtils.parseObject(bodyParamsString, new TypeReference<Map<String, Object>>() {});
             if (bodyParams == null) {
                 throw new IllegalArgumentException("bodyParams is not a valid json");
             }
@@ -215,6 +215,7 @@ public final class HttpSender {
         }
 
         bodyParams.forEach((key, value) -> {
+			String valueOf = String.valueOf(value);
             if (value.contains(HttpAlertConstants.MSG_PARAMS)) {
                 bodyParams.put(key, value.replace(HttpAlertConstants.MSG_PARAMS, msg));
             }

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -219,8 +219,8 @@ public final class HttpSender {
 
         bodyParams.forEach((key, value) -> {
             String valueOf = String.valueOf(value);
-            if (value.contains(HttpAlertConstants.MSG_PARAMS)) {
-                bodyParams.put(key, value.replace(HttpAlertConstants.MSG_PARAMS, msg));
+            if (valueOf.contains(HttpAlertConstants.MSG_PARAMS)) {
+                bodyParams.put(key, valueOf.replace(HttpAlertConstants.MSG_PARAMS, msg));
             }
         });
     }

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 @Slf4j
 public final class HttpSender {
 

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -69,7 +69,8 @@ public final class HttpSender {
 
         String bodyParamsString = paramsMap.get(HttpAlertConstants.NAME_BODY_PARAMS);
         if (StringUtils.isNotBlank(bodyParamsString)) {
-            bodyParams = JSONUtils.parseObject(bodyParamsString, new TypeReference<Map<String, Object>>() {});
+            bodyParams = JSONUtils.parseObject(bodyParamsString, new TypeReference<Map<String, Object>>() {
+            });
             if (bodyParams == null) {
                 throw new IllegalArgumentException("bodyParams is not a valid json");
             }
@@ -215,7 +216,7 @@ public final class HttpSender {
         }
 
         bodyParams.forEach((key, value) -> {
-			String valueOf = String.valueOf(value);
+            String valueOf = String.valueOf(value);
             if (value.contains(HttpAlertConstants.MSG_PARAMS)) {
                 bodyParams.put(key, value.replace(HttpAlertConstants.MSG_PARAMS, msg));
             }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request
The original HTTP plugin cannot send JSON nested types. For example, the HTTP plugin can only send JSON like {"msgtype": "text", "content": "test"}, but cannot send JSON like {"msgtype": "text", "text": {"content": "test"}}. 

fix #17912

## Brief change log

Modify the type of org.apache.dolphinscheduler.plugin.alert.http.HttpSender#bodyParams to Map<String, Object>

## Verify this pull request
*Modify the previous log*
```shell
java.lang.IllegalArgumentException: Parse json: {"msgtype":"text", "text":{"content":"测试"}} to type: java.util.Map<java.lang.String, java.lang.String> failed
        at org.apache.dolphinscheduler.common.utils.JSONUtils.parseObject(JSONUtils.java:295)
        at org.apache.dolphinscheduler.common.utils.JSONUtils.toMap(JSONUtils.java:251)
        at org.apache.dolphinscheduler.plugin.alert.http.HttpSender.paramsValidator(HttpSender.java:72)
        at org.apache.dolphinscheduler.plugin.alert.http.HttpSender.<init>(HttpSender.java:51)
        at org.apache.dolphinscheduler.plugin.alert.http.HttpAlertChannel.process(HttpAlertChannel.java:37) 
        at org.apache.dolphinscheduler.alert.service.AbstractEventSender.syncTestSend(AbstractEventSender.java:166)
        at org.apache.dolphinscheduler.alert.rpc.AlertOperatorImpl.sendTestAlert(AlertOperatorImpl.java:52)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.dolphinscheduler.extract.base.server.ServerMethodInvokerImpl.invoke(ServerMethodInvokerImpl.java:47)
        at org.apache.dolphinscheduler.extract.base.server.JdkDynamicServerHandler.lambda$processReceived$0(JdkDynamicServerHandler.java:117)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: (String)"{"msgtype":"text", "text":{"content":"测试"}}"; line: 1, column: 27] (through reference chain: java.util.LinkedHashMap["text"])
        at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
        at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1741)
        at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1515)
        at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1420)
        at com.fasterxml.jackson.databind.DeserializationContext.extractScalarFromObject(DeserializationContext.java:932)
        at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:62)
        at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:11)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:609)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:437)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4674)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3629)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3612)
        at org.apache.dolphinscheduler.common.utils.JSONUtils.parseObject(JSONUtils.java:293)
        ... 15 common frames omitted
```
*Log after modification*
```shell
[INFO] 2026-01-27 19:35:49.761 +0800 org.apache.dolphinscheduler.plugin.alert.http.HttpSender:[166] - sending http alert post request, url: https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=ea529f1d-f509-4af5-a83e-76d9d642d6bf, header: {Content-Type=application/json}, requestBody: {msgtype=text, text={content=测试}}, contentType: application/json,timeout:1200000
```
You can now send Http messages normally
## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
