### PR TITLE
[Fix-17389][Common] Fix JSONUtils.toMap() fails when JSON values are …

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -35,6 +35,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -243,13 +245,37 @@ public final class JSONUtils {
 
     /**
      * json to map
+     * <p>
+     * Converts a JSON object string to a {@code Map<String, String>}.
+     * String values are returned as-is; non-string values (arrays, objects,
+     * numbers, booleans) are serialized back to their JSON string representation.
      *
      * @param json json
      * @return json to map
      */
     public static Map<String, String> toMap(String json) {
-        return parseObject(json, new TypeReference<Map<String, String>>() {
-        });
+        if (Strings.isNullOrEmpty(json)) {
+            return null;
+        }
+        try {
+            JsonNode rootNode = objectMapper.readTree(json);
+            if (!rootNode.isObject()) {
+                throw new IllegalArgumentException(
+                        "Parse json: " + json + " to Map<String, String> failed, root element is not a JSON object");
+            }
+            Map<String, String> result = new HashMap<>();
+            Iterator<Map.Entry<String, JsonNode>> fields = rootNode.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                JsonNode valueNode = entry.getValue();
+                result.put(entry.getKey(), valueNode.isTextual() ? valueNode.asText() : valueNode.toString());
+            }
+            return result;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Parse json: " + json + " to Map<String, String> failed", e);
+        }
     }
 
     /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/JSONUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/JSONUtilsTest.java
@@ -134,6 +134,17 @@ public class JSONUtilsTest {
         String str = "{\"resourceList\":[],\"localParams\":[],\"rawScript\":\"#!/bin/bash\\necho \\\"shell-1\\\"\"}";
         Map<String, String> m = JSONUtils.toMap(str);
         Assertions.assertNotNull(m);
+
+        // issue #17389: toMap should handle non-string values (arrays, objects, numbers)
+        // without throwing MismatchedInputException
+        String jsonWithArray =
+                "{\"applyId\":\"CA2024011800236476\",\"featureSourceDataList\":[{\"data\":\"test\",\"dataType\":\"TEST\"}],\"params\":{}}";
+        Map<String, String> mapWithArray = JSONUtils.toMap(jsonWithArray);
+        Assertions.assertNotNull(mapWithArray);
+        Assertions.assertEquals("CA2024011800236476", mapWithArray.get("applyId"));
+        Assertions.assertEquals("[{\"data\":\"test\",\"dataType\":\"TEST\"}]",
+                mapWithArray.get("featureSourceDataList"));
+        Assertions.assertEquals("{}", mapWithArray.get("params"));
     }
 
     @Test


### PR DESCRIPTION
…arrays or objects

When calling JSONUtils.toMap(String json) with a JSON that contains non-string values (arrays, nested objects, numbers, booleans), the method threw MismatchedInputException because it tried to deserialize directly into Map<String, String>.

The fix parses the JSON as a JsonNode first, then iterates over fields and converts each value to a string: textual nodes use asText() to return the plain string, while all other types (arrays, objects, etc.) use toString() to return their JSON string representation.

Fixes #17389

<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?
<!--(Please answer YES or NO. If YES, please specify which parts were generated or assisted by AI)-->

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
