### PR TITLE
[Fix-17979][DAO] Fix INT/BIGINT mismatch of workflow_definition_code in t_ds_serial_command.

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
@@ -348,7 +348,7 @@ CREATE TABLE t_ds_command
 DROP TABLE IF EXISTS `t_ds_serial_command`;
 CREATE TABLE `t_ds_serial_command` (
    `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'primary key',
-   `workflow_definition_code` int(11) NOT NULL COMMENT 'workflow definition code',
+   `workflow_definition_code` bigint(20) NOT NULL COMMENT 'workflow definition code',
    `workflow_definition_version` int(11) NOT NULL COMMENT 'workflow definition code',
    `workflow_instance_id` bigint(20) NOT NULL COMMENT 'workflow instance id',
    `state` tinyint(4) NOT NULL DEFAULT 0 COMMENT 'state of the serial queue: 0 waiting, 1 fired',

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
@@ -356,7 +356,7 @@ CREATE TABLE `t_ds_command` (
 DROP TABLE IF EXISTS `t_ds_serial_command`;
 CREATE TABLE `t_ds_serial_command` (
   `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'primary key',
-  `workflow_definition_code` int(11) NOT NULL COMMENT 'workflow definition code',
+  `workflow_definition_code` bigint(20) NOT NULL COMMENT 'workflow definition code',
   `workflow_definition_version` int(11) NOT NULL COMMENT 'workflow definition version',
   `workflow_instance_id` bigint(20) NOT NULL COMMENT 'workflow instance id',
   `state` tinyint(4) NOT NULL DEFAULT 0 COMMENT 'state of the serial queue: 0 waiting, 1 fired',

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/mysql/dolphinscheduler_ddl.sql
@@ -14,3 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
+ALTER TABLE `t_ds_serial_command`
+MODIFY COLUMN `workflow_definition_code` BIGINT(20) NOT NULL COMMENT 'workflow definition code';

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/postgresql/dolphinscheduler_ddl.sql
@@ -19,6 +19,3 @@ CREATE SEQUENCE IF NOT EXISTS t_ds_task_instance_context_id_seq;
 ALTER TABLE t_ds_task_instance_context
 ALTER COLUMN id SET DEFAULT nextval('t_ds_task_instance_context_id_seq'::regclass);
 
--- Change column type to BIGint
-ALTER TABLE t_ds_serial_command
-    ALTER COLUMN workflow_definition_code TYPE BIGINT;

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/postgresql/dolphinscheduler_ddl.sql
@@ -18,4 +18,3 @@
 CREATE SEQUENCE IF NOT EXISTS t_ds_task_instance_context_id_seq;
 ALTER TABLE t_ds_task_instance_context
 ALTER COLUMN id SET DEFAULT nextval('t_ds_task_instance_context_id_seq'::regclass);
-

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.4.1_schema/postgresql/dolphinscheduler_ddl.sql
@@ -18,3 +18,7 @@
 CREATE SEQUENCE IF NOT EXISTS t_ds_task_instance_context_id_seq;
 ALTER TABLE t_ds_task_instance_context
 ALTER COLUMN id SET DEFAULT nextval('t_ds_task_instance_context_id_seq'::regclass);
+
+-- Change column type to BIGint
+ALTER TABLE t_ds_serial_command
+    ALTER COLUMN workflow_definition_code TYPE BIGINT;


### PR DESCRIPTION
## Purpose of the pull request

This PR fixes a data type mismatch between the MySQL schema and Java entity mapping for `t_ds_serial_command`.

The column `workflow_definition_code` was defined as `INT(11)` in the 3.4.0 MySQL schema, while the corresponding Java field uses `Long`. This may cause data truncation errors when values exceed the range of `INT`.

close #17979

## Brief change log

- Change `workflow_definition_code` from  `INT(11)` to `BIGINT(20)` in `3.4.0_schema/mysql`
- Add upgrade SQL in `3.4.1_schema/mysql` to modify the existing column to `BIGINT(20)`
- Align `workflowInstanceId` Java type from `Integer` to `Long` to match existing    DB definition (`BIGINT(20)`)

## Verify this pull request

This change is covered by existing tests.

Additionally:
- Verified schema consistency manually
- Confirmed no remaining `INT(11)` definition for `workflow_definition_code`
- Ensured upgrade SQL is provided for existing deployments

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

Fixes #17979

