### PR TITLE
[Chore][Doc] Fix typos in WorkflowInstanceServiceTest and JVM.json

### DIFF
--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -324,7 +324,7 @@ public class WorkflowInstanceServiceTest {
         Map<String, Object> proejctAuthFailMap =
                 workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L);
         Assertions.assertEquals(Status.PROJECT_NOT_FOUND, proejctAuthFailMap.get(Constants.STATUS));
-        // project auth sucess
+        // project auth success
         putMsg(result, Status.SUCCESS, projectCode);
         when(workflowInstanceMapper.queryByTriggerCode(projectCode)).thenReturn(new ArrayList());
         proejctAuthFailMap =

--- a/dolphinscheduler-meter/src/main/resources/grafana/JVM.json
+++ b/dolphinscheduler-meter/src/main/resources/grafana/JVM.json
@@ -2183,7 +2183,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "commited",
+          "legendFormat": "committed",
           "metric": "",
           "refId": "B",
           "step": 1800
@@ -2336,7 +2336,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "commited",
+          "legendFormat": "committed",
           "metric": "",
           "refId": "B",
           "step": 1800


### PR DESCRIPTION
## Purpose of the pull request

This PR just fixes a couple of minor spelling mistakes I noticed while reading the code.

- `sucess` -> `success` in `WorkflowInstanceServiceTest.java`
- `commited` -> `committed` in the `JVM.json` dashboard.

Just some basic cleanup to keep things tidy!

## Brief change log

- Fixed a spelling mistake in a comment in `WorkflowInstanceServiceTest.java`.
- Fixed spelling mistakes in the legend format of `JVM.json`.

## Verify this pull request

This pull request is code cleanup without any test coverage.