### PR TITLE
[Chore] Bump zk to 3.8.3

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -1048,7 +1048,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <zookeeper.version>3.8.0</zookeeper.version>
+                <zookeeper.version>3.8.3</zookeeper.version>
                 <curator.version>5.5.0</curator.version>
             </properties>
         </profile>

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -372,7 +372,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     token-provider 1.0.1: https://mvnrepository.com/artifact/org.apache.kerby/token-provider/1.0.1, Apache 2.0
     tomcat-embed-el 9.0.74: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-el/9.0.74, Apache 2.0
     woodstox-core 5.3.0: https://mvnrepository.com/artifact/com.fasterxml.woodstox/woodstox-core/5.3.0, Apache 2.0
-    zookeeper 3.8.0: https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper/3.8.0, Apache 2.0
+    zookeeper 3.8.3: https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper/3.8.3, Apache 2.0
     prometheus client_java(simpleclient) 0.15.0: https://github.com/prometheus/client_java, Apache 2.0
     snowflake snowflake-2010: https://github.com/twitter-archive/snowflake/tree/snowflake-2010, Apache 2.0
     kubernetes-client 6.0.0: https://mvnrepository.com/artifact/io.fabric8/kubernetes-client/6.0.0, Apache 2.0

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -200,7 +200,6 @@ netty-common-4.1.53.Final.jar
 netty-handler-4.1.53.Final.jar
 netty-nio-client-2.17.282.jar
 netty-resolver-4.1.53.Final.jar
-netty-tcnative-2.0.48.Final.jar
 netty-tcnative-classes-2.0.59.Final.jar
 netty-transport-4.1.53.Final.jar
 netty-transport-classes-epoll-4.1.91.Final.jar
@@ -305,8 +304,8 @@ protobuf-java-3.17.2.jar
 protobuf-java-util-3.17.2.jar
 webjars-locator-core-0.50.jar
 zjsonpatch-0.3.0.jar
-zookeeper-3.8.0.jar
-zookeeper-jute-3.8.0.jar
+zookeeper-3.8.3.jar
+zookeeper-jute-3.8.3.jar
 aliyun-java-sdk-core-4.5.10.jar
 aliyun-java-sdk-kms-2.11.0.jar
 aliyun-java-sdk-ram-3.1.0.jar


### PR DESCRIPTION
## Purpose of the pull request

Fix https://zookeeper.apache.org/security.html#CVE-2023-44981

## Brief change log

Change zookeeper from `3.8.0` to `3.8.3`

## Verify this pull request

This pull request is already covered by existing UT tests.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
