### PR TITLE
[Chore] Move generateK8sTaskExecutionContext from AbstractParameters to K8sTaskParameters

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/K8sTaskExecutionContext.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/K8sTaskExecutionContext.java
@@ -19,7 +19,10 @@ package org.apache.dolphinscheduler.plugin.task.api;
 
 import java.io.Serializable;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,6 +31,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *  k8s Task ExecutionContext
  */
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class K8sTaskExecutionContext implements Serializable {
 
     private String configYaml;
@@ -36,23 +42,11 @@ public class K8sTaskExecutionContext implements Serializable {
 
     private String connectionParams;
 
-    public K8sTaskExecutionContext() {
-    }
-
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public K8sTaskExecutionContext(
                                    @JsonProperty("configYaml") String configYaml,
                                    @JsonProperty("namespace") String namespace) {
         this.configYaml = configYaml;
         this.namespace = namespace;
-    }
-
-    @Override
-    public String toString() {
-        return "K8sTaskExecutionContext{"
-                + "namespace=" + namespace
-                + ", configYaml='" + configYaml + '\''
-                + ", connectionParams='" + connectionParams + '\''
-                + '}';
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/AbstractParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/AbstractParameters.java
@@ -18,12 +18,9 @@
 package org.apache.dolphinscheduler.plugin.task.api.parameters;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
-import org.apache.dolphinscheduler.plugin.task.api.K8sTaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
-import org.apache.dolphinscheduler.plugin.task.api.enums.ResourceType;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
-import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.DataSourceParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.ResourceParametersHelper;
 import org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils;
 
@@ -70,16 +67,6 @@ public abstract class AbstractParameters implements IParameters {
             }
         }
         return localParametersMaps;
-    }
-
-    public K8sTaskExecutionContext generateK8sTaskExecutionContext(ResourceParametersHelper parametersHelper,
-                                                                   int datasource) {
-        DataSourceParameters dataSourceParameters =
-                (DataSourceParameters) parametersHelper.getResourceParameters(ResourceType.DATASOURCE, datasource);
-        K8sTaskExecutionContext k8sTaskExecutionContext = new K8sTaskExecutionContext();
-        k8sTaskExecutionContext.setConnectionParams(
-                Objects.nonNull(dataSourceParameters) ? dataSourceParameters.getConnectionParams() : null);
-        return k8sTaskExecutionContext;
     }
 
     /**

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/K8sTaskParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parameters/K8sTaskParameters.java
@@ -17,10 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.parameters;
 
+import org.apache.dolphinscheduler.plugin.task.api.K8sTaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.ResourceType;
 import org.apache.dolphinscheduler.plugin.task.api.model.Label;
 import org.apache.dolphinscheduler.plugin.task.api.model.NodeSelectorExpression;
 import org.apache.dolphinscheduler.plugin.task.api.model.ResourceInfo;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.DataSourceParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.ResourceParametersHelper;
 
 import org.apache.commons.lang3.StringUtils;
@@ -31,9 +33,6 @@ import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * k8s task parameters
- */
 @Data
 @Slf4j
 public class K8sTaskParameters extends AbstractParameters {
@@ -66,5 +65,22 @@ public class K8sTaskParameters extends AbstractParameters {
         ResourceParametersHelper resources = super.getResources();
         resources.put(ResourceType.DATASOURCE, datasource);
         return resources;
+    }
+
+    public K8sTaskExecutionContext generateK8sTaskExecutionContext(
+                                                                   ResourceParametersHelper parametersHelper,
+                                                                   int datasource) {
+        DataSourceParameters dataSourceParameters =
+                (DataSourceParameters) parametersHelper
+                        .getResourceParameters(ResourceType.DATASOURCE, datasource);
+
+        String connectionParams = null;
+        if (dataSourceParameters != null) {
+            connectionParams = dataSourceParameters.getConnectionParams();
+        }
+
+        return K8sTaskExecutionContext.builder()
+                .connectionParams(connectionParams)
+                .build();
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Purpose of the pull request

Polish code. The `generateK8sTaskExecutionContext` method only needed by K8sTaskParameters

## Brief change log

Remove generateK8sTaskExecutionContext method from AbstractParameters

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
