### PR TITLE
[Chore] Remove unused method in IWorkflowFailureStrategy

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/ContinueWorkflowFailureStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/ContinueWorkflowFailureStrategy.java
@@ -32,10 +32,4 @@ public class ContinueWorkflowFailureStrategy implements IWorkflowFailureStrategy
         // do nothing, just continue workflow execution
     }
 
-    @Override
-    public boolean canTriggerSuccessor(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                       ITaskExecutionRunnable taskExecutionRunnable) {
-        return true;
-    }
-
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/EndWorkflowFailureStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/EndWorkflowFailureStrategy.java
@@ -37,10 +37,4 @@ public class EndWorkflowFailureStrategy implements IWorkflowFailureStrategy {
         workflowExecutionRunnable.killActiveTasks();
     }
 
-    @Override
-    public boolean canTriggerSuccessor(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                       ITaskExecutionRunnable taskExecutionRunnable) {
-        return !workflowExecutionRunnable.getWorkflowExecutionGraph().isExistFailureTaskExecutionRunnableChain();
-    }
-
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/IWorkflowFailureStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/IWorkflowFailureStrategy.java
@@ -28,7 +28,4 @@ public interface IWorkflowFailureStrategy {
     void onTaskFailure(IWorkflowExecutionRunnable workflowExecutionRunnable,
                        ITaskExecutionRunnable taskExecutionRunnable);
 
-    boolean canTriggerSuccessor(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                ITaskExecutionRunnable taskExecutionRunnable);
-
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/AbstractWorkflowStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/AbstractWorkflowStateAction.java
@@ -140,11 +140,6 @@ public abstract class AbstractWorkflowStateAction implements IWorkflowStateActio
             return;
         }
 
-        if (!workflowFailureStrategy.canTriggerSuccessor(workflowExecutionRunnable, taskExecutionRunnable)) {
-            emitWorkflowFinishedEventIfApplicable(workflowExecutionRunnable);
-            return;
-        }
-
         triggerTasks(workflowExecutionRunnable, workflowExecutionGraph.getSuccessors(taskExecutionRunnable));
     }
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContext.java
@@ -29,6 +29,7 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -66,9 +67,15 @@ public class WorkflowTestCaseContext {
         if (CollectionUtils.isEmpty(workflows)) {
             throw new IllegalStateException("workflows is empty");
         }
-        return workflows.stream()
+        List<WorkflowDefinition> collect = workflows.stream()
                 .filter(workflow -> workflow.getName().equals(name))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Workflow with name " + name + " not found"));
+                .collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(collect)) {
+            throw new IllegalStateException("Workflow with name " + name + " not found");
+        }
+        if (collect.size() > 1) {
+            throw new IllegalStateException("Multiple workflows with name " + name + " found");
+        }
+        return collect.get(0);
     }
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContextFactory.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/WorkflowTestCaseContextFactory.java
@@ -90,34 +90,36 @@ public class WorkflowTestCaseContextFactory {
         initializeWorkflowDefinitionToDB(workflowTestCaseContext.getWorkflows());
         initializeTaskDefinitionsToDB(workflowTestCaseContext.getTasks());
         initializeTaskRelationsToDB(workflowTestCaseContext.getTaskRelations());
-        if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getWorkflowInstances())) {
-            initializeWorkflowInstancesToDB(workflowTestCaseContext.getWorkflowInstances());
-        }
-        if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getTaskInstances())) {
-            initializeTaskInstancesToDB(workflowTestCaseContext.getTaskInstances());
-        }
-        if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getTaskGroups())) {
-            initializeTaskGroupsToDB(workflowTestCaseContext.getTaskGroups());
-        }
-        if (CollectionUtils.isNotEmpty(workflowTestCaseContext.getEnvironments())) {
-            initializeEnvironmentToDB(workflowTestCaseContext.getEnvironments());
-        }
+
+        initializeWorkflowInstancesToDB(workflowTestCaseContext.getWorkflowInstances());
+        initializeTaskInstancesToDB(workflowTestCaseContext.getTaskInstances());
+        initializeTaskGroupsToDB(workflowTestCaseContext.getTaskGroups());
+        initializeEnvironmentToDB(workflowTestCaseContext.getEnvironments());
         return workflowTestCaseContext;
     }
 
     private void initializeTaskInstancesToDB(List<TaskInstance> taskInstances) {
+        if (CollectionUtils.isEmpty(taskInstances)) {
+            return;
+        }
         for (TaskInstance taskInstance : taskInstances) {
             taskInstanceDao.insert(taskInstance);
         }
     }
 
     private void initializeWorkflowInstancesToDB(List<WorkflowInstance> workflowInstances) {
+        if (CollectionUtils.isEmpty(workflowInstances)) {
+            return;
+        }
         for (WorkflowInstance workflowInstance : workflowInstances) {
             workflowInstanceDao.insert(workflowInstance);
         }
     }
 
     private void initializeWorkflowDefinitionToDB(final List<WorkflowDefinition> workflowDefinitions) {
+        if (CollectionUtils.isEmpty(workflowDefinitions)) {
+            return;
+        }
         for (final WorkflowDefinition workflowDefinition : workflowDefinitions) {
             workflowDefinitionDao.insert(workflowDefinition);
             final WorkflowDefinitionLog workflowDefinitionLog = new WorkflowDefinitionLog(workflowDefinition);
@@ -128,6 +130,9 @@ public class WorkflowTestCaseContextFactory {
     }
 
     private void initializeTaskDefinitionsToDB(final List<TaskDefinition> taskDefinitions) {
+        if (CollectionUtils.isEmpty(taskDefinitions)) {
+            return;
+        }
         for (final TaskDefinition taskDefinition : taskDefinitions) {
             taskDefinitionDao.insert(taskDefinition);
 
@@ -139,6 +144,9 @@ public class WorkflowTestCaseContextFactory {
     }
 
     private void initializeTaskRelationsToDB(final List<WorkflowTaskRelation> taskRelations) {
+        if (CollectionUtils.isEmpty(taskRelations)) {
+            return;
+        }
         for (final WorkflowTaskRelation taskRelation : taskRelations) {
             workflowTaskRelationMapper.insert(taskRelation);
 
@@ -153,12 +161,18 @@ public class WorkflowTestCaseContextFactory {
     }
 
     private void initializeTaskGroupsToDB(final List<TaskGroup> taskGroups) {
+        if (CollectionUtils.isEmpty(taskGroups)) {
+            return;
+        }
         for (final TaskGroup taskGroup : taskGroups) {
             taskGroupDao.insert(taskGroup);
         }
     }
 
     private void initializeEnvironmentToDB(final List<Environment> environments) {
+        if (CollectionUtils.isEmpty(environments)) {
+            return;
+        }
         for (final Environment environment : environments) {
             environmentDao.insert(environment);
         }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

NO

## Purpose of the pull request

After #18146, the `canTriggerSuccessor` is useless, we should remove this.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request


This pull request is already covered by existing IT tests.


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
