### PR TITLE
[Fix-17915][alert] Fix the issue of setting timeout exceptions in the HTTP alert plugin, where the unit in the code is not consistent with the page.

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-http/src/main/java/org/apache/dolphinscheduler/plugin/alert/http/HttpSender.java
@@ -88,9 +88,9 @@ public final class HttpSender {
             throw new IllegalArgumentException("contentType is not a valid value");
         }
 
-        timeout = StringUtils.isNotBlank(paramsMap.get(HttpAlertConstants.NAME_TIMEOUT))
+        timeout = (StringUtils.isNotBlank(paramsMap.get(HttpAlertConstants.NAME_TIMEOUT))
                 ? Integer.parseInt(paramsMap.get(HttpAlertConstants.NAME_TIMEOUT))
-                : HttpAlertConstants.DEFAULT_TIMEOUT * 1000;
+                : HttpAlertConstants.DEFAULT_TIMEOUT) * 1000;
     }
 
     public AlertResult send(String msg) {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Handling http alarm timeout exception

fix #17915

## Brief change log

Fixed the error in the timeout unit in the HTTP alert plugin

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This change added tests and can be verified as follows:

- *Manually verified the change by testing locally.* -->

Before repair：

<img width="441" height="392" alt="Snipaste_2026-01-27_19-02-08" src="https://github.com/user-attachments/assets/c2ecec4c-9dcd-455b-a602-57299cdb49be" />

<img width="692" height="269" alt="Snipaste_2026-01-27_19-04-12" src="https://github.com/user-attachments/assets/e8292fa4-f731-444c-a3f5-d0c1fbbecafd" />

After repair：
<img width="400" height="394" alt="Snipaste_2026-01-27_19-06-45" src="https://github.com/user-attachments/assets/322c96dc-758c-45d4-97af-c71663d81b74" />


