### PR TITLE
[Chore] Polish ci

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -138,7 +138,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-api-test
           restore-keys: ${{ runner.os }}-maven-
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         name: Download Docker Images
         with:
           name: standalone-image-api-test

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -121,7 +121,7 @@ jobs:
           submodules: true
       - name: Collect Workflow Metrics
         uses: ./.github/actions/actions-workflow-metrics
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         name: Download Binary Package
         with:
           # Only run cluster test on jdk8
@@ -151,7 +151,7 @@ jobs:
       - name: Collect Workflow Metrics
         uses: ./.github/actions/actions-workflow-metrics
       - name: Download Binary Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: binary-package-8
           path: ds_schema_check_test/dev

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -38,12 +38,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: java
         queries: +security-and-quality
@@ -55,4 +55,4 @@ jobs:
           -Prelease
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Run Dev Relative Reference

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -68,7 +68,7 @@ jobs:
         name: Sanity Check
         uses: ./.github/actions/sanity-check
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 16
       - name: Code Format Check


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

No.

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

Fix ci warning
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/download-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
