### PR TITLE
[Improvement-17924] Remove Slack references and update Community sections in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![codecov](https://codecov.io/gh/apache/dolphinscheduler/branch/dev/graph/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=apache-dolphinscheduler&metric=alert_status)](https://sonarcloud.io/dashboard?id=apache-dolphinscheduler)
 [![Twitter Follow](https://img.shields.io/twitter/follow/dolphinschedule.svg?style=social&label=Follow)](https://twitter.com/dolphinschedule) <!-- markdown-link-check-disable-line -->
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://s.apache.org/dolphinscheduler-slack)
 [![CN doc](https://img.shields.io/badge/文档-中文版-blue.svg)](README_zh_CN.md)
 
 ## About
@@ -64,7 +63,7 @@ Check out good first issue in [here](https://github.com/apache/dolphinscheduler/
 
 Welcome to join the Apache DolphinScheduler community by:
 
-- Join the [DolphinScheduler Slack](https://s.apache.org/dolphinscheduler-slack) to keep in touch with the community
+- Use [GitHub Issues](https://github.com/apache/dolphinscheduler/issues) for questions, discussions, and bug reports
 - Follow the [DolphinScheduler Twitter](https://twitter.com/dolphinschedule) and get the latest news <!-- markdown-link-check-disable-line -->
 - Subscribe DolphinScheduler mail list, [users@dolphinscheduler.apache.org](mailto:users-subscribe@dolphinscheduler.apache.org) for users and [dev@dolphinscheduler.apache.org](mailto:dev-subscribe@dolphinscheduler.apache.org) for developers
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -4,7 +4,6 @@
 [![codecov](https://codecov.io/gh/apache/dolphinscheduler/branch/dev/graph/badge.svg)]()
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=apache-dolphinscheduler&metric=alert_status)](https://sonarcloud.io/dashboard?id=apache-dolphinscheduler)
 [![Twitter Follow](https://img.shields.io/twitter/follow/dolphinschedule.svg?style=social&label=Follow)](https://twitter.com/dolphinschedule) <!-- markdown-link-check-disable-line -->
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://s.apache.org/dolphinscheduler-slack)
 [![EN doc](https://img.shields.io/badge/document-English-blue.svg)](README.md)
 
 ## 关于
@@ -60,7 +59,7 @@ DolphinScheduler 的主要特性如下：
 
 欢迎通过以方式加入社区：
 
-- 加入 [DolphinScheduler Slack](https://s.apache.org/dolphinscheduler-slack)
+- 讨论和提问请通过 [GitHub Issues](https://github.com/apache/dolphinscheduler/issues)
 - 关注 [DolphinScheduler Twitter](https://twitter.com/dolphinschedule) 来获取最新消息 <!-- markdown-link-check-disable-line -->
 - 订阅 DolphinScheduler 邮件列表, 用户订阅 [users@dolphinscheduler.apache.org](mailto:users-subscribe@dolphinscheduler.apache.org) 开发者请订阅 [dev@dolphinscheduler.apache.org](mailto:dev-subscribe@dolphinscheduler.apache.org)
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Remove Slack badges and links from README.md and README_zh_CN, since the Slack channel is no longer active.  
Updated Community sections to point to GitHub Issues for discussion.

close #17924

## Brief change log

- Removed Slack badge from top of both READMEs
- Removed Slack link from Community sections
- Updated Community sections to reference GitHub Issues only

## Verify this pull request

This pull request is documentation cleanup only; no test coverage is required.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)
