### PR TITLE
[Chore] Change required_approving_review_count to 1

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,7 +52,7 @@ github:
           - "Title Validator"
       required_pull_request_reviews:
         dismiss_stale_reviews: true
-        required_approving_review_count: 2
+        required_approving_review_count: 1
   features:
     # Enable issues management
     issues: true


### PR DESCRIPTION
## Was this PR generated or assisted by AI?
No

## Purpose of the pull request

We don't have enough active committers, it's better to set `required_approving_review_count` to 1 to make sure the PR can be merged smoothly.



## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request


This pull request is code cleanup without any test coverage.


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
