### PR TITLE
[Fix-18061] Fix end time is empty when workflow insstance stopped by serial discard

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/serial/AbstractSerialCommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/serial/AbstractSerialCommandHandler.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.serial;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.dao.entity.Command;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.model.SerialCommandDto;
@@ -82,6 +83,7 @@ public abstract class AbstractSerialCommandHandler implements ISerialCommandHand
                 // todo: call api to stop the workflow instance
                 final Integer workflowInstanceId = serialCommand.getWorkflowInstanceId();
                 final WorkflowInstance workflowInstance = workflowInstanceDao.queryById(workflowInstanceId);
+                workflowInstance.setEndTime(DateUtils.getCurrentDate());
                 workflowInstance.setState(WorkflowExecutionStatus.STOP);
                 workflowInstanceDao.upsertWorkflowInstance(workflowInstance);
                 return null;

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowStartTestCase.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/cases/WorkflowStartTestCase.java
@@ -212,12 +212,16 @@ public class WorkflowStartTestCase extends AbstractMasterIntegrationTestCase {
         await()
                 .atMost(Duration.ofMinutes(1))
                 .untilAsserted(() -> {
-                    assertThat(repository.queryWorkflowInstance(workflowInstanceId1).getState())
-                            .isEqualTo(WorkflowExecutionStatus.SUCCESS);
-                    assertThat(repository.queryWorkflowInstance(workflowInstanceId2).getState())
-                            .isEqualTo(WorkflowExecutionStatus.STOP);
-                    assertThat(repository.queryWorkflowInstance(workflowInstanceId3).getState())
-                            .isEqualTo(WorkflowExecutionStatus.STOP);
+                    final WorkflowInstance workflowInstance1 = repository.queryWorkflowInstance(workflowInstanceId1);
+                    final WorkflowInstance workflowInstance2 = repository.queryWorkflowInstance(workflowInstanceId2);
+                    final WorkflowInstance workflowInstance3 = repository.queryWorkflowInstance(workflowInstanceId3);
+                    assertThat(workflowInstance1.getState()).isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                    assertThat(workflowInstance2.getState()).isEqualTo(WorkflowExecutionStatus.STOP);
+                    assertThat(workflowInstance2.getEndTime()).isNotNull();
+                    assertThat(workflowInstance2.getEndTime()).isAtLeast(workflowInstance2.getStartTime());
+                    assertThat(workflowInstance3.getState()).isEqualTo(WorkflowExecutionStatus.STOP);
+                    assertThat(workflowInstance3.getEndTime()).isNotNull();
+                    assertThat(workflowInstance3.getEndTime()).isAtLeast(workflowInstance3.getStartTime());
                 });
 
         masterContainer.assertAllResourceReleased();
@@ -241,12 +245,16 @@ public class WorkflowStartTestCase extends AbstractMasterIntegrationTestCase {
         await()
                 .atMost(Duration.ofMinutes(1))
                 .untilAsserted(() -> {
-                    assertThat(repository.queryWorkflowInstance(workflowInstanceId1).getState())
-                            .isEqualTo(WorkflowExecutionStatus.STOP);
-                    assertThat(repository.queryWorkflowInstance(workflowInstanceId2).getState())
-                            .isEqualTo(WorkflowExecutionStatus.STOP);
-                    assertThat(repository.queryWorkflowInstance(workflowInstanceId3).getState())
-                            .isEqualTo(WorkflowExecutionStatus.SUCCESS);
+                    final WorkflowInstance workflowInstance1 = repository.queryWorkflowInstance(workflowInstanceId1);
+                    final WorkflowInstance workflowInstance2 = repository.queryWorkflowInstance(workflowInstanceId2);
+                    final WorkflowInstance workflowInstance3 = repository.queryWorkflowInstance(workflowInstanceId3);
+                    assertThat(workflowInstance1.getState()).isEqualTo(WorkflowExecutionStatus.STOP);
+                    assertThat(workflowInstance1.getEndTime()).isNotNull();
+                    assertThat(workflowInstance1.getEndTime()).isAtLeast(workflowInstance1.getStartTime());
+                    assertThat(workflowInstance2.getState()).isEqualTo(WorkflowExecutionStatus.STOP);
+                    assertThat(workflowInstance2.getEndTime()).isNotNull();
+                    assertThat(workflowInstance2.getEndTime()).isAtLeast(workflowInstance2.getStartTime());
+                    assertThat(workflowInstance3.getState()).isEqualTo(WorkflowExecutionStatus.SUCCESS);
                 });
 
         masterContainer.assertAllResourceReleased();


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

No.

## Purpose of the pull request

close #18061

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
