### PR TITLE
[Improvement-17947][ui] Improve delete confirmation to show workflow name

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -150,6 +150,7 @@ export default {
     end_time: 'End Time',
     crontab: 'Crontab',
     delete_confirm: 'Delete?',
+    delete_confirm_with_name: 'Delete "{name}"?',
     delete_irreversible:
       'This action cannot be undone. The workflow and its associated data will be permanently deleted.',
     enter_name_tips: 'Please enter name',

--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -150,6 +150,8 @@ export default {
     end_time: 'End Time',
     crontab: 'Crontab',
     delete_confirm: 'Delete?',
+    delete_irreversible:
+      'This action cannot be undone. The workflow and its associated data will be permanently deleted.',
     enter_name_tips: 'Please enter name',
     switch_version: 'Switch To This Version',
     confirm_switch_version: 'Confirm Switch To This Version?',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -149,6 +149,7 @@ export default {
     end_time: '结束时间',
     crontab: 'Crontab',
     delete_confirm: '确定删除吗?',
+    delete_confirm_with_name: '确定删除“{name}”吗?',
     delete_irreversible: '此操作不可撤销。工作流及其关联数据将被永久删除。',
     enter_name_tips: '请输入名称',
     switch_version: '切换到该版本',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -149,6 +149,7 @@ export default {
     end_time: '结束时间',
     crontab: 'Crontab',
     delete_confirm: '确定删除吗?',
+    delete_irreversible: '此操作不可撤销。工作流及其关联数据将被永久删除。',
     enter_name_tips: '请输入名称',
     switch_version: '切换到该版本',
     confirm_switch_version: '确定切换到该版本吗?',

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/table-action.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/table-action.tsx
@@ -271,7 +271,19 @@ export default defineComponent({
                 onPositiveClick={this.handleDeleteWorkflow}
               >
                 {{
-                  default: () => t('project.workflow.delete_confirm'),
+                  default: () => (
+                    <div style={{ maxWidth: 360 }}>
+                      <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                        {`${t('project.workflow.delete_confirm')} "${
+                          this.row?.name || ''
+                        }"`}
+                      </div>
+                      <div style={{ color: '#ff4d4f' }}>
+                        {t('project.workflow.delete_irreversible') ||
+                          'This action cannot be undone. The workflow and its associated data will be permanently deleted.'}
+                      </div>
+                    </div>
+                  ),
                   trigger: () => (
                     <NButton
                       size='small'

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/table-action.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/table-action.tsx
@@ -16,7 +16,7 @@
  */
 
 import { defineComponent, PropType, toRefs } from 'vue'
-import { NSpace, NTooltip, NButton, NIcon, NPopconfirm } from 'naive-ui'
+import { NSpace, NTooltip, NButton, NIcon, NPopconfirm, NText } from 'naive-ui'
 import {
   DeleteOutlined,
   DownloadOutlined,
@@ -274,14 +274,22 @@ export default defineComponent({
                   default: () => (
                     <div style={{ maxWidth: 360 }}>
                       <div style={{ fontWeight: 600, marginBottom: 6 }}>
-                        {`${t('project.workflow.delete_confirm')} "${
-                          this.row?.name || ''
-                        }"`}
+                        {(() => {
+                          const workflowName = (this.row?.name || '').trim()
+                          if (!workflowName) {
+                            return t('project.workflow.delete_confirm')
+                          }
+                          return t(
+                            'project.workflow.delete_confirm_with_name',
+                            {
+                              name: workflowName
+                            }
+                          )
+                        })()}
                       </div>
-                      <div style={{ color: '#ff4d4f' }}>
-                        {t('project.workflow.delete_irreversible') ||
-                          'This action cannot be undone. The workflow and its associated data will be permanently deleted.'}
-                      </div>
+                      <NText type='error'>
+                        {t('project.workflow.delete_irreversible')}
+                      </NText>
                     </div>
                   ),
                   trigger: () => (


### PR DESCRIPTION
## Description

Enhance the workflow delete confirmation to display the workflow name and an irreversible-action warning to reduce accidental deletions.

### Changes
- `dolphinscheduler-ui/src/views/projects/workflow/definition/components/table-action.tsx`
  - Show workflow name inside the existing `NPopconfirm`
  - Display irreversibility warning in red
- `dolphinscheduler-ui/src/locales/en_US/project.ts`
  - Add `delete_irreversible` key
- `dolphinscheduler-ui/src/locales/zh_CN/project.ts`
  - Add `delete_irreversible` key

### Why
Users couldn’t see which workflow they'd delete; adding the name and clear warning improves safety and UX for destructive actions.

### How to test
1. In UI: Project → Workflows → Definitions
2. Click the delete (trash) icon for a workflow
3. Verify the popconfirm shows the workflow name and the irreversibility warning
4. Cancel closes the dialog; Confirm deletes the workflow

### Related
Closes #17947