### PR TITLE
[Doc-17913] Add frontend code check section in development documentation in both Chinese and English

### DIFF
--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -29,11 +29,11 @@ Supporting system:
 
 Run `./mvnw clean install -Prelease -Dmaven.test.skip=true`
 
-### Code Style
+### Backend Code Style
 
-DolphinScheduler uses `Spotless` for code style and formatting checks.
+DolphinScheduler uses `Spotless` for backend code style and formatting checks.
 You could run the following command and `Spotless` will automatically fix
-the code style and formatting errors for you:
+the backend code style and formatting errors for you:
 
 ```shell
 ./mvnw spotless:apply
@@ -53,6 +53,27 @@ pre-commit install
 ```
 
 Now, every time you commit your code, `pre-commit` will automatically run `Spotless` to check the code style and formatting.
+
+### Frontend Code Style
+
+DolphinScheduler uses `pnpm` to check and automatically fix frontend code style and formatting issues.
+First, navigate to the frontend project directory:
+
+```shell
+cd dolphinscheduler-ui
+```
+
+Then, run `pnpm run lint` to check and fix frontend code style and formatting issues:
+
+```shell
+pnpm run lint
+```
+
+Finally, you can run `pnpm run build:prod` to perform a full TypeScript type check, ensuring that only type-safe code is committed.
+
+```shell
+pnpm run build:prod
+```
 
 ### Helm Template Guidelines
 

--- a/docs/docs/en/contribute/development-environment-setup.md
+++ b/docs/docs/en/contribute/development-environment-setup.md
@@ -63,16 +63,17 @@ First, navigate to the frontend project directory:
 cd dolphinscheduler-ui
 ```
 
-Then, run `pnpm run lint` to check and fix frontend code style and formatting issues:
+Then, run the following commands to automatically fix ESLint-fixable issues and format the code:
 
 ```shell
-pnpm run lint
+pnpm run lint      # Fix ESLint issues
+pnpm run prettier  # Format code
 ```
 
-Finally, you can run `pnpm run build:prod` to perform a full TypeScript type check, ensuring that only type-safe code is committed.
+Finally, you can run the following command to perform a full TypeScript type check and catch type-related errors early:
 
 ```shell
-pnpm run build:prod
+pnpm exec vue-tsc --noEmit  # Type check
 ```
 
 ### Helm Template Guidelines

--- a/docs/docs/zh/contribute/development-environment-setup.md
+++ b/docs/docs/zh/contribute/development-environment-setup.md
@@ -60,16 +60,17 @@ DolphinScheduler使用`pnpm`检查并修复前端代码风格和格式问题。
 cd dolphinscheduler-ui
 ```
 
-然后，使用`pnpm run lint`检查并修复前端代码风格和格式问题。
+然后，运行以下命令来自动修复 ESLint 可修复的问题，并格式化代码。
 
 ```shell
-pnpm run lint
+pnpm run lint      # 修复 ESLint 问题
+pnpm run prettier  # 格式化代码
 ```
 
-最后，可以运行`pnpm run build:prod`来执行完整的 TypeScript 类型检查，确保只有类型正确的代码才能被提交。
+最后，可以运行以下命令来执行完整的 TypeScript 类型检查，提前发现类型异常。
 
 ```shell
-pnpm run build:prod
+pnpm exec vue-tsc --noEmit  # 类型检查
 ```
 
 ### Helm 模板规范

--- a/docs/docs/zh/contribute/development-environment-setup.md
+++ b/docs/docs/zh/contribute/development-environment-setup.md
@@ -28,10 +28,10 @@ git clone git@github.com:apache/dolphinscheduler.git
 
 运行 `mvn clean install -Pstaging -Dmaven.test.skip=true`
 
-### 代码风格
+### 后端代码风格
 
-DolphinScheduler使用`Spotless`检查并修复代码风格和格式问题。
-您可以执行如下的命令，`Spotless`将会为您自动检查并修复代码风格和格式问题。
+DolphinScheduler使用`Spotless`检查并修复后端代码风格和格式问题。
+您可以执行如下的命令，`Spotless`将会为您自动检查并修复后端代码风格和格式问题。
 
 ```shell
 ./mvnw spotless:apply
@@ -50,6 +50,27 @@ pre-commit install
 ```
 
 现在，每次您提交代码时，`pre-commit`都会自动运行`Spotless`来检查代码风格和格式。
+
+### 前端代码风格
+
+DolphinScheduler使用`pnpm`检查并修复前端代码风格和格式问题。
+首先，进入前端项目文件夹：
+
+```shell
+cd dolphinscheduler-ui
+```
+
+然后，使用`pnpm run lint`检查并修复前端代码风格和格式问题。
+
+```shell
+pnpm run lint
+```
+
+最后，可以运行`pnpm run build:prod`来执行完整的 TypeScript 类型检查，确保只有类型正确的代码才能被提交。
+
+```shell
+pnpm run build:prod
+```
 
 ### Helm 模板规范
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

close #17913 

## Brief change log

Add frontend code check section in development documentation in both Chinese and English

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
