### PR TITLE
fix(ci): make docs workflow fail when dead-link/helm-doc fails

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -108,6 +108,8 @@ jobs:
     needs:
       - style
       - img-check
+      - dead-link
+      - helm-doc
     if: always()
     steps:
       - name: Status


### PR DESCRIPTION
### What
The `Docs` workflow runs `dead-link` and `helm-doc`, but the final `result` job only depends on `style` and `img-check`.

This can make the workflow appear successful even if dead-link check or helm-doc check fails.

### How
- Add `dead-link` and `helm-doc` to `jobs.result.needs` in `.github/workflows/docs.yml`.

### Verification
- YAML parsed locally; existing jobs unchanged.