### PR TITLE
[Improvement-18137][Master] Rename IWorkflowExecutionRunnable/ITaskExecutionRunnable to IWorkflowExecution/ITaskExecution

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/ILifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/ILifecycleEventHandler.java
@@ -17,14 +17,14 @@
 
 package org.apache.dolphinscheduler.server.master.engine;
 
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 /**
  * The event handler interface, used to handle the event
  */
 public interface ILifecycleEventHandler<T extends AbstractLifecycleEvent> {
 
-    void handle(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void handle(final IWorkflowExecution workflowExecution,
                 final T event);
 
     ILifecycleEventType matchEventType();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/IWorkflowRepository.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/IWorkflowRepository.java
@@ -17,7 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.engine;
 
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import java.util.Collection;
 
@@ -25,11 +25,11 @@ import lombok.NonNull;
 
 public interface IWorkflowRepository {
 
-    IWorkflowExecutionRunnable get(int workflowInstanceId);
+    IWorkflowExecution get(int workflowInstanceId);
 
-    Collection<IWorkflowExecutionRunnable> getAll();
+    Collection<IWorkflowExecution> getAll();
 
-    void put(@NonNull IWorkflowExecutionRunnable workflowExecuteThread);
+    void put(@NonNull IWorkflowExecution workflowExecuteThread);
 
     boolean contains(int workflowInstanceId);
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/WorkflowCacheRepository.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/WorkflowCacheRepository.java
@@ -17,7 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.engine;
 
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.metrics.WorkflowInstanceMetrics;
 
 import java.util.Collection;
@@ -35,37 +35,37 @@ import com.google.common.collect.ImmutableList;
 @Component
 public class WorkflowCacheRepository implements IWorkflowRepository {
 
-    private final Map<Integer, IWorkflowExecutionRunnable> workflowExecutionRunnableMap = new ConcurrentHashMap<>();
+    private final Map<Integer, IWorkflowExecution> workflowExecutionMap = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void registerMetrics() {
-        WorkflowInstanceMetrics.registerWorkflowInstanceRunningGauge(workflowExecutionRunnableMap::size);
+        WorkflowInstanceMetrics.registerWorkflowInstanceRunningGauge(workflowExecutionMap::size);
     }
 
     @Override
-    public IWorkflowExecutionRunnable get(final int workflowInstanceId) {
-        return workflowExecutionRunnableMap.get(workflowInstanceId);
+    public IWorkflowExecution get(final int workflowInstanceId) {
+        return workflowExecutionMap.get(workflowInstanceId);
     }
 
     @Override
     public boolean contains(final int workflowInstanceId) {
-        return workflowExecutionRunnableMap.containsKey(workflowInstanceId);
+        return workflowExecutionMap.containsKey(workflowInstanceId);
     }
 
     @Override
     public void remove(final int workflowInstanceId) {
-        workflowExecutionRunnableMap.remove(workflowInstanceId);
+        workflowExecutionMap.remove(workflowInstanceId);
     }
 
     @Override
-    public void put(@NonNull final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final Integer workflowInstanceId = workflowExecutionRunnable.getId();
-        workflowExecutionRunnableMap.put(workflowInstanceId, workflowExecutionRunnable);
+    public void put(@NonNull final IWorkflowExecution workflowExecution) {
+        final Integer workflowInstanceId = workflowExecution.getId();
+        workflowExecutionMap.put(workflowInstanceId, workflowExecution);
     }
 
     @Override
-    public Collection<IWorkflowExecutionRunnable> getAll() {
-        return ImmutableList.copyOf(workflowExecutionRunnableMap.values());
+    public Collection<IWorkflowExecution> getAll() {
+        return ImmutableList.copyOf(workflowExecutionMap.values());
     }
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/WorkflowEventBusCoordinator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/WorkflowEventBusCoordinator.java
@@ -18,7 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine;
 
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.runner.IWorkflowExecuteContext;
 
 import lombok.extern.slf4j.Slf4j;
@@ -44,20 +44,20 @@ public class WorkflowEventBusCoordinator implements AutoCloseable {
      * Register a WorkflowExecuteRunnable to the corresponding WorkflowEventBusFireWorker, once the WorkflowExecuteRunnable has been registered,
      * then the event will auto handler by the WorkflowEventBusFireWorker
      */
-    public void registerWorkflowEventBus(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final int workerSlot = calculateWorkflowEventBusFireWorkerSlot(workflowExecutionRunnable);
+    public void registerWorkflowEventBus(IWorkflowExecution workflowExecution) {
+        final int workerSlot = calculateWorkflowEventBusFireWorkerSlot(workflowExecution);
         final WorkflowEventBusFireWorker workflowEventBusFireWorker = workflowEventBusFireWorkers.getWorker(workerSlot);
-        workflowEventBusFireWorker.registerWorkflowEventBus(workflowExecutionRunnable);
+        workflowEventBusFireWorker.registerWorkflowEventBus(workflowExecution);
     }
 
     /**
      * UeRegister a WorkflowExecuteRunnable to the corresponding WorkflowEventBusFireWorker, once the WorkflowExecuteRunnable has been deregistered,
      * then the EventBus will be removed from the WorkflowEventBusFireWorker.
      */
-    public void unRegisterWorkflowEventBus(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final int workerSlot = calculateWorkflowEventBusFireWorkerSlot(workflowExecutionRunnable);
+    public void unRegisterWorkflowEventBus(IWorkflowExecution workflowExecution) {
+        final int workerSlot = calculateWorkflowEventBusFireWorkerSlot(workflowExecution);
         final WorkflowEventBusFireWorker workflowEventBusFireWorker = workflowEventBusFireWorkers.getWorker(workerSlot);
-        workflowEventBusFireWorker.unRegisterWorkflowEventBus(workflowExecutionRunnable);
+        workflowEventBusFireWorker.unRegisterWorkflowEventBus(workflowExecution);
     }
 
     /**
@@ -66,8 +66,8 @@ public class WorkflowEventBusCoordinator implements AutoCloseable {
      * <p> e.g. If the workflowInstanceId is 1, and the workerSize is 3, then the slot is 1, the workflow will be registered to the worker[1].
      * <p> If the workflowInstanceIds are not consecutive numbers, these will cause some worker busy.
      */
-    private int calculateWorkflowEventBusFireWorkerSlot(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final IWorkflowExecuteContext workflowExecuteContext = workflowExecutionRunnable.getWorkflowExecuteContext();
+    private int calculateWorkflowEventBusFireWorkerSlot(IWorkflowExecution workflowExecution) {
+        final IWorkflowExecuteContext workflowExecuteContext = workflowExecution.getWorkflowExecuteContext();
         final WorkflowInstance workflowInstance = workflowExecuteContext.getWorkflowInstance();
         final Integer workflowInstanceId = workflowInstance.getId();
         return workflowInstanceId % workflowEventBusFireWorkers.getWorkerSize();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/WorkflowEventBusFireWorker.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/WorkflowEventBusFireWorker.java
@@ -26,7 +26,7 @@ import org.apache.dolphinscheduler.plugin.task.api.utils.LogUtils;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.WorkflowEventFireException;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFatalLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.runner.IWorkflowExecuteContext;
 import org.apache.dolphinscheduler.server.master.utils.ExceptionUtils;
 
@@ -47,7 +47,7 @@ import lombok.extern.slf4j.Slf4j;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class WorkflowEventBusFireWorker {
 
-    private final Map<Integer, IWorkflowExecutionRunnable> registeredWorkflowExecuteRunnableMap =
+    private final Map<Integer, IWorkflowExecution> registeredWorkflowExecuteRunnableMap =
             new ConcurrentHashMap<>();
 
     private final Map<ILifecycleEventType, ILifecycleEventHandler> eventHandlerMap = new ConcurrentHashMap<>();
@@ -58,35 +58,35 @@ public class WorkflowEventBusFireWorker {
         eventHandlerMap.put(eventHandler.matchEventType(), eventHandler);
     }
 
-    public void registerWorkflowEventBus(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final IWorkflowExecuteContext workflowExecuteContext = workflowExecutionRunnable.getWorkflowExecuteContext();
+    public void registerWorkflowEventBus(IWorkflowExecution workflowExecution) {
+        final IWorkflowExecuteContext workflowExecuteContext = workflowExecution.getWorkflowExecuteContext();
         final WorkflowInstance workflowInstance = workflowExecuteContext.getWorkflowInstance();
         final Integer workflowInstanceId = workflowInstance.getId();
         final String workflowInstanceName = workflowInstance.getName();
         checkState(!registeredWorkflowExecuteRunnableMap.containsKey(workflowInstanceId),
                 "WorkflowExecuteRunnable(%s/%s already registered at WorkflowEventBusFireWorker", workflowInstanceId,
                 workflowInstanceName);
-        registeredWorkflowExecuteRunnableMap.put(workflowInstanceId, workflowExecutionRunnable);
+        registeredWorkflowExecuteRunnableMap.put(workflowInstanceId, workflowExecution);
     }
 
-    public void unRegisterWorkflowEventBus(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final IWorkflowExecuteContext workflowExecuteContext = workflowExecutionRunnable.getWorkflowExecuteContext();
+    public void unRegisterWorkflowEventBus(IWorkflowExecution workflowExecution) {
+        final IWorkflowExecuteContext workflowExecuteContext = workflowExecution.getWorkflowExecuteContext();
         final WorkflowInstance workflowInstance = workflowExecuteContext.getWorkflowInstance();
         final Integer workflowInstanceId = workflowInstance.getId();
-        registeredWorkflowExecuteRunnableMap.remove(workflowInstanceId, workflowExecutionRunnable);
+        registeredWorkflowExecuteRunnableMap.remove(workflowInstanceId, workflowExecution);
     }
 
     public void fireAllRegisteredEvent() {
-        final List<IWorkflowExecutionRunnable> workflowExecutionRunnables = getWaitingFireWorkflowExecutionRunnables();
-        if (CollectionUtils.isEmpty(workflowExecutionRunnables)) {
+        final List<IWorkflowExecution> workflowExecutions = getWaitingFireWorkflowExecutions();
+        if (CollectionUtils.isEmpty(workflowExecutions)) {
             return;
         }
-        for (final IWorkflowExecutionRunnable workflowExecutionRunnable : workflowExecutionRunnables) {
-            final Integer workflowInstanceId = workflowExecutionRunnable.getId();
-            final String workflowInstanceName = workflowExecutionRunnable.getName();
+        for (final IWorkflowExecution workflowExecution : workflowExecutions) {
+            final Integer workflowInstanceId = workflowExecution.getId();
+            final String workflowInstanceName = workflowExecution.getName();
             try {
                 LogUtils.setWorkflowInstanceIdMDC(workflowInstanceId);
-                doFireSingleWorkflowEventBus(workflowExecutionRunnable);
+                doFireSingleWorkflowEventBus(workflowExecution);
             } catch (Exception ex) {
                 log.error("Fire event failed for WorkflowExecuteRunnable: {}", workflowInstanceName, ex);
             } finally {
@@ -99,7 +99,7 @@ public class WorkflowEventBusFireWorker {
         return registeredWorkflowExecuteRunnableMap.size();
     }
 
-    private List<IWorkflowExecutionRunnable> getWaitingFireWorkflowExecutionRunnables() {
+    private List<IWorkflowExecution> getWaitingFireWorkflowExecutions() {
         if (MapUtils.isEmpty(registeredWorkflowExecuteRunnableMap)) {
             return Collections.emptyList();
         }
@@ -109,8 +109,8 @@ public class WorkflowEventBusFireWorker {
                 .collect(Collectors.toList());
     }
 
-    private void doFireSingleWorkflowEventBus(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final WorkflowEventBus workflowEventBus = workflowExecutionRunnable.getWorkflowEventBus();
+    private void doFireSingleWorkflowEventBus(final IWorkflowExecution workflowExecution) {
+        final WorkflowEventBus workflowEventBus = workflowExecution.getWorkflowEventBus();
         while (!workflowEventBus.isEmpty()) {
             Optional<AbstractLifecycleEvent> eventOptional = workflowEventBus.poll();
             if (!eventOptional.isPresent()) {
@@ -122,7 +122,7 @@ public class WorkflowEventBusFireWorker {
                 // So we increase the event count before the event fired then we can get the correct event count
                 // And if the event handle failed we will decrease the success event count
                 workflowEventBus.getWorkflowEventBusSummary().increaseFireSuccessEventCount();
-                doFireSingleEvent(workflowExecutionRunnable, lifecycleEvent);
+                doFireSingleEvent(workflowExecution, lifecycleEvent);
             } catch (Exception ex) {
                 // If the database connection is failed, do not remove the event from the event bus
                 // so that the event can be fired again when the database connection is recovered
@@ -136,7 +136,7 @@ public class WorkflowEventBusFireWorker {
                 if (ExceptionUtils.isTaskExecutionContextCreateException(ex)) {
                     AbstractTaskLifecycleEvent taskLifecycleEvent = (AbstractTaskLifecycleEvent) lifecycleEvent;
                     final TaskFatalLifecycleEvent taskFatalEvent = TaskFatalLifecycleEvent.builder()
-                            .taskExecutionRunnable(taskLifecycleEvent.getTaskExecutionRunnable())
+                            .taskExecution(taskLifecycleEvent.getTaskExecution())
                             .endTime(new Date())
                             .build();
                     workflowEventBus.publish(taskFatalEvent);
@@ -149,13 +149,13 @@ public class WorkflowEventBusFireWorker {
         }
     }
 
-    private void doFireSingleEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    private void doFireSingleEvent(final IWorkflowExecution workflowExecution,
                                    final AbstractLifecycleEvent event) {
         final ILifecycleEventHandler lifecycleEventHandler = eventHandlerMap.get(event.getEventType());
         if (lifecycleEventHandler == null) {
             throw new RuntimeException("No EventHandler found for event: " + event.getEventType());
         }
-        lifecycleEventHandler.handle(workflowExecutionRunnable, event);
+        lifecycleEventHandler.handle(workflowExecution, event);
     }
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/CommandEngine.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/CommandEngine.java
@@ -35,9 +35,9 @@ import org.apache.dolphinscheduler.server.master.config.MasterServerLoadProtecti
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBusCoordinator;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.CommandDuplicateHandleException;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecutionFactory;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStartLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnableFactory;
 import org.apache.dolphinscheduler.server.master.metrics.MasterServerMetrics;
 import org.apache.dolphinscheduler.server.master.metrics.WorkflowInstanceMetrics;
 import org.apache.dolphinscheduler.service.command.CommandService;
@@ -82,7 +82,7 @@ public class CommandEngine extends BaseDaemonThread implements AutoCloseable {
     private WorkflowInstanceDao workflowInstanceDao;
 
     @Autowired
-    private WorkflowExecutionRunnableFactory workflowExecutionRunnableFactory;
+    private WorkflowExecutionFactory workflowExecutionFactory;
 
     @Autowired
     private MetricsProvider metricsProvider;
@@ -144,7 +144,7 @@ public class CommandEngine extends BaseDaemonThread implements AutoCloseable {
                         return command;
                     }, commandHandleThreadPool)
                             .thenApply(this::bootstrapCommand)
-                            .thenAccept(this::bootstrapWorkflowExecutionRunnable)
+                            .thenAccept(this::bootstrapWorkflowExecution)
                             .thenAccept((unused) -> bootstrapSuccess(command))
                             .exceptionally(throwable -> bootstrapError(command, throwable))
                             .whenComplete((result, throwable) -> LogUtils.removeWorkflowInstanceIdMDC());
@@ -163,13 +163,13 @@ public class CommandEngine extends BaseDaemonThread implements AutoCloseable {
         }
     }
 
-    private IWorkflowExecutionRunnable bootstrapCommand(Command command) {
-        return workflowExecutionRunnableFactory.createWorkflowExecuteRunnable(command);
+    private IWorkflowExecution bootstrapCommand(Command command) {
+        return workflowExecutionFactory.createWorkflowExecuteRunnable(command);
     }
 
-    private CompletableFuture<Void> bootstrapWorkflowExecutionRunnable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    private CompletableFuture<Void> bootstrapWorkflowExecution(IWorkflowExecution workflowExecution) {
         final WorkflowInstance workflowInstance =
-                workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowInstance();
+                workflowExecution.getWorkflowExecuteContext().getWorkflowInstance();
 
         if (workflowInstance.getState() == WorkflowExecutionStatus.SERIAL_WAIT) {
             log.info("The workflow {} state is: {} will not be trigger now",
@@ -179,10 +179,10 @@ public class CommandEngine extends BaseDaemonThread implements AutoCloseable {
         }
 
         WorkflowInstanceMetrics.recordWorkflowInstanceSubmit(workflowInstance.getWorkflowDefinitionCode());
-        workflowRepository.put(workflowExecutionRunnable);
-        workflowEventBusCoordinator.registerWorkflowEventBus(workflowExecutionRunnable);
-        workflowExecutionRunnable.getWorkflowEventBus()
-                .publish(WorkflowStartLifecycleEvent.of(workflowExecutionRunnable));
+        workflowRepository.put(workflowExecution);
+        workflowEventBusCoordinator.registerWorkflowEventBus(workflowExecution);
+        workflowExecution.getWorkflowEventBus()
+                .publish(WorkflowStartLifecycleEvent.of(workflowExecution));
         return CompletableFuture.completedFuture(null);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/ICommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/ICommandHandler.java
@@ -22,7 +22,7 @@ import org.apache.dolphinscheduler.dao.entity.Command;
 import org.apache.dolphinscheduler.server.master.engine.command.handler.ReRunWorkflowCommandHandler;
 import org.apache.dolphinscheduler.server.master.engine.command.handler.RecoverFailureTaskCommandHandler;
 import org.apache.dolphinscheduler.server.master.engine.command.handler.RunWorkflowCommandHandler;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecution;
 
 /**
  * The interface represent the handler used to handle the {@link Command}.
@@ -35,9 +35,9 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.Workfl
 public interface ICommandHandler {
 
     /**
-     * Handle the command and return the WorkflowExecutionRunnable.
+     * Handle the command and return the WorkflowExecution.
      */
-    WorkflowExecutionRunnable handleCommand(final Command command);
+    WorkflowExecution handleCommand(final Command command);
 
     /**
      * The type of the command which should be handled by this handler.

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/AbstractCommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/AbstractCommandHandler.java
@@ -34,9 +34,9 @@ import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.command.ICommandHandler;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowGraphFactory;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecutionBuilder;
 import org.apache.dolphinscheduler.server.master.engine.workflow.listener.IWorkflowLifecycleListener;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnableBuilder;
 import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext;
 import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext.WorkflowExecuteContextBuilder;
 
@@ -70,7 +70,7 @@ public abstract class AbstractCommandHandler implements ICommandHandler {
     protected ProjectDao projectDao;
 
     @Override
-    public WorkflowExecutionRunnable handleCommand(final Command command) {
+    public WorkflowExecution handleCommand(final Command command) {
         final WorkflowExecuteContextBuilder workflowExecuteContextBuilder = WorkflowExecuteContext.builder()
                 .withCommand(command);
 
@@ -82,12 +82,12 @@ public abstract class AbstractCommandHandler implements ICommandHandler {
         assembleWorkflowEventBus(workflowExecuteContextBuilder);
         assembleWorkflowExecutionGraph(workflowExecuteContextBuilder);
 
-        final WorkflowExecutionRunnableBuilder workflowExecutionRunnableBuilder = WorkflowExecutionRunnableBuilder
+        final WorkflowExecutionBuilder workflowExecutionBuilder = WorkflowExecutionBuilder
                 .builder()
                 .workflowExecuteContextBuilder(workflowExecuteContextBuilder)
                 .applicationContext(applicationContext)
                 .build();
-        return new WorkflowExecutionRunnable(workflowExecutionRunnableBuilder);
+        return new WorkflowExecution(workflowExecutionBuilder);
     }
 
     protected void assembleWorkflowEventBus(

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/ExecuteTaskCommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/ExecuteTaskCommandHandler.java
@@ -33,8 +33,8 @@ import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowGraphTopologyLogicalVisitor;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnableBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecutionBuilder;
 import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext.WorkflowExecuteContextBuilder;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -119,9 +119,9 @@ public class ExecuteTaskCommandHandler extends AbstractCommandHandler {
         }
 
         final WorkflowExecutionGraph workflowExecutionGraph = new WorkflowExecutionGraph();
-        final BiConsumer<String, Set<String>> taskExecutionRunnableCreator = (task, successors) -> {
-            final TaskExecutionRunnableBuilder taskExecutionRunnableBuilder =
-                    TaskExecutionRunnableBuilder
+        final BiConsumer<String, Set<String>> taskExecutionCreator = (task, successors) -> {
+            final TaskExecutionBuilder taskExecutionBuilder =
+                    TaskExecutionBuilder
                             .builder()
                             .workflowExecutionGraph(workflowExecutionGraph)
                             .workflowDefinition(workflowExecuteContextBuilder.getWorkflowDefinition())
@@ -132,7 +132,7 @@ public class ExecuteTaskCommandHandler extends AbstractCommandHandler {
                             .workflowEventBus(workflowExecuteContextBuilder.getWorkflowEventBus())
                             .applicationContext(applicationContext)
                             .build();
-            workflowExecutionGraph.addNode(new TaskExecutionRunnable(taskExecutionRunnableBuilder));
+            workflowExecutionGraph.addNode(new TaskExecution(taskExecutionBuilder));
             workflowExecutionGraph.addEdge(task, successors);
         };
 
@@ -141,7 +141,7 @@ public class ExecuteTaskCommandHandler extends AbstractCommandHandler {
                         .taskDependType(workflowExecuteContextBuilder.getWorkflowInstance().getTaskDependType())
                         .onWorkflowGraph(workflowGraph)
                         .fromTask(startNodes)
-                        .doVisitFunction(taskExecutionRunnableCreator)
+                        .doVisitFunction(taskExecutionCreator)
                         .build();
         workflowGraphTopologyLogicalVisitor.visit();
         workflowExecutionGraph.removeUnReachableEdge();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/RecoverFailureTaskCommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/RecoverFailureTaskCommandHandler.java
@@ -29,9 +29,9 @@ import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowGraphTopologyLogicalVisitor;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnableBuilder;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskInstanceFactories;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecutionBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskInstanceFactories;
 import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext.WorkflowExecuteContextBuilder;
 
 import java.util.ArrayList;
@@ -114,9 +114,9 @@ public class RecoverFailureTaskCommandHandler extends AbstractCommandHandler {
         final IWorkflowGraph workflowGraph = workflowExecuteContextBuilder.getWorkflowGraph();
         final WorkflowExecutionGraph workflowExecutionGraph = new WorkflowExecutionGraph();
 
-        final BiConsumer<String, Set<String>> taskExecutionRunnableCreator = (task, successors) -> {
-            final TaskExecutionRunnableBuilder taskExecutionRunnableBuilder =
-                    TaskExecutionRunnableBuilder
+        final BiConsumer<String, Set<String>> taskExecutionCreator = (task, successors) -> {
+            final TaskExecutionBuilder taskExecutionBuilder =
+                    TaskExecutionBuilder
                             .builder()
                             .workflowExecutionGraph(workflowExecutionGraph)
                             .workflowDefinition(workflowExecuteContextBuilder.getWorkflowDefinition())
@@ -127,7 +127,7 @@ public class RecoverFailureTaskCommandHandler extends AbstractCommandHandler {
                             .workflowEventBus(workflowExecuteContextBuilder.getWorkflowEventBus())
                             .applicationContext(applicationContext)
                             .build();
-            workflowExecutionGraph.addNode(new TaskExecutionRunnable(taskExecutionRunnableBuilder));
+            workflowExecutionGraph.addNode(new TaskExecution(taskExecutionBuilder));
             workflowExecutionGraph.addEdge(task, successors);
         };
 
@@ -136,7 +136,7 @@ public class RecoverFailureTaskCommandHandler extends AbstractCommandHandler {
                         .taskDependType(workflowExecuteContextBuilder.getWorkflowInstance().getTaskDependType())
                         .onWorkflowGraph(workflowGraph)
                         .fromTask(parseStartNodesFromWorkflowInstance(workflowExecuteContextBuilder))
-                        .doVisitFunction(taskExecutionRunnableCreator)
+                        .doVisitFunction(taskExecutionCreator)
                         .build();
         workflowGraphTopologyLogicalVisitor.visit();
         workflowExecutionGraph.removeUnReachableEdge();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/RunWorkflowCommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/RunWorkflowCommandHandler.java
@@ -32,8 +32,8 @@ import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowGraphTopologyLogicalVisitor;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnableBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecutionBuilder;
 import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext.WorkflowExecuteContextBuilder;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -85,9 +85,9 @@ public class RunWorkflowCommandHandler extends AbstractCommandHandler {
     protected void assembleWorkflowExecutionGraph(final WorkflowExecuteContextBuilder workflowExecuteContextBuilder) {
         final IWorkflowGraph workflowGraph = workflowExecuteContextBuilder.getWorkflowGraph();
         final WorkflowExecutionGraph workflowExecutionGraph = new WorkflowExecutionGraph();
-        final BiConsumer<String, Set<String>> taskExecutionRunnableCreator = (task, successors) -> {
-            final TaskExecutionRunnableBuilder taskExecutionRunnableBuilder =
-                    TaskExecutionRunnableBuilder
+        final BiConsumer<String, Set<String>> taskExecutionCreator = (task, successors) -> {
+            final TaskExecutionBuilder taskExecutionBuilder =
+                    TaskExecutionBuilder
                             .builder()
                             .workflowExecutionGraph(workflowExecutionGraph)
                             .workflowDefinition(workflowExecuteContextBuilder.getWorkflowDefinition())
@@ -97,7 +97,7 @@ public class RunWorkflowCommandHandler extends AbstractCommandHandler {
                             .workflowEventBus(workflowExecuteContextBuilder.getWorkflowEventBus())
                             .applicationContext(applicationContext)
                             .build();
-            workflowExecutionGraph.addNode(new TaskExecutionRunnable(taskExecutionRunnableBuilder));
+            workflowExecutionGraph.addNode(new TaskExecution(taskExecutionBuilder));
             workflowExecutionGraph.addEdge(task, successors);
         };
 
@@ -106,7 +106,7 @@ public class RunWorkflowCommandHandler extends AbstractCommandHandler {
                         .taskDependType(workflowExecuteContextBuilder.getWorkflowInstance().getTaskDependType())
                         .onWorkflowGraph(workflowGraph)
                         .fromTask(parseStartNodesFromWorkflowInstance(workflowExecuteContextBuilder))
-                        .doVisitFunction(taskExecutionRunnableCreator)
+                        .doVisitFunction(taskExecutionCreator)
                         .build();
         workflowGraphTopologyLogicalVisitor.visit();
         workflowExecutionGraph.removeUnReachableEdge();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/WorkflowFailoverCommandHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/handler/WorkflowFailoverCommandHandler.java
@@ -28,8 +28,8 @@ import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.WorkflowGraphTopologyLogicalVisitor;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionRunnableBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecutionBuilder;
 import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext.WorkflowExecuteContextBuilder;
 
 import java.util.Date;
@@ -108,9 +108,9 @@ public class WorkflowFailoverCommandHandler extends AbstractCommandHandler {
         final IWorkflowGraph workflowGraph = workflowExecuteContextBuilder.getWorkflowGraph();
         final WorkflowExecutionGraph workflowExecutionGraph = new WorkflowExecutionGraph();
 
-        final BiConsumer<String, Set<String>> taskExecutionRunnableCreator = (task, successors) -> {
-            final TaskExecutionRunnableBuilder taskExecutionRunnableBuilder =
-                    TaskExecutionRunnableBuilder
+        final BiConsumer<String, Set<String>> taskExecutionCreator = (task, successors) -> {
+            final TaskExecutionBuilder taskExecutionBuilder =
+                    TaskExecutionBuilder
                             .builder()
                             .workflowExecutionGraph(workflowExecutionGraph)
                             .workflowDefinition(workflowExecuteContextBuilder.getWorkflowDefinition())
@@ -121,7 +121,7 @@ public class WorkflowFailoverCommandHandler extends AbstractCommandHandler {
                             .workflowEventBus(workflowExecuteContextBuilder.getWorkflowEventBus())
                             .applicationContext(applicationContext)
                             .build();
-            workflowExecutionGraph.addNode(new TaskExecutionRunnable(taskExecutionRunnableBuilder));
+            workflowExecutionGraph.addNode(new TaskExecution(taskExecutionBuilder));
             workflowExecutionGraph.addEdge(task, successors);
         };
 
@@ -130,7 +130,7 @@ public class WorkflowFailoverCommandHandler extends AbstractCommandHandler {
                         .taskDependType(workflowExecuteContextBuilder.getWorkflowInstance().getTaskDependType())
                         .onWorkflowGraph(workflowGraph)
                         .fromTask(parseStartNodesFromWorkflowInstance(workflowExecuteContextBuilder))
-                        .doVisitFunction(taskExecutionRunnableCreator)
+                        .doVisitFunction(taskExecutionCreator)
                         .build();
         workflowGraphTopologyLogicalVisitor.visit();
         workflowExecutionGraph.removeUnReachableEdge();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/condition/ConditionLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/condition/ConditionLogicTask.java
@@ -27,7 +27,7 @@ import org.apache.dolphinscheduler.plugin.task.api.parameters.ConditionsParamete
 import org.apache.dolphinscheduler.plugin.task.api.utils.DependentUtils;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.AbstractLogicTask;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
 
 import java.util.List;
@@ -47,14 +47,14 @@ public class ConditionLogicTask extends AbstractLogicTask<ConditionsParameters> 
 
     private final TaskInstance taskInstance;
 
-    public ConditionLogicTask(IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public ConditionLogicTask(IWorkflowExecution workflowExecution,
                               TaskExecutionContext taskExecutionContext,
                               TaskInstanceDao taskInstanceDao) {
         super(taskExecutionContext);
-        this.taskInstance = workflowExecutionRunnable
+        this.taskInstance = workflowExecution
                 .getWorkflowExecuteContext()
                 .getWorkflowExecutionGraph()
-                .getTaskExecutionRunnableById(taskExecutionContext.getTaskInstanceId())
+                .getTaskExecutionById(taskExecutionContext.getTaskInstanceId())
                 .getTaskInstance();
         this.taskInstanceDao = taskInstanceDao;
         onTaskRunning();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/condition/ConditionLogicTaskPluginFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/condition/ConditionLogicTaskPluginFactory.java
@@ -22,7 +22,7 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.task.ConditionsLogicTaskChannelFactory;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ILogicTaskPluginFactory;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -38,14 +38,14 @@ public class ConditionLogicTaskPluginFactory implements ILogicTaskPluginFactory<
     private TaskInstanceDao taskInstanceDao;
 
     @Autowired
-    private IWorkflowRepository workflowExecutionRunnableMemoryRepository;
+    private IWorkflowRepository workflowExecutionMemoryRepository;
 
     @Override
     public ConditionLogicTask createLogicTask(final ITaskExecutor taskExecutor) {
         final TaskExecutionContext taskExecutionContext = taskExecutor.getTaskExecutionContext();
-        final IWorkflowExecutionRunnable workflowExecutionRunnable =
-                workflowExecutionRunnableMemoryRepository.get(taskExecutionContext.getWorkflowInstanceId());
-        return new ConditionLogicTask(workflowExecutionRunnable, taskExecutionContext, taskInstanceDao);
+        final IWorkflowExecution workflowExecution =
+                workflowExecutionMemoryRepository.get(taskExecutionContext.getWorkflowInstanceId());
+        return new ConditionLogicTask(workflowExecution, taskExecutionContext, taskInstanceDao);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/dependent/DependentLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/dependent/DependentLogicTask.java
@@ -29,7 +29,7 @@ import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.DependentParameters;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.AbstractLogicTask;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -49,7 +49,7 @@ public class DependentLogicTask extends AbstractLogicTask<DependentParameters> {
                               TaskDefinitionDao taskDefinitionDao,
                               TaskInstanceDao taskInstanceDao,
                               WorkflowInstanceDao workflowInstanceDao,
-                              IWorkflowExecutionRunnable workflowExecutionRunnable,
+                              IWorkflowExecution workflowExecution,
                               TaskInstanceContextDao taskInstanceContextDao) {
         super(taskExecutionContext);
         this.taskExecutionContext = taskExecutionContext;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/dependent/DependentLogicTaskPluginFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/dependent/DependentLogicTaskPluginFactory.java
@@ -27,7 +27,7 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.task.DependentLogicTaskChannelFactory;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ILogicTaskPluginFactory;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.exception.LogicTaskInitializeException;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 
@@ -65,8 +65,8 @@ public class DependentLogicTaskPluginFactory implements ILogicTaskPluginFactory<
     public DependentLogicTask createLogicTask(final ITaskExecutor taskExecutor) throws LogicTaskInitializeException {
         final TaskExecutionContext taskExecutionContext = taskExecutor.getTaskExecutionContext();
         final int workflowInstanceId = taskExecutionContext.getWorkflowInstanceId();
-        final IWorkflowExecutionRunnable workflowExecutionRunnable = IWorkflowRepository.get(workflowInstanceId);
-        if (workflowExecutionRunnable == null) {
+        final IWorkflowExecution workflowExecution = IWorkflowRepository.get(workflowInstanceId);
+        if (workflowExecution == null) {
             throw new LogicTaskInitializeException("Cannot find the WorkflowExecuteRunnable: " + workflowInstanceId);
         }
         return new DependentLogicTask(
@@ -76,7 +76,7 @@ public class DependentLogicTaskPluginFactory implements ILogicTaskPluginFactory<
                 taskDefinitionDao,
                 taskInstanceDao,
                 workflowInstanceDao,
-                workflowExecutionRunnable,
+                workflowExecution,
                 taskInstanceContextDao);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTask.java
@@ -42,7 +42,7 @@ import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.SubWorkflowParameters;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.AbstractLogicTask;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.exception.MasterTaskExecuteException;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
@@ -66,7 +66,7 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
 
     private SubWorkflowLogicTaskRuntimeContext subWorkflowLogicTaskRuntimeContext;
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
     private final ApplicationContext applicationContext;
 
@@ -75,12 +75,12 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
     private ITaskExecutor taskExecutor;
 
     public SubWorkflowLogicTask(final TaskExecutionContext taskExecutionContext,
-                                final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final IWorkflowExecution workflowExecution,
                                 final ITaskExecutor taskExecutor,
                                 final ApplicationContext applicationContext) {
         super(taskExecutionContext);
         this.taskExecutor = taskExecutor;
-        this.workflowExecutionRunnable = workflowExecutionRunnable;
+        this.workflowExecution = workflowExecution;
         this.applicationContext = applicationContext;
         this.subWorkflowLogicTaskRuntimeContext = JSONUtils.parseObject(
                 taskExecutionContext.getAppIds(),
@@ -162,7 +162,7 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
 
         // In some cases, workflow instance's command type has not been changed,
         // there should better to use command.type instead
-        switch (workflowExecutionRunnable.getWorkflowExecuteContext().getCommand().getCommandType()) {
+        switch (workflowExecution.getWorkflowExecuteContext().getCommand().getCommandType()) {
             case RECOVER_TOLERANCE_FAULT_PROCESS:
                 return recoverFromFaultTolerantTasks();
             case RECOVER_SUSPENDED_PROCESS:
@@ -224,7 +224,7 @@ public class SubWorkflowLogicTask extends AbstractLogicTask<SubWorkflowParameter
     }
 
     private SubWorkflowLogicTaskRuntimeContext triggerNewSubWorkflow() {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
 
         final WorkflowDefinition subWorkflowDefinition = applicationContext.getBean(WorkflowDefinitionDao.class)
                 .queryByCode(taskParameters.getWorkflowDefinitionCode())

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTaskPluginFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/subworkflow/SubWorkflowLogicTaskPluginFactory.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.task.SubWorkflowLogicTaskChannelFactory;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ILogicTaskPluginFactory;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -47,10 +47,10 @@ public class SubWorkflowLogicTaskPluginFactory implements ILogicTaskPluginFactor
     public SubWorkflowLogicTask createLogicTask(final ITaskExecutor taskExecutor) {
         final TaskExecutionContext taskExecutionContext = taskExecutor.getTaskExecutionContext();
         final int workflowInstanceId = taskExecutionContext.getWorkflowInstanceId();
-        final IWorkflowExecutionRunnable workflowExecutionRunnable = workflowRepository.get(workflowInstanceId);
+        final IWorkflowExecution workflowExecution = workflowRepository.get(workflowInstanceId);
         return new SubWorkflowLogicTask(
                 taskExecutionContext,
-                workflowExecutionRunnable,
+                workflowExecution,
                 taskExecutor,
                 applicationContext);
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/switchtask/SwitchLogicTask.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/switchtask/SwitchLogicTask.java
@@ -27,7 +27,7 @@ import org.apache.dolphinscheduler.plugin.task.api.parameters.SwitchParameters;
 import org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.AbstractLogicTask;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ITaskParameterDeserializer;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.runner.IWorkflowExecuteContext;
 import org.apache.dolphinscheduler.server.master.utils.SwitchTaskUtils;
 
@@ -45,17 +45,17 @@ import com.fasterxml.jackson.core.type.TypeReference;
 @Slf4j
 public class SwitchLogicTask extends AbstractLogicTask<SwitchParameters> {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
     private final TaskInstance taskInstance;
 
-    public SwitchLogicTask(IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public SwitchLogicTask(IWorkflowExecution workflowExecution,
                            TaskExecutionContext taskExecutionContext) {
         super(taskExecutionContext);
-        this.workflowExecutionRunnable = workflowExecutionRunnable;
-        this.taskInstance = workflowExecutionRunnable
+        this.workflowExecution = workflowExecution;
+        this.taskInstance = workflowExecution
                 .getWorkflowExecuteContext()
                 .getWorkflowExecutionGraph()
-                .getTaskExecutionRunnableById(taskExecutionContext.getTaskInstanceId())
+                .getTaskExecutionById(taskExecutionContext.getTaskInstanceId())
                 .getTaskInstance();
         onTaskRunning();
     }
@@ -127,7 +127,7 @@ public class SwitchLogicTask extends AbstractLogicTask<SwitchParameters> {
         if (branchNode == null) {
             throw new IllegalArgumentException("The branch is empty, please check the switch task configuration");
         }
-        if (workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowGraph()
+        if (workflowExecution.getWorkflowExecuteContext().getWorkflowGraph()
                 .getTaskNodeByCode(branchNode) == null) {
             throw new IllegalArgumentException(
                     "The branch(code= " + branchNode
@@ -136,7 +136,7 @@ public class SwitchLogicTask extends AbstractLogicTask<SwitchParameters> {
     }
 
     private String getTaskName(Long taskCode) {
-        return Optional.ofNullable(workflowExecutionRunnable.getWorkflowExecuteContext())
+        return Optional.ofNullable(workflowExecution.getWorkflowExecuteContext())
                 .map(IWorkflowExecuteContext::getWorkflowGraph)
                 .map(iWorkflowGraph -> iWorkflowGraph.getTaskNodeByCode(taskCode))
                 .map(TaskDefinition::getName)

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/switchtask/SwitchLogicTaskPluginFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/executor/plugin/switchtask/SwitchLogicTaskPluginFactory.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.task.SwitchLogicTaskChannelFactory;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ILogicTaskPluginFactory;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.exception.LogicTaskInitializeException;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 
@@ -41,13 +41,13 @@ public class SwitchLogicTaskPluginFactory implements ILogicTaskPluginFactory<Swi
     public SwitchLogicTask createLogicTask(final ITaskExecutor taskExecutor) throws LogicTaskInitializeException {
         final TaskExecutionContext taskExecutionContext = taskExecutor.getTaskExecutionContext();
         final int workflowInstanceId = taskExecutionContext.getWorkflowInstanceId();
-        IWorkflowExecutionRunnable workflowExecutionRunnable =
+        IWorkflowExecution workflowExecution =
                 IWorkflowRepository.get(workflowInstanceId);
-        if (workflowExecutionRunnable == null) {
+        if (workflowExecution == null) {
             throw new LogicTaskInitializeException(
                     "Cannot find the WorkflowExecuteRunnable by : " + workflowInstanceId);
         }
-        return new SwitchLogicTask(workflowExecutionRunnable, taskExecutionContext);
+        return new SwitchLogicTask(workflowExecution, taskExecutionContext);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/IWorkflowExecutionGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/IWorkflowExecutionGraph.java
@@ -17,7 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.engine.graph;
 
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 import java.util.List;
 import java.util.Set;
@@ -32,7 +32,7 @@ public interface IWorkflowExecutionGraph {
     /**
      * Add a new task to the graph.
      */
-    void addNode(final ITaskExecutionRunnable taskExecutionRunnable);
+    void addNode(final ITaskExecution taskExecution);
 
     /**
      * Add a new edge to the graph.
@@ -48,102 +48,102 @@ public interface IWorkflowExecutionGraph {
     /**
      * Return the start tasks, the start tasks in the workflow execution graph is the tasks which predecessors is empty.
      */
-    List<ITaskExecutionRunnable> getStartNodes();
+    List<ITaskExecution> getStartNodes();
 
     /**
      * Get the predecessor tasks of the given task.
      */
-    List<ITaskExecutionRunnable> getPredecessors(final String taskName);
+    List<ITaskExecution> getPredecessors(final String taskName);
 
     /**
      * Return the successor tasks of the given task.
      */
-    List<ITaskExecutionRunnable> getSuccessors(final String taskName);
+    List<ITaskExecution> getSuccessors(final String taskName);
 
     /**
      * Return the successor tasks of the given task.
      */
-    List<ITaskExecutionRunnable> getSuccessors(final ITaskExecutionRunnable taskExecutionRunnable);
+    List<ITaskExecution> getSuccessors(final ITaskExecution taskExecution);
 
     /**
-     * Get the ITaskExecutionRunnable by task code.
+     * Get the ITaskExecution by task code.
      */
-    ITaskExecutionRunnable getTaskExecutionRunnableByName(final String taskName);
+    ITaskExecution getTaskExecutionByName(final String taskName);
 
     /**
-     * Get the ITaskExecutionRunnable by task instance id.
+     * Get the ITaskExecution by task instance id.
      */
-    ITaskExecutionRunnable getTaskExecutionRunnableById(final Integer taskInstanceId);
+    ITaskExecution getTaskExecutionById(final Integer taskInstanceId);
 
     /**
-     * Get the ITaskExecutionRunnable by task code.
+     * Get the ITaskExecution by task code.
      */
-    ITaskExecutionRunnable getTaskExecutionRunnableByTaskCode(final Long taskCode);
+    ITaskExecution getTaskExecutionByTaskCode(final Long taskCode);
 
     /**
      * Whether the given task is active.
      */
-    boolean isTaskExecutionRunnableActive(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionActive(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task is inactive.
      * <p> A task is inactive means the task has been `executed`.
      */
-    boolean isTaskExecutionRunnableInActive(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionInActive(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task is killed.
      */
-    boolean isTaskExecutionRunnableKilled(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionKilled(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task is failure.
      */
-    boolean isTaskExecutionRunnableFailed(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionFailed(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task is paused.
      */
-    boolean isTaskExecutionRunnablePaused(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionPaused(final ITaskExecution taskExecution);
 
     /**
-     * Get the active TaskExecutionRunnable list.
-     * <p> The active TaskExecutionRunnable means the task is handling in the workflow execution graph.
+     * Get the active TaskExecution list.
+     * <p> The active TaskExecution means the task is handling in the workflow execution graph.
      */
-    List<ITaskExecutionRunnable> getActiveTaskExecutionRunnable();
+    List<ITaskExecution> getActiveTaskExecution();
 
     /**
-     * Get all the TaskExecutionRunnable in the graph, this method will return all the TaskExecutionRunnable in the graph,
-     * include active and inactive TaskExecutionRunnable.
+     * Get all the TaskExecution in the graph, this method will return all the TaskExecution in the graph,
+     * include active and inactive TaskExecution.
      */
-    List<ITaskExecutionRunnable> getAllTaskExecutionRunnable();
+    List<ITaskExecution> getAllTaskExecution();
 
     /**
      * Check whether the given task can be trigger now.
      * <p> The task can be trigger only all the predecessors are finished and all predecessors are not failure/pause/kill.
      * <p> Once the task has been triggered, then will also return false.
      */
-    boolean isTriggerConditionMet(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTriggerConditionMet(final ITaskExecution taskExecution);
 
     /**
-     * Mark the TaskExecutionRunnable is active.
-     * <p> If the TaskExecutionRunnable is active means the task is handling by the workflow.
-     * <p> Once we begin to handle a task, we should mark the TaskExecutionRunnable active.
+     * Mark the TaskExecution is active.
+     * <p> If the TaskExecution is active means the task is handling by the workflow.
+     * <p> Once we begin to handle a task, we should mark the TaskExecution active.
      */
-    void markTaskExecutionRunnableActive(final ITaskExecutionRunnable taskExecutionRunnable);
+    void markTaskExecutionActive(final ITaskExecution taskExecution);
 
     /**
-     * Mark the TaskExecutionRunnable is inactive.
-     * <p> If the TaskExecutionRunnable is inactive means the task has not been handled by the workflow.
-     * <p> Once we finish to handle a task, we should mark the TaskExecutionRunnable inactive.
+     * Mark the TaskExecution is inactive.
+     * <p> If the TaskExecution is inactive means the task has not been handled by the workflow.
+     * <p> Once we finish to handle a task, we should mark the TaskExecution inactive.
      */
-    void markTaskExecutionRunnableInActive(final ITaskExecutionRunnable taskExecutionRunnable);
+    void markTaskExecutionInActive(final ITaskExecution taskExecution);
 
     /**
-     * Mark the TaskExecutionRunnable is skipped.
-     * <p> Once the TaskExecutionRunnable is marked as skipped, this means the task will not be trigger.
+     * Mark the TaskExecution is skipped.
+     * <p> Once the TaskExecution is marked as skipped, this means the task will not be trigger.
      */
-    void markTaskSkipped(final ITaskExecutionRunnable taskExecutionRunnable);
+    void markTaskSkipped(final ITaskExecution taskExecution);
 
     /**
      * Mark the Task is skipped.
@@ -152,47 +152,47 @@ public interface IWorkflowExecutionGraph {
     void markTaskSkipped(final String taskName);
 
     /**
-     * Mark the TaskExecutionRunnable chain is failure.
-     * <p> Once the TaskExecutionRunnable chain is failure, then the successors will not be trigger, and the workflow execution graph might be failure.
+     * Mark the TaskExecution chain is failure.
+     * <p> Once the TaskExecution chain is failure, then the successors will not be trigger, and the workflow execution graph might be failure.
      */
-    void markTaskExecutionRunnableChainFailure(final ITaskExecutionRunnable taskExecutionRunnable);
+    void markTaskExecutionChainFailure(final ITaskExecution taskExecution);
 
     /**
-     * Mark the TaskExecutionRunnable chain is pause.
-     * <p> Once the TaskExecutionRunnable chain is pause, then the successors will not be trigger, and the workflow execution graph might be paused.
+     * Mark the TaskExecution chain is pause.
+     * <p> Once the TaskExecution chain is pause, then the successors will not be trigger, and the workflow execution graph might be paused.
      */
-    void markTaskExecutionRunnableChainPause(final ITaskExecutionRunnable taskExecutionRunnable);
+    void markTaskExecutionChainPause(final ITaskExecution taskExecution);
 
     /**
-     * Mark the TaskExecutionRunnable chain is kill.
-     * <p> Once the TaskExecutionRunnable chain is kill, then the successors will not be trigger, and the workflow execution graph might be stop.
+     * Mark the TaskExecution chain is kill.
+     * <p> Once the TaskExecution chain is kill, then the successors will not be trigger, and the workflow execution graph might be stop.
      */
-    void markTaskExecutionRunnableChainKill(final ITaskExecutionRunnable taskExecutionRunnable);
+    void markTaskExecutionChainKill(final ITaskExecution taskExecution);
 
     /**
-     * Whether all the TaskExecutionRunnable chain in the graph is finish.
+     * Whether all the TaskExecution chain in the graph is finish.
      */
-    boolean isAllTaskExecutionRunnableChainFinish();
+    boolean isAllTaskExecutionChainFinish();
 
     /**
-     * Whether all the TaskExecutionRunnable chain in the graph is finish with success.
+     * Whether all the TaskExecution chain in the graph is finish with success.
      */
-    boolean isAllTaskExecutionRunnableChainSuccess();
+    boolean isAllTaskExecutionChainSuccess();
 
     /**
-     * Whether there exist the TaskExecutionRunnable chain in the graph is finish with failure.
+     * Whether there exist the TaskExecution chain in the graph is finish with failure.
      */
-    boolean isExistFailureTaskExecutionRunnableChain();
+    boolean isExistFailureTaskExecutionChain();
 
     /**
-     * Whether there exist the TaskExecutionRunnable chain in the graph is finish with paused.
+     * Whether there exist the TaskExecution chain in the graph is finish with paused.
      */
-    boolean isExistPausedTaskExecutionRunnableChain();
+    boolean isExistPausedTaskExecutionChain();
 
     /**
-     * Whether there exist the TaskExecutionRunnable chain in the graph is finish with kill.
+     * Whether there exist the TaskExecution chain in the graph is finish with kill.
      */
-    boolean isExistKilledTaskExecutionRunnableChain();
+    boolean isExistKilledTaskExecutionChain();
 
     /**
      * Check whether the given task is the end of the task chain.
@@ -200,33 +200,33 @@ public interface IWorkflowExecutionGraph {
      * <p> If the given task is killed or paused, then it is the end of the task chain.
      * <p> If the given task is failure, and all its successors are condition task then it is not end of a task chain.
      */
-    boolean isEndOfTaskChain(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isEndOfTaskChain(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task is skipped.
      * <p> Once we mark the task is skipped, then the task will not be trigger, and will trigger its successors.
      */
-    boolean isTaskExecutionRunnableSkipped(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionSkipped(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task is forbidden.
      * <p> Once the task is forbidden then it will be passed, and will trigger its successors.
      */
-    boolean isTaskExecutionRunnableForbidden(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionForbidden(final ITaskExecution taskExecution);
 
     /**
      * Whether the given task's execution is failure and waiting for retry.
      */
-    boolean isTaskExecutionRunnableRetrying(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isTaskExecutionRetrying(final ITaskExecution taskExecution);
 
     /**
      * Whether all predecessors task is skipped.
      * <p> Once all predecessors are marked as skipped, then the task will be marked as skipped, and will trigger its successors.
      */
-    boolean isAllPredecessorsSkipped(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isAllPredecessorsSkipped(final ITaskExecution taskExecution);
 
     /**
      * Whether all predecessors task are condition task.
      */
-    boolean isAllSuccessorsAreConditionTask(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean isAllSuccessorsAreConditionTask(final ITaskExecution taskExecution);
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/SuccessorFlowAdjuster.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/SuccessorFlowAdjuster.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.plugin.task.api.parameters.SwitchParameters;
 import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.condition.ConditionLogicTask;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.switchtask.SwitchLogicTask;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -52,12 +52,12 @@ public class SuccessorFlowAdjuster {
      * <p> If the task {@link ConditionLogicTask}, then will adjust the flow according to the condition result.
      * <p> If the task {@link SwitchLogicTask}, then will adjust the flow according to the switch result.
      */
-    public void adjustSuccessorFlow(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
+    public void adjustSuccessorFlow(final ITaskExecution taskExecution) {
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecution.getWorkflowExecutionGraph();
 
-        if (workflowExecutionGraph.isTaskExecutionRunnableSkipped(taskExecutionRunnable)) {
+        if (workflowExecutionGraph.isTaskExecutionSkipped(taskExecution)) {
             // If the successor flow's all parent is skipped, then mark the successor skipped.
-            for (ITaskExecutionRunnable successor : workflowExecutionGraph.getSuccessors(taskExecutionRunnable)) {
+            for (ITaskExecution successor : workflowExecutionGraph.getSuccessors(taskExecution)) {
                 if (workflowExecutionGraph.isAllPredecessorsSkipped(successor)) {
                     workflowExecutionGraph.markTaskSkipped(successor);
                 }
@@ -65,24 +65,24 @@ public class SuccessorFlowAdjuster {
             return;
         }
 
-        if (workflowExecutionGraph.isTaskExecutionRunnableForbidden(taskExecutionRunnable)) {
+        if (workflowExecutionGraph.isTaskExecutionForbidden(taskExecution)) {
             return;
         }
 
-        final String taskType = taskExecutionRunnable.getTaskInstance().getTaskType();
+        final String taskType = taskExecution.getTaskInstance().getTaskType();
         if (TaskTypeUtils.isConditionTask(taskType)) {
-            adjustConditionTaskSuccessorFlow(taskExecutionRunnable);
+            adjustConditionTaskSuccessorFlow(taskExecution);
             return;
         }
 
         if (TaskTypeUtils.isSwitchTask(taskType)) {
-            adjustSwitchTaskSuccessorFlow(taskExecutionRunnable);
+            adjustSwitchTaskSuccessorFlow(taskExecution);
             return;
         }
     }
 
-    private void adjustConditionTaskSuccessorFlow(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final String taskParams = taskExecutionRunnable.getTaskInstance().getTaskParams();
+    private void adjustConditionTaskSuccessorFlow(final ITaskExecution taskExecution) {
+        final String taskParams = taskExecution.getTaskInstance().getTaskParams();
         final ConditionsParameters conditionsParameters = JSONUtils.parseObject(taskParams, ConditionsParameters.class);
         if (conditionsParameters == null) {
             throw new IllegalArgumentException("Condition task params: " + taskParams + " is invalid.");
@@ -97,11 +97,11 @@ public class SuccessorFlowAdjuster {
         } else {
             needSkippedBranch = conditionResult.getSuccessNode();
         }
-        markTaskSkipped(taskExecutionRunnable, needSkippedBranch);
+        markTaskSkipped(taskExecution, needSkippedBranch);
     }
 
-    private void adjustSwitchTaskSuccessorFlow(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final String taskParams = taskExecutionRunnable.getTaskInstance().getTaskParams();
+    private void adjustSwitchTaskSuccessorFlow(final ITaskExecution taskExecution) {
+        final String taskParams = taskExecution.getTaskInstance().getTaskParams();
         final SwitchParameters switchParameters = JSONUtils.parseObject(taskParams, SwitchParameters.class);
         if (switchParameters == null) {
             throw new IllegalArgumentException("Switch task params: " + taskParams + " is invalid.");
@@ -120,20 +120,20 @@ public class SuccessorFlowAdjuster {
             }
         }
         needSkippedBranch.remove(switchParameters.getNextBranch());
-        markTaskSkipped(taskExecutionRunnable, needSkippedBranch);
+        markTaskSkipped(taskExecution, needSkippedBranch);
     }
 
-    private void markTaskSkipped(final ITaskExecutionRunnable taskExecutionRunnable,
+    private void markTaskSkipped(final ITaskExecution taskExecution,
                                  final Collection<Long> needSkippedTaskCodes) {
         if (CollectionUtils.isEmpty(needSkippedTaskCodes)) {
             return;
         }
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecution.getWorkflowExecutionGraph();
         for (Long taskCode : needSkippedTaskCodes) {
-            final ITaskExecutionRunnable branch = workflowExecutionGraph.getTaskExecutionRunnableByTaskCode(taskCode);
+            final ITaskExecution branch = workflowExecutionGraph.getTaskExecutionByTaskCode(taskCode);
             if (branch == null) {
                 log.info("Branch(taskCode={}) is not found in the workflow: {}.", taskCode,
-                        taskExecutionRunnable.getWorkflowInstance().getName());
+                        taskExecution.getWorkflowInstance().getName());
                 continue;
             }
             workflowExecutionGraph.markTaskSkipped(branch);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowExecutionGraph.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/graph/WorkflowExecutionGraph.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
 
     // Store all the task execution runnable in the execution graph.
-    private final Map<String, ITaskExecutionRunnable> totalTaskExecuteRunnableMap;
+    private final Map<String, ITaskExecution> totalTaskExecuteRunnableMap;
 
     private final Set<String> failureTaskChains;
 
@@ -52,9 +52,9 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
 
     private final Map<String, Set<String>> successors;
 
-    private final Set<String> activeTaskExecutionRunnable;
+    private final Set<String> activeTaskExecution;
 
-    private final Set<String> inActiveTaskExecutionRunnable;
+    private final Set<String> inActiveTaskExecution;
 
     public WorkflowExecutionGraph() {
         this.failureTaskChains = new HashSet<>();
@@ -64,15 +64,15 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
         this.predecessors = new HashMap<>();
         this.successors = new HashMap<>();
         this.totalTaskExecuteRunnableMap = new HashMap<>();
-        this.activeTaskExecutionRunnable = new HashSet<>();
-        this.inActiveTaskExecutionRunnable = new HashSet<>();
+        this.activeTaskExecution = new HashSet<>();
+        this.inActiveTaskExecution = new HashSet<>();
     }
 
     @Override
-    public void addNode(final ITaskExecutionRunnable taskExecutionRunnable) {
-        totalTaskExecuteRunnableMap.put(taskExecutionRunnable.getName(), taskExecutionRunnable);
-        predecessors.computeIfAbsent(taskExecutionRunnable.getName(), k -> new HashSet<>());
-        successors.computeIfAbsent(taskExecutionRunnable.getName(), k -> new HashSet<>());
+    public void addNode(final ITaskExecution taskExecution) {
+        totalTaskExecuteRunnableMap.put(taskExecution.getName(), taskExecution);
+        predecessors.computeIfAbsent(taskExecution.getName(), k -> new HashSet<>());
+        successors.computeIfAbsent(taskExecution.getName(), k -> new HashSet<>());
     }
 
     @Override
@@ -102,182 +102,182 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
     }
 
     @Override
-    public List<ITaskExecutionRunnable> getStartNodes() {
+    public List<ITaskExecution> getStartNodes() {
         return totalTaskExecuteRunnableMap.values()
                 .stream()
-                .filter(taskExecutionRunnable -> CollectionUtils
-                        .isEmpty(predecessors.get(taskExecutionRunnable.getName())))
+                .filter(taskExecution -> CollectionUtils
+                        .isEmpty(predecessors.get(taskExecution.getName())))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<ITaskExecutionRunnable> getPredecessors(final String taskName) {
+    public List<ITaskExecution> getPredecessors(final String taskName) {
         if (!predecessors.containsKey(taskName)) {
             throw new IllegalArgumentException("Cannot find the task: " + taskName + " in graph");
         }
         return predecessors
                 .get(taskName)
                 .stream()
-                .map(this::getTaskExecutionRunnableByName)
+                .map(this::getTaskExecutionByName)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<ITaskExecutionRunnable> getSuccessors(final String taskName) {
+    public List<ITaskExecution> getSuccessors(final String taskName) {
         if (!successors.containsKey(taskName)) {
             throw new IllegalArgumentException("Cannot find the task code in graph");
         }
         return successors
                 .get(taskName)
                 .stream()
-                .map(this::getTaskExecutionRunnableByName)
+                .map(this::getTaskExecutionByName)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<ITaskExecutionRunnable> getSuccessors(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return getSuccessors(taskExecutionRunnable.getName());
+    public List<ITaskExecution> getSuccessors(final ITaskExecution taskExecution) {
+        return getSuccessors(taskExecution.getName());
     }
 
     @Override
-    public ITaskExecutionRunnable getTaskExecutionRunnableByName(final String taskName) {
+    public ITaskExecution getTaskExecutionByName(final String taskName) {
         return totalTaskExecuteRunnableMap.get(taskName);
     }
 
     @Override
-    public ITaskExecutionRunnable getTaskExecutionRunnableById(final Integer taskInstanceId) {
+    public ITaskExecution getTaskExecutionById(final Integer taskInstanceId) {
         return totalTaskExecuteRunnableMap.values()
                 .stream()
-                .filter(taskExecutionRunnable -> taskExecutionRunnable.getTaskInstance() != null
-                        && taskInstanceId.equals(taskExecutionRunnable.getTaskInstance().getId()))
+                .filter(taskExecution -> taskExecution.getTaskInstance() != null
+                        && taskInstanceId.equals(taskExecution.getTaskInstance().getId()))
                 .findFirst()
                 .orElse(null);
     }
 
     @Override
-    public ITaskExecutionRunnable getTaskExecutionRunnableByTaskCode(final Long taskCode) {
+    public ITaskExecution getTaskExecutionByTaskCode(final Long taskCode) {
         return totalTaskExecuteRunnableMap.values()
                 .stream()
-                .filter(taskExecutionRunnable -> taskExecutionRunnable.getTaskDefinition() != null
-                        && taskCode.equals(taskExecutionRunnable.getTaskDefinition().getCode()))
+                .filter(taskExecution -> taskExecution.getTaskDefinition() != null
+                        && taskCode.equals(taskExecution.getTaskDefinition().getCode()))
                 .findFirst()
                 .orElse(null);
     }
 
     @Override
-    public boolean isTaskExecutionRunnableActive(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return activeTaskExecutionRunnable.contains(taskExecutionRunnable.getName());
+    public boolean isTaskExecutionActive(final ITaskExecution taskExecution) {
+        return activeTaskExecution.contains(taskExecution.getName());
     }
 
     @Override
-    public boolean isTaskExecutionRunnableInActive(ITaskExecutionRunnable taskExecutionRunnable) {
-        return inActiveTaskExecutionRunnable.contains(taskExecutionRunnable.getName());
+    public boolean isTaskExecutionInActive(ITaskExecution taskExecution) {
+        return inActiveTaskExecution.contains(taskExecution.getName());
     }
 
     @Override
-    public boolean isTaskExecutionRunnableKilled(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return killedTaskChains.contains(taskExecutionRunnable.getName());
+    public boolean isTaskExecutionKilled(final ITaskExecution taskExecution) {
+        return killedTaskChains.contains(taskExecution.getName());
     }
 
     @Override
-    public boolean isTaskExecutionRunnableFailed(ITaskExecutionRunnable taskExecutionRunnable) {
-        return failureTaskChains.contains(taskExecutionRunnable.getName());
+    public boolean isTaskExecutionFailed(ITaskExecution taskExecution) {
+        return failureTaskChains.contains(taskExecution.getName());
     }
 
     @Override
-    public boolean isTaskExecutionRunnablePaused(ITaskExecutionRunnable taskExecutionRunnable) {
-        return pausedTaskChains.contains(taskExecutionRunnable.getName());
+    public boolean isTaskExecutionPaused(ITaskExecution taskExecution) {
+        return pausedTaskChains.contains(taskExecution.getName());
     }
 
     @Override
-    public List<ITaskExecutionRunnable> getActiveTaskExecutionRunnable() {
-        return activeTaskExecutionRunnable
+    public List<ITaskExecution> getActiveTaskExecution() {
+        return activeTaskExecution
                 .stream()
-                .map(this::getTaskExecutionRunnableByName)
+                .map(this::getTaskExecutionByName)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<ITaskExecutionRunnable> getAllTaskExecutionRunnable() {
+    public List<ITaskExecution> getAllTaskExecution() {
         return new ArrayList<>(totalTaskExecuteRunnableMap.values());
     }
 
     @Override
-    public boolean isTriggerConditionMet(final ITaskExecutionRunnable taskExecutionRunnable) {
-        if (isTaskExecutionRunnableActive(taskExecutionRunnable)
-                || isTaskExecutionRunnableInActive(taskExecutionRunnable)) {
+    public boolean isTriggerConditionMet(final ITaskExecution taskExecution) {
+        if (isTaskExecutionActive(taskExecution)
+                || isTaskExecutionInActive(taskExecution)) {
             return false;
         }
-        return getPredecessors(taskExecutionRunnable.getName())
+        return getPredecessors(taskExecution.getName())
                 .stream()
-                .allMatch(predecessor -> isTaskExecutionRunnableInActive(predecessor)
-                        && !isTaskExecutionRunnableFailed(predecessor)
-                        && !isTaskExecutionRunnablePaused(predecessor)
-                        && !isTaskExecutionRunnableKilled(predecessor));
+                .allMatch(predecessor -> isTaskExecutionInActive(predecessor)
+                        && !isTaskExecutionFailed(predecessor)
+                        && !isTaskExecutionPaused(predecessor)
+                        && !isTaskExecutionKilled(predecessor));
     }
 
     @Override
-    public boolean isAllTaskExecutionRunnableChainFinish() {
-        return activeTaskExecutionRunnable.isEmpty();
+    public boolean isAllTaskExecutionChainFinish() {
+        return activeTaskExecution.isEmpty();
     }
 
     @Override
-    public boolean isAllTaskExecutionRunnableChainSuccess() {
-        if (!isAllTaskExecutionRunnableChainFinish()) {
+    public boolean isAllTaskExecutionChainSuccess() {
+        if (!isAllTaskExecutionChainFinish()) {
             return false;
         }
-        return !isExistFailureTaskExecutionRunnableChain()
-                && !isExistPausedTaskExecutionRunnableChain()
-                && !isExistKilledTaskExecutionRunnableChain();
+        return !isExistFailureTaskExecutionChain()
+                && !isExistPausedTaskExecutionChain()
+                && !isExistKilledTaskExecutionChain();
     }
 
     @Override
-    public boolean isExistFailureTaskExecutionRunnableChain() {
+    public boolean isExistFailureTaskExecutionChain() {
         return CollectionUtils.isNotEmpty(failureTaskChains);
     }
 
     @Override
-    public boolean isExistPausedTaskExecutionRunnableChain() {
+    public boolean isExistPausedTaskExecutionChain() {
         return CollectionUtils.isNotEmpty(pausedTaskChains);
     }
 
     @Override
-    public boolean isExistKilledTaskExecutionRunnableChain() {
+    public boolean isExistKilledTaskExecutionChain() {
         return CollectionUtils.isNotEmpty(killedTaskChains);
     }
 
     @Override
-    public void markTaskExecutionRunnableActive(final ITaskExecutionRunnable taskExecutionRunnable) {
-        activeTaskExecutionRunnable.add(taskExecutionRunnable.getName());
+    public void markTaskExecutionActive(final ITaskExecution taskExecution) {
+        activeTaskExecution.add(taskExecution.getName());
     }
 
     @Override
-    public void markTaskExecutionRunnableInActive(final ITaskExecutionRunnable taskExecutionRunnable) {
-        activeTaskExecutionRunnable.remove(taskExecutionRunnable.getName());
-        inActiveTaskExecutionRunnable.add(taskExecutionRunnable.getName());
+    public void markTaskExecutionInActive(final ITaskExecution taskExecution) {
+        activeTaskExecution.remove(taskExecution.getName());
+        inActiveTaskExecution.add(taskExecution.getName());
     }
 
     @Override
-    public void markTaskExecutionRunnableChainFailure(final ITaskExecutionRunnable taskExecutionRunnable) {
-        assertTaskExecutionRunnableState(taskExecutionRunnable, TaskExecutionStatus.FAILURE);
-        failureTaskChains.add(taskExecutionRunnable.getName());
+    public void markTaskExecutionChainFailure(final ITaskExecution taskExecution) {
+        assertTaskExecutionState(taskExecution, TaskExecutionStatus.FAILURE);
+        failureTaskChains.add(taskExecution.getName());
     }
 
     @Override
-    public void markTaskExecutionRunnableChainPause(final ITaskExecutionRunnable taskExecutionRunnable) {
-        assertTaskExecutionRunnableState(taskExecutionRunnable, TaskExecutionStatus.PAUSE);
-        pausedTaskChains.add(taskExecutionRunnable.getName());
+    public void markTaskExecutionChainPause(final ITaskExecution taskExecution) {
+        assertTaskExecutionState(taskExecution, TaskExecutionStatus.PAUSE);
+        pausedTaskChains.add(taskExecution.getName());
     }
 
     @Override
-    public void markTaskExecutionRunnableChainKill(final ITaskExecutionRunnable taskExecutionRunnable) {
-        assertTaskExecutionRunnableState(taskExecutionRunnable, TaskExecutionStatus.KILL);
-        killedTaskChains.add(taskExecutionRunnable.getName());
+    public void markTaskExecutionChainKill(final ITaskExecution taskExecution) {
+        assertTaskExecutionState(taskExecution, TaskExecutionStatus.KILL);
+        killedTaskChains.add(taskExecution.getName());
     }
 
     @Override
-    public void markTaskSkipped(final ITaskExecutionRunnable taskExecutionRunnable) {
-        markTaskSkipped(taskExecutionRunnable.getName());
+    public void markTaskSkipped(final ITaskExecution taskExecution) {
+        markTaskSkipped(taskExecution.getName());
     }
 
     @Override
@@ -286,32 +286,32 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
     }
 
     @Override
-    public boolean isEndOfTaskChain(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return successors.get(taskExecutionRunnable.getName()).isEmpty()
-                || isTaskExecutionRunnableKilled(taskExecutionRunnable)
-                || isTaskExecutionRunnablePaused(taskExecutionRunnable)
-                || (isTaskExecutionRunnableFailed(taskExecutionRunnable)
-                        && !isAllSuccessorsAreConditionTask(taskExecutionRunnable));
+    public boolean isEndOfTaskChain(final ITaskExecution taskExecution) {
+        return successors.get(taskExecution.getName()).isEmpty()
+                || isTaskExecutionKilled(taskExecution)
+                || isTaskExecutionPaused(taskExecution)
+                || (isTaskExecutionFailed(taskExecution)
+                        && !isAllSuccessorsAreConditionTask(taskExecution));
     }
 
     @Override
-    public boolean isTaskExecutionRunnableSkipped(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return skippedTask.contains(taskExecutionRunnable.getName());
+    public boolean isTaskExecutionSkipped(final ITaskExecution taskExecution) {
+        return skippedTask.contains(taskExecution.getName());
     }
 
     @Override
-    public boolean isTaskExecutionRunnableForbidden(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return (taskExecutionRunnable.getTaskDefinition().getFlag() == Flag.NO);
+    public boolean isTaskExecutionForbidden(final ITaskExecution taskExecution) {
+        return (taskExecution.getTaskDefinition().getFlag() == Flag.NO);
     }
 
     @Override
-    public boolean isTaskExecutionRunnableRetrying(final ITaskExecutionRunnable taskExecutionRunnable) {
-        if (!taskExecutionRunnable.isTaskInstanceInitialized()) {
+    public boolean isTaskExecutionRetrying(final ITaskExecution taskExecution) {
+        if (!taskExecution.isTaskInstanceInitialized()) {
             return false;
         }
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
-        return taskInstance.getState() == TaskExecutionStatus.FAILURE && taskExecutionRunnable.isTaskInstanceCanRetry()
-                && isTaskExecutionRunnableActive(taskExecutionRunnable);
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
+        return taskInstance.getState() == TaskExecutionStatus.FAILURE && taskExecution.isTaskInstanceCanRetry()
+                && isTaskExecutionActive(taskExecution);
     }
 
     /**
@@ -319,35 +319,35 @@ public class WorkflowExecutionGraph implements IWorkflowExecutionGraph {
      * <p> Only when all predecessors are skipped, will return true. If the given task doesn't have any predecessors, will return false.
      */
     @Override
-    public boolean isAllPredecessorsSkipped(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final List<ITaskExecutionRunnable> predecessors = getPredecessors(taskExecutionRunnable.getName());
+    public boolean isAllPredecessorsSkipped(final ITaskExecution taskExecution) {
+        final List<ITaskExecution> predecessors = getPredecessors(taskExecution.getName());
         if (CollectionUtils.isEmpty(predecessors)) {
             return false;
         }
         return CollectionUtils.isEmpty(predecessors)
-                || predecessors.stream().allMatch(this::isTaskExecutionRunnableSkipped);
+                || predecessors.stream().allMatch(this::isTaskExecutionSkipped);
     }
 
     @Override
-    public boolean isAllSuccessorsAreConditionTask(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final List<ITaskExecutionRunnable> successors = getSuccessors(taskExecutionRunnable.getName());
+    public boolean isAllSuccessorsAreConditionTask(final ITaskExecution taskExecution) {
+        final List<ITaskExecution> successors = getSuccessors(taskExecution.getName());
         if (CollectionUtils.isEmpty(successors)) {
             return false;
         }
         return successors.stream().allMatch(
-                successor -> isTaskExecutionRunnableSkipped(successor)
+                successor -> isTaskExecutionSkipped(successor)
                         || (TaskTypeUtils.isConditionTask(successor.getTaskDefinition().getTaskType())
-                                && !isTaskExecutionRunnableForbidden(successor)));
+                                && !isTaskExecutionForbidden(successor)));
     }
 
-    private void assertTaskExecutionRunnableState(final ITaskExecutionRunnable taskExecutionRunnable,
-                                                  final TaskExecutionStatus taskExecutionStatus) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    private void assertTaskExecutionState(final ITaskExecution taskExecution,
+                                          final TaskExecutionStatus taskExecutionStatus) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         if (taskInstance.getState() == taskExecutionStatus) {
             return;
         }
         throw new IllegalStateException(
-                "The task: " + taskExecutionRunnable.getName() + " state: " + taskInstance.getState() + " is not "
+                "The task: " + taskExecution.getName() + " state: " + taskInstance.getState() + " is not "
                         + taskExecutionStatus);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/ITaskExecutorClient.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/ITaskExecutorClient.java
@@ -20,7 +20,7 @@ package org.apache.dolphinscheduler.server.master.engine.task.client;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskKillException;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskPauseException;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskReassignMasterHostException;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.TaskDispatchException;
 import org.apache.dolphinscheduler.task.executor.TaskEngine;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
@@ -35,14 +35,14 @@ public interface ITaskExecutorClient {
      *
      * @throws TaskDispatchException If dispatch failed or error occurs.
      */
-    void dispatch(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskDispatchException;
+    void dispatch(final ITaskExecution taskExecution) throws TaskDispatchException;
 
     /**
      * Reassign the workflow instance host from task executor.
      *
      * @throws TaskReassignMasterHostException If an error occurs.
      */
-    boolean reassignWorkflowInstanceHost(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskReassignMasterHostException;
+    boolean reassignWorkflowInstanceHost(final ITaskExecution taskExecution) throws TaskReassignMasterHostException;
 
     /**
      * Pause task from task executor.
@@ -52,7 +52,7 @@ public interface ITaskExecutorClient {
      *
      * @throws TaskPauseException If an error occurs.
      */
-    void pause(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskPauseException;
+    void pause(final ITaskExecution taskExecution) throws TaskPauseException;
 
     /**
      * Kill task from task executor.
@@ -62,14 +62,14 @@ public interface ITaskExecutorClient {
      *
      * @throws TaskKillException If an error occurs.
      */
-    void kill(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskKillException;
+    void kill(final ITaskExecution taskExecution) throws TaskKillException;
 
     /**
      * Send TaskExecutorLifecycleEventAck to TaskEngine.
      * <p> This method will not throw exception, once send ack failed, the executor engine will retry.
      */
     void ackTaskExecutorLifecycleEvent(
-                                       final ITaskExecutionRunnable taskExecutionRunnable,
+                                       final ITaskExecution taskExecution,
                                        final ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck taskExecutorLifecycleEventAck);
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/ITaskExecutorClientDelegator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/ITaskExecutorClientDelegator.java
@@ -17,7 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.engine.task.client;
 
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.TaskDispatchException;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 
@@ -34,27 +34,27 @@ public interface ITaskExecutorClientDelegator {
      *
      * @throws TaskDispatchException If dispatch failed
      */
-    void dispatch(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskDispatchException;
+    void dispatch(final ITaskExecution taskExecution) throws TaskDispatchException;
 
     /**
      * Take over the task from task executor.
      */
-    boolean reassignMasterHost(final ITaskExecutionRunnable taskExecutionRunnable);
+    boolean reassignMasterHost(final ITaskExecution taskExecution);
 
     /**
      * Pause the task, this method doesn't guarantee the task is paused success.
      */
-    void pause(final ITaskExecutionRunnable taskExecutionRunnable);
+    void pause(final ITaskExecution taskExecution);
 
     /**
      * Kill the task, this method doesn't guarantee the task is killed success.
      */
-    void kill(final ITaskExecutionRunnable taskExecutionRunnable);
+    void kill(final ITaskExecution taskExecution);
 
     /**
      * Ack the task executor lifecycle event.
      */
     void ackTaskExecutorLifecycleEvent(
-                                       final ITaskExecutionRunnable taskExecutionRunnable,
+                                       final ITaskExecution taskExecution,
                                        final ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck taskExecutorLifecycleEventAck);
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/LogicTaskExecutorClientDelegator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/LogicTaskExecutorClientDelegator.java
@@ -25,7 +25,7 @@ import org.apache.dolphinscheduler.extract.master.ILogicTaskExecutorOperator;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskKillException;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.TaskDispatchException;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.operations.TaskExecutorDispatchRequest;
@@ -50,12 +50,12 @@ public class LogicTaskExecutorClientDelegator implements ITaskExecutorClientDele
     private MasterConfig masterConfig;
 
     @Override
-    public void dispatch(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskDispatchException {
+    public void dispatch(final ITaskExecution taskExecution) throws TaskDispatchException {
         final String logicTaskExecutorAddress = masterConfig.getMasterAddress();
-        final TaskExecutionContext taskExecutionContext = taskExecutionRunnable.getTaskExecutionContext();
+        final TaskExecutionContext taskExecutionContext = taskExecution.getTaskExecutionContext();
 
         taskExecutionContext.setHost(logicTaskExecutorAddress);
-        taskExecutionRunnable.getTaskInstance().setHost(logicTaskExecutorAddress);
+        taskExecution.getTaskInstance().setHost(logicTaskExecutorAddress);
 
         final TaskExecutorDispatchResponse logicTaskDispatchResponse = Clients
                 .withService(ILogicTaskExecutorOperator.class)
@@ -69,14 +69,14 @@ public class LogicTaskExecutorClientDelegator implements ITaskExecutorClientDele
     }
 
     @Override
-    public boolean reassignMasterHost(final ITaskExecutionRunnable taskExecutionRunnable) {
+    public boolean reassignMasterHost(final ITaskExecution taskExecution) {
         // The Logic Task doesn't support take-over, since the logic task is not executed on the worker.
         return false;
     }
 
     @Override
-    public void pause(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    public void pause(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String executorHost = taskInstance.getHost();
         final String taskName = taskInstance.getName();
         checkArgument(StringUtils.isNotEmpty(executorHost), "Executor host is empty");
@@ -93,8 +93,8 @@ public class LogicTaskExecutorClientDelegator implements ITaskExecutorClientDele
     }
 
     @Override
-    public void kill(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskKillException {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    public void kill(final ITaskExecution taskExecution) throws TaskKillException {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String executorHost = taskInstance.getHost();
         final String taskName = taskInstance.getName();
         checkArgument(StringUtils.isNotEmpty(executorHost), "Executor host is empty");
@@ -112,9 +112,9 @@ public class LogicTaskExecutorClientDelegator implements ITaskExecutorClientDele
 
     @Override
     public void ackTaskExecutorLifecycleEvent(
-                                              final ITaskExecutionRunnable taskExecutionRunnable,
+                                              final ITaskExecution taskExecution,
                                               final ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck taskExecutorLifecycleEventAck) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String executorHost = taskInstance.getHost();
         checkArgument(StringUtils.isNotEmpty(executorHost), "Executor host is empty");
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/PhysicalTaskExecutorClientDelegator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/PhysicalTaskExecutorClientDelegator.java
@@ -27,7 +27,7 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.master.cluster.ClusterManager;
 import org.apache.dolphinscheduler.server.master.cluster.loadbalancer.IWorkerLoadBalancer;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.NoAvailableWorkerException;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.TaskDispatchException;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.WorkerGroupNotFoundException;
@@ -62,8 +62,8 @@ public class PhysicalTaskExecutorClientDelegator implements ITaskExecutorClientD
     private ClusterManager clusterManager;
 
     @Override
-    public void dispatch(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskDispatchException {
-        final TaskExecutionContext taskExecutionContext = taskExecutionRunnable.getTaskExecutionContext();
+    public void dispatch(final ITaskExecution taskExecution) throws TaskDispatchException {
+        final TaskExecutionContext taskExecutionContext = taskExecution.getTaskExecutionContext();
         final String taskName = taskExecutionContext.getTaskName();
         final String workerGroup = taskExecutionContext.getWorkerGroup();
 
@@ -80,13 +80,13 @@ public class PhysicalTaskExecutorClientDelegator implements ITaskExecutorClientD
                 .orElseThrow(() -> new NoAvailableWorkerException(workerGroup));
 
         taskExecutionContext.setHost(physicalTaskExecutorAddress);
-        taskExecutionRunnable.getTaskInstance().setHost(physicalTaskExecutorAddress);
+        taskExecution.getTaskInstance().setHost(physicalTaskExecutorAddress);
 
         try {
             final TaskExecutorDispatchResponse taskExecutorDispatchResponse = Clients
                     .withService(IPhysicalTaskExecutorOperator.class)
                     .withHost(physicalTaskExecutorAddress)
-                    .dispatchTask(TaskExecutorDispatchRequest.of(taskExecutionRunnable.getTaskExecutionContext()));
+                    .dispatchTask(TaskExecutorDispatchRequest.of(taskExecution.getTaskExecutionContext()));
             if (!taskExecutorDispatchResponse.isDispatchSuccess()) {
                 throw new TaskDispatchException(
                         "Dispatch task: " + taskName + " to " + physicalTaskExecutorAddress + " failed: "
@@ -101,12 +101,12 @@ public class PhysicalTaskExecutorClientDelegator implements ITaskExecutorClientD
     }
 
     @Override
-    public boolean reassignMasterHost(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final String taskName = taskExecutionRunnable.getName();
-        checkArgument(taskExecutionRunnable.isTaskInstanceInitialized(),
+    public boolean reassignMasterHost(final ITaskExecution taskExecution) {
+        final String taskName = taskExecution.getName();
+        checkArgument(taskExecution.isTaskInstanceInitialized(),
                 "Task " + taskName + "is not initialized cannot take-over");
 
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String taskExecutorHost = taskInstance.getHost();
         if (StringUtils.isEmpty(taskExecutorHost)) {
             log.debug(
@@ -138,8 +138,8 @@ public class PhysicalTaskExecutorClientDelegator implements ITaskExecutorClientD
     }
 
     @Override
-    public void pause(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    public void pause(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String executorHost = taskInstance.getHost();
         final String taskName = taskInstance.getName();
         checkArgument(StringUtils.isNotEmpty(executorHost), "Executor host is empty");
@@ -156,8 +156,8 @@ public class PhysicalTaskExecutorClientDelegator implements ITaskExecutorClientD
     }
 
     @Override
-    public void kill(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    public void kill(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String executorHost = taskInstance.getHost();
         final String taskName = taskInstance.getName();
         checkArgument(StringUtils.isNotEmpty(executorHost), "Executor host is empty");
@@ -174,9 +174,9 @@ public class PhysicalTaskExecutorClientDelegator implements ITaskExecutorClientD
     }
 
     @Override
-    public void ackTaskExecutorLifecycleEvent(final ITaskExecutionRunnable taskExecutionRunnable,
+    public void ackTaskExecutorLifecycleEvent(final ITaskExecution taskExecution,
                                               final ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck taskExecutorLifecycleEventAck) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         final String executorHost = taskInstance.getHost();
         checkArgument(StringUtils.isNotEmpty(executorHost), "Executor host is empty");
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/TaskExecutorClient.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/client/TaskExecutorClient.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskKillException;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskPauseException;
 import org.apache.dolphinscheduler.server.master.engine.exceptions.TaskReassignMasterHostException;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.TaskDispatchException;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 
@@ -49,67 +49,67 @@ public class TaskExecutorClient implements ITaskExecutorClient {
     private PhysicalTaskExecutorClientDelegator physicalTaskExecutorClientDelegator;
 
     @Override
-    public void dispatch(ITaskExecutionRunnable taskExecutionRunnable) throws TaskDispatchException {
+    public void dispatch(ITaskExecution taskExecution) throws TaskDispatchException {
         try {
-            getTaskExecutorClientDelegator(taskExecutionRunnable).dispatch(taskExecutionRunnable);
+            getTaskExecutorClientDelegator(taskExecution).dispatch(taskExecution);
         } catch (TaskDispatchException taskDispatchException) {
             throw taskDispatchException;
         } catch (Exception ex) {
-            throw new TaskDispatchException("Dispatch task: " + taskExecutionRunnable.getName() + " to executor failed",
+            throw new TaskDispatchException("Dispatch task: " + taskExecution.getName() + " to executor failed",
                     ex);
         }
     }
 
     @Override
-    public boolean reassignWorkflowInstanceHost(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskReassignMasterHostException {
+    public boolean reassignWorkflowInstanceHost(final ITaskExecution taskExecution) throws TaskReassignMasterHostException {
         try {
-            return getTaskExecutorClientDelegator(taskExecutionRunnable)
-                    .reassignMasterHost(taskExecutionRunnable);
+            return getTaskExecutorClientDelegator(taskExecution)
+                    .reassignMasterHost(taskExecution);
         } catch (Exception ex) {
             throw new TaskReassignMasterHostException(
-                    "Take over task: " + taskExecutionRunnable.getName() + " from executor failed",
+                    "Take over task: " + taskExecution.getName() + " from executor failed",
                     ex);
         }
     }
 
     @Override
-    public void pause(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskPauseException {
+    public void pause(final ITaskExecution taskExecution) throws TaskPauseException {
         try {
-            getTaskExecutorClientDelegator(taskExecutionRunnable).pause(taskExecutionRunnable);
+            getTaskExecutorClientDelegator(taskExecution).pause(taskExecution);
         } catch (Exception ex) {
-            throw new TaskPauseException("Pause task: " + taskExecutionRunnable.getName() + " from executor failed",
+            throw new TaskPauseException("Pause task: " + taskExecution.getName() + " from executor failed",
                     ex);
         }
     }
 
     @Override
-    public void kill(final ITaskExecutionRunnable taskExecutionRunnable) throws TaskKillException {
+    public void kill(final ITaskExecution taskExecution) throws TaskKillException {
         try {
-            getTaskExecutorClientDelegator(taskExecutionRunnable).kill(taskExecutionRunnable);
+            getTaskExecutorClientDelegator(taskExecution).kill(taskExecution);
         } catch (Exception ex) {
-            throw new TaskKillException("Kill task: " + taskExecutionRunnable.getName() + " from executor failed", ex);
+            throw new TaskKillException("Kill task: " + taskExecution.getName() + " from executor failed", ex);
         }
     }
 
     @Override
     public void ackTaskExecutorLifecycleEvent(
-                                              final ITaskExecutionRunnable taskExecutionRunnable,
+                                              final ITaskExecution taskExecution,
                                               final ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck taskExecutorLifecycleEventAck) {
         try {
-            if (StringUtils.isEmpty(taskExecutionRunnable.getTaskInstance().getHost())) {
+            if (StringUtils.isEmpty(taskExecution.getTaskInstance().getHost())) {
                 log.info("The task: {} is didn't dispatched to executor, skip ack taskExecutorLifecycleEventAck: {}",
-                        taskExecutionRunnable.getName(), taskExecutorLifecycleEventAck);
+                        taskExecution.getName(), taskExecutorLifecycleEventAck);
                 return;
             }
-            getTaskExecutorClientDelegator(taskExecutionRunnable)
-                    .ackTaskExecutorLifecycleEvent(taskExecutionRunnable, taskExecutorLifecycleEventAck);
+            getTaskExecutorClientDelegator(taskExecution)
+                    .ackTaskExecutorLifecycleEvent(taskExecution, taskExecutorLifecycleEventAck);
         } catch (Exception ex) {
             log.error("Send taskExecutorLifecycleEventAck: {} failed", taskExecutorLifecycleEventAck, ex);
         }
     }
 
-    private ITaskExecutorClientDelegator getTaskExecutorClientDelegator(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    private ITaskExecutorClientDelegator getTaskExecutorClientDelegator(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         checkArgument(taskInstance != null, "taskType cannot be empty");
         if (TaskTypeUtils.isLogicTask(taskInstance.getTaskType())) {
             return logicTaskExecutorClientDelegator;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcher.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcher.java
@@ -23,8 +23,8 @@ import org.apache.dolphinscheduler.plugin.task.api.utils.LogUtils;
 import org.apache.dolphinscheduler.server.master.config.TaskDispatchPolicy;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
 import org.apache.dolphinscheduler.server.master.engine.task.dispatcher.event.TaskDispatchableEvent;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.task.executor.log.TaskExecutorMDCUtils;
 
 import java.util.Date;
@@ -48,7 +48,7 @@ public class WorkerGroupDispatcher extends BaseDaemonThread {
 
     private final ITaskExecutorClient taskExecutorClient;
 
-    private final TaskDispatchableEventBus<TaskDispatchableEvent<ITaskExecutionRunnable>, ITaskExecutionRunnable> workerGroupEventBus;
+    private final TaskDispatchableEventBus<TaskDispatchableEvent<ITaskExecution>, ITaskExecution> workerGroupEventBus;
 
     private final Set<Integer> waitingDispatchTaskIds;
 
@@ -87,22 +87,22 @@ public class WorkerGroupDispatcher extends BaseDaemonThread {
     @Override
     public void run() {
         while (runningFlag.get()) {
-            TaskDispatchableEvent<ITaskExecutionRunnable> taskEntry = workerGroupEventBus.take();
-            ITaskExecutionRunnable taskExecutionRunnable = taskEntry.getData();
+            TaskDispatchableEvent<ITaskExecution> taskEntry = workerGroupEventBus.take();
+            ITaskExecution taskExecution = taskEntry.getData();
             try (
                     TaskExecutorMDCUtils.MDCAutoClosable ignore =
-                            TaskExecutorMDCUtils.logWithMDC(taskExecutionRunnable.getId())) {
-                LogUtils.setWorkflowInstanceIdMDC(taskExecutionRunnable.getTaskInstance().getWorkflowInstanceId());
-                doDispatchTask(taskExecutionRunnable);
+                            TaskExecutorMDCUtils.logWithMDC(taskExecution.getId())) {
+                LogUtils.setWorkflowInstanceIdMDC(taskExecution.getTaskInstance().getWorkflowInstanceId());
+                doDispatchTask(taskExecution);
             } finally {
                 LogUtils.removeWorkflowInstanceIdMDC();
             }
         }
     }
 
-    private void doDispatchTask(ITaskExecutionRunnable taskExecutionRunnable) {
-        final int taskInstanceId = taskExecutionRunnable.getId();
-        final TaskExecutionContext taskExecutionContext = taskExecutionRunnable.getTaskExecutionContext();
+    private void doDispatchTask(ITaskExecution taskExecution) {
+        final int taskInstanceId = taskExecution.getId();
+        final TaskExecutionContext taskExecutionContext = taskExecution.getTaskExecutionContext();
         try {
             if (!waitingDispatchTaskIds.remove(taskInstanceId)) {
                 log.info(
@@ -110,13 +110,13 @@ public class WorkerGroupDispatcher extends BaseDaemonThread {
                         taskInstanceId);
                 return;
             }
-            taskExecutorClient.dispatch(taskExecutionRunnable);
+            taskExecutorClient.dispatch(taskExecution);
         } catch (Exception ex) {
             if (taskDispatchPolicy.isDispatchTimeoutEnabled()) {
                 // If a dispatch timeout occurs, the task will not be put back into the queue.
                 long elapsed = System.currentTimeMillis() - taskExecutionContext.getFirstDispatchTime();
                 if (elapsed > maxTaskDispatchMillis) {
-                    onDispatchTimeout(taskExecutionRunnable, ex, elapsed, maxTaskDispatchMillis);
+                    onDispatchTimeout(taskExecution, ex, elapsed, maxTaskDispatchMillis);
                     return;
                 }
             }
@@ -125,8 +125,8 @@ public class WorkerGroupDispatcher extends BaseDaemonThread {
             // The task will be dispatched after waiting time.
             // the waiting time will increase multiple of times, but will not exceed 60 seconds
             long waitingTimeMillis = Math.min(
-                    taskExecutionRunnable.getTaskExecutionContext().increaseDispatchFailTimes() * 1_000L, 60_000L);
-            dispatchTask(taskExecutionRunnable, waitingTimeMillis);
+                    taskExecution.getTaskExecutionContext().increaseDispatchFailTimes() * 1_000L, 60_000L);
+            dispatchTask(taskExecution, waitingTimeMillis);
             log.warn("Dispatch Task: {} failed will retry after: {}/ms", taskInstanceId,
                     waitingTimeMillis, ex);
         }
@@ -136,17 +136,17 @@ public class WorkerGroupDispatcher extends BaseDaemonThread {
      * Marks a task as permanently failed due to dispatch timeout.
      * Once called, the task is considered permanently failed and will not be retried.
      */
-    private void onDispatchTimeout(ITaskExecutionRunnable taskExecutionRunnable, Exception ex,
+    private void onDispatchTimeout(ITaskExecution taskExecution, Exception ex,
                                    long elapsed, long timeout) {
-        String taskName = taskExecutionRunnable.getName();
+        String taskName = taskExecution.getName();
         log.error("Task: {} dispatch timeout after {}ms (limit: {}ms)",
                 taskName, elapsed, timeout, ex);
 
         final TaskFailedLifecycleEvent taskFailedEvent = TaskFailedLifecycleEvent.builder()
-                .taskExecutionRunnable(taskExecutionRunnable)
+                .taskExecution(taskExecution)
                 .endTime(new Date())
                 .build();
-        taskExecutionRunnable.getWorkflowEventBus().publish(taskFailedEvent);
+        taskExecution.getWorkflowEventBus().publish(taskFailedEvent);
     }
 
     /**
@@ -155,21 +155,21 @@ public class WorkerGroupDispatcher extends BaseDaemonThread {
      * The task is only added if the current dispatcher status is either STARTED or INIT. If the dispatcher is in any other state,
      * the task addition will fail, and a warning message will be logged.
      *
-     * @param taskExecutionRunnable The task execution object to add to the queue, which implements the {@link ITaskExecutionRunnable} interface.
+     * @param taskExecution The task execution object to add to the queue, which implements the {@link ITaskExecution} interface.
      * @param delayTimeMills        The delay time in milliseconds before the task should be executed.
      */
-    public void dispatchTask(final ITaskExecutionRunnable taskExecutionRunnable, final long delayTimeMills) {
-        waitingDispatchTaskIds.add(taskExecutionRunnable.getId());
-        workerGroupEventBus.add(new TaskDispatchableEvent<>(delayTimeMills, taskExecutionRunnable,
-                taskExecutionRunnable.getTaskExecutionContext().getDispatchFailTimes()));
+    public void dispatchTask(final ITaskExecution taskExecution, final long delayTimeMills) {
+        waitingDispatchTaskIds.add(taskExecution.getId());
+        workerGroupEventBus.add(new TaskDispatchableEvent<>(delayTimeMills, taskExecution,
+                taskExecution.getTaskExecutionContext().getDispatchFailTimes()));
     }
 
-    public boolean removeTask(ITaskExecutionRunnable taskExecutionRunnable) {
-        return waitingDispatchTaskIds.remove(taskExecutionRunnable.getId());
+    public boolean removeTask(ITaskExecution taskExecution) {
+        return waitingDispatchTaskIds.remove(taskExecution.getId());
     }
 
-    public boolean existTask(ITaskExecutionRunnable taskExecutionRunnable) {
-        return waitingDispatchTaskIds.contains(taskExecutionRunnable.getId());
+    public boolean existTask(ITaskExecution taskExecution) {
+        return waitingDispatchTaskIds.contains(taskExecution.getId());
     }
 
     public synchronized void close() {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcherCoordinator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcherCoordinator.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.server.master.engine.task.dispatcher;
 
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,11 +59,11 @@ public class WorkerGroupDispatcherCoordinator implements AutoCloseable {
     /**
      * Dispatch task to the worker group with the specified remaining time.
      */
-    public void dispatchTask(final ITaskExecutionRunnable taskExecutionRunnable,
+    public void dispatchTask(final ITaskExecution taskExecution,
                              final long delayTimeMills) {
-        final String workerGroup = taskExecutionRunnable.getTaskInstance().getWorkerGroup();
-        getOrCreateWorkerGroupDispatcher(workerGroup).dispatchTask(taskExecutionRunnable, delayTimeMills);
-        log.info("Success add Task[id={}] to WorkerGroupDispatcher[name={}]", taskExecutionRunnable.getId(),
+        final String workerGroup = taskExecution.getTaskInstance().getWorkerGroup();
+        getOrCreateWorkerGroupDispatcher(workerGroup).dispatchTask(taskExecution, delayTimeMills);
+        log.info("Success add Task[id={}] to WorkerGroupDispatcher[name={}]", taskExecution.getId(),
                 workerGroup);
     }
 
@@ -71,15 +71,15 @@ public class WorkerGroupDispatcherCoordinator implements AutoCloseable {
      * Remove task from the dispatcher.
      * <p> If the task doesn't exist in the dispatcher, it will return false, this means the task might already be dispatched.
      */
-    public boolean removeTask(ITaskExecutionRunnable taskExecutionRunnable) {
-        final String workerGroup = taskExecutionRunnable.getTaskInstance().getWorkerGroup();
-        boolean removed = getOrCreateWorkerGroupDispatcher(workerGroup).removeTask(taskExecutionRunnable);
+    public boolean removeTask(ITaskExecution taskExecution) {
+        final String workerGroup = taskExecution.getTaskInstance().getWorkerGroup();
+        boolean removed = getOrCreateWorkerGroupDispatcher(workerGroup).removeTask(taskExecution);
         if (removed) {
             log.info("Success removed Task[id={}] from WorkerGroupDispatcher[name={}]",
-                    taskExecutionRunnable.getId(), workerGroup);
+                    taskExecution.getId(), workerGroup);
         } else {
             log.info("Failed to remove Task[id={}] from WorkerGroupDispatcher[name={}], this task has been dispatched",
-                    taskExecutionRunnable.getId(), workerGroup);
+                    taskExecution.getId(), workerGroup);
         }
         return removed;
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/AbstractTaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/AbstractTaskInstanceFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/FailedRecoverTaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/FailedRecoverTaskInstanceFactory.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.RetryTaskInstanceFactory.RetryTaskInstanceBuilder;
 
 import java.util.Date;
 
@@ -30,57 +29,55 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-public class RetryTaskInstanceFactory extends AbstractTaskInstanceFactory<RetryTaskInstanceBuilder> {
+public class FailedRecoverTaskInstanceFactory
+        extends
+            AbstractTaskInstanceFactory<FailedRecoverTaskInstanceFactory.FailedRecoverTaskInstanceBuilder> {
 
     @Autowired
     private TaskInstanceDao taskInstanceDao;
 
     @Override
-    public RetryTaskInstanceBuilder builder() {
-        return new RetryTaskInstanceBuilder(this);
+    public FailedRecoverTaskInstanceFactory.FailedRecoverTaskInstanceBuilder builder() {
+        return new FailedRecoverTaskInstanceBuilder(this);
     }
 
     @Transactional
     @Override
-    public TaskInstance createTaskInstance(RetryTaskInstanceBuilder builder) {
-        final TaskInstance needRetryTaskInstance = builder.taskInstance;
-        final TaskInstance taskInstance = cloneTaskInstance(needRetryTaskInstance);
+    public TaskInstance createTaskInstance(FailedRecoverTaskInstanceBuilder builder) {
+        final TaskInstance needRecoverTaskInstance = builder.needRecoverTaskInstance;
+        final TaskInstance taskInstance = cloneTaskInstance(needRecoverTaskInstance);
         taskInstance.setId(null);
         taskInstance.setState(TaskExecutionStatus.SUBMITTED_SUCCESS);
-        taskInstance.setPid(0);
         taskInstance.setHost(null);
-        taskInstance.setExecutePath(null);
-        taskInstance.setLogPath(null);
-        taskInstance.setStartTime(null);
-        taskInstance.setEndTime(null);
+        taskInstance.setVarPool(null);
         taskInstance.setSubmitTime(new Date());
-        taskInstance.setRetryTimes(taskInstance.getRetryTimes() + 1);
+        taskInstance.setLogPath(null);
+        taskInstance.setExecutePath(null);
         taskInstanceDao.insert(taskInstance);
 
-        needRetryTaskInstance.setFlag(Flag.NO);
-        taskInstanceDao.updateById(needRetryTaskInstance);
+        needRecoverTaskInstance.setFlag(Flag.NO);
+        taskInstanceDao.updateById(needRecoverTaskInstance);
         return taskInstance;
     }
 
-    public static class RetryTaskInstanceBuilder implements ITaskInstanceFactory.ITaskInstanceBuilder {
+    public static class FailedRecoverTaskInstanceBuilder implements ITaskInstanceFactory.ITaskInstanceBuilder {
 
-        private final RetryTaskInstanceFactory retryTaskInstanceFactory;
+        private final FailedRecoverTaskInstanceFactory failedRecoverTaskInstanceFactory;
 
-        private TaskInstance taskInstance;
+        private TaskInstance needRecoverTaskInstance;
 
-        public RetryTaskInstanceBuilder(RetryTaskInstanceFactory retryTaskInstanceFactory) {
-            this.retryTaskInstanceFactory = retryTaskInstanceFactory;
+        public FailedRecoverTaskInstanceBuilder(FailedRecoverTaskInstanceFactory failedRecoverTaskInstanceFactory) {
+            this.failedRecoverTaskInstanceFactory = failedRecoverTaskInstanceFactory;
         }
 
-        public RetryTaskInstanceBuilder withTaskInstance(TaskInstance taskInstance) {
-            this.taskInstance = taskInstance;
+        public FailedRecoverTaskInstanceBuilder withTaskInstance(TaskInstance needRecoverTaskInstance) {
+            this.needRecoverTaskInstance = needRecoverTaskInstance;
             return this;
         }
 
         @Override
         public TaskInstance build() {
-            return retryTaskInstanceFactory.createTaskInstance(this);
+            return failedRecoverTaskInstanceFactory.createTaskInstance(this);
         }
-
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/FailoverTaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/FailoverTaskInstanceFactory.java
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.ITaskGroupCoordinator;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.FailoverTaskInstanceFactory.FailoverTaskInstanceBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.FailoverTaskInstanceFactory.FailoverTaskInstanceBuilder;
 
 import java.util.Date;
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/FirstRunTaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/FirstRunTaskInstanceFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
@@ -23,7 +23,7 @@ import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.FirstRunTaskInstanceFactory.FirstRunTaskInstanceBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.FirstRunTaskInstanceFactory.FirstRunTaskInstanceBuilder;
 
 import java.util.Date;
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/ITaskExecution.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/ITaskExecution.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
@@ -23,14 +23,14 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecution;
 
 /**
- * The interface represent a running TaskInstance which belongs to a {@link WorkflowExecutionRunnable}.
+ * The interface represent a running TaskInstance which belongs to a {@link WorkflowExecution}.
  */
-public interface ITaskExecutionRunnable
+public interface ITaskExecution
         extends
-            Comparable<ITaskExecutionRunnable> {
+            Comparable<ITaskExecution> {
 
     /**
      * Get the task instance id.
@@ -46,8 +46,8 @@ public interface ITaskExecutionRunnable
 
     /**
      * Whether the task instance is initialized.
-     * <p> If the ITaskExecutionRunnable is never triggered, it is not initialized.
-     * <p> If the ITaskExecutionRunnable is created by failover, recovered then it is initialized.
+     * <p> If the ITaskExecution is never triggered, it is not initialized.
+     * <p> If the ITaskExecution is created by failover, recovered then it is initialized.
      */
     boolean isTaskInstanceInitialized();
 
@@ -70,24 +70,24 @@ public interface ITaskExecutionRunnable
     boolean isFailure();
 
     /**
-     * Retry the TaskExecutionRunnable.
+     * Retry the TaskExecution.
      * <p> Will create retry task instance and start it.
      */
     void retry();
 
     /**
-     * Failover the TaskExecutionRunnable.
+     * Failover the TaskExecution.
      * <p> The failover logic is judged by the task instance state.
      */
     void failover();
 
     /**
-     * Pause the TaskExecutionRunnable.
+     * Pause the TaskExecution.
      */
     void pause();
 
     /**
-     * Kill the TaskExecutionRunnable.
+     * Kill the TaskExecution.
      */
     void kill();
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/ITaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/ITaskInstanceFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/PauseRecoverTaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/PauseRecoverTaskInstanceFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/RetryTaskInstanceFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/RetryTaskInstanceFactory.java
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.RetryTaskInstanceFactory.RetryTaskInstanceBuilder;
 
 import java.util.Date;
 
@@ -29,55 +30,57 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-public class FailedRecoverTaskInstanceFactory
-        extends
-            AbstractTaskInstanceFactory<FailedRecoverTaskInstanceFactory.FailedRecoverTaskInstanceBuilder> {
+public class RetryTaskInstanceFactory extends AbstractTaskInstanceFactory<RetryTaskInstanceBuilder> {
 
     @Autowired
     private TaskInstanceDao taskInstanceDao;
 
     @Override
-    public FailedRecoverTaskInstanceFactory.FailedRecoverTaskInstanceBuilder builder() {
-        return new FailedRecoverTaskInstanceBuilder(this);
+    public RetryTaskInstanceBuilder builder() {
+        return new RetryTaskInstanceBuilder(this);
     }
 
     @Transactional
     @Override
-    public TaskInstance createTaskInstance(FailedRecoverTaskInstanceBuilder builder) {
-        final TaskInstance needRecoverTaskInstance = builder.needRecoverTaskInstance;
-        final TaskInstance taskInstance = cloneTaskInstance(needRecoverTaskInstance);
+    public TaskInstance createTaskInstance(RetryTaskInstanceBuilder builder) {
+        final TaskInstance needRetryTaskInstance = builder.taskInstance;
+        final TaskInstance taskInstance = cloneTaskInstance(needRetryTaskInstance);
         taskInstance.setId(null);
         taskInstance.setState(TaskExecutionStatus.SUBMITTED_SUCCESS);
+        taskInstance.setPid(0);
         taskInstance.setHost(null);
-        taskInstance.setVarPool(null);
-        taskInstance.setSubmitTime(new Date());
-        taskInstance.setLogPath(null);
         taskInstance.setExecutePath(null);
+        taskInstance.setLogPath(null);
+        taskInstance.setStartTime(null);
+        taskInstance.setEndTime(null);
+        taskInstance.setSubmitTime(new Date());
+        taskInstance.setRetryTimes(taskInstance.getRetryTimes() + 1);
         taskInstanceDao.insert(taskInstance);
 
-        needRecoverTaskInstance.setFlag(Flag.NO);
-        taskInstanceDao.updateById(needRecoverTaskInstance);
+        needRetryTaskInstance.setFlag(Flag.NO);
+        taskInstanceDao.updateById(needRetryTaskInstance);
         return taskInstance;
     }
 
-    public static class FailedRecoverTaskInstanceBuilder implements ITaskInstanceFactory.ITaskInstanceBuilder {
+    public static class RetryTaskInstanceBuilder implements ITaskInstanceFactory.ITaskInstanceBuilder {
 
-        private final FailedRecoverTaskInstanceFactory failedRecoverTaskInstanceFactory;
+        private final RetryTaskInstanceFactory retryTaskInstanceFactory;
 
-        private TaskInstance needRecoverTaskInstance;
+        private TaskInstance taskInstance;
 
-        public FailedRecoverTaskInstanceBuilder(FailedRecoverTaskInstanceFactory failedRecoverTaskInstanceFactory) {
-            this.failedRecoverTaskInstanceFactory = failedRecoverTaskInstanceFactory;
+        public RetryTaskInstanceBuilder(RetryTaskInstanceFactory retryTaskInstanceFactory) {
+            this.retryTaskInstanceFactory = retryTaskInstanceFactory;
         }
 
-        public FailedRecoverTaskInstanceBuilder withTaskInstance(TaskInstance needRecoverTaskInstance) {
-            this.needRecoverTaskInstance = needRecoverTaskInstance;
+        public RetryTaskInstanceBuilder withTaskInstance(TaskInstance taskInstance) {
+            this.taskInstance = taskInstance;
             return this;
         }
 
         @Override
         public TaskInstance build() {
-            return failedRecoverTaskInstanceFactory.createTaskInstance(this);
+            return retryTaskInstanceFactory.createTaskInstance(this);
         }
+
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecution.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecution.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -42,7 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 
 @Slf4j
-public class TaskExecutionRunnable implements ITaskExecutionRunnable {
+public class TaskExecution implements ITaskExecution {
 
     private final ApplicationContext applicationContext;
 
@@ -63,15 +63,15 @@ public class TaskExecutionRunnable implements ITaskExecutionRunnable {
     @Getter
     private TaskExecutionContext taskExecutionContext;
 
-    public TaskExecutionRunnable(TaskExecutionRunnableBuilder taskExecutionRunnableBuilder) {
-        this.applicationContext = taskExecutionRunnableBuilder.getApplicationContext();
-        this.workflowExecutionGraph = checkNotNull(taskExecutionRunnableBuilder.getWorkflowExecutionGraph());
-        this.workflowEventBus = checkNotNull(taskExecutionRunnableBuilder.getWorkflowEventBus());
-        this.workflowDefinition = checkNotNull(taskExecutionRunnableBuilder.getWorkflowDefinition());
-        this.project = checkNotNull(taskExecutionRunnableBuilder.getProject());
-        this.workflowInstance = checkNotNull(taskExecutionRunnableBuilder.getWorkflowInstance());
-        this.taskDefinition = checkNotNull(taskExecutionRunnableBuilder.getTaskDefinition());
-        this.taskInstance = taskExecutionRunnableBuilder.getTaskInstance();
+    public TaskExecution(TaskExecutionBuilder taskExecutionBuilder) {
+        this.applicationContext = taskExecutionBuilder.getApplicationContext();
+        this.workflowExecutionGraph = checkNotNull(taskExecutionBuilder.getWorkflowExecutionGraph());
+        this.workflowEventBus = checkNotNull(taskExecutionBuilder.getWorkflowEventBus());
+        this.workflowDefinition = checkNotNull(taskExecutionBuilder.getWorkflowDefinition());
+        this.project = checkNotNull(taskExecutionBuilder.getProject());
+        this.workflowInstance = checkNotNull(taskExecutionBuilder.getWorkflowInstance());
+        this.taskDefinition = checkNotNull(taskExecutionBuilder.getTaskDefinition());
+        this.taskInstance = taskExecutionBuilder.getTaskInstance();
     }
 
     @Override
@@ -164,7 +164,7 @@ public class TaskExecutionRunnable implements ITaskExecutionRunnable {
     }
 
     @Override
-    public int compareTo(ITaskExecutionRunnable other) {
+    public int compareTo(ITaskExecution other) {
         if (other == null) {
             return 1;
         }
@@ -194,8 +194,8 @@ public class TaskExecutionRunnable implements ITaskExecutionRunnable {
     @Override
     public String toString() {
         if (taskInstance != null) {
-            return "TaskExecutionRunnable{" + "name=" + getName() + ", state=" + taskInstance.getState() + '}';
+            return "TaskExecution{" + "name=" + getName() + ", state=" + taskInstance.getState() + '}';
         }
-        return "TaskExecutionRunnable{" + "name=" + getName() + '}';
+        return "TaskExecution{" + "name=" + getName() + '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecutionBuilder.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecutionBuilder.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
@@ -36,7 +36,7 @@ import org.springframework.context.ApplicationContext;
 @Getter
 @Builder
 @AllArgsConstructor
-public class TaskExecutionRunnableBuilder {
+public class TaskExecutionBuilder {
 
     private final IWorkflowExecutionGraph workflowExecutionGraph;
     private final WorkflowDefinition workflowDefinition;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecutionContextBuilder.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecutionContextBuilder.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecutionContextCreateRequest.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskExecutionContextCreateRequest.java
@@ -15,25 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.workflow.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
-import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
+import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-import org.springframework.context.ApplicationContext;
-
-@Data
+@Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
-public class WorkflowExecutionRunnableBuilder {
+public class TaskExecutionContextCreateRequest {
 
-    private WorkflowExecuteContext.WorkflowExecuteContextBuilder workflowExecuteContextBuilder;
-
-    private ApplicationContext applicationContext;
+    private IWorkflowExecutionGraph workflowExecutionGraph;
+    private WorkflowDefinition workflowDefinition;
+    private WorkflowInstance workflowInstance;
+    private TaskDefinition taskDefinition;
+    private TaskInstance taskInstance;
+    private Project project;
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskInstanceFactories.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/execution/TaskInstanceFactories.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.task.execution;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/AbstractTaskLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/AbstractTaskLifecycleEvent.java
@@ -18,7 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle;
 
 import org.apache.dolphinscheduler.server.master.engine.AbstractLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 public abstract class AbstractTaskLifecycleEvent extends AbstractLifecycleEvent {
 
@@ -30,6 +30,6 @@ public abstract class AbstractTaskLifecycleEvent extends AbstractLifecycleEvent 
         super(delayTime);
     }
 
-    public abstract ITaskExecutionRunnable getTaskExecutionRunnable();
+    public abstract ITaskExecution getTaskExecution();
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskDispatchLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskDispatchLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,10 +29,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskDispatchLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    public static TaskDispatchLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return new TaskDispatchLifecycleEvent(taskExecutionRunnable);
+    public static TaskDispatchLifecycleEvent of(final ITaskExecution taskExecution) {
+        return new TaskDispatchLifecycleEvent(taskExecution);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class TaskDispatchLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskDispatchLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskDispatchedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskDispatchedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,7 +31,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskDispatchedLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private ITaskExecutionRunnable taskExecutionRunnable;
+    private ITaskExecution taskExecution;
 
     private String executorHost;
 
@@ -43,7 +43,7 @@ public class TaskDispatchedLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskDispatchedLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", executorHost='" + executorHost + '\'' +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskFailedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskFailedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.Date;
 
@@ -33,7 +33,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class TaskFailedLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final Date endTime;
 
@@ -45,7 +45,7 @@ public class TaskFailedLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskFailedLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", endTime=" + endTime +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskFailoverLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskFailoverLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,9 +29,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskFailoverLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    public static TaskFailoverLifecycleEvent of(final ITaskExecutionRunnable taskExecuteRunnable) {
+    public static TaskFailoverLifecycleEvent of(final ITaskExecution taskExecuteRunnable) {
         return new TaskFailoverLifecycleEvent(taskExecuteRunnable);
     }
 
@@ -42,7 +42,7 @@ public class TaskFailoverLifecycleEvent extends AbstractTaskLifecycleEvent {
 
     public String toString() {
         return "TaskFailoverLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskFatalLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskFatalLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.Date;
 
@@ -33,7 +33,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class TaskFatalLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final Date endTime;
 
@@ -45,7 +45,7 @@ public class TaskFatalLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskFatalLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", endTime=" + endTime +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskKillLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskKillLifecycleEvent.java
@@ -18,28 +18,28 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.Getter;
 
 @Getter
 public class TaskKillLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    private TaskKillLifecycleEvent(ITaskExecutionRunnable taskExecutionRunnable, long delayTime) {
+    private TaskKillLifecycleEvent(ITaskExecution taskExecution, long delayTime) {
         super(delayTime);
-        this.taskExecutionRunnable = taskExecutionRunnable;
+        this.taskExecution = taskExecution;
     }
 
-    public static TaskKillLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return of(taskExecutionRunnable, 0);
+    public static TaskKillLifecycleEvent of(final ITaskExecution taskExecution) {
+        return of(taskExecution, 0);
     }
 
-    public static TaskKillLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable, long delayTime) {
-        return new TaskKillLifecycleEvent(taskExecutionRunnable, delayTime);
+    public static TaskKillLifecycleEvent of(final ITaskExecution taskExecution, long delayTime) {
+        return new TaskKillLifecycleEvent(taskExecution, delayTime);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class TaskKillLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskKillLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() + ", " +
+                "task=" + taskExecution.getName() + ", " +
                 "delayTime=" + delayTime +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskKilledLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskKilledLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.Date;
 
@@ -33,12 +33,12 @@ import lombok.Data;
 @AllArgsConstructor
 public class TaskKilledLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final Date endTime;
 
-    public static TaskKilledLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return new TaskKilledLifecycleEvent(taskExecutionRunnable, new Date());
+    public static TaskKilledLifecycleEvent of(final ITaskExecution taskExecution) {
+        return new TaskKilledLifecycleEvent(taskExecution, new Date());
     }
 
     @Override
@@ -49,7 +49,7 @@ public class TaskKilledLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskKilledLifecycleEvent{" +
-                "task" + taskExecutionRunnable.getName() +
+                "task" + taskExecution.getName() +
                 ", endTime=" + endTime +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskPauseLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskPauseLifecycleEvent.java
@@ -18,28 +18,28 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.Getter;
 
 @Getter
 public class TaskPauseLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    private TaskPauseLifecycleEvent(final ITaskExecutionRunnable taskExecutionRunnable, long delayTime) {
+    private TaskPauseLifecycleEvent(final ITaskExecution taskExecution, long delayTime) {
         super(delayTime);
-        this.taskExecutionRunnable = taskExecutionRunnable;
+        this.taskExecution = taskExecution;
     }
 
-    public static TaskPauseLifecycleEvent of(ITaskExecutionRunnable taskExecutionRunnable) {
-        return of(taskExecutionRunnable, 0);
+    public static TaskPauseLifecycleEvent of(ITaskExecution taskExecution) {
+        return of(taskExecution, 0);
     }
 
-    public static TaskPauseLifecycleEvent of(ITaskExecutionRunnable taskExecutionRunnable, long delayTime) {
-        return new TaskPauseLifecycleEvent(taskExecutionRunnable, delayTime);
+    public static TaskPauseLifecycleEvent of(ITaskExecution taskExecution, long delayTime) {
+        return new TaskPauseLifecycleEvent(taskExecution, delayTime);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class TaskPauseLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskPauseLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() + ", " +
+                "task=" + taskExecution.getName() + ", " +
                 "delayTime=" + delayTime +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskPausedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskPausedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,10 +29,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskPausedLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    public static TaskPausedLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable) {
-        return new TaskPausedLifecycleEvent(taskExecutionRunnable);
+    public static TaskPausedLifecycleEvent of(final ITaskExecution taskExecution) {
+        return new TaskPausedLifecycleEvent(taskExecution);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class TaskPausedLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskPausedLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRetryLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRetryLifecycleEvent.java
@@ -21,9 +21,9 @@ import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -32,16 +32,16 @@ import lombok.Getter;
 @Getter
 public class TaskRetryLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    protected TaskRetryLifecycleEvent(final ITaskExecutionRunnable taskExecutionRunnable,
+    protected TaskRetryLifecycleEvent(final ITaskExecution taskExecution,
                                       final long delayTime) {
         super(delayTime);
-        this.taskExecutionRunnable = taskExecutionRunnable;
+        this.taskExecution = taskExecution;
     }
 
-    public static TaskRetryLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    public static TaskRetryLifecycleEvent of(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         checkState(taskInstance != null, "The task instance must be initialized before retrying.");
         final int delayTime = taskInstance.getRetryInterval();
 
@@ -53,7 +53,7 @@ public class TaskRetryLifecycleEvent extends AbstractTaskLifecycleEvent {
                 maxRetryTimes);
         final long remainingTime =
                 TimeUnit.MINUTES.toMillis(delayTime) + System.currentTimeMillis() - taskInstance.getEndTime().getTime();
-        return new TaskRetryLifecycleEvent(taskExecutionRunnable, remainingTime);
+        return new TaskRetryLifecycleEvent(taskExecution, remainingTime);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class TaskRetryLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskRetryLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", delayTime=" + delayTime + "/ms" +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRunningLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRunningLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.Date;
 
@@ -33,7 +33,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskRunningLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final String logPath;
 
@@ -47,7 +47,7 @@ public class TaskRunningLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskRunningLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", logPath='" + logPath + '\'' +
                 ", startTime=" + startTime +
                 '}';

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRuntimeContextChangedEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRuntimeContextChangedEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,7 +31,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskRuntimeContextChangedEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final String runtimeContext;
 
@@ -43,7 +43,7 @@ public class TaskRuntimeContextChangedEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskRunningLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", runtimeContext=" + runtimeContext +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskStartLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskStartLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,10 +29,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskStartLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
-    public static TaskStartLifecycleEvent of(ITaskExecutionRunnable taskExecutionRunnable) {
-        return new TaskStartLifecycleEvent(taskExecutionRunnable);
+    public static TaskStartLifecycleEvent of(ITaskExecution taskExecution) {
+        return new TaskStartLifecycleEvent(taskExecution);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class TaskStartLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskStartLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskSuccessLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskSuccessLifecycleEvent.java
@@ -19,9 +19,9 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
 
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.Date;
 import java.util.List;
@@ -35,7 +35,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TaskSuccessLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final Date endTime;
 
@@ -49,7 +49,7 @@ public class TaskSuccessLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskSuccessLifecycleEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", endTime=" + endTime +
                 ", varPool='" + varPool + '\'' +
                 '}';

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskTimeoutLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskTimeoutLifecycleEvent.java
@@ -22,9 +22,9 @@ import static com.google.common.base.Preconditions.checkState;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskTimeoutStrategy;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -33,29 +33,29 @@ import lombok.Getter;
 @Getter
 public class TaskTimeoutLifecycleEvent extends AbstractTaskLifecycleEvent {
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     private final TaskTimeoutStrategy timeoutStrategy;
 
-    protected TaskTimeoutLifecycleEvent(final ITaskExecutionRunnable taskExecutionRunnable,
+    protected TaskTimeoutLifecycleEvent(final ITaskExecution taskExecution,
                                         final TaskTimeoutStrategy timeoutStrategy,
                                         final long timeout) {
         super(timeout);
         this.timeoutStrategy = timeoutStrategy;
-        this.taskExecutionRunnable = taskExecutionRunnable;
+        this.taskExecution = taskExecution;
     }
 
-    public static TaskTimeoutLifecycleEvent of(final ITaskExecutionRunnable taskExecutionRunnable,
+    public static TaskTimeoutLifecycleEvent of(final ITaskExecution taskExecution,
                                                final TaskTimeoutStrategy timeoutStrategy,
                                                final long timeoutInMinutes) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
 
         checkState(timeoutStrategy != null, "The task timeoutStrategy must not be null");
         checkState(timeoutInMinutes > 0, "The task timeout: %s must > 0 minutes", timeoutInMinutes);
 
         long delayTime = System.currentTimeMillis() - taskInstance.getSubmitTime().getTime()
                 + TimeUnit.MINUTES.toMillis(timeoutInMinutes);
-        return new TaskTimeoutLifecycleEvent(taskExecutionRunnable, timeoutStrategy, delayTime);
+        return new TaskTimeoutLifecycleEvent(taskExecution, timeoutStrategy, delayTime);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class TaskTimeoutLifecycleEvent extends AbstractTaskLifecycleEvent {
     @Override
     public String toString() {
         return "TaskRetryEvent{" +
-                "task=" + taskExecutionRunnable.getName() +
+                "task=" + taskExecution.getName() +
                 ", timeout=" + delayTime +
                 '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/AbstractTaskLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/AbstractTaskLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventHandler;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.AbstractTaskLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.TaskStateActionFactory;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,21 +38,21 @@ public abstract class AbstractTaskLifecycleEventHandler<T extends AbstractTaskLi
     protected TaskStateActionFactory taskStateActionFactory;
 
     @Override
-    public void handle(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void handle(final IWorkflowExecution workflowExecution,
                        final T event) {
-        final ITaskExecutionRunnable taskExecutionRunnable = event.getTaskExecutionRunnable();
-        final TaskExecutionStatus state = taskExecutionRunnable.getTaskInstance().getState();
+        final ITaskExecution taskExecution = event.getTaskExecution();
+        final TaskExecutionStatus state = taskExecution.getTaskInstance().getState();
         final ITaskStateAction taskStateAction = taskStateActionFactory.getTaskStateAction(state);
-        handle(taskStateAction, workflowExecutionRunnable, taskExecutionRunnable, event);
+        handle(taskStateAction, workflowExecution, taskExecution, event);
         log.info("Fired task {} {} with state {}",
-                taskExecutionRunnable.getName(),
+                taskExecution.getName(),
                 event,
                 state.name());
     }
 
     public abstract void handle(final ITaskStateAction taskStateAction,
-                                final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+                                final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final T event);
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchLifecycleEventHandler.java
@@ -18,11 +18,11 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,10 +34,10 @@ public class TaskDispatchLifecycleEventHandler extends AbstractTaskLifecycleEven
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskDispatchLifecycleEvent event) {
-        taskStateAction.onDispatchEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onDispatchEvent(workflowExecution, taskExecution, event);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskDispatchedLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.TaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -45,14 +45,14 @@ public class TaskDispatchedLifecycleEventHandler
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        taskStateAction.onDispatchedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskDispatchedEvent);
+        taskStateAction.onDispatchedEvent(workflowExecution, taskExecution, taskDispatchedEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.DISPATCHED));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailedLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.TaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -40,14 +40,14 @@ public class TaskFailedLifecycleEventHandler extends AbstractTaskLifecycleEventH
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskFailedLifecycleEvent event) {
-        taskStateAction.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onFailedEvent(workflowExecution, taskExecution, event);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.FAILED));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailoverLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFailoverLifecycleEventHandler.java
@@ -18,11 +18,11 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailoverLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import org.springframework.stereotype.Component;
 
@@ -31,10 +31,10 @@ public class TaskFailoverLifecycleEventHandler extends AbstractTaskLifecycleEven
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        taskStateAction.onFailoverEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailoverEvent);
+        taskStateAction.onFailoverEvent(workflowExecution, taskExecution, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFatalLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskFatalLifecycleEventHandler.java
@@ -18,11 +18,11 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFatalLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import org.springframework.stereotype.Component;
 
@@ -31,10 +31,10 @@ public class TaskFatalLifecycleEventHandler extends AbstractTaskLifecycleEventHa
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskFatalLifecycleEvent taskFatalEvent) {
-        taskStateAction.onFatalEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFatalEvent);
+        taskStateAction.onFatalEvent(workflowExecution, taskExecution, taskFatalEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKillLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKillLifecycleEventHandler.java
@@ -18,11 +18,11 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskKillLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,10 +34,10 @@ public class TaskKillLifecycleEventHandler extends AbstractTaskLifecycleEventHan
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskKillLifecycleEvent taskKillEvent) {
-        taskStateAction.onKillEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKillEvent);
+        taskStateAction.onKillEvent(workflowExecution, taskExecution, taskKillEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKilledLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskKilledLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.TaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskKilledLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -40,14 +40,14 @@ public class TaskKilledLifecycleEventHandler extends AbstractTaskLifecycleEventH
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskKilledLifecycleEvent taskKilledEvent) {
-        taskStateAction.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        taskStateAction.onKilledEvent(workflowExecution, taskExecution, taskKilledEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.KILLED));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPauseLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPauseLifecycleEventHandler.java
@@ -18,11 +18,11 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskPauseLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import org.springframework.stereotype.Component;
 
@@ -31,10 +31,10 @@ public class TaskPauseLifecycleEventHandler extends AbstractTaskLifecycleEventHa
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskPauseLifecycleEvent taskPauseEvent) {
-        taskStateAction.onPauseEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPauseEvent);
+        taskStateAction.onPauseEvent(workflowExecution, taskExecution, taskPauseEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPausedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskPausedLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.TaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskPausedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -40,14 +40,14 @@ public class TaskPausedLifecycleEventHandler extends AbstractTaskLifecycleEventH
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskPausedLifecycleEvent event) {
-        taskStateAction.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onPausedEvent(workflowExecution, taskExecution, event);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.PAUSED));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRetryLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRetryLifecycleEventHandler.java
@@ -18,11 +18,11 @@
 package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRetryLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,10 +34,10 @@ public class TaskRetryLifecycleEventHandler extends AbstractTaskLifecycleEventHa
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskRetryLifecycleEvent taskRetryLifecycleEvent) {
-        taskStateAction.onRetryEvent(workflowExecutionRunnable, taskExecutionRunnable, taskRetryLifecycleEvent);
+        taskStateAction.onRetryEvent(workflowExecution, taskExecution, taskRetryLifecycleEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRunningLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRunningLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -43,14 +43,14 @@ public class TaskRunningLifecycleEventHandler extends AbstractTaskLifecycleEvent
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskRunningLifecycleEvent taskRunningEvent) {
-        taskStateAction.onStartedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskRunningEvent);
+        taskStateAction.onStartedEvent(workflowExecution, taskExecution, taskRunningEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.RUNNING));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRuntimeContextChangedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskRuntimeContextChangedLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRuntimeContextChangedEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -45,15 +45,15 @@ public class TaskRuntimeContextChangedLifecycleEventHandler
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskRuntimeContextChangedEvent event) {
-        taskStateAction.onRuntimeContextChangedEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onRuntimeContextChangedEvent(workflowExecution, taskExecution, event);
 
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.RUNTIME_CONTEXT_CHANGE));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskStartLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskStartLifecycleEventHandler.java
@@ -21,12 +21,12 @@ import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskTimeoutStrategy;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskTimeoutLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,25 +41,25 @@ public class TaskStartLifecycleEventHandler extends AbstractTaskLifecycleEventHa
     private MasterConfig masterConfig;
 
     @Override
-    public void handle(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void handle(final IWorkflowExecution workflowExecution,
                        final TaskStartLifecycleEvent taskStartLifecycleEvent) {
-        final ITaskExecutionRunnable taskExecutionRunnable = taskStartLifecycleEvent.getTaskExecutionRunnable();
-        // Since if the ITaskExecutionRunnable is start at the first time, then it might not be initialized.
+        final ITaskExecution taskExecution = taskStartLifecycleEvent.getTaskExecution();
+        // Since if the ITaskExecution is start at the first time, then it might not be initialized.
         // So we need to initialize the task instance here.
         // Otherwise, we cannot find the statemachine by task instance state.
-        if (!taskExecutionRunnable.isTaskInstanceInitialized()) {
-            taskExecutionRunnable.initializeFirstRunTaskInstance();
+        if (!taskExecution.isTaskInstanceInitialized()) {
+            taskExecution.initializeFirstRunTaskInstance();
         }
-        taskTimeoutMonitor(taskExecutionRunnable);
-        super.handle(workflowExecutionRunnable, taskStartLifecycleEvent);
+        taskTimeoutMonitor(taskExecution);
+        super.handle(workflowExecution, taskStartLifecycleEvent);
     }
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskStartLifecycleEvent event) {
-        taskStateAction.onStartEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
+        taskStateAction.onStartEvent(workflowExecution, taskExecution, event);
     }
 
     @Override
@@ -67,21 +67,21 @@ public class TaskStartLifecycleEventHandler extends AbstractTaskLifecycleEventHa
         return TaskLifecycleEventType.START;
     }
 
-    private void taskTimeoutMonitor(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskDefinition taskDefinition = taskExecutionRunnable.getTaskDefinition();
+    private void taskTimeoutMonitor(final ITaskExecution taskExecution) {
+        final TaskDefinition taskDefinition = taskExecution.getTaskDefinition();
         int taskTimeout = taskDefinition.getTimeout();
         if (taskTimeout > 0 && taskDefinition.getTimeoutNotifyStrategy() != null) {
             log.debug("The task {} timeout {} is invalided, so the timeout monitor will not be started.",
                     taskDefinition.getName(),
                     taskDefinition.getTimeout());
-            taskExecutionRunnable.getWorkflowEventBus().publish(TaskTimeoutLifecycleEvent.of(
-                    taskExecutionRunnable, taskDefinition.getTimeoutNotifyStrategy(), taskTimeout));
+            taskExecution.getWorkflowEventBus().publish(TaskTimeoutLifecycleEvent.of(
+                    taskExecution, taskDefinition.getTimeoutNotifyStrategy(), taskTimeout));
         }
 
         int systemTimeout = (int) masterConfig.getServerLoadProtection().getMaxTaskInstanceRuntime().toMinutes();
         if (systemTimeout > 0) {
-            taskExecutionRunnable.getWorkflowEventBus().publish(TaskTimeoutLifecycleEvent.of(
-                    taskExecutionRunnable, TaskTimeoutStrategy.FAILED, systemTimeout));
+            taskExecution.getWorkflowEventBus().publish(TaskTimeoutLifecycleEvent.of(
+                    taskExecution, TaskTimeoutStrategy.FAILED, systemTimeout));
         }
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskSuccessLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskSuccessLifecycleEventHandler.java
@@ -19,11 +19,11 @@ package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.client.TaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.eventbus.ITaskExecutorLifecycleEventReporter;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorLifecycleEventType;
 
@@ -40,14 +40,14 @@ public class TaskSuccessLifecycleEventHandler extends AbstractTaskLifecycleEvent
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        taskStateAction.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
+        taskStateAction.onSucceedEvent(workflowExecution, taskExecution, taskSuccessEvent);
         taskExecutorClient.ackTaskExecutorLifecycleEvent(
-                taskExecutionRunnable,
+                taskExecution,
                 new ITaskExecutorLifecycleEventReporter.TaskExecutorLifecycleEventAck(
-                        taskExecutionRunnable.getId(),
+                        taskExecution.getId(),
                         TaskExecutorLifecycleEventType.SUCCESS));
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskTimeoutLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/handler/TaskTimeoutLifecycleEventHandler.java
@@ -22,12 +22,12 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskTimeoutStrategy;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.TaskLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskKillLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskTimeoutLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.task.statemachine.ITaskStateAction;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.service.alert.WorkflowAlertManager;
 
 import lombok.extern.slf4j.Slf4j;
@@ -46,44 +46,44 @@ public class TaskTimeoutLifecycleEventHandler extends AbstractTaskLifecycleEvent
 
     @Override
     public void handle(final ITaskStateAction taskStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskTimeoutLifecycleEvent taskTimeoutLifecycleEvent) {
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        if (!workflowExecutionGraph.isTaskExecutionRunnableActive(taskExecutionRunnable)) {
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        if (!workflowExecutionGraph.isTaskExecutionActive(taskExecution)) {
             // The task instance is not active, means it is already finished.
             return;
         }
-        final String taskName = taskExecutionRunnable.getName();
+        final String taskName = taskExecution.getName();
         final TaskTimeoutStrategy timeoutNotifyStrategy = taskTimeoutLifecycleEvent.getTimeoutStrategy();
         if (timeoutNotifyStrategy == null) {
             log.info("The task {} TimeoutStrategy is null.", taskName);
             return;
         }
 
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         final boolean shouldSendAlert = workflowInstance.getWarningGroupId() != null;
 
         switch (timeoutNotifyStrategy) {
             case WARN:
                 log.info("The task {} TimeoutStrategy is WARN, try to send a timeout alert.", taskName);
                 if (shouldSendAlert) {
-                    doTaskTimeoutAlert(taskExecutionRunnable);
+                    doTaskTimeoutAlert(taskExecution);
                 } else {
                     log.info("Skipped sending timeout alert for task {} because warningGroupId is null.", taskName);
                 }
                 break;
             case FAILED:
                 log.info("The task {} TimeoutStrategy is FAILED, try to publish a kill event.", taskName);
-                doTaskTimeoutKill(taskExecutionRunnable);
+                doTaskTimeoutKill(taskExecution);
                 break;
             case WARNFAILED:
                 log.info(
                         "The task {} TimeoutStrategy is WARNFAILED, try to publish a kill event and send a timeout alert.",
                         taskName);
-                doTaskTimeoutKill(taskExecutionRunnable);
+                doTaskTimeoutKill(taskExecution);
                 if (shouldSendAlert) {
-                    doTaskTimeoutAlert(taskExecutionRunnable);
+                    doTaskTimeoutAlert(taskExecution);
                 } else {
                     log.info("Skipped sending timeout alert for task {} because warningGroupId is null.", taskName);
                 }
@@ -93,13 +93,13 @@ public class TaskTimeoutLifecycleEventHandler extends AbstractTaskLifecycleEvent
         }
     }
 
-    private void doTaskTimeoutKill(final ITaskExecutionRunnable taskExecutionRunnable) {
-        taskExecutionRunnable.getWorkflowEventBus().publish(TaskKillLifecycleEvent.of(taskExecutionRunnable));
+    private void doTaskTimeoutKill(final ITaskExecution taskExecution) {
+        taskExecution.getWorkflowEventBus().publish(TaskKillLifecycleEvent.of(taskExecution));
     }
 
-    private void doTaskTimeoutAlert(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final WorkflowInstance workflowInstance = taskExecutionRunnable.getWorkflowInstance();
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    private void doTaskTimeoutAlert(final ITaskExecution taskExecution) {
+        final WorkflowInstance workflowInstance = taskExecution.getWorkflowInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         workflowAlertManager.sendTaskTimeoutAlert(workflowInstance, taskInstance);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/listener/ITaskExecutionLifecycleListener.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/listener/ITaskExecutionLifecycleListener.java
@@ -28,7 +28,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
  * Todo: this interface is used to listen to the lifecycle of the task execution runnable.
  * We should use this to listen the state and trigger alert
  */
-public interface ITaskExecutionRunnableLifecycleListener {
+public interface ITaskExecutionLifecycleListener {
 
     void onDispatched(TaskDispatchedLifecycleEvent taskDispatchedEvent);
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/AbstractTaskStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/AbstractTaskStateAction.java
@@ -33,6 +33,7 @@ import org.apache.dolphinscheduler.server.master.engine.ITaskGroupCoordinator;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -43,9 +44,8 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRuntimeContextChangedEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -75,8 +75,8 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     /**
      * Whether the task needs to acquire the task group slot.
      */
-    protected boolean isTaskNeedAcquireTaskGroupSlot(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    protected boolean isTaskNeedAcquireTaskGroupSlot(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         return taskGroupCoordinator.needAcquireTaskGroupSlot(taskInstance);
     }
 
@@ -84,79 +84,79 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
      * Acquire the resources needed by the task instance.
      * <p> If the task instance is using a task group, the task group slot will be acquired.
      */
-    protected void acquireTaskGroupSlot(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
-        final TaskDefinition taskDefinition = taskExecutionRunnable.getTaskDefinition();
+    protected void acquireTaskGroupSlot(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
+        final TaskDefinition taskDefinition = taskExecution.getTaskDefinition();
         taskGroupCoordinator.acquireTaskGroupSlot(taskInstance, taskDefinition);
     }
 
     /**
      * Release the resources needed by the task instance.
      */
-    protected void releaseTaskInstanceResourcesIfNeeded(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+    protected void releaseTaskInstanceResourcesIfNeeded(final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         if (taskGroupCoordinator.needToReleaseTaskGroupSlot(taskInstance)) {
             taskGroupCoordinator.releaseTaskGroupSlot(taskInstance);
         }
     }
 
     @Override
-    public void onFatalEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFatalEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskFatalLifecycleEvent taskFatalEvent) {
-        releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
-        persistentTaskInstanceFatalEventToDB(taskExecutionRunnable, taskFatalEvent);
+        releaseTaskInstanceResourcesIfNeeded(taskExecution);
+        persistentTaskInstanceFatalEventToDB(taskExecution, taskFatalEvent);
 
-        if (taskExecutionRunnable.isTaskInstanceCanRetry()) {
-            taskExecutionRunnable.getWorkflowEventBus().publish(TaskRetryLifecycleEvent.of(taskExecutionRunnable));
+        if (taskExecution.isTaskInstanceCanRetry()) {
+            taskExecution.getWorkflowEventBus().publish(TaskRetryLifecycleEvent.of(taskExecution));
             return;
         }
 
         // If all successors are condition tasks, then the task will not be marked as failure.
         // And the DAG will continue to execute.
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
-        if (workflowExecutionGraph.isAllSuccessorsAreConditionTask(taskExecutionRunnable)) {
-            mergeTaskVarPoolToWorkflow(workflowExecutionRunnable, taskExecutionRunnable);
-            publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecution.getWorkflowExecutionGraph();
+        if (workflowExecutionGraph.isAllSuccessorsAreConditionTask(taskExecution)) {
+            mergeTaskVarPoolToWorkflow(workflowExecution, taskExecution);
+            publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
             return;
         }
 
-        taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainFailure(taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        taskExecution.getWorkflowExecutionGraph().markTaskExecutionChainFailure(taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
-    private void persistentTaskInstanceFatalEventToDB(final ITaskExecutionRunnable taskExecutionRunnable,
+    private void persistentTaskInstanceFatalEventToDB(final ITaskExecution taskExecution,
                                                       final TaskFatalLifecycleEvent taskFatalEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.FAILURE);
         taskInstance.setEndTime(taskFatalEvent.getEndTime());
         taskInstanceDao.updateById(taskInstance);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(DISPATCH);
         taskInstance.setHost(taskDispatchedEvent.getExecutorHost());
         taskInstanceDao.updateById(taskInstance);
     }
 
     @Override
-    public void onRuntimeContextChangedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRuntimeContextChangedEvent(final IWorkflowExecution workflowExecution,
+                                             final ITaskExecution taskExecution,
                                              final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         if (StringUtils.isNotEmpty(taskRuntimeContextChangedEvent.getRuntimeContext())) {
             taskInstance.setAppLink(taskRuntimeContextChangedEvent.getRuntimeContext());
         }
         taskInstanceDao.updateById(taskInstance);
     }
 
-    protected void persistentTaskInstanceStartedEventToDB(final ITaskExecutionRunnable taskExecutionRunnable,
+    protected void persistentTaskInstanceStartedEventToDB(final ITaskExecution taskExecution,
                                                           final TaskRunningLifecycleEvent taskRunningEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.RUNNING_EXECUTION);
         taskInstance.setStartTime(taskRunningEvent.getStartTime());
         taskInstance.setLogPath(taskRunningEvent.getLogPath());
@@ -164,35 +164,35 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
-        persistentTaskInstancePausedEventToDB(taskExecutionRunnable, taskPausedEvent);
-        taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainPause(taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        releaseTaskInstanceResourcesIfNeeded(taskExecution);
+        persistentTaskInstancePausedEventToDB(taskExecution, taskPausedEvent);
+        taskExecution.getWorkflowExecutionGraph().markTaskExecutionChainPause(taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
-    private void persistentTaskInstancePausedEventToDB(final ITaskExecutionRunnable taskExecutionRunnable,
+    private void persistentTaskInstancePausedEventToDB(final ITaskExecution taskExecution,
                                                        final TaskPausedLifecycleEvent taskPausedEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.PAUSE);
         taskInstanceDao.updateById(taskInstance);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskInstanceKillEvent) {
-        releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
-        persistentTaskInstanceKilledEventToDB(taskExecutionRunnable, taskInstanceKillEvent);
-        taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainKill(taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        releaseTaskInstanceResourcesIfNeeded(taskExecution);
+        persistentTaskInstanceKilledEventToDB(taskExecution, taskInstanceKillEvent);
+        taskExecution.getWorkflowExecutionGraph().markTaskExecutionChainKill(taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
-    private void persistentTaskInstanceKilledEventToDB(final ITaskExecutionRunnable taskExecutionRunnable,
+    private void persistentTaskInstanceKilledEventToDB(final ITaskExecution taskExecution,
                                                        final TaskKilledLifecycleEvent taskKilledEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.KILL);
         taskInstance.setEndTime(taskKilledEvent.getEndTime());
         taskInstanceDao.updateById(taskInstance);
@@ -200,59 +200,59 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
-        persistentTaskInstanceFailedEventToDB(taskExecutionRunnable, taskFailedEvent);
+        releaseTaskInstanceResourcesIfNeeded(taskExecution);
+        persistentTaskInstanceFailedEventToDB(taskExecution, taskFailedEvent);
 
-        if (taskExecutionRunnable.isTaskInstanceCanRetry()) {
-            taskExecutionRunnable.getWorkflowEventBus().publish(TaskRetryLifecycleEvent.of(taskExecutionRunnable));
+        if (taskExecution.isTaskInstanceCanRetry()) {
+            taskExecution.getWorkflowEventBus().publish(TaskRetryLifecycleEvent.of(taskExecution));
             return;
         }
         // If all successors are condition tasks, then the task will not be marked as failure.
         // And the DAG will continue to execute.
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
-        if (workflowExecutionGraph.isAllSuccessorsAreConditionTask(taskExecutionRunnable)) {
-            mergeTaskVarPoolToWorkflow(workflowExecutionRunnable, taskExecutionRunnable);
-            publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecution.getWorkflowExecutionGraph();
+        if (workflowExecutionGraph.isAllSuccessorsAreConditionTask(taskExecution)) {
+            mergeTaskVarPoolToWorkflow(workflowExecution, taskExecution);
+            publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
             return;
         }
         // todo: Use Plugin to extend the act strategy on xxEvent.
-        taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainFailure(taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        taskExecution.getWorkflowExecutionGraph().markTaskExecutionChainFailure(taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
-    private void persistentTaskInstanceFailedEventToDB(final ITaskExecutionRunnable taskExecutionRunnable,
+    private void persistentTaskInstanceFailedEventToDB(final ITaskExecution taskExecution,
                                                        final TaskFailedLifecycleEvent taskFailedEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.FAILURE);
         taskInstance.setEndTime(taskFailedEvent.getEndTime());
         taskInstanceDao.updateById(taskInstance);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        releaseTaskInstanceResourcesIfNeeded(taskExecutionRunnable);
-        persistentTaskInstanceSuccessEventToDB(taskExecutionRunnable, taskSuccessEvent);
-        mergeTaskVarPoolToWorkflow(workflowExecutionRunnable, taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        releaseTaskInstanceResourcesIfNeeded(taskExecution);
+        persistentTaskInstanceSuccessEventToDB(taskExecution, taskSuccessEvent);
+        mergeTaskVarPoolToWorkflow(workflowExecution, taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
-    protected void mergeTaskVarPoolToWorkflow(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                              final ITaskExecutionRunnable taskExecutionRunnable) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+    protected void mergeTaskVarPoolToWorkflow(final IWorkflowExecution workflowExecution,
+                                              final ITaskExecution taskExecution) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         final List<Property> finalVarPool = VarPoolUtils.mergeVarPoolJsonString(
                 Lists.newArrayList(workflowInstance.getVarPool(), taskInstance.getVarPool()));
         workflowInstance.setVarPool(VarPoolUtils.serializeVarPool(finalVarPool));
     }
 
-    protected void persistentTaskInstanceSuccessEventToDB(final ITaskExecutionRunnable taskExecutionRunnable,
+    protected void persistentTaskInstanceSuccessEventToDB(final ITaskExecution taskExecution,
                                                           final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.SUCCESS);
         taskInstance.setEndTime(taskSuccessEvent.getEndTime());
         final List<Property> finalVarPool = VarPoolUtils.mergeVarPoolJsonString(taskInstance.getVarPool(),
@@ -266,33 +266,33 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
      * <p> Will try to take over the task from remote executor, if take-over success, the task has no effect.
      * <p> If the take-over fails, will generate a failover task-instance and mark the task instance status to {@link TaskExecutionStatus#NEED_FAULT_TOLERANCE}.
      */
-    protected void failoverTask(final ITaskExecutionRunnable taskExecutionRunnable) {
-        taskExecutionRunnable.failover();
+    protected void failoverTask(final ITaskExecution taskExecution) {
+        taskExecution.failover();
     }
 
-    protected void tryToDispatchTask(final ITaskExecutionRunnable taskExecutionRunnable) {
-        if (isTaskNeedAcquireTaskGroupSlot(taskExecutionRunnable)) {
-            acquireTaskGroupSlot(taskExecutionRunnable);
-            log.info("Task[name={}] using taskGroup, success acquire taskGroup slot", taskExecutionRunnable.getName());
+    protected void tryToDispatchTask(final ITaskExecution taskExecution) {
+        if (isTaskNeedAcquireTaskGroupSlot(taskExecution)) {
+            acquireTaskGroupSlot(taskExecution);
+            log.info("Task[name={}] using taskGroup, success acquire taskGroup slot", taskExecution.getName());
             return;
         }
-        taskExecutionRunnable.getWorkflowEventBus().publish(TaskDispatchLifecycleEvent.of(taskExecutionRunnable));
+        taskExecution.getWorkflowEventBus().publish(TaskDispatchLifecycleEvent.of(taskExecution));
     }
 
     protected void publishWorkflowInstanceTopologyLogicalTransitionEvent(
-                                                                         final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                                         final ITaskExecutionRunnable taskExecutionRunnable) {
-        taskExecutionRunnable
+                                                                         final IWorkflowExecution workflowExecution,
+                                                                         final ITaskExecution taskExecution) {
+        taskExecution
                 .getWorkflowEventBus()
                 .publish(
                         WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent.of(
-                                workflowExecutionRunnable,
-                                taskExecutionRunnable));
+                                workflowExecution,
+                                taskExecution));
     }
 
-    protected void throwExceptionIfStateIsNotMatch(final ITaskExecutionRunnable taskExecutionRunnable) {
-        checkNotNull(taskExecutionRunnable, "taskExecutionRunnable is null");
-        final TaskInstance taskInstance = checkNotNull(taskExecutionRunnable.getTaskInstance(), "taskInstance is null");
+    protected void throwExceptionIfStateIsNotMatch(final ITaskExecution taskExecution) {
+        checkNotNull(taskExecution, "taskExecution is null");
+        final TaskInstance taskInstance = checkNotNull(taskExecution.getTaskInstance(), "taskInstance is null");
         final TaskExecutionStatus actualState = taskInstance.getState();
         final TaskExecutionStatus expectState = matchState();
         if (actualState != expectState) {
@@ -302,9 +302,9 @@ public abstract class AbstractTaskStateAction implements ITaskStateAction {
         }
     }
 
-    protected void logWarningIfCannotDoAction(final ITaskExecutionRunnable taskExecutionRunnable,
+    protected void logWarningIfCannotDoAction(final ITaskExecution taskExecution,
                                               final AbstractLifecycleEvent event) {
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         log.warn("Task[name={}] state is {} cannot do action on event: {}",
                 taskInstance.getName(),
                 taskInstance.getState(),

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/ITaskStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/ITaskStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -32,8 +33,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRuntimeContextChangedEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 /**
  * Represents the action to be taken when a task is in a certain state and receive a target event.
@@ -56,112 +56,112 @@ public interface ITaskStateAction {
      * Perform the necessary actions when the task in a certain state receive a {@link TaskStartLifecycleEvent}.
      * <p> This method is called when you want to start a task.
      */
-    void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                      final ITaskExecutionRunnable taskExecutionRunnable,
+    void onStartEvent(final IWorkflowExecution workflowExecution,
+                      final ITaskExecution taskExecution,
                       final TaskStartLifecycleEvent taskStartEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskRunningLifecycleEvent}.
      * <p> This method is called when the master receive task running event from executor.
      */
-    void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                        final ITaskExecutionRunnable taskExecutionRunnable,
+    void onStartedEvent(final IWorkflowExecution workflowExecution,
+                        final ITaskExecution taskExecution,
                         final TaskRunningLifecycleEvent taskRunningEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskRuntimeContextChangedEvent}.
      * <p> This method is called when the master receive task runtime context changed event from executor.
      */
-    void onRuntimeContextChangedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                      final ITaskExecutionRunnable taskExecutionRunnable,
+    void onRuntimeContextChangedEvent(final IWorkflowExecution workflowExecution,
+                                      final ITaskExecution taskExecution,
                                       final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskRetryLifecycleEvent}.
      * <p> This method is called when the task need to retry.
      */
-    void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                      final ITaskExecutionRunnable taskExecutionRunnable,
+    void onRetryEvent(final IWorkflowExecution workflowExecution,
+                      final ITaskExecution taskExecution,
                       final TaskRetryLifecycleEvent taskRetryEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskDispatchLifecycleEvent}.
      * <p> This method is called when you want to dispatch a task.
      */
-    void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                         final ITaskExecutionRunnable taskExecutionRunnable,
+    void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                         final ITaskExecution taskExecution,
                          final TaskDispatchLifecycleEvent taskDispatchEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskFatalLifecycleEvent}.
      * <p> This method is called when the task encounters catastrophic failure (e.g., initialization failure).
      */
-    void onFatalEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                      final ITaskExecutionRunnable taskExecutionRunnable,
+    void onFatalEvent(final IWorkflowExecution workflowExecution,
+                      final ITaskExecution taskExecution,
                       final TaskFatalLifecycleEvent taskFatalEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskDispatchedLifecycleEvent}.
      * <p> This method is called when the task has been dispatched to executor.
      */
-    void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                           final ITaskExecutionRunnable taskExecutionRunnable,
+    void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                           final ITaskExecution taskExecution,
                            final TaskDispatchedLifecycleEvent taskDispatchedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskPauseLifecycleEvent}.
      * <p> This method is called when you want to pause a task.
      */
-    void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                      final ITaskExecutionRunnable taskExecutionRunnable,
+    void onPauseEvent(final IWorkflowExecution workflowExecution,
+                      final ITaskExecution taskExecution,
                       final TaskPauseLifecycleEvent taskPauseEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskPausedLifecycleEvent}.
      * <p> This method is called when the task has been paused.
      */
-    void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+    void onPausedEvent(final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskPausedLifecycleEvent taskPausedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskKillLifecycleEvent}.
      * <p> This method is called when you want to kill a task.
      */
-    void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                     final ITaskExecutionRunnable taskExecutionRunnable,
+    void onKillEvent(final IWorkflowExecution workflowExecution,
+                     final ITaskExecution taskExecution,
                      final TaskKillLifecycleEvent taskKillEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskKilledLifecycleEvent}.
      * <p> This method is called when the task has been killed.
      */
-    void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+    void onKilledEvent(final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskKilledLifecycleEvent taskKilledEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskFailedLifecycleEvent}.
      * <p> This method is called when the task has been failed.
      */
-    void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       final ITaskExecutionRunnable taskExecutionRunnable,
+    void onFailedEvent(final IWorkflowExecution workflowExecution,
+                       final ITaskExecution taskExecution,
                        final TaskFailedLifecycleEvent taskFailedEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskSuccessLifecycleEvent}.
      * <p> This method is called when the task has been success.
      */
-    void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                        final ITaskExecutionRunnable taskExecutionRunnable,
+    void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                        final ITaskExecution taskExecution,
                         final TaskSuccessLifecycleEvent taskSuccessEvent);
 
     /**
      * Perform the necessary actions when the task in a certain state receive a {@link TaskFailoverLifecycleEvent}.
      * <p> This method is called when the task need to failover.
      */
-    void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                         final ITaskExecutionRunnable taskExecutionRunnable,
+    void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                         final ITaskExecution taskExecution,
                          final TaskFailoverLifecycleEvent taskFailoverEvent);
 
     /**

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskDispatchStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskDispatchStateAction.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.task.client.TaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -31,8 +32,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,99 +47,99 @@ public class TaskDispatchStateAction extends AbstractTaskStateAction {
     private TaskExecutorClient taskExecutorClient;
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutionRunnable.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecutionRunnable));
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecution.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecution));
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        persistentTaskInstanceStartedEventToDB(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        persistentTaskInstanceStartedEventToDB(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutorClient.pause(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecutorClient.pause(taskExecution);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onPausedEvent(workflowExecution, taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutorClient.kill(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecutorClient.kill(taskExecution);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent event) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, event);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onKilledEvent(workflowExecution, taskExecution, event);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onFailedEvent(workflowExecution, taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onSucceedEvent(workflowExecution, taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.failoverTask(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.failoverTask(taskExecution);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailoverStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailoverStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -30,8 +31,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,99 +46,99 @@ import org.springframework.stereotype.Component;
 public class TaskFailoverStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskStartEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskStartEvent);
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKillEvent);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskFailureStateAction.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -32,8 +33,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,138 +47,138 @@ import org.springframework.stereotype.Component;
 public class TaskFailureStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         final TaskFailedLifecycleEvent taskFailedEvent = TaskFailedLifecycleEvent.builder()
-                .taskExecutionRunnable(taskExecutionRunnable)
-                .endTime(taskExecutionRunnable.getTaskInstance().getEndTime())
+                .taskExecution(taskExecution)
+                .endTime(taskExecution.getTaskInstance().getEndTime())
                 .build();
-        taskExecutionRunnable.getWorkflowEventBus().publish(taskFailedEvent);
+        taskExecution.getWorkflowEventBus().publish(taskFailedEvent);
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         // check the retry times
-        if (!taskExecutionRunnable.isTaskInstanceCanRetry()) {
+        if (!taskExecution.isTaskInstanceCanRetry()) {
             log.info("The task: {} cannot retry, because the retry times: {} is over the max retry times: {}",
                     taskInstance.getName(),
                     taskInstance.getRetryTimes(),
                     taskInstance.getMaxRetryTimes());
             return;
         }
-        taskExecutionRunnable.retry();
+        taskExecution.retry();
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         // When the failed task is awaiting retry, we can mark it as 'paused' to ignore the retry event.
-        if (isTaskRetrying(taskExecutionRunnable)) {
-            super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable,
-                    TaskPausedLifecycleEvent.of(taskExecutionRunnable));
+        if (isTaskRetrying(taskExecution)) {
+            super.onPausedEvent(workflowExecution, taskExecution,
+                    TaskPausedLifecycleEvent.of(taskExecution));
             return;
         }
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
+        logWarningIfCannotDoAction(taskExecution, taskPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
-        if (isTaskRetrying(taskExecutionRunnable)) {
-            super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        if (isTaskRetrying(taskExecution)) {
+            super.onPausedEvent(workflowExecution, taskExecution, taskPausedEvent);
             return;
         }
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
+        logWarningIfCannotDoAction(taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         // When the failed task is awaiting retry, we can mark it as 'killed' to ignore the retry event.
-        if (isTaskRetrying(taskExecutionRunnable)) {
-            super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable,
-                    TaskKilledLifecycleEvent.of(taskExecutionRunnable));
+        if (isTaskRetrying(taskExecution)) {
+            super.onKilledEvent(workflowExecution, taskExecution,
+                    TaskKilledLifecycleEvent.of(taskExecution));
             return;
         }
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
+        logWarningIfCannotDoAction(taskExecution, taskKillEvent);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         // This case happen when the task is failure but the task is in delay retry queue.
         // We don't remove the event in GlobalWorkflowDelayEventCoordinator the event should be dropped when the task is
         // killed.
-        if (isTaskRetrying(taskExecutionRunnable)) {
-            super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        if (isTaskRetrying(taskExecution)) {
+            super.onKilledEvent(workflowExecution, taskExecution, taskKilledEvent);
             return;
         }
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
+        logWarningIfCannotDoAction(taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onFailedEvent(workflowExecution, taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailoverEvent);
     }
 
     @Override
@@ -186,8 +186,8 @@ public class TaskFailureStateAction extends AbstractTaskStateAction {
         return TaskExecutionStatus.FAILURE;
     }
 
-    private boolean isTaskRetrying(final ITaskExecutionRunnable taskExecutionRunnable) {
-        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecutionRunnable.getWorkflowExecutionGraph();
-        return workflowExecutionGraph.isTaskExecutionRunnableRetrying(taskExecutionRunnable);
+    private boolean isTaskRetrying(final ITaskExecution taskExecution) {
+        final IWorkflowExecutionGraph workflowExecutionGraph = taskExecution.getWorkflowExecutionGraph();
+        return workflowExecutionGraph.isTaskExecutionRetrying(taskExecution);
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskKillStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskKillStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -30,8 +31,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,100 +42,100 @@ import org.springframework.stereotype.Component;
 public class TaskKillStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainKill(taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecution.getWorkflowExecutionGraph().markTaskExecutionChainKill(taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKillEvent);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskPauseStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskPauseStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -30,8 +31,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,100 +42,100 @@ import org.springframework.stereotype.Component;
 public class TaskPauseStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableChainPause(taskExecutionRunnable);
-        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecutionRunnable, taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecution.getWorkflowExecutionGraph().markTaskExecutionChainPause(taskExecution);
+        publishWorkflowInstanceTopologyLogicalTransitionEvent(workflowExecution, taskExecution);
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKillEvent);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskRunningStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskRunningStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -30,8 +31,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,100 +42,100 @@ import org.springframework.stereotype.Component;
 public class TaskRunningStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutionRunnable.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecutionRunnable));
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecution.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecution));
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        persistentTaskInstanceStartedEventToDB(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        persistentTaskInstanceStartedEventToDB(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutorClient.pause(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecutorClient.pause(taskExecution);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onPausedEvent(workflowExecution, taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        taskExecutorClient.kill(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        taskExecutorClient.kill(taskExecution);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onKilledEvent(workflowExecution, taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onFailedEvent(workflowExecution, taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onSucceedEvent(workflowExecution, taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         // regenerate a failover task instance
-        super.failoverTask(taskExecutionRunnable);
+        super.failoverTask(taskExecution);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSubmittedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSubmittedStateAction.java
@@ -22,6 +22,7 @@ import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.task.dispatcher.WorkerGroupDispatcherCoordinator;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -34,8 +35,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.exception.TaskExecutionContextCreateException;
 import org.apache.dolphinscheduler.server.master.utils.ExceptionUtils;
 
@@ -60,46 +60,46 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
     private TaskInstanceDao taskInstanceDao;
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
 
-        if (workflowExecutionRunnable.isWorkflowReadyPause()) {
-            workflowExecutionRunnable.getWorkflowEventBus().publish(TaskPausedLifecycleEvent.of(taskExecutionRunnable));
+        if (workflowExecution.isWorkflowReadyPause()) {
+            workflowExecution.getWorkflowEventBus().publish(TaskPausedLifecycleEvent.of(taskExecution));
             return;
         }
 
-        if (workflowExecutionRunnable.isWorkflowReadyStop()) {
-            workflowExecutionRunnable.getWorkflowEventBus().publish(TaskKilledLifecycleEvent.of(taskExecutionRunnable));
+        if (workflowExecution.isWorkflowReadyStop()) {
+            workflowExecution.getWorkflowEventBus().publish(TaskKilledLifecycleEvent.of(taskExecution));
             return;
         }
 
-        tryToDispatchTask(taskExecutionRunnable);
+        tryToDispatchTask(taskExecution);
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        final TaskInstance taskInstance = taskExecutionRunnable.getTaskInstance();
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
         long remainTimeMills = DateUtils.getRemainTime(
                 taskInstance.getFirstSubmitTime(),
                 taskInstance.getDelayTime() * 60L) * 1_000;
@@ -113,7 +113,7 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
         }
 
         try {
-            taskExecutionRunnable.initializeTaskExecutionContext();
+            taskExecution.initializeTaskExecutionContext();
         } catch (Exception ex) {
             if (ExceptionUtils.isDatabaseConnectedFailedException(ex)) {
                 throw ex;
@@ -122,87 +122,87 @@ public class TaskSubmittedStateAction extends AbstractTaskStateAction {
             throw new TaskExecutionContextCreateException(ex.getMessage());
         }
 
-        workerGroupDispatcherCoordinator.dispatchTask(taskExecutionRunnable, remainTimeMills);
+        workerGroupDispatcherCoordinator.dispatchTask(taskExecution, remainTimeMills);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onDispatchedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onDispatchedEvent(workflowExecution, taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        if (workerGroupDispatcherCoordinator.removeTask(taskExecutionRunnable)) {
-            log.info("Success pause task: {} before dispatch", taskExecutionRunnable.getName());
-            taskExecutionRunnable.getWorkflowEventBus().publish(TaskPausedLifecycleEvent.of(taskExecutionRunnable));
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        if (workerGroupDispatcherCoordinator.removeTask(taskExecution)) {
+            log.info("Success pause task: {} before dispatch", taskExecution.getName());
+            taskExecution.getWorkflowEventBus().publish(TaskPausedLifecycleEvent.of(taskExecution));
             return;
         }
         log.info("The task[id={}] is submitted and already dispatched, cannot pause, will try to pause it after 5s",
-                taskExecutionRunnable.getId());
-        taskExecutionRunnable.getWorkflowEventBus()
-                .publish(TaskPauseLifecycleEvent.of(taskExecutionRunnable, TimeUnit.SECONDS.toMillis(5)));
+                taskExecution.getId());
+        taskExecution.getWorkflowEventBus()
+                .publish(TaskPauseLifecycleEvent.of(taskExecution, TimeUnit.SECONDS.toMillis(5)));
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onPausedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onPausedEvent(workflowExecution, taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        if (workerGroupDispatcherCoordinator.removeTask(taskExecutionRunnable)) {
-            log.info("Success kill task[id={}] before dispatch", taskExecutionRunnable.getId());
-            taskExecutionRunnable.getWorkflowEventBus().publish(TaskKilledLifecycleEvent.of(taskExecutionRunnable));
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        if (workerGroupDispatcherCoordinator.removeTask(taskExecution)) {
+            log.info("Success kill task[id={}] before dispatch", taskExecution.getId());
+            taskExecution.getWorkflowEventBus().publish(TaskKilledLifecycleEvent.of(taskExecution));
             return;
         }
         log.info("The task[id={}] is submitted and already dispatched, cannot kill, will kill it after 5s",
-                taskExecutionRunnable.getId());
-        taskExecutionRunnable.getWorkflowEventBus()
-                .publish(TaskKillLifecycleEvent.of(taskExecutionRunnable, TimeUnit.SECONDS.toMillis(5)));
+                taskExecution.getId());
+        taskExecution.getWorkflowEventBus()
+                .publish(TaskKillLifecycleEvent.of(taskExecution, TimeUnit.SECONDS.toMillis(5)));
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onKilledEvent(workflowExecutionRunnable, taskExecutionRunnable, taskKilledEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onKilledEvent(workflowExecution, taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        super.onFailedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        super.onFailedEvent(workflowExecution, taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSuccessStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskSuccessStateAction.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 import org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
@@ -31,8 +32,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,104 +46,104 @@ import org.springframework.stereotype.Component;
 public class TaskSuccessStateAction extends AbstractTaskStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskStartLifecycleEvent taskStartEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(taskExecution);
         final TaskSuccessLifecycleEvent taskSuccessLifecycleEvent = TaskSuccessLifecycleEvent.builder()
-                .taskExecutionRunnable(taskExecutionRunnable)
-                .varPool(VarPoolUtils.deserializeVarPool(taskExecutionRunnable.getTaskInstance().getVarPool()))
-                .endTime(taskExecutionRunnable.getTaskInstance().getEndTime())
+                .taskExecution(taskExecution)
+                .varPool(VarPoolUtils.deserializeVarPool(taskExecution.getTaskInstance().getVarPool()))
+                .endTime(taskExecution.getTaskInstance().getEndTime())
                 .build();
-        super.onSucceedEvent(workflowExecutionRunnable, taskExecutionRunnable, taskSuccessLifecycleEvent);
+        super.onSucceedEvent(workflowExecution, taskExecution, taskSuccessLifecycleEvent);
     }
 
     @Override
-    public void onStartedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onStartedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskRunningLifecycleEvent taskRunningEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRunningEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRunningEvent);
     }
 
     @Override
-    public void onRetryEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onRetryEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskRetryLifecycleEvent taskRetryEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskRetryEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskRetryEvent);
     }
 
     @Override
-    public void onDispatchEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskDispatchLifecycleEvent taskDispatchEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchEvent);
     }
 
     @Override
-    public void onDispatchedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                  final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onDispatchedEvent(final IWorkflowExecution workflowExecution,
+                                  final ITaskExecution taskExecution,
                                   final TaskDispatchedLifecycleEvent taskDispatchedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskDispatchedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskDispatchedEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                             final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
+                             final ITaskExecution taskExecution,
                              final TaskPauseLifecycleEvent taskPauseEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPauseEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskPausedLifecycleEvent taskPausedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskPausedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskPausedEvent);
     }
 
     @Override
-    public void onKillEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                            final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKillEvent(final IWorkflowExecution workflowExecution,
+                            final ITaskExecution taskExecution,
                             final TaskKillLifecycleEvent taskKillEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKillEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKillEvent);
     }
 
     @Override
-    public void onKilledEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onKilledEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskKilledLifecycleEvent taskKilledEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskKilledEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskKilledEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
+                              final ITaskExecution taskExecution,
                               final TaskFailedLifecycleEvent taskFailedEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailedEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                               final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
+                               final ITaskExecution taskExecution,
                                final TaskSuccessLifecycleEvent taskSuccessEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskSuccessEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskSuccessEvent);
     }
 
     @Override
-    public void onFailoverEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final ITaskExecutionRunnable taskExecutionRunnable,
+    public void onFailoverEvent(final IWorkflowExecution workflowExecution,
+                                final ITaskExecution taskExecution,
                                 final TaskFailoverLifecycleEvent taskFailoverEvent) {
-        throwExceptionIfStateIsNotMatch(taskExecutionRunnable);
-        logWarningIfCannotDoAction(taskExecutionRunnable, taskFailoverEvent);
+        throwExceptionIfStateIsNotMatch(taskExecution);
+        logWarningIfCannotDoAction(taskExecution, taskFailoverEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/IWorkflowExecution.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/IWorkflowExecution.java
@@ -15,37 +15,37 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.workflow.runnable;
+package org.apache.dolphinscheduler.server.master.engine.workflow.execution;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.listener.IWorkflowLifecycleListener;
 import org.apache.dolphinscheduler.server.master.engine.workflow.policy.IWorkflowFailureStrategy;
 import org.apache.dolphinscheduler.server.master.runner.IWorkflowExecuteContext;
 
 import java.util.List;
 
-public interface IWorkflowExecutionRunnable {
+public interface IWorkflowExecution {
 
     /**
-     * Get the id of the WorkflowExecutionRunnable.
+     * Get the id of the WorkflowExecution.
      */
     default int getId() {
         return getWorkflowInstance().getId();
     }
 
     /**
-     * Get the name of the WorkflowExecutionRunnable.
+     * Get the name of the WorkflowExecution.
      */
     default String getName() {
         return getWorkflowInstance().getName();
     }
 
     /**
-     * Pause the WorkflowExecutionRunnable.
+     * Pause the WorkflowExecution.
      */
     void pause();
 
@@ -58,7 +58,7 @@ public interface IWorkflowExecutionRunnable {
     }
 
     /**
-     * Stop the WorkflowExecutionRunnable.
+     * Stop the WorkflowExecution.
      */
     void stop();
 
@@ -71,26 +71,26 @@ public interface IWorkflowExecutionRunnable {
     }
 
     /**
-     * Kill the active tasks of the WorkflowExecutionRunnable.
+     * Kill the active tasks of the WorkflowExecution.
      */
     default void killActiveTasks() {
-        getWorkflowExecutionGraph().getActiveTaskExecutionRunnable().forEach(ITaskExecutionRunnable::kill);
+        getWorkflowExecutionGraph().getActiveTaskExecution().forEach(ITaskExecution::kill);
     }
 
     /**
-     * Get the WorkflowExecuteContext belongs to the WorkflowExecutionRunnable.
+     * Get the WorkflowExecuteContext belongs to the WorkflowExecution.
      */
     IWorkflowExecuteContext getWorkflowExecuteContext();
 
     /**
-     * Get the WorkflowInstance belongs to the WorkflowExecutionRunnable.
+     * Get the WorkflowInstance belongs to the WorkflowExecution.
      */
     default WorkflowInstance getWorkflowInstance() {
         return getWorkflowExecuteContext().getWorkflowInstance();
     }
 
     /**
-     * Get the state of the WorkflowExecutionRunnable.
+     * Get the state of the WorkflowExecution.
      */
     default WorkflowExecutionStatus getState() {
         return getWorkflowInstance().getState();

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/WorkflowExecution.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/WorkflowExecution.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.workflow.runnable;
+package org.apache.dolphinscheduler.server.master.engine.workflow.execution;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -34,7 +34,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class WorkflowExecutionRunnable implements IWorkflowExecutionRunnable {
+public class WorkflowExecution implements IWorkflowExecution {
 
     @Getter
     private final IWorkflowExecuteContext workflowExecuteContext;
@@ -45,8 +45,8 @@ public class WorkflowExecutionRunnable implements IWorkflowExecutionRunnable {
     @Getter
     private final IWorkflowFailureStrategy workflowFailureStrategy;
 
-    public WorkflowExecutionRunnable(WorkflowExecutionRunnableBuilder workflowExecutionRunnableBuilder) {
-        this.workflowExecuteContext = workflowExecutionRunnableBuilder.getWorkflowExecuteContextBuilder().build();
+    public WorkflowExecution(WorkflowExecutionBuilder workflowExecutionBuilder) {
+        this.workflowExecuteContext = workflowExecutionBuilder.getWorkflowExecuteContextBuilder().build();
         this.workflowInstanceLifecycleListeners =
                 new ArrayList<>(workflowExecuteContext.getWorkflowInstanceLifecycleListeners());
         this.workflowFailureStrategy = WorkflowFailureStrategyFactory
@@ -77,7 +77,7 @@ public class WorkflowExecutionRunnable implements IWorkflowExecutionRunnable {
     @Override
     public String toString() {
         final WorkflowInstance workflowInstance = workflowExecuteContext.getWorkflowInstance();
-        return "WorkflowExecutionRunnable{" +
+        return "WorkflowExecution{" +
                 "name=" + workflowInstance.getName() +
                 ", state=" + workflowInstance.getState().name() +
                 '}';

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/WorkflowExecutionBuilder.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/WorkflowExecutionBuilder.java
@@ -15,29 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.task.runnable;
+package org.apache.dolphinscheduler.server.master.engine.workflow.execution;
 
-import org.apache.dolphinscheduler.dao.entity.Project;
-import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
-import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
+import org.apache.dolphinscheduler.server.master.runner.WorkflowExecuteContext;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+import org.springframework.context.ApplicationContext;
+
+@Data
 @Builder
 @AllArgsConstructor
-public class TaskExecutionContextCreateRequest {
+@NoArgsConstructor
+public class WorkflowExecutionBuilder {
 
-    private IWorkflowExecutionGraph workflowExecutionGraph;
-    private WorkflowDefinition workflowDefinition;
-    private WorkflowInstance workflowInstance;
-    private TaskDefinition taskDefinition;
-    private TaskInstance taskInstance;
-    private Project project;
+    private WorkflowExecuteContext.WorkflowExecuteContextBuilder workflowExecuteContextBuilder;
+
+    private ApplicationContext applicationContext;
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/WorkflowExecutionFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/execution/WorkflowExecutionFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.workflow.runnable;
+package org.apache.dolphinscheduler.server.master.engine.workflow.execution;
 
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.dao.entity.Command;
@@ -34,7 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
-public class WorkflowExecutionRunnableFactory {
+public class WorkflowExecutionFactory {
 
     @Autowired
     private List<ICommandHandler> commandHandlers;
@@ -46,21 +46,21 @@ public class WorkflowExecutionRunnableFactory {
     private CommandDao commandDao;
 
     /**
-     * Generate WorkflowExecutionRunnable from command.
+     * Generate WorkflowExecution from command.
      * <p> We use transaction here to make sure that the command will be handled only once. Since in some case if the
      * master cluster is reblancing, the master slot might different in different master.
      */
     @Transactional
-    public IWorkflowExecutionRunnable createWorkflowExecuteRunnable(Command command) {
+    public IWorkflowExecution createWorkflowExecuteRunnable(Command command) {
         deleteCommandOrThrow(command);
-        return doCreateWorkflowExecutionRunnable(command);
+        return doCreateWorkflowExecution(command);
     }
 
     /**
-     * Create WorkflowExecutionRunnable from command.
-     * <p> Each WorkflowExecutionRunnable represent a workflow instance, so this method might create workflow instance in db, dependents on the command type.
+     * Create WorkflowExecution from command.
+     * <p> Each WorkflowExecution represent a workflow instance, so this method might create workflow instance in db, dependents on the command type.
      */
-    private IWorkflowExecutionRunnable doCreateWorkflowExecutionRunnable(Command command) {
+    private IWorkflowExecution doCreateWorkflowExecution(Command command) {
         final CommandType commandType = command.getCommandType();
         final ICommandHandler commandHandler = commandHandlers
                 .stream()

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/AbstractWorkflowLifecycleLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/AbstractWorkflowLifecycleLifecycleEvent.java
@@ -18,7 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle;
 
 import org.apache.dolphinscheduler.server.master.engine.AbstractLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 public abstract class AbstractWorkflowLifecycleLifecycleEvent extends AbstractLifecycleEvent {
 
@@ -30,6 +30,6 @@ public abstract class AbstractWorkflowLifecycleLifecycleEvent extends AbstractLi
         super(delayTime);
     }
 
-    public abstract IWorkflowExecutionRunnable getWorkflowExecutionRunnable();
+    public abstract IWorkflowExecution getWorkflowExecution();
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowFailedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowFailedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,10 +33,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowFailedLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    public static WorkflowFailedLifecycleEvent of(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return new WorkflowFailedLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowFailedLifecycleEvent of(final IWorkflowExecution workflowExecution) {
+        return new WorkflowFailedLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -47,7 +47,7 @@ public class WorkflowFailedLifecycleEvent extends AbstractWorkflowLifecycleLifec
     @Override
     public String toString() {
         return "WorkflowFailedLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getName() +
+                "workflow=" + workflowExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowFinalizeLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowFinalizeLifecycleEvent.java
@@ -20,28 +20,28 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.even
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * The workflow instance finalize event, used to remove the {@link WorkflowExecutionRunnable} from the master, will
+ * The workflow instance finalize event, used to remove the {@link WorkflowExecution} from the master, will
  * clear the workflow instance related resources in memory.
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowFinalizeLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private IWorkflowExecution workflowExecution;
 
-    public static WorkflowFinalizeLifecycleEvent of(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        checkNotNull(workflowExecutionRunnable, "workflowExecutionRunnable is null");
-        return new WorkflowFinalizeLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowFinalizeLifecycleEvent of(IWorkflowExecution workflowExecution) {
+        checkNotNull(workflowExecution, "workflowExecution is null");
+        return new WorkflowFinalizeLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class WorkflowFinalizeLifecycleEvent extends AbstractWorkflowLifecycleLif
     @Override
     public String toString() {
         return "WorkflowFinalizeLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getName() +
+                "workflow=" + workflowExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowPauseLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowPauseLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,10 +30,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowPauseLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    public static WorkflowPauseLifecycleEvent of(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return new WorkflowPauseLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowPauseLifecycleEvent of(final IWorkflowExecution workflowExecution) {
+        return new WorkflowPauseLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class WorkflowPauseLifecycleEvent extends AbstractWorkflowLifecycleLifecy
     @Override
     public String toString() {
         return "WorkflowPauseLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getName() +
+                "workflow=" + workflowExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowPausedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowPausedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -32,11 +32,11 @@ import com.google.common.base.Preconditions;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowPausedLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    public static WorkflowPausedLifecycleEvent of(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        Preconditions.checkNotNull(workflowExecutionRunnable, "workflowExecutionRunnable is null");
-        return new WorkflowPausedLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowPausedLifecycleEvent of(final IWorkflowExecution workflowExecution) {
+        Preconditions.checkNotNull(workflowExecution, "workflowExecution is null");
+        return new WorkflowPausedLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -47,7 +47,7 @@ public class WorkflowPausedLifecycleEvent extends AbstractWorkflowLifecycleLifec
     @Override
     public String toString() {
         return "WorkflowPausedLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getName() +
+                "workflow=" + workflowExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowStartLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowStartLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,10 +30,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowStartLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private IWorkflowExecution workflowExecution;
 
-    public static WorkflowStartLifecycleEvent of(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return new WorkflowStartLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowStartLifecycleEvent of(IWorkflowExecution workflowExecution) {
+        return new WorkflowStartLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class WorkflowStartLifecycleEvent extends AbstractWorkflowLifecycleLifecy
     @Override
     public String toString() {
         return "WorkflowStartLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowInstance().getName() +
+                "workflow=" + workflowExecution.getWorkflowExecuteContext().getWorkflowInstance().getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowStopLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowStopLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,10 +30,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowStopLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    public static WorkflowStopLifecycleEvent of(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return new WorkflowStopLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowStopLifecycleEvent of(final IWorkflowExecution workflowExecution) {
+        return new WorkflowStopLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class WorkflowStopLifecycleEvent extends AbstractWorkflowLifecycleLifecyc
     @Override
     public String toString() {
         return "WorkflowStopLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getName() +
+                "workflow=" + workflowExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowStoppedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowStoppedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,10 +30,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowStoppedLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    public static WorkflowStoppedLifecycleEvent of(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return new WorkflowStoppedLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowStoppedLifecycleEvent of(final IWorkflowExecution workflowExecution) {
+        return new WorkflowStoppedLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class WorkflowStoppedLifecycleEvent extends AbstractWorkflowLifecycleLife
     @Override
     public String toString() {
         return "WorkflowStoppedLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable +
+                "workflow=" + workflowExecution +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowSucceedLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowSucceedLifecycleEvent.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,10 +29,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class WorkflowSucceedLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    public static WorkflowSucceedLifecycleEvent of(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return new WorkflowSucceedLifecycleEvent(workflowExecutionRunnable);
+    public static WorkflowSucceedLifecycleEvent of(final IWorkflowExecution workflowExecution) {
+        return new WorkflowSucceedLifecycleEvent(workflowExecution);
     }
 
     @Override
@@ -42,7 +42,7 @@ public class WorkflowSucceedLifecycleEvent extends AbstractWorkflowLifecycleLife
 
     public String toString() {
         return "WorkflowSucceedLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getName() +
+                "workflow=" + workflowExecution.getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowTimeoutLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowTimeoutLifecycleEvent.java
@@ -21,9 +21,9 @@ import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,16 +35,16 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WorkflowTimeoutLifecycleEvent extends AbstractWorkflowLifecycleLifecycleEvent {
 
-    private IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private IWorkflowExecution workflowExecution;
 
-    protected WorkflowTimeoutLifecycleEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    protected WorkflowTimeoutLifecycleEvent(final IWorkflowExecution workflowExecution,
                                             final long timeout) {
         super(timeout);
-        this.workflowExecutionRunnable = workflowExecutionRunnable;
+        this.workflowExecution = workflowExecution;
     }
 
-    public static WorkflowTimeoutLifecycleEvent of(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+    public static WorkflowTimeoutLifecycleEvent of(IWorkflowExecution workflowExecution) {
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         checkState(workflowInstance != null,
                 "The workflow instance must be initialized before creating workflow timeout event.");
 
@@ -53,7 +53,7 @@ public class WorkflowTimeoutLifecycleEvent extends AbstractWorkflowLifecycleLife
 
         long delayTime = System.currentTimeMillis() - workflowInstance.getRestartTime().getTime()
                 + TimeUnit.MINUTES.toMillis(timeout);
-        return new WorkflowTimeoutLifecycleEvent(workflowExecutionRunnable, delayTime);
+        return new WorkflowTimeoutLifecycleEvent(workflowExecution, delayTime);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class WorkflowTimeoutLifecycleEvent extends AbstractWorkflowLifecycleLife
     @Override
     public String toString() {
         return "WorkflowTimeoutLifecycleEvent{" +
-                "workflow=" + workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowInstance().getName() +
+                "workflow=" + workflowExecution.getWorkflowExecuteContext().getWorkflowInstance().getName() +
                 '}';
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/event/WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent.java
@@ -21,10 +21,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import java.util.Optional;
 
@@ -41,18 +41,18 @@ public class WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent
         extends
             AbstractWorkflowLifecycleLifecycleEvent {
 
-    private final IWorkflowExecutionRunnable workflowExecutionRunnable;
+    private final IWorkflowExecution workflowExecution;
 
-    private final ITaskExecutionRunnable taskExecutionRunnable;
+    private final ITaskExecution taskExecution;
 
     public static WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent of(
-                                                                                   final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                                                   final ITaskExecutionRunnable taskExecutionRunnable) {
-        checkNotNull(workflowExecutionRunnable, "workflowExecutionRunnable is null");
-        checkNotNull(taskExecutionRunnable, "taskExecutionRunnable is null");
+                                                                                   final IWorkflowExecution workflowExecution,
+                                                                                   final ITaskExecution taskExecution) {
+        checkNotNull(workflowExecution, "workflowExecution is null");
+        checkNotNull(taskExecution, "taskExecution is null");
         return new WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent(
-                workflowExecutionRunnable,
-                taskExecutionRunnable);
+                workflowExecution,
+                taskExecution);
     }
 
     @Override
@@ -63,9 +63,9 @@ public class WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent
     @Override
     public String toString() {
         return "WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent{"
-                + "task=" + taskExecutionRunnable.getName()
+                + "task=" + taskExecution.getName()
                 + "taskState="
-                + Optional.ofNullable(taskExecutionRunnable.getTaskInstance()).map(TaskInstance::getState)
+                + Optional.ofNullable(taskExecution.getTaskInstance()).map(TaskInstance::getState)
                         .map(Enum::name).orElse(null)
                 + '}';
     }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/AbstractWorkflowLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/AbstractWorkflowLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventHandler;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.listener.IWorkflowLifecycleListener;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.WorkflowStateActionFactory;
 
@@ -41,37 +41,37 @@ public abstract class AbstractWorkflowLifecycleEventHandler<T extends AbstractWo
     private WorkflowStateActionFactory workflowStateActionFactory;
 
     @Override
-    public void handle(final IWorkflowExecutionRunnable workflowExecutionRunnable, final T event) {
-        final IWorkflowStateAction action = workflowStateActionFactory.getAction(workflowExecutionRunnable.getState());
+    public void handle(final IWorkflowExecution workflowExecution, final T event) {
+        final IWorkflowStateAction action = workflowStateActionFactory.getAction(workflowExecution.getState());
 
         log.info("Begin fire workflow {} LifecycleEvent[{}] with state: {}",
-                workflowExecutionRunnable.getName(),
+                workflowExecution.getName(),
                 event,
-                workflowExecutionRunnable.getState().name());
-        handle(action, workflowExecutionRunnable, event);
+                workflowExecution.getState().name());
+        handle(action, workflowExecution, event);
         log.info("Fired workflow {} LifecycleEvent[{}] with state: {}",
-                workflowExecutionRunnable.getName(),
+                workflowExecution.getName(),
                 event,
-                workflowExecutionRunnable.getState().name());
-        doTriggerWorkflowLifecycleListener(workflowExecutionRunnable, event);
+                workflowExecution.getState().name());
+        doTriggerWorkflowLifecycleListener(workflowExecution, event);
     }
 
     public abstract void handle(
                                 final IWorkflowStateAction workflowStateAction,
-                                final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                final IWorkflowExecution workflowExecution,
                                 final T event);
 
     private void doTriggerWorkflowLifecycleListener(
-                                                    final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                    final IWorkflowExecution workflowExecution,
                                                     final T event) {
-        final List<IWorkflowLifecycleListener> listeners = workflowExecutionRunnable.getWorkflowLifecycleListeners();
+        final List<IWorkflowLifecycleListener> listeners = workflowExecution.getWorkflowLifecycleListeners();
         if (CollectionUtils.isEmpty(listeners)) {
             return;
         }
         for (final IWorkflowLifecycleListener listener : listeners) {
             try {
                 if (listener.match(event)) {
-                    listener.notifyWorkflowLifecycleEvent(workflowExecutionRunnable, event);
+                    listener.notifyWorkflowLifecycleEvent(workflowExecution, event);
                 }
             } catch (Exception e) {
                 log.warn("Trigger WorkflowLifecycleListener on event: {} failed", event, e);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFailedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFailedLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,9 +35,9 @@ public class WorkflowFailedLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        workflowStateAction.onFailedEvent(workflowExecutionRunnable, workflowFailedEvent);
+        workflowStateAction.onFailedEvent(workflowExecution, workflowFailedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFinalizeLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowFinalizeLifecycleEventHandler.java
@@ -20,9 +20,9 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.hand
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBusCoordinator;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -49,9 +49,9 @@ public class WorkflowFinalizeLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        workflowStateAction.onFinalizeEvent(workflowExecutionRunnable, workflowFinalizeEvent);
+        workflowStateAction.onFinalizeEvent(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPauseLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPauseLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,10 +35,10 @@ public class WorkflowPauseLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowPauseLifecycleEvent pauseEvent) {
 
-        workflowStateAction.onPauseEvent(workflowExecutionRunnable, pauseEvent);
+        workflowStateAction.onPauseEvent(workflowExecution, pauseEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPausedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowPausedLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPausedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import org.springframework.stereotype.Component;
@@ -32,9 +32,9 @@ public class WorkflowPausedLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        workflowStateAction.onPausedEvent(workflowExecutionRunnable, workflowPausedEvent);
+        workflowStateAction.onPausedEvent(workflowExecution, workflowPausedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStartLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStartLifecycleEventHandler.java
@@ -19,10 +19,10 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.hand
 
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStartLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTimeoutLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -37,11 +37,11 @@ public class WorkflowStartLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowStartLifecycleEvent workflowStartEvent) {
 
-        workflowTimeoutMonitor(workflowExecutionRunnable);
-        workflowStateAction.onStartEvent(workflowExecutionRunnable, workflowStartEvent);
+        workflowTimeoutMonitor(workflowExecution);
+        workflowStateAction.onStartEvent(workflowExecution, workflowStartEvent);
     }
 
     @Override
@@ -49,15 +49,15 @@ public class WorkflowStartLifecycleEventHandler
         return WorkflowLifecycleEventType.START;
     }
 
-    private void workflowTimeoutMonitor(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+    private void workflowTimeoutMonitor(final IWorkflowExecution workflowExecution) {
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         if (workflowInstance.getTimeout() <= 0) {
             log.debug("The workflow {} timeout {} is not configured or invalid, skip timeout monitor.",
                     workflowInstance.getName(),
                     workflowInstance.getTimeout());
             return;
         }
-        workflowExecutionRunnable.getWorkflowEventBus()
-                .publish(WorkflowTimeoutLifecycleEvent.of(workflowExecutionRunnable));
+        workflowExecution.getWorkflowEventBus()
+                .publish(WorkflowTimeoutLifecycleEvent.of(workflowExecution));
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStopLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStopLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStopLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,9 +35,9 @@ public class WorkflowStopLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowStopLifecycleEvent event) {
-        workflowStateAction.onStopEvent(workflowExecutionRunnable, event);
+        workflowStateAction.onStopEvent(workflowExecution, event);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStoppedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowStoppedLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,9 +35,9 @@ public class WorkflowStoppedLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        workflowStateAction.onStoppedEvent(workflowExecutionRunnable, workflowStoppedEvent);
+        workflowStateAction.onStoppedEvent(workflowExecution, workflowStoppedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowSucceedLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowSucceedLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,9 +35,9 @@ public class WorkflowSucceedLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        workflowStateAction.onSucceedEvent(workflowExecutionRunnable, workflowSucceedEvent);
+        workflowStateAction.onSucceedEvent(workflowExecution, workflowSucceedEvent);
     }
 
     @Override

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowTimeoutLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowTimeoutLifecycleEventHandler.java
@@ -19,9 +19,9 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.hand
 
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTimeoutLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 import org.apache.dolphinscheduler.service.alert.WorkflowAlertManager;
 
@@ -43,13 +43,13 @@ public class WorkflowTimeoutLifecycleEventHandler
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowTimeoutLifecycleEvent workflowTimeoutLifecycleEvent) {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         final boolean shouldSendAlert = workflowInstance.getWarningGroupId() != null;
 
         if (shouldSendAlert) {
-            doWorkflowTimeoutAlert(workflowExecutionRunnable);
+            doWorkflowTimeoutAlert(workflowExecution);
         } else {
             log.info("Skipped sending timeout alert for workflow {} because warningGroupId is null.",
                     workflowInstance.getName());
@@ -62,8 +62,8 @@ public class WorkflowTimeoutLifecycleEventHandler
         return WorkflowLifecycleEventType.TIMEOUT;
     }
 
-    private void doWorkflowTimeoutAlert(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+    private void doWorkflowTimeoutAlert(final IWorkflowExecution workflowExecution) {
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         workflowAlertManager.sendWorkflowTimeoutAlert(workflowInstance);
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEventHandler.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/lifecycle/handler/WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEventHandler.java
@@ -18,9 +18,9 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.handler;
 
 import org.apache.dolphinscheduler.server.master.engine.ILifecycleEventType;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.statemachine.IWorkflowStateAction;
 
 import org.springframework.stereotype.Component;
@@ -32,11 +32,11 @@ public class WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEventHandle
 
     @Override
     public void handle(final IWorkflowStateAction workflowStateAction,
-                       final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                       final IWorkflowExecution workflowExecution,
                        final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
 
         workflowStateAction.onTopologyLogicalTransitionEvent(
-                workflowExecutionRunnable,
+                workflowExecution,
                 workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/listener/IWorkflowLifecycleListener.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/listener/IWorkflowLifecycleListener.java
@@ -17,12 +17,12 @@
 
 package org.apache.dolphinscheduler.server.master.engine.workflow.listener;
 
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 public interface IWorkflowLifecycleListener {
 
-    void notifyWorkflowLifecycleEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void notifyWorkflowLifecycleEvent(final IWorkflowExecution workflowExecution,
                                       final AbstractWorkflowLifecycleLifecycleEvent workflowLifecycleLifecycleEvent);
 
     boolean match(AbstractWorkflowLifecycleLifecycleEvent event);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/listener/WorkflowSuccessLifecycleListener.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/listener/WorkflowSuccessLifecycleListener.java
@@ -27,9 +27,9 @@ import org.apache.dolphinscheduler.extract.master.command.BackfillWorkflowComman
 import org.apache.dolphinscheduler.extract.master.command.ICommandParam;
 import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowBackfillTriggerRequest;
 import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowBackfillTriggerResponse;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.AbstractWorkflowLifecycleLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.WorkflowLifecycleEventType;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.engine.workflow.trigger.WorkflowBackfillTrigger;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -51,9 +51,9 @@ public class WorkflowSuccessLifecycleListener implements IWorkflowLifecycleListe
     @Autowired
     private CommandDao commandDao;
 
-    public void notifyWorkflowLifecycleEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void notifyWorkflowLifecycleEvent(final IWorkflowExecution workflowExecution,
                                              final AbstractWorkflowLifecycleLifecycleEvent lifecycleEvent) {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         if (Flag.YES == workflowInstance.getIsSubWorkflow()) {
             // The sub workflow does not need to generate the backfill command
             // Since the parent workflow will trigger the task to generate the sub workflow instance.

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/ContinueWorkflowFailureStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/ContinueWorkflowFailureStrategy.java
@@ -17,8 +17,8 @@
 
 package org.apache.dolphinscheduler.server.master.engine.workflow.policy;
 
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 /**
  * The strategy used to deal with {@link org.apache.dolphinscheduler.common.enums.FailureStrategy#CONTINUE} when task failure occurs.
@@ -27,8 +27,8 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkf
 public class ContinueWorkflowFailureStrategy implements IWorkflowFailureStrategy {
 
     @Override
-    public void onTaskFailure(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              ITaskExecutionRunnable taskExecutionRunnable) {
+    public void onTaskFailure(IWorkflowExecution workflowExecution,
+                              ITaskExecution taskExecution) {
         // do nothing, just continue workflow execution
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/EndWorkflowFailureStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/EndWorkflowFailureStrategy.java
@@ -17,8 +17,8 @@
 
 package org.apache.dolphinscheduler.server.master.engine.workflow.policy;
 
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,11 +30,11 @@ import lombok.extern.slf4j.Slf4j;
 public class EndWorkflowFailureStrategy implements IWorkflowFailureStrategy {
 
     @Override
-    public void onTaskFailure(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                              ITaskExecutionRunnable taskExecutionRunnable) {
+    public void onTaskFailure(IWorkflowExecution workflowExecution,
+                              ITaskExecution taskExecution) {
         log.info("The workflow instance: [{}] using END failure strategy, will kill the active tasks.",
-                workflowExecutionRunnable.getName());
-        workflowExecutionRunnable.killActiveTasks();
+                workflowExecution.getName());
+        workflowExecution.killActiveTasks();
     }
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/IWorkflowFailureStrategy.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/policy/IWorkflowFailureStrategy.java
@@ -17,15 +17,15 @@
 
 package org.apache.dolphinscheduler.server.master.engine.workflow.policy;
 
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 /**
  * Used to deal with {@link org.apache.dolphinscheduler.common.enums.FailureStrategy} when task failure occurs
  */
 public interface IWorkflowFailureStrategy {
 
-    void onTaskFailure(IWorkflowExecutionRunnable workflowExecutionRunnable,
-                       ITaskExecutionRunnable taskExecutionRunnable);
+    void onTaskFailure(IWorkflowExecution workflowExecution,
+                       ITaskExecution taskExecution);
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/AbstractWorkflowStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/AbstractWorkflowStateAction.java
@@ -30,12 +30,12 @@ import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBusCoordinator;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.SuccessorFlowAdjuster;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskStartLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.policy.IWorkflowFailureStrategy;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.metrics.WorkflowInstanceMetrics;
 import org.apache.dolphinscheduler.server.master.utils.WorkflowInstanceUtils;
 import org.apache.dolphinscheduler.service.alert.WorkflowAlertManager;
@@ -80,88 +80,88 @@ public abstract class AbstractWorkflowStateAction implements IWorkflowStateActio
      * Try to trigger the tasks if the trigger condition is met.
      * <p> If all the given tasks trigger condition is not met then will try to emit workflow finish event.
      */
-    protected void triggerTasks(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                final List<ITaskExecutionRunnable> triggerCandidateTasks) {
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        final List<ITaskExecutionRunnable> readyToTriggerTasks = triggerCandidateTasks
+    protected void triggerTasks(final IWorkflowExecution workflowExecution,
+                                final List<ITaskExecution> triggerCandidateTasks) {
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        final List<ITaskExecution> readyToTriggerTasks = triggerCandidateTasks
                 .stream()
                 .filter(workflowExecutionGraph::isTriggerConditionMet)
-                .sorted(Comparator.comparing(ITaskExecutionRunnable::getName))
+                .sorted(Comparator.comparing(ITaskExecution::getName))
                 .collect(Collectors.toList());
         if (CollectionUtils.isEmpty(readyToTriggerTasks)) {
             final boolean isAllCandidateTaskPredecessorsInActive = triggerCandidateTasks.stream()
-                    .flatMap(taskExecutionRunnable -> workflowExecutionGraph
-                            .getPredecessors(taskExecutionRunnable.getName())
+                    .flatMap(taskExecution -> workflowExecutionGraph
+                            .getPredecessors(taskExecution.getName())
                             .stream())
-                    .allMatch(workflowExecutionGraph::isTaskExecutionRunnableInActive);
+                    .allMatch(workflowExecutionGraph::isTaskExecutionInActive);
             if (isAllCandidateTaskPredecessorsInActive) {
-                emitWorkflowFinishedEventIfApplicable(workflowExecutionRunnable);
+                emitWorkflowFinishedEventIfApplicable(workflowExecution);
             }
             return;
         }
-        final WorkflowEventBus workflowEventBus = workflowExecutionRunnable.getWorkflowEventBus();
-        for (ITaskExecutionRunnable readyToTriggerTask : readyToTriggerTasks) {
-            workflowExecutionGraph.markTaskExecutionRunnableActive(readyToTriggerTask);
-            if (workflowExecutionGraph.isTaskExecutionRunnableSkipped(readyToTriggerTask)
-                    || workflowExecutionGraph.isTaskExecutionRunnableForbidden(readyToTriggerTask)) {
+        final WorkflowEventBus workflowEventBus = workflowExecution.getWorkflowEventBus();
+        for (ITaskExecution readyToTriggerTask : readyToTriggerTasks) {
+            workflowExecutionGraph.markTaskExecutionActive(readyToTriggerTask);
+            if (workflowExecutionGraph.isTaskExecutionSkipped(readyToTriggerTask)
+                    || workflowExecutionGraph.isTaskExecutionForbidden(readyToTriggerTask)) {
                 workflowEventBus.publish(
                         WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent.of(
-                                workflowExecutionRunnable, readyToTriggerTask));
+                                workflowExecution, readyToTriggerTask));
                 continue;
             }
             workflowEventBus.publish(TaskStartLifecycleEvent.of(readyToTriggerTask));
         }
     }
 
-    protected void pauseActiveTask(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void pauseActiveTask(final IWorkflowExecution workflowExecution) {
         try {
-            LogUtils.setWorkflowInstanceIdMDC(workflowExecutionRunnable.getId());
-            workflowExecutionRunnable
+            LogUtils.setWorkflowInstanceIdMDC(workflowExecution.getId());
+            workflowExecution
                     .getWorkflowExecutionGraph()
-                    .getActiveTaskExecutionRunnable()
-                    .forEach(ITaskExecutionRunnable::pause);
+                    .getActiveTaskExecution()
+                    .forEach(ITaskExecution::pause);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
     }
 
-    protected void tryToTriggerSuccessorsAfterTaskFinish(final IWorkflowExecutionRunnable workflowExecutionRunnable,
-                                                         final ITaskExecutionRunnable taskExecutionRunnable) {
-        successorFlowAdjuster.adjustSuccessorFlow(taskExecutionRunnable);
+    protected void tryToTriggerSuccessorsAfterTaskFinish(final IWorkflowExecution workflowExecution,
+                                                         final ITaskExecution taskExecution) {
+        successorFlowAdjuster.adjustSuccessorFlow(taskExecution);
 
-        final IWorkflowFailureStrategy workflowFailureStrategy = workflowExecutionRunnable.getWorkflowFailureStrategy();
-        if (taskExecutionRunnable.isFailure()) {
-            workflowFailureStrategy.onTaskFailure(workflowExecutionRunnable, taskExecutionRunnable);
+        final IWorkflowFailureStrategy workflowFailureStrategy = workflowExecution.getWorkflowFailureStrategy();
+        if (taskExecution.isFailure()) {
+            workflowFailureStrategy.onTaskFailure(workflowExecution, taskExecution);
         }
 
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        if (workflowExecutionGraph.isEndOfTaskChain(taskExecutionRunnable)) {
-            emitWorkflowFinishedEventIfApplicable(workflowExecutionRunnable);
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        if (workflowExecutionGraph.isEndOfTaskChain(taskExecution)) {
+            emitWorkflowFinishedEventIfApplicable(workflowExecution);
             return;
         }
 
-        triggerTasks(workflowExecutionRunnable, workflowExecutionGraph.getSuccessors(taskExecutionRunnable));
+        triggerTasks(workflowExecution, workflowExecutionGraph.getSuccessors(taskExecution));
     }
 
-    protected void workflowFinish(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    protected void workflowFinish(final IWorkflowExecution workflowExecution,
                                   final WorkflowExecutionStatus workflowExecutionStatus) {
         // todo: add transaction configuration in lifecycle event, all sync lifecycle should be in transaction
         transactionTemplate.execute(status -> {
-            final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+            final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
             workflowInstance.setEndTime(new Date());
-            transformWorkflowInstanceState(workflowExecutionRunnable, workflowExecutionStatus);
+            transformWorkflowInstanceState(workflowExecution, workflowExecutionStatus);
             WorkflowInstanceMetrics.recordWorkflowInstanceFinish(
                     workflowExecutionStatus,
                     workflowInstance.getWorkflowDefinitionCode());
-            if (workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowDefinition().getExecutionType()
+            if (workflowExecution.getWorkflowExecuteContext().getWorkflowDefinition().getExecutionType()
                     .isSerial()) {
                 if (serialCommandDao.deleteByWorkflowInstanceId(workflowInstance.getId()) > 0) {
                     log.info("Success clear SerialCommand for WorkflowExecuteRunnable: {}",
-                            workflowExecutionRunnable.getName());
+                            workflowExecution.getName());
                 }
             }
-            workflowExecutionRunnable.getWorkflowEventBus()
-                    .publish(WorkflowFinalizeLifecycleEvent.of(workflowExecutionRunnable));
+            workflowExecution.getWorkflowEventBus()
+                    .publish(WorkflowFinalizeLifecycleEvent.of(workflowExecution));
             return null;
         });
     }
@@ -170,9 +170,9 @@ public abstract class AbstractWorkflowStateAction implements IWorkflowStateActio
      * Transformer the workflow instance state to targetState. This method will both update the
      * workflow instance state in memory and in the database.
      */
-    protected void transformWorkflowInstanceState(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    protected void transformWorkflowInstanceState(final IWorkflowExecution workflowExecution,
                                                   final WorkflowExecutionStatus targetState) {
-        final WorkflowInstance workflowInstance = workflowExecutionRunnable.getWorkflowInstance();
+        final WorkflowInstance workflowInstance = workflowExecution.getWorkflowInstance();
         WorkflowExecutionStatus originState = workflowInstance.getState();
         try {
             workflowInstance.setState(targetState);
@@ -189,10 +189,10 @@ public abstract class AbstractWorkflowStateAction implements IWorkflowStateActio
      * Emit the workflow finished event if the workflow can finish, otherwise do nothing.
      * <p> The workflow finish state is determined by the state of the task in the workflow.
      */
-    protected abstract void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecutionRunnable workflowExecutionRunnable);
+    protected abstract void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecution workflowExecution);
 
-    protected boolean isWorkflowFinishable(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        return workflowExecutionRunnable.getWorkflowExecutionGraph().isAllTaskExecutionRunnableChainFinish();
+    protected boolean isWorkflowFinishable(final IWorkflowExecution workflowExecution) {
+        return workflowExecution.getWorkflowExecutionGraph().isAllTaskExecutionChainFinish();
     }
 
     /**
@@ -200,32 +200,32 @@ public abstract class AbstractWorkflowStateAction implements IWorkflowStateActio
      *
      * @throws IllegalStateException if the state of the task is not the expected state.
      */
-    protected void throwExceptionIfStateIsNotMatch(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        checkNotNull(workflowExecutionRunnable, "workflowExecutionRunnable is null");
-        final WorkflowExecutionStatus actualState = workflowExecutionRunnable.getState();
+    protected void throwExceptionIfStateIsNotMatch(final IWorkflowExecution workflowExecution) {
+        checkNotNull(workflowExecution, "workflowExecution is null");
+        final WorkflowExecutionStatus actualState = workflowExecution.getState();
         final WorkflowExecutionStatus expectState = matchState();
         if (actualState != expectState) {
-            final String workflowName = workflowExecutionRunnable.getName();
+            final String workflowName = workflowExecution.getName();
             throw new IllegalStateException(
                     "The workflow: " + workflowName + " state: " + actualState + " is not match:" + expectState);
         }
     }
 
-    protected void logWarningIfCannotDoAction(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    protected void logWarningIfCannotDoAction(final IWorkflowExecution workflowExecution,
                                               final AbstractLifecycleEvent event) {
         log.warn("Workflow {} state is {} cannot do action on event: {}",
-                workflowExecutionRunnable.getName(),
-                workflowExecutionRunnable.getState(),
+                workflowExecution.getName(),
+                workflowExecution.getState(),
                 event);
     }
 
-    protected void finalizeEventAction(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        log.info(WorkflowInstanceUtils.logWorkflowInstanceInDetails(workflowExecutionRunnable));
+    protected void finalizeEventAction(final IWorkflowExecution workflowExecution) {
+        log.info(WorkflowInstanceUtils.logWorkflowInstanceInDetails(workflowExecution));
 
-        workflowCacheRepository.remove(workflowExecutionRunnable.getId());
-        workflowEventBusCoordinator.unRegisterWorkflowEventBus(workflowExecutionRunnable);
-        workflowAlertManager.sendAlertWorkflowInstance(workflowExecutionRunnable.getWorkflowInstance());
+        workflowCacheRepository.remove(workflowExecution.getId());
+        workflowEventBusCoordinator.unRegisterWorkflowEventBus(workflowExecution);
+        workflowAlertManager.sendAlertWorkflowInstance(workflowExecution.getWorkflowInstance());
 
-        log.info("Successfully finalize WorkflowExecuteRunnable: {}", workflowExecutionRunnable.getName());
+        log.info("Successfully finalize WorkflowExecuteRunnable: {}", workflowExecution.getName());
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/IWorkflowStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/IWorkflowStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 /**
  * Represents the action to be taken when a workflow is in a certain state and receive a target event.
@@ -49,55 +49,55 @@ public interface IWorkflowStateAction {
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowStartLifecycleEvent}.
      */
-    void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onStartEvent(final IWorkflowExecution workflowExecution,
                       final WorkflowStartLifecycleEvent workflowStartEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent}.
      */
-    void onTopologyLogicalTransitionEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onTopologyLogicalTransitionEvent(final IWorkflowExecution workflowExecution,
                                           final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowPauseLifecycleEvent}.
      */
-    void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onPauseEvent(final IWorkflowExecution workflowExecution,
                       final WorkflowPauseLifecycleEvent workflowPauseEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowPausedLifecycleEvent}.
      */
-    void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onPausedEvent(final IWorkflowExecution workflowExecution,
                        final WorkflowPausedLifecycleEvent workflowPausedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowStopLifecycleEvent}.
      */
-    void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onStopEvent(final IWorkflowExecution workflowExecution,
                      final WorkflowStopLifecycleEvent workflowStopEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowStoppedLifecycleEvent}.
      */
-    void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onStoppedEvent(final IWorkflowExecution workflowExecution,
                         final WorkflowStoppedLifecycleEvent workflowStoppedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowSucceedLifecycleEvent}.
      */
-    void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onSucceedEvent(final IWorkflowExecution workflowExecution,
                         final WorkflowSucceedLifecycleEvent workflowSucceedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowFailedLifecycleEvent}.
      */
-    void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onFailedEvent(final IWorkflowExecution workflowExecution,
                        final WorkflowFailedLifecycleEvent workflowFailedEvent);
 
     /**
      * Perform the necessary actions when the workflow in a certain state receive a {@link WorkflowFinalizeLifecycleEvent}.
      */
-    void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                          final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent);
 
     /**

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailedStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,67 +38,67 @@ import org.springframework.stereotype.Component;
 public class WorkflowFailedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.finalizeEventAction(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.finalizeEventAction(workflowExecution);
     }
 
     @Override
@@ -110,9 +110,9 @@ public class WorkflowFailedStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
         throw new IllegalStateException(
-                "The workflow " + workflowExecutionRunnable.getName() +
+                "The workflow " + workflowExecution.getName() +
                         "is failed, shouldn't emit workflow finished event");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailoverStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowFailoverStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,67 +41,67 @@ import org.springframework.stereotype.Component;
 public class WorkflowFailoverStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override
@@ -113,9 +113,9 @@ public class WorkflowFailoverStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
         throw new IllegalStateException(
-                "The workflow " + workflowExecutionRunnable.getName() +
+                "The workflow " + workflowExecution.getName() +
                         "is success, shouldn't emit workflow finished event");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowPausedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowPausedStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,67 +38,67 @@ import org.springframework.stereotype.Component;
 public class WorkflowPausedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.finalizeEventAction(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.finalizeEventAction(workflowExecution);
     }
 
     @Override
@@ -110,9 +110,9 @@ public class WorkflowPausedStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
         throw new IllegalStateException(
-                "The workflow " + workflowExecutionRunnable.getName() +
+                "The workflow " + workflowExecution.getName() +
                         "is paused, shouldn't emit workflow finished event");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyPauseStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyPauseStateAction.java
@@ -20,7 +20,8 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -30,7 +31,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import java.util.List;
 
@@ -43,78 +43,78 @@ import org.springframework.stereotype.Component;
 public class WorkflowReadyPauseStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
         final IWorkflowExecutionGraph workflowExecutionGraph =
-                workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
-        final List<ITaskExecutionRunnable> startNodes = workflowExecutionGraph.getStartNodes();
+                workflowExecution.getWorkflowExecuteContext().getWorkflowExecutionGraph();
+        final List<ITaskExecution> startNodes = workflowExecutionGraph.getStartNodes();
         if (startNodes.isEmpty()) {
             log.info("Workflow start node is empty, try to emit workflow finished event");
-            emitWorkflowFinishedEventIfApplicable(workflowExecutionRunnable);
+            emitWorkflowFinishedEventIfApplicable(workflowExecution);
             return;
         }
-        triggerTasks(workflowExecutionRunnable, startNodes);
+        triggerTasks(workflowExecution, startNodes);
     }
 
     @Override
-    public void onTopologyLogicalTransitionEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onTopologyLogicalTransitionEvent(final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        final ITaskExecutionRunnable taskExecutionRunnable =
-                workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecutionRunnable();
-        workflowExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableInActive(taskExecutionRunnable);
-        super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecutionRunnable, taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        final ITaskExecution taskExecution =
+                workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecution();
+        workflowExecution.getWorkflowExecutionGraph().markTaskExecutionInActive(taskExecution);
+        super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecution, taskExecution);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.PAUSE);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        workflowFinish(workflowExecution, WorkflowExecutionStatus.PAUSE);
 
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.SUCCESS);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.workflowFinish(workflowExecution, WorkflowExecutionStatus.SUCCESS);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.FAILURE);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.workflowFinish(workflowExecution, WorkflowExecutionStatus.FAILURE);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override
@@ -123,31 +123,31 @@ public class WorkflowReadyPauseStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        if (!isWorkflowFinishable(workflowExecutionRunnable)) {
+    protected void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecution workflowExecution) {
+        if (!isWorkflowFinishable(workflowExecution)) {
             log.debug("There exist task which is not finish, don't need to emit workflow finished event");
             return;
         }
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        final WorkflowEventBus workflowEventBus = workflowExecutionRunnable.getWorkflowEventBus();
-        if (workflowExecutionGraph.isExistPausedTaskExecutionRunnableChain()) {
-            workflowEventBus.publish(WorkflowPausedLifecycleEvent.of(workflowExecutionRunnable));
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        final WorkflowEventBus workflowEventBus = workflowExecution.getWorkflowEventBus();
+        if (workflowExecutionGraph.isExistPausedTaskExecutionChain()) {
+            workflowEventBus.publish(WorkflowPausedLifecycleEvent.of(workflowExecution));
             return;
         }
 
-        if (workflowExecutionGraph.isExistFailureTaskExecutionRunnableChain()) {
-            workflowEventBus.publish(WorkflowFailedLifecycleEvent.of(workflowExecutionRunnable));
+        if (workflowExecutionGraph.isExistFailureTaskExecutionChain()) {
+            workflowEventBus.publish(WorkflowFailedLifecycleEvent.of(workflowExecution));
             return;
         }
 
-        if (workflowExecutionGraph.isAllTaskExecutionRunnableChainSuccess()) {
-            workflowEventBus.publish(WorkflowSucceedLifecycleEvent.of(workflowExecutionRunnable));
+        if (workflowExecutionGraph.isAllTaskExecutionChainSuccess()) {
+            workflowEventBus.publish(WorkflowSucceedLifecycleEvent.of(workflowExecution));
             return;
         }
 
         throw new IllegalStateException(
-                "The workflow: " + workflowExecutionRunnable.getName() + " state is "
-                        + workflowExecutionRunnable.getState()
+                "The workflow: " + workflowExecution.getName() + " state is "
+                        + workflowExecution.getState()
                         + " can only finish with success/failed/paused but exist task chain which state is not success/failure/pause");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyStopStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowReadyStopStateAction.java
@@ -20,7 +20,8 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -30,7 +31,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import java.util.List;
 
@@ -43,77 +43,77 @@ import org.springframework.stereotype.Component;
 public class WorkflowReadyStopStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
         final IWorkflowExecutionGraph workflowExecutionGraph =
-                workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
-        final List<ITaskExecutionRunnable> startNodes = workflowExecutionGraph.getStartNodes();
+                workflowExecution.getWorkflowExecuteContext().getWorkflowExecutionGraph();
+        final List<ITaskExecution> startNodes = workflowExecutionGraph.getStartNodes();
         if (startNodes.isEmpty()) {
             log.info("Workflow start node is empty, try to emit workflow finished event");
-            emitWorkflowFinishedEventIfApplicable(workflowExecutionRunnable);
+            emitWorkflowFinishedEventIfApplicable(workflowExecution);
             return;
         }
-        triggerTasks(workflowExecutionRunnable, startNodes);
+        triggerTasks(workflowExecution, startNodes);
     }
 
     @Override
-    public void onTopologyLogicalTransitionEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onTopologyLogicalTransitionEvent(final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        final ITaskExecutionRunnable taskExecutionRunnable =
-                workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecutionRunnable();
-        workflowExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableInActive(taskExecutionRunnable);
-        super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecutionRunnable, taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        final ITaskExecution taskExecution =
+                workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecution();
+        workflowExecution.getWorkflowExecutionGraph().markTaskExecutionInActive(taskExecution);
+        super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecution, taskExecution);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        workflowExecutionRunnable.killActiveTasks();
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        workflowExecution.killActiveTasks();
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.STOP);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.workflowFinish(workflowExecution, WorkflowExecutionStatus.STOP);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.SUCCESS);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.workflowFinish(workflowExecution, WorkflowExecutionStatus.SUCCESS);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.FAILURE);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.workflowFinish(workflowExecution, WorkflowExecutionStatus.FAILURE);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override
@@ -122,33 +122,33 @@ public class WorkflowReadyStopStateAction extends AbstractWorkflowStateAction {
     }
 
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        if (!isWorkflowFinishable(workflowExecutionRunnable)) {
+    protected void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecution workflowExecution) {
+        if (!isWorkflowFinishable(workflowExecution)) {
             log.debug("There exist task which is not finish, don't need to emit workflow finished event");
             return;
         }
 
         final IWorkflowExecutionGraph workflowExecutionGraph =
-                workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
-        final WorkflowEventBus workflowEventBus = workflowExecutionRunnable.getWorkflowEventBus();
-        if (workflowExecutionGraph.isExistKilledTaskExecutionRunnableChain()) {
-            workflowEventBus.publish(WorkflowStoppedLifecycleEvent.of(workflowExecutionRunnable));
+                workflowExecution.getWorkflowExecuteContext().getWorkflowExecutionGraph();
+        final WorkflowEventBus workflowEventBus = workflowExecution.getWorkflowEventBus();
+        if (workflowExecutionGraph.isExistKilledTaskExecutionChain()) {
+            workflowEventBus.publish(WorkflowStoppedLifecycleEvent.of(workflowExecution));
             return;
         }
 
-        if (workflowExecutionGraph.isExistFailureTaskExecutionRunnableChain()) {
-            workflowEventBus.publish(WorkflowFailedLifecycleEvent.of(workflowExecutionRunnable));
+        if (workflowExecutionGraph.isExistFailureTaskExecutionChain()) {
+            workflowEventBus.publish(WorkflowFailedLifecycleEvent.of(workflowExecution));
             return;
         }
 
-        if (workflowExecutionGraph.isAllTaskExecutionRunnableChainSuccess()) {
-            workflowEventBus.publish(WorkflowSucceedLifecycleEvent.of(workflowExecutionRunnable));
+        if (workflowExecutionGraph.isAllTaskExecutionChainSuccess()) {
+            workflowEventBus.publish(WorkflowSucceedLifecycleEvent.of(workflowExecution));
             return;
         }
 
         throw new IllegalStateException(
-                "The workflow: " + workflowExecutionRunnable.getName() + " state is "
-                        + workflowExecutionRunnable.getState()
+                "The workflow: " + workflowExecution.getName() + " state is "
+                        + workflowExecution.getState()
                         + " can only finish with success/failed/stop but exist task chain which state is not success/failure/kill");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowRunningStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowRunningStateAction.java
@@ -20,7 +20,8 @@ package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -30,7 +31,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import java.util.List;
 
@@ -43,97 +43,97 @@ import org.springframework.stereotype.Component;
 public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
         final IWorkflowExecutionGraph workflowExecutionGraph =
-                workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph();
-        final List<ITaskExecutionRunnable> startNodes = workflowExecutionGraph.getStartNodes();
+                workflowExecution.getWorkflowExecuteContext().getWorkflowExecutionGraph();
+        final List<ITaskExecution> startNodes = workflowExecutionGraph.getStartNodes();
         if (startNodes.isEmpty()) {
             log.info("Workflow start node is empty, try to emit workflow finished event");
-            emitWorkflowFinishedEventIfApplicable(workflowExecutionRunnable);
+            emitWorkflowFinishedEventIfApplicable(workflowExecution);
             return;
         }
-        triggerTasks(workflowExecutionRunnable, startNodes);
+        triggerTasks(workflowExecution, startNodes);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        final ITaskExecutionRunnable taskExecutionRunnable =
-                workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecutionRunnable();
-        workflowExecutionRunnable.getWorkflowExecutionGraph().markTaskExecutionRunnableInActive(taskExecutionRunnable);
-        super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecutionRunnable, taskExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        final ITaskExecution taskExecution =
+                workflowTopologyLogicalTransitionWithTaskFinishEvent.getTaskExecution();
+        workflowExecution.getWorkflowExecutionGraph().markTaskExecutionInActive(taskExecution);
+        super.tryToTriggerSuccessorsAfterTaskFinish(workflowExecution, taskExecution);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.transformWorkflowInstanceState(workflowExecutionRunnable, WorkflowExecutionStatus.READY_PAUSE);
-        super.pauseActiveTask(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.transformWorkflowInstanceState(workflowExecution, WorkflowExecutionStatus.READY_PAUSE);
+        super.pauseActiveTask(workflowExecution);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.transformWorkflowInstanceState(workflowExecutionRunnable, WorkflowExecutionStatus.READY_STOP);
-        workflowExecutionRunnable.killActiveTasks();
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.transformWorkflowInstanceState(workflowExecution, WorkflowExecutionStatus.READY_STOP);
+        workflowExecution.killActiveTasks();
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
         // [Fix-17354]
-        if (!workflowExecutionRunnable.getWorkflowExecutionGraph().isExistKilledTaskExecutionRunnableChain()) {
+        if (!workflowExecution.getWorkflowExecutionGraph().isExistKilledTaskExecutionChain()) {
             throw new IllegalStateException(
-                    "The workflow: " + workflowExecutionRunnable.getName()
+                    "The workflow: " + workflowExecution.getName()
                             + " does not exist tasks chain which is killed");
         }
-        super.workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.STOP);
+        super.workflowFinish(workflowExecution, WorkflowExecutionStatus.STOP);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        if (!workflowExecutionGraph.isAllTaskExecutionRunnableChainSuccess()) {
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        if (!workflowExecutionGraph.isAllTaskExecutionChainSuccess()) {
             throw new IllegalStateException(
-                    "The workflow: " + workflowExecutionRunnable.getName() + "exist tasks chain which is not success");
+                    "The workflow: " + workflowExecution.getName() + "exist tasks chain which is not success");
         }
-        workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.SUCCESS);
+        workflowFinish(workflowExecution, WorkflowExecutionStatus.SUCCESS);
     }
 
     @Override
-    public void onFailedEvent(IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(IWorkflowExecution workflowExecution,
                               WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        if (!workflowExecutionGraph.isExistFailureTaskExecutionRunnableChain()) {
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        if (!workflowExecutionGraph.isExistFailureTaskExecutionChain()) {
             throw new IllegalStateException(
-                    "The workflow: " + workflowExecutionRunnable.getName()
+                    "The workflow: " + workflowExecution.getName()
                             + " does not exist tasks chain which is failed");
         }
-        workflowFinish(workflowExecutionRunnable, WorkflowExecutionStatus.FAILURE);
+        workflowFinish(workflowExecution, WorkflowExecutionStatus.FAILURE);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override
@@ -145,15 +145,15 @@ public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        if (!isWorkflowFinishable(workflowExecutionRunnable)) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
+        if (!isWorkflowFinishable(workflowExecution)) {
             log.debug("There exist task which is not finish, don't need to emit workflow finished event");
             return;
         }
-        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecutionRunnable.getWorkflowExecutionGraph();
-        final WorkflowEventBus workflowEventBus = workflowExecutionRunnable.getWorkflowEventBus();
-        if (workflowExecutionGraph.isExistFailureTaskExecutionRunnableChain()) {
-            workflowEventBus.publish(WorkflowFailedLifecycleEvent.of(workflowExecutionRunnable));
+        final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecution.getWorkflowExecutionGraph();
+        final WorkflowEventBus workflowEventBus = workflowExecution.getWorkflowEventBus();
+        if (workflowExecutionGraph.isExistFailureTaskExecutionChain()) {
+            workflowEventBus.publish(WorkflowFailedLifecycleEvent.of(workflowExecution));
             return;
         }
 
@@ -162,18 +162,18 @@ public class WorkflowRunningStateAction extends AbstractWorkflowStateAction {
         // So there might exist task which is killed, and the workflow instance state is running.
         // This is a special case, the workflow instance can transform from running to stop state.
         // Is there better way to handle this case?
-        if (workflowExecutionGraph.isExistKilledTaskExecutionRunnableChain()) {
-            workflowEventBus.publish(WorkflowStoppedLifecycleEvent.of(workflowExecutionRunnable));
+        if (workflowExecutionGraph.isExistKilledTaskExecutionChain()) {
+            workflowEventBus.publish(WorkflowStoppedLifecycleEvent.of(workflowExecution));
             return;
         }
 
-        if (workflowExecutionGraph.isAllTaskExecutionRunnableChainSuccess()) {
-            workflowEventBus.publish(WorkflowSucceedLifecycleEvent.of(workflowExecutionRunnable));
+        if (workflowExecutionGraph.isAllTaskExecutionChainSuccess()) {
+            workflowEventBus.publish(WorkflowSucceedLifecycleEvent.of(workflowExecution));
             return;
         }
 
-        throw new IllegalStateException("The workflow: " + workflowExecutionRunnable.getName() +
-                " state is " + workflowExecutionRunnable.getState()
+        throw new IllegalStateException("The workflow: " + workflowExecution.getName() +
+                " state is " + workflowExecution.getState()
                 + " can only finish with task success/failed/killed but exist task which state is not success、failure、killed");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSerialWaitStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSerialWaitStateAction.java
@@ -18,6 +18,8 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.WorkflowExecutionFactory;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,82 +29,80 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.WorkflowExecutionRunnableFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Component;
 
 /**
- * The serial wait state shouldn't occur in runtime, it should be transformed to running state by {@link WorkflowExecutionRunnableFactory}
+ * The serial wait state shouldn't occur in runtime, it should be transformed to running state by {@link WorkflowExecutionFactory}
  */
 @Slf4j
 @Component
 public class WorkflowSerialWaitStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override
@@ -114,8 +114,8 @@ public class WorkflowSerialWaitStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(final IWorkflowExecution workflowExecution) {
         log.warn("The workflow: {} is in serial_wait state, shouldn't emit workflow finished event",
-                workflowExecutionRunnable.getName());
+                workflowExecution.getName());
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowStoppedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowStoppedStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,67 +38,67 @@ import org.springframework.stereotype.Component;
 public class WorkflowStoppedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.finalizeEventAction(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.finalizeEventAction(workflowExecution);
     }
 
     @Override
@@ -110,9 +110,9 @@ public class WorkflowStoppedStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
         throw new IllegalStateException(
-                "The workflow " + workflowExecutionRunnable.getName() +
+                "The workflow " + workflowExecution.getName() +
                         "is stopped, shouldn't emit workflow finished event");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSubmittedStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSubmittedStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,67 +41,67 @@ import org.springframework.stereotype.Component;
 public class WorkflowSubmittedStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFinalizeEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFinalizeEvent);
     }
 
     @Override
@@ -113,9 +113,9 @@ public class WorkflowSubmittedStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
         throw new IllegalStateException(
-                "The workflow " + workflowExecutionRunnable.getName() +
+                "The workflow " + workflowExecution.getName() +
                         "is submitted, shouldn't emit workflow finished event");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSuccessStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/workflow/statemachine/WorkflowSuccessStateAction.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.server.master.engine.workflow.statemachine;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowFinalizeLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowPauseLifecycleEvent;
@@ -27,7 +28,6 @@ import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowStoppedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowSucceedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.workflow.lifecycle.event.WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,67 +38,67 @@ import org.springframework.stereotype.Component;
 public class WorkflowSuccessStateAction extends AbstractWorkflowStateAction {
 
     @Override
-    public void onStartEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStartEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowStartLifecycleEvent workflowStartEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStartEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStartEvent);
     }
 
     @Override
     public void onTopologyLogicalTransitionEvent(
-                                                 final IWorkflowExecutionRunnable workflowExecutionRunnable,
+                                                 final IWorkflowExecution workflowExecution,
                                                  final WorkflowTopologyLogicalTransitionWithTaskFinishLifecycleEvent workflowTopologyLogicalTransitionWithTaskFinishEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowTopologyLogicalTransitionWithTaskFinishEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowTopologyLogicalTransitionWithTaskFinishEvent);
     }
 
     @Override
-    public void onPauseEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPauseEvent(final IWorkflowExecution workflowExecution,
                              final WorkflowPauseLifecycleEvent workflowPauseEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPauseEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPauseEvent);
     }
 
     @Override
-    public void onPausedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onPausedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowPausedLifecycleEvent workflowPausedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowPausedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowPausedEvent);
     }
 
     @Override
-    public void onStopEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStopEvent(final IWorkflowExecution workflowExecution,
                             final WorkflowStopLifecycleEvent workflowStopEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStopEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStopEvent);
     }
 
     @Override
-    public void onStoppedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onStoppedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowStoppedLifecycleEvent workflowStoppedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowStoppedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowStoppedEvent);
     }
 
     @Override
-    public void onSucceedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onSucceedEvent(final IWorkflowExecution workflowExecution,
                                final WorkflowSucceedLifecycleEvent workflowSucceedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowSucceedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowSucceedEvent);
     }
 
     @Override
-    public void onFailedEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFailedEvent(final IWorkflowExecution workflowExecution,
                               final WorkflowFailedLifecycleEvent workflowFailedEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        logWarningIfCannotDoAction(workflowExecutionRunnable, workflowFailedEvent);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        logWarningIfCannotDoAction(workflowExecution, workflowFailedEvent);
     }
 
     @Override
-    public void onFinalizeEvent(final IWorkflowExecutionRunnable workflowExecutionRunnable,
+    public void onFinalizeEvent(final IWorkflowExecution workflowExecution,
                                 final WorkflowFinalizeLifecycleEvent workflowFinalizeEvent) {
-        throwExceptionIfStateIsNotMatch(workflowExecutionRunnable);
-        super.finalizeEventAction(workflowExecutionRunnable);
+        throwExceptionIfStateIsNotMatch(workflowExecution);
+        super.finalizeEventAction(workflowExecution);
     }
 
     @Override
@@ -110,9 +110,9 @@ public class WorkflowSuccessStateAction extends AbstractWorkflowStateAction {
      * The running state can only finish with success/failure.
      */
     @Override
-    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecutionRunnable workflowExecutionRunnable) {
+    protected void emitWorkflowFinishedEventIfApplicable(IWorkflowExecution workflowExecution) {
         throw new IllegalStateException(
-                "The workflow " + workflowExecutionRunnable.getName() +
+                "The workflow " + workflowExecution.getName() +
                         "is success, shouldn't emit workflow finished event");
     }
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/failover/FailoverCoordinator.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/failover/FailoverCoordinator.java
@@ -31,8 +31,8 @@ import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.system.event.GlobalMasterFailoverEvent;
 import org.apache.dolphinscheduler.server.master.engine.system.event.MasterFailoverEvent;
 import org.apache.dolphinscheduler.server.master.engine.system.event.WorkerFailoverEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -244,7 +244,7 @@ public class FailoverCoordinator implements IFailoverCoordinator {
         final StopWatch failoverTimeCost = StopWatch.createStarted();
         // we don't check the workerFailoverNodePath exist, since the worker may be failovered multiple master
 
-        final List<ITaskExecutionRunnable> needFailoverTasks =
+        final List<ITaskExecution> needFailoverTasks =
                 getFailoverTaskForWorker(workerAddress, new Date(taskFailoverDeadline));
         needFailoverTasks.forEach(taskFailover::failoverTask);
 
@@ -258,23 +258,23 @@ public class FailoverCoordinator implements IFailoverCoordinator {
                 failoverTimeCost.getTime());
     }
 
-    private List<ITaskExecutionRunnable> getFailoverTaskForWorker(final String workerAddress,
-                                                                  final Date taskFailoverDeadline) {
+    private List<ITaskExecution> getFailoverTaskForWorker(final String workerAddress,
+                                                          final Date taskFailoverDeadline) {
         return workflowRepository.getAll()
                 .stream()
-                .map(IWorkflowExecutionRunnable::getWorkflowExecutionGraph)
-                .flatMap(workflowExecutionGraph -> workflowExecutionGraph.getActiveTaskExecutionRunnable().stream())
-                .filter(ITaskExecutionRunnable::isTaskInstanceInitialized)
-                .filter(taskExecutionRunnable -> workerAddress
-                        .equals(taskExecutionRunnable.getTaskInstance().getHost()))
-                .filter(taskExecutionRunnable -> {
-                    final TaskExecutionStatus state = taskExecutionRunnable.getTaskInstance().getState();
+                .map(IWorkflowExecution::getWorkflowExecutionGraph)
+                .flatMap(workflowExecutionGraph -> workflowExecutionGraph.getActiveTaskExecution().stream())
+                .filter(ITaskExecution::isTaskInstanceInitialized)
+                .filter(taskExecution -> workerAddress
+                        .equals(taskExecution.getTaskInstance().getHost()))
+                .filter(taskExecution -> {
+                    final TaskExecutionStatus state = taskExecution.getTaskInstance().getState();
                     return state == TaskExecutionStatus.DISPATCH || state == TaskExecutionStatus.RUNNING_EXECUTION;
                 })
-                .filter(taskExecutionRunnable -> {
+                .filter(taskExecution -> {
                     // The submitTime should not be null.
                     // This is a bad case unless someone manually set the submitTime to null.
-                    final Date submitTime = taskExecutionRunnable.getTaskInstance().getSubmitTime();
+                    final Date submitTime = taskExecution.getTaskInstance().getSubmitTime();
                     return submitTime != null && submitTime.before(taskFailoverDeadline);
                 })
                 .collect(Collectors.toList());

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/failover/TaskFailover.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/failover/TaskFailover.java
@@ -18,17 +18,17 @@
 package org.apache.dolphinscheduler.server.master.failover;
 
 import org.apache.dolphinscheduler.plugin.task.api.utils.LogUtils;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailoverLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class TaskFailover {
 
-    public void failoverTask(final ITaskExecutionRunnable taskExecutionRunnable) {
-        LogUtils.setWorkflowInstanceIdMDC(taskExecutionRunnable.getWorkflowInstance().getId());
-        taskExecutionRunnable.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecutionRunnable));
+    public void failoverTask(final ITaskExecution taskExecution) {
+        LogUtils.setWorkflowInstanceIdMDC(taskExecution.getWorkflowInstance().getId());
+        taskExecution.getWorkflowEventBus().publish(TaskFailoverLifecycleEvent.of(taskExecution));
         LogUtils.removeWorkflowInstanceIdMDC();
     }
 

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/TaskExecutorEventListenerImpl.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/TaskExecutorEventListenerImpl.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.server.master.rpc;
 import org.apache.dolphinscheduler.extract.master.ITaskExecutorEventListener;
 import org.apache.dolphinscheduler.plugin.task.api.utils.LogUtils;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskKilledLifecycleEvent;
@@ -27,8 +28,7 @@ import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.Tas
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRunningLifecycleEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskRuntimeContextChangedEvent;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.task.executor.events.IReportableTaskExecutorLifecycleEvent;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorDispatchedLifecycleEvent;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorFailedLifecycleEvent;
@@ -56,14 +56,14 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorDispatched(final TaskExecutorDispatchedLifecycleEvent taskExecutorDispatchedLifecycleEvent) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorDispatchedLifecycleEvent.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorDispatchedLifecycleEvent);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorDispatchedLifecycleEvent);
             final TaskDispatchedLifecycleEvent taskDispatchedLifecycleEvent = TaskDispatchedLifecycleEvent.builder()
-                    .taskExecutionRunnable(taskExecutionRunnable)
+                    .taskExecution(taskExecution)
                     .executorHost(taskExecutorDispatchedLifecycleEvent.getTaskInstanceHost())
                     .build();
 
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskDispatchedLifecycleEvent);
+            taskExecution.getWorkflowEventBus().publish(taskDispatchedLifecycleEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
@@ -73,15 +73,15 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorRunning(final TaskExecutorStartedLifecycleEvent taskExecutorStartedLifecycleEvent) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorStartedLifecycleEvent.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorStartedLifecycleEvent);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorStartedLifecycleEvent);
             final TaskRunningLifecycleEvent taskRunningEvent = TaskRunningLifecycleEvent.builder()
-                    .taskExecutionRunnable(taskExecutionRunnable)
+                    .taskExecution(taskExecution)
                     .startTime(new Date(taskExecutorStartedLifecycleEvent.getStartTime()))
                     .logPath(taskExecutorStartedLifecycleEvent.getLogPath())
                     .build();
 
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskRunningEvent);
+            taskExecution.getWorkflowEventBus().publish(taskRunningEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
@@ -91,16 +91,16 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorRuntimeContextChanged(final TaskExecutorRuntimeContextChangedLifecycleEvent taskExecutorRuntimeContextChangedLifecycleEventr) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorRuntimeContextChangedLifecycleEventr.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorRuntimeContextChangedLifecycleEventr);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorRuntimeContextChangedLifecycleEventr);
 
             final TaskRuntimeContextChangedEvent taskRuntimeContextChangedEvent =
                     TaskRuntimeContextChangedEvent.builder()
-                            .taskExecutionRunnable(taskExecutionRunnable)
+                            .taskExecution(taskExecution)
                             .runtimeContext(taskExecutorRuntimeContextChangedLifecycleEventr.getAppIds())
                             .build();
 
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskRuntimeContextChangedEvent);
+            taskExecution.getWorkflowEventBus().publish(taskRuntimeContextChangedEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
@@ -110,14 +110,14 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorSuccess(final TaskExecutorSuccessLifecycleEvent taskExecutorSuccessLifecycleEvent) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorSuccessLifecycleEvent.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorSuccessLifecycleEvent);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorSuccessLifecycleEvent);
             final TaskSuccessLifecycleEvent taskSuccessEvent = TaskSuccessLifecycleEvent.builder()
-                    .taskExecutionRunnable(taskExecutionRunnable)
+                    .taskExecution(taskExecution)
                     .endTime(new Date(taskExecutorSuccessLifecycleEvent.getEndTime()))
                     .varPool(taskExecutorSuccessLifecycleEvent.getVarPool())
                     .build();
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskSuccessEvent);
+            taskExecution.getWorkflowEventBus().publish(taskSuccessEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
@@ -127,13 +127,13 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorFailed(final TaskExecutorFailedLifecycleEvent taskExecutorFailedLifecycleEvent) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorFailedLifecycleEvent.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorFailedLifecycleEvent);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorFailedLifecycleEvent);
             final TaskFailedLifecycleEvent taskFailedEvent = TaskFailedLifecycleEvent.builder()
-                    .taskExecutionRunnable(taskExecutionRunnable)
+                    .taskExecution(taskExecution)
                     .endTime(new Date(taskExecutorFailedLifecycleEvent.getEndTime()))
                     .build();
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskFailedEvent);
+            taskExecution.getWorkflowEventBus().publish(taskFailedEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
@@ -143,13 +143,13 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorKilled(final TaskExecutorKilledLifecycleEvent taskExecutorKilledLifecycleEvent) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorKilledLifecycleEvent.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorKilledLifecycleEvent);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorKilledLifecycleEvent);
             final TaskKilledLifecycleEvent taskKilledEvent = TaskKilledLifecycleEvent.builder()
-                    .taskExecutionRunnable(taskExecutionRunnable)
+                    .taskExecution(taskExecution)
                     .endTime(new Date(taskExecutorKilledLifecycleEvent.getEndTime()))
                     .build();
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskKilledEvent);
+            taskExecution.getWorkflowEventBus().publish(taskKilledEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
@@ -159,30 +159,30 @@ public class TaskExecutorEventListenerImpl implements ITaskExecutorEventListener
     public void onTaskExecutorPaused(final TaskExecutorPausedLifecycleEvent taskExecutorPausedLifecycleEvent) {
         LogUtils.setWorkflowInstanceIdMDC(taskExecutorPausedLifecycleEvent.getWorkflowInstanceId());
         try {
-            final ITaskExecutionRunnable taskExecutionRunnable =
-                    getTaskExecutionRunnable(taskExecutorPausedLifecycleEvent);
-            final TaskPausedLifecycleEvent taskPausedEvent = TaskPausedLifecycleEvent.of(taskExecutionRunnable);
-            taskExecutionRunnable.getWorkflowEventBus().publish(taskPausedEvent);
+            final ITaskExecution taskExecution =
+                    getTaskExecution(taskExecutorPausedLifecycleEvent);
+            final TaskPausedLifecycleEvent taskPausedEvent = TaskPausedLifecycleEvent.of(taskExecution);
+            taskExecution.getWorkflowEventBus().publish(taskPausedEvent);
         } finally {
             LogUtils.removeWorkflowInstanceIdMDC();
         }
     }
 
-    private ITaskExecutionRunnable getTaskExecutionRunnable(final IReportableTaskExecutorLifecycleEvent reportableTaskExecutorLifecycleEvent) {
+    private ITaskExecution getTaskExecution(final IReportableTaskExecutorLifecycleEvent reportableTaskExecutorLifecycleEvent) {
         final int workflowInstanceId = reportableTaskExecutorLifecycleEvent.getWorkflowInstanceId();
         final int taskInstanceId = reportableTaskExecutorLifecycleEvent.getTaskInstanceId();
 
-        final IWorkflowExecutionRunnable workflowExecutionRunnable = workflowRepository.get(workflowInstanceId);
-        if (workflowExecutionRunnable == null) {
+        final IWorkflowExecution workflowExecution = workflowRepository.get(workflowInstanceId);
+        if (workflowExecution == null) {
             throw new IllegalArgumentException("Cannot find the WorkflowExecuteRunnable: " + workflowInstanceId);
         }
-        final ITaskExecutionRunnable taskExecutionRunnable = workflowExecutionRunnable.getWorkflowExecuteContext()
+        final ITaskExecution taskExecution = workflowExecution.getWorkflowExecuteContext()
                 .getWorkflowExecutionGraph()
-                .getTaskExecutionRunnableById(taskInstanceId);
-        if (taskExecutionRunnable == null) {
+                .getTaskExecutionById(taskInstanceId);
+        if (taskExecution == null) {
             throw new IllegalArgumentException("Cannot find the TaskExecuteRunnable: " + taskInstanceId);
         }
-        return taskExecutionRunnable;
+        return taskExecution;
     }
 
 }

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/TaskInstanceControllerImpl.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/TaskInstanceControllerImpl.java
@@ -22,9 +22,9 @@ import org.apache.dolphinscheduler.extract.master.transportor.TaskGroupSlotAcqui
 import org.apache.dolphinscheduler.extract.master.transportor.TaskGroupSlotAcquireSuccessNotifyResponse;
 import org.apache.dolphinscheduler.plugin.task.api.utils.LogUtils;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskDispatchLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 public class TaskInstanceControllerImpl implements ITaskInstanceController {
 
     @Autowired
-    private IWorkflowRepository workflowExecutionRunnableMemoryRepository;
+    private IWorkflowRepository workflowExecutionMemoryRepository;
 
     @Override
     public TaskGroupSlotAcquireSuccessNotifyResponse notifyTaskGroupSlotAcquireSuccess(
@@ -46,24 +46,24 @@ public class TaskInstanceControllerImpl implements ITaskInstanceController {
             final int workflowInstanceId = taskGroupSlotAcquireSuccessNotifyRequest.getWorkflowInstanceId();
             final int taskInstanceId = taskGroupSlotAcquireSuccessNotifyRequest.getTaskInstanceId();
             LogUtils.setWorkflowAndTaskInstanceIDMDC(workflowInstanceId, taskInstanceId);
-            final IWorkflowExecutionRunnable workflowExecutionRunnable =
-                    workflowExecutionRunnableMemoryRepository.get(workflowInstanceId);
-            if (workflowExecutionRunnable == null) {
+            final IWorkflowExecution workflowExecution =
+                    workflowExecutionMemoryRepository.get(workflowInstanceId);
+            if (workflowExecution == null) {
                 log.warn("cannot find WorkflowExecuteRunnable: {}, no need to Wakeup task", workflowInstanceId);
                 return TaskGroupSlotAcquireSuccessNotifyResponse
                         .failed("cannot find WorkflowExecuteRunnable: " + workflowInstanceId);
             }
-            final ITaskExecutionRunnable taskExecutionRunnable = workflowExecutionRunnable
+            final ITaskExecution taskExecution = workflowExecution
                     .getWorkflowExecuteContext()
                     .getWorkflowExecutionGraph()
-                    .getTaskExecutionRunnableById(taskInstanceId);
-            if (taskExecutionRunnable == null) {
-                log.warn("Cannot find TaskExecutionRunnable: {}, no need to Wakeup task", taskInstanceId);
+                    .getTaskExecutionById(taskInstanceId);
+            if (taskExecution == null) {
+                log.warn("Cannot find TaskExecution: {}, no need to Wakeup task", taskInstanceId);
                 return TaskGroupSlotAcquireSuccessNotifyResponse
-                        .failed("Cannot find TaskExecutionRunnable: " + taskInstanceId);
+                        .failed("Cannot find TaskExecution: " + taskInstanceId);
             }
-            workflowExecutionRunnable.getWorkflowEventBus()
-                    .publish(TaskDispatchLifecycleEvent.of(taskExecutionRunnable));
+            workflowExecution.getWorkflowEventBus()
+                    .publish(TaskDispatchLifecycleEvent.of(taskExecution));
             log.info("Success Wakeup TaskInstance: {}", taskInstanceId);
             return TaskGroupSlotAcquireSuccessNotifyResponse.success();
         } finally {

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/WorkflowControlClient.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/WorkflowControlClient.java
@@ -35,7 +35,7 @@ import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowM
 import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowScheduleTriggerRequest;
 import org.apache.dolphinscheduler.extract.master.transportor.workflow.WorkflowScheduleTriggerResponse;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowCacheRepository;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.engine.workflow.trigger.WorkflowBackfillTrigger;
 import org.apache.dolphinscheduler.server.master.engine.workflow.trigger.WorkflowInstanceRecoverFailureTaskTrigger;
 import org.apache.dolphinscheduler.server.master.engine.workflow.trigger.WorkflowInstanceRecoverSuspendTaskTrigger;
@@ -148,7 +148,7 @@ public class WorkflowControlClient implements IWorkflowControlClient {
     public WorkflowInstancePauseResponse pauseWorkflowInstance(final WorkflowInstancePauseRequest workflowInstancePauseRequest) {
         try {
             final Integer workflowInstanceId = workflowInstancePauseRequest.getWorkflowInstanceId();
-            final IWorkflowExecutionRunnable workflow = workflowRepository.get(workflowInstanceId);
+            final IWorkflowExecution workflow = workflowRepository.get(workflowInstanceId);
             if (workflow == null) {
                 return WorkflowInstancePauseResponse.fail(
                         "Cannot find the WorkflowExecuteRunnable: " + workflowInstanceId);
@@ -166,7 +166,7 @@ public class WorkflowControlClient implements IWorkflowControlClient {
     public WorkflowInstanceStopResponse stopWorkflowInstance(final WorkflowInstanceStopRequest workflowInstanceStopRequest) {
         try {
             final Integer workflowInstanceId = workflowInstanceStopRequest.getWorkflowInstanceId();
-            final IWorkflowExecutionRunnable workflow = workflowRepository.get(workflowInstanceId);
+            final IWorkflowExecution workflow = workflowRepository.get(workflowInstanceId);
             if (workflow == null) {
                 return WorkflowInstanceStopResponse
                         .fail("Cannot find the WorkflowExecuteRunnable: " + workflowInstanceId);

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/TaskExecutionContextFactory.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/TaskExecutionContextFactory.java
@@ -43,9 +43,9 @@ import org.apache.dolphinscheduler.plugin.task.api.utils.MapUtils;
 import org.apache.dolphinscheduler.plugin.task.api.utils.VarPoolUtils;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionContextBuilder;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.TaskExecutionContextCreateRequest;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecutionContextBuilder;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.TaskExecutionContextCreateRequest;
 import org.apache.dolphinscheduler.service.expand.CuringParamsService;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
@@ -207,8 +207,8 @@ public class TaskExecutionContextFactory {
 
         List<String> varPoolsFromPredecessors = workflowExecutionGraph.getPredecessors(taskDefinition.getName())
                 .stream()
-                .filter(ITaskExecutionRunnable::isTaskInstanceInitialized)
-                .map(ITaskExecutionRunnable::getTaskInstance)
+                .filter(ITaskExecution::isTaskInstanceInitialized)
+                .map(ITaskExecution::getTaskInstance)
                 .sorted(Comparator.comparing(TaskInstance::getEndTime, Comparator.nullsLast(Comparator.naturalOrder())))
                 .map(TaskInstance::getVarPool)
                 .filter(StringUtils::isNotBlank)

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/WorkflowInstanceUtils.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/WorkflowInstanceUtils.java
@@ -22,8 +22,8 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowExecutionGraph;
 import org.apache.dolphinscheduler.server.master.engine.graph.IWorkflowGraph;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 import org.apache.dolphinscheduler.server.master.runner.IWorkflowExecuteContext;
 
 import java.util.List;
@@ -36,8 +36,8 @@ import com.google.common.base.Strings;
 @UtilityClass
 public class WorkflowInstanceUtils {
 
-    public static String logWorkflowInstanceInDetails(IWorkflowExecutionRunnable workflowExecutionRunnable) {
-        final IWorkflowExecuteContext workflowExecuteContext = workflowExecutionRunnable.getWorkflowExecuteContext();
+    public static String logWorkflowInstanceInDetails(IWorkflowExecution workflowExecution) {
+        final IWorkflowExecuteContext workflowExecuteContext = workflowExecution.getWorkflowExecuteContext();
         final IWorkflowExecutionGraph workflowExecutionGraph = workflowExecuteContext.getWorkflowExecutionGraph();
         final IWorkflowGraph workflowGraph = workflowExecuteContext.getWorkflowGraph();
         final WorkflowInstance workflowInstance = workflowExecuteContext.getWorkflowInstance();
@@ -46,7 +46,7 @@ public class WorkflowInstanceUtils {
         final List<String> startNodes = workflowExecutionGraph
                 .getStartNodes()
                 .stream()
-                .map(ITaskExecutionRunnable::getName)
+                .map(ITaskExecution::getName)
                 .collect(Collectors.toList());
 
         final StringBuilder logBuilder = new StringBuilder();
@@ -64,8 +64,8 @@ public class WorkflowInstanceUtils {
                 .append("State:                   ").append(workflowInstance.getState().name()).append("\n")
                 .append("StartNodes:              ").append(startNodes).append("\n")
                 .append("TotalTasks:              ")
-                .append(workflowExecutionRunnable.getWorkflowExecuteContext().getWorkflowExecutionGraph()
-                        .getAllTaskExecutionRunnable().size())
+                .append(workflowExecution.getWorkflowExecuteContext().getWorkflowExecutionGraph()
+                        .getAllTaskExecution().size())
                 .append("\n")
                 .append("Host:                    ").append(workflowInstance.getHost()).append("\n")
                 .append("Is SubWorkflow:          ").append(workflowInstance.getIsSubWorkflow().name()).append("\n")

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/config/MasterServerLoadProtectionTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/config/MasterServerLoadProtectionTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.dolphinscheduler.meter.metrics.SystemMetrics;
 import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
-import org.apache.dolphinscheduler.server.master.engine.workflow.runnable.IWorkflowExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.workflow.execution.IWorkflowExecution;
 
 import java.util.Collections;
 
@@ -110,7 +110,7 @@ class MasterServerLoadProtectionTest {
     @Test
     void isOverloadWithMaxConcurrentWorkflowInstances() {
         Mockito.when(mockRepository.getAll())
-                .thenReturn(Collections.nCopies(5, Mockito.mock(IWorkflowExecutionRunnable.class)));
+                .thenReturn(Collections.nCopies(5, Mockito.mock(IWorkflowExecution.class)));
 
         // With a workflow count below the threshold, the system should not be overloaded.
         MasterConfig masterConfig = new MasterConfig();

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/command/handler/ExecuteTaskCommandHandlerTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/command/handler/ExecuteTaskCommandHandlerTest.java
@@ -160,7 +160,7 @@ class ExecuteTaskCommandHandlerTest {
         executeTaskCommandHandler.assembleWorkflowExecutionGraph(contextBuilder);
 
         assertNotNull(contextBuilder.getWorkflowExecutionGraph());
-        assertEquals(1, contextBuilder.getWorkflowExecutionGraph().getAllTaskExecutionRunnable().size());
+        assertEquals(1, contextBuilder.getWorkflowExecutionGraph().getAllTaskExecution().size());
     }
 
     @Test

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/TaskDispatchableEventBusTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/TaskDispatchableEventBusTest.java
@@ -22,35 +22,35 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import org.apache.dolphinscheduler.server.master.engine.task.dispatcher.event.TaskDispatchableEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TaskDispatchableEventBusTest {
 
-    private TaskDispatchableEventBus<TaskDispatchableEvent<ITaskExecutionRunnable>, ITaskExecutionRunnable> queue;
-    private ITaskExecutionRunnable taskExecutionRunnable;
+    private TaskDispatchableEventBus<TaskDispatchableEvent<ITaskExecution>, ITaskExecution> queue;
+    private ITaskExecution taskExecution;
 
     @BeforeEach
     public void setUp() {
         queue = new TaskDispatchableEventBus<>();
-        taskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        taskExecution = mock(ITaskExecution.class);
     }
 
     @Test
     public void testAdd() {
-        queue.add(new TaskDispatchableEvent<>(1000, taskExecutionRunnable));
+        queue.add(new TaskDispatchableEvent<>(1000, taskExecution));
         assertEquals(1, queue.size());
 
-        queue.add(new TaskDispatchableEvent<>(2000, taskExecutionRunnable));
+        queue.add(new TaskDispatchableEvent<>(2000, taskExecution));
         assertEquals(2, queue.size());
     }
 
     @Test
     public void testTake() throws InterruptedException {
-        queue.add(new TaskDispatchableEvent<>(1000, taskExecutionRunnable));
-        TaskDispatchableEvent<ITaskExecutionRunnable> entry = queue.take();
+        queue.add(new TaskDispatchableEvent<>(1000, taskExecution));
+        TaskDispatchableEvent<ITaskExecution> entry = queue.take();
         assertNotNull(entry);
         assertEquals(0, queue.size());
 
@@ -60,14 +60,14 @@ public class TaskDispatchableEventBusTest {
     public void testSize() {
         assertEquals(0, queue.size());
 
-        queue.add(new TaskDispatchableEvent<>(1000, taskExecutionRunnable));
+        queue.add(new TaskDispatchableEvent<>(1000, taskExecution));
         assertEquals(1, queue.size());
     }
 
     @Test
     public void testClear() {
-        queue.add(new TaskDispatchableEvent<>(1000, taskExecutionRunnable));
-        queue.add(new TaskDispatchableEvent<>(2000, taskExecutionRunnable));
+        queue.add(new TaskDispatchableEvent<>(1000, taskExecution));
+        queue.add(new TaskDispatchableEvent<>(2000, taskExecution));
         assertEquals(2, queue.size());
 
         queue.clear();

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcherCoordinatorTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcherCoordinatorTest.java
@@ -26,7 +26,7 @@ import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,18 +56,18 @@ class WorkerGroupDispatcherCoordinatorTest {
         String workerGroup = "newGroup";
         long delayTimeMills = 1000;
 
-        ITaskExecutionRunnable taskExecutionRunnable = Mockito.mock(ITaskExecutionRunnable.class);
+        ITaskExecution taskExecution = Mockito.mock(ITaskExecution.class);
         TaskInstance taskInstance = mock(TaskInstance.class);
         TaskExecutionContext taskExecutionContext = mock(TaskExecutionContext.class);
 
-        when(taskExecutionRunnable.getTaskInstance()).thenReturn(taskInstance);
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
         when(taskInstance.getWorkerGroup()).thenReturn(workerGroup);
-        when(taskExecutionRunnable.getTaskExecutionContext()).thenReturn(taskExecutionContext);
+        when(taskExecution.getTaskExecutionContext()).thenReturn(taskExecutionContext);
         when(taskExecutionContext.getDispatchFailTimes()).thenReturn(1);
 
         assertFalse(workerGroupDispatcherCoordinator.existWorkerGroup(workerGroup));
 
-        workerGroupDispatcherCoordinator.dispatchTask(taskExecutionRunnable, delayTimeMills);
+        workerGroupDispatcherCoordinator.dispatchTask(taskExecution, delayTimeMills);
 
         assertTrue(workerGroupDispatcherCoordinator.existWorkerGroup(workerGroup));
     }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcherTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/dispatcher/WorkerGroupDispatcherTest.java
@@ -37,8 +37,8 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.master.config.TaskDispatchPolicy;
 import org.apache.dolphinscheduler.server.master.engine.WorkflowEventBus;
 import org.apache.dolphinscheduler.server.master.engine.task.client.ITaskExecutorClient;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
 import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskFailedLifecycleEvent;
-import org.apache.dolphinscheduler.server.master.engine.task.runnable.ITaskExecutionRunnable;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.NoAvailableWorkerException;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.TaskDispatchException;
 import org.apache.dolphinscheduler.server.master.exception.dispatch.WorkerGroupNotFoundException;
@@ -73,108 +73,108 @@ class WorkerGroupDispatcherTest {
 
     @Test
     void dispatchTask() {
-        ITaskExecutionRunnable taskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        ITaskExecution taskExecution = mock(ITaskExecution.class);
         TaskInstance taskInstance = mock(TaskInstance.class);
-        when(taskExecutionRunnable.getTaskInstance()).thenReturn(taskInstance);
-        when(taskExecutionRunnable.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
+        when(taskExecution.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
         dispatcher.start();
 
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
         await()
                 .atMost(Duration.ofSeconds(5))
-                .untilAsserted(() -> verify(taskExecutorClient, times(1)).dispatch(taskExecutionRunnable));
+                .untilAsserted(() -> verify(taskExecutorClient, times(1)).dispatch(taskExecution));
     }
 
     @Test
     void dispatchTask_withDelay() {
-        ITaskExecutionRunnable taskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        ITaskExecution taskExecution = mock(ITaskExecution.class);
         TaskInstance taskInstance = mock(TaskInstance.class);
-        when(taskExecutionRunnable.getTaskInstance()).thenReturn(taskInstance);
-        when(taskExecutionRunnable.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
+        when(taskExecution.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
         dispatcher.start();
 
-        dispatcher.dispatchTask(taskExecutionRunnable, 2000);
+        dispatcher.dispatchTask(taskExecution, 2000);
         await()
                 .atLeast(Duration.ofMillis(1500))
-                .untilAsserted(() -> verify(taskExecutorClient, times(1)).dispatch(taskExecutionRunnable));
+                .untilAsserted(() -> verify(taskExecutorClient, times(1)).dispatch(taskExecution));
     }
 
     @Test
     void dispatchTask_withOneDelayTaskAnotherIsDispatchRetryTask() throws TaskDispatchException {
-        final ITaskExecutionRunnable delayTaskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        final ITaskExecution delayTaskExecution = mock(ITaskExecution.class);
         final TaskInstance delayTaskInstance = mock(TaskInstance.class);
-        when(delayTaskExecutionRunnable.getTaskInstance()).thenReturn(delayTaskInstance);
-        when(delayTaskExecutionRunnable.getTaskExecutionContext()).thenReturn(TaskExecutionContext.builder().build());
-        when(delayTaskExecutionRunnable.getId()).thenReturn(1);
+        when(delayTaskExecution.getTaskInstance()).thenReturn(delayTaskInstance);
+        when(delayTaskExecution.getTaskExecutionContext()).thenReturn(TaskExecutionContext.builder().build());
+        when(delayTaskExecution.getId()).thenReturn(1);
 
-        final ITaskExecutionRunnable dispatchRetryTaskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        final ITaskExecution dispatchRetryTaskExecution = mock(ITaskExecution.class);
         final TaskInstance dispatchRetryTaskInstance = mock(TaskInstance.class);
-        when(dispatchRetryTaskExecutionRunnable.getTaskInstance()).thenReturn(dispatchRetryTaskInstance);
-        when(dispatchRetryTaskExecutionRunnable.getTaskExecutionContext())
+        when(dispatchRetryTaskExecution.getTaskInstance()).thenReturn(dispatchRetryTaskInstance);
+        when(dispatchRetryTaskExecution.getTaskExecutionContext())
                 .thenReturn(TaskExecutionContext.builder().dispatchFailTimes(1).build());
-        when(dispatchRetryTaskExecutionRunnable.getId()).thenReturn(2);
+        when(dispatchRetryTaskExecution.getId()).thenReturn(2);
         dispatcher.start();
 
-        dispatcher.dispatchTask(delayTaskExecutionRunnable, 2000);
-        dispatcher.dispatchTask(dispatchRetryTaskExecutionRunnable, 100);
+        dispatcher.dispatchTask(delayTaskExecution, 2000);
+        dispatcher.dispatchTask(dispatchRetryTaskExecution, 100);
         await()
                 .atLeast(Duration.ofMillis(1500))
                 .untilAsserted(() -> verify(taskExecutorClient, times(2)).dispatch(any()));
 
         InOrder inOrder = inOrder(taskExecutorClient);
-        inOrder.verify(taskExecutorClient).dispatch(dispatchRetryTaskExecutionRunnable);
-        inOrder.verify(taskExecutorClient).dispatch(delayTaskExecutionRunnable);
+        inOrder.verify(taskExecutorClient).dispatch(dispatchRetryTaskExecution);
+        inOrder.verify(taskExecutorClient).dispatch(delayTaskExecution);
     }
 
     @Test
     void dispatchTask_HasBeenRemoved() {
-        ITaskExecutionRunnable taskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        ITaskExecution taskExecution = mock(ITaskExecution.class);
         TaskInstance taskInstance = mock(TaskInstance.class);
-        when(taskExecutionRunnable.getTaskInstance()).thenReturn(taskInstance);
-        when(taskExecutionRunnable.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
+        when(taskExecution.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
 
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
-        dispatcher.removeTask(taskExecutionRunnable);
+        dispatcher.dispatchTask(taskExecution, 0);
+        dispatcher.removeTask(taskExecution);
 
         dispatcher.start();
         await()
                 .pollDelay(Duration.ofSeconds(2))
-                .untilAsserted(() -> verify(taskExecutorClient, times(0)).dispatch(taskExecutionRunnable));
+                .untilAsserted(() -> verify(taskExecutorClient, times(0)).dispatch(taskExecution));
     }
 
     @Test
     void dispatch_TaskDispatchFails_RetryLogicWorks() throws TaskDispatchException {
         // Arrange
-        ITaskExecutionRunnable taskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+        ITaskExecution taskExecution = mock(ITaskExecution.class);
         TaskInstance taskInstance = mock(TaskInstance.class);
-        when(taskExecutionRunnable.getTaskInstance()).thenReturn(taskInstance);
-        when(taskExecutionRunnable.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
+        when(taskExecution.getTaskExecutionContext()).thenReturn(new TaskExecutionContext());
 
         doThrow(new RuntimeException()).when(taskExecutorClient).dispatch(any());
         dispatcher.start();
 
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .pollDelay(Duration.ofSeconds(2))
-                .untilAsserted(() -> verify(taskExecutorClient, times(2)).dispatch(taskExecutionRunnable));
+                .untilAsserted(() -> verify(taskExecutorClient, times(2)).dispatch(taskExecution));
     }
 
     @Test
     void dispatchTask_WorkerGroupNotFound_TimeoutDisabled_ShouldKeepRetrying() throws TaskDispatchException {
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis());
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis());
         WorkerGroupNotFoundException ex = new WorkerGroupNotFoundException("no worker group");
-        doThrow(ex).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        doThrow(ex).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .atMost(Duration.ofSeconds(3))
                 .untilAsserted(() -> {
-                    verify(taskExecutorClient, atLeast(2)).dispatch(taskExecutionRunnable);
-                    verify(taskExecutionRunnable.getWorkflowEventBus(), never())
+                    verify(taskExecutorClient, atLeast(2)).dispatch(taskExecution);
+                    verify(taskExecution.getWorkflowEventBus(), never())
                             .publish(any(TaskFailedLifecycleEvent.class));
                 });
     }
@@ -187,22 +187,22 @@ class WorkerGroupDispatcherTest {
 
         dispatcher = new WorkerGroupDispatcher("TestGroup", taskExecutorClient, taskDispatchPolicy);
 
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis() - 500);
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis() - 500);
         WorkerGroupNotFoundException ex = new WorkerGroupNotFoundException("worker group not found");
-        doThrow(ex).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        doThrow(ex).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .atMost(Duration.ofSeconds(2))
                 .untilAsserted(() -> {
-                    verify(taskExecutorClient, times(1)).dispatch(taskExecutionRunnable);
-                    verify(taskExecutionRunnable.getWorkflowEventBus()).publish(
+                    verify(taskExecutorClient, times(1)).dispatch(taskExecution);
+                    verify(taskExecution.getWorkflowEventBus()).publish(
                             argThat(event -> event instanceof TaskFailedLifecycleEvent &&
                                     ((TaskFailedLifecycleEvent) event)
-                                            .getTaskExecutionRunnable() == taskExecutionRunnable));
+                                            .getTaskExecution() == taskExecution));
                 });
     }
 
@@ -214,36 +214,36 @@ class WorkerGroupDispatcherTest {
 
         dispatcher = new WorkerGroupDispatcher("TestGroup", taskExecutorClient, taskDispatchPolicy);
 
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis() - 100);
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis() - 100);
         CountDownLatch countDownLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
             countDownLatch.countDown();
             throw new WorkerGroupNotFoundException("Worker group 'TestGroup' does not exist");
-        }).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        }).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
-        verify(taskExecutionRunnable.getWorkflowEventBus(), never()).publish(any(TaskFailedLifecycleEvent.class));
+        verify(taskExecution.getWorkflowEventBus(), never()).publish(any(TaskFailedLifecycleEvent.class));
     }
 
     @Test
     void dispatchTask_NoAvailableWorker_TimeoutDisabled_ShouldKeepRetrying() throws TaskDispatchException {
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis());
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis());
         NoAvailableWorkerException ex = new NoAvailableWorkerException("no worker");
-        doThrow(ex).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        doThrow(ex).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .atMost(Duration.ofSeconds(3))
                 .untilAsserted(() -> {
-                    verify(taskExecutorClient, atLeast(2)).dispatch(taskExecutionRunnable);
-                    verify(taskExecutionRunnable.getWorkflowEventBus(), never())
+                    verify(taskExecutorClient, atLeast(2)).dispatch(taskExecution);
+                    verify(taskExecution.getWorkflowEventBus(), never())
                             .publish(any(TaskFailedLifecycleEvent.class));
                 });
     }
@@ -256,22 +256,22 @@ class WorkerGroupDispatcherTest {
 
         dispatcher = new WorkerGroupDispatcher("TestGroup", taskExecutorClient, taskDispatchPolicy);
 
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis() - 500);
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis() - 500);
         NoAvailableWorkerException ex = new NoAvailableWorkerException("no worker");
-        doThrow(ex).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        doThrow(ex).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .atMost(Duration.ofSeconds(2))
                 .untilAsserted(() -> {
-                    verify(taskExecutorClient, times(1)).dispatch(taskExecutionRunnable);
-                    verify(taskExecutionRunnable.getWorkflowEventBus()).publish(
+                    verify(taskExecutorClient, times(1)).dispatch(taskExecution);
+                    verify(taskExecution.getWorkflowEventBus()).publish(
                             argThat(event -> event instanceof TaskFailedLifecycleEvent &&
                                     ((TaskFailedLifecycleEvent) event)
-                                            .getTaskExecutionRunnable() == taskExecutionRunnable));
+                                            .getTaskExecution() == taskExecution));
                 });
     }
 
@@ -283,36 +283,36 @@ class WorkerGroupDispatcherTest {
 
         dispatcher = new WorkerGroupDispatcher("TestGroup", taskExecutorClient, taskDispatchPolicy);
 
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis() - 100);
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis() - 100);
         CountDownLatch countDownLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
             countDownLatch.countDown();
             throw new NoAvailableWorkerException("no worker");
-        }).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        }).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
-        verify(taskExecutionRunnable.getWorkflowEventBus(), never()).publish(any(TaskFailedLifecycleEvent.class));
+        verify(taskExecution.getWorkflowEventBus(), never()).publish(any(TaskFailedLifecycleEvent.class));
     }
 
     @Test
     void dispatchTask_GenericTaskDispatchException_TimeoutDisabled_ShouldKeepRetrying() throws TaskDispatchException {
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis());
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis());
         TaskDispatchException ex = new TaskDispatchException("generic dispatch error");
-        doThrow(ex).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        doThrow(ex).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .atMost(Duration.ofSeconds(3))
                 .untilAsserted(() -> {
-                    verify(taskExecutorClient, atLeast(2)).dispatch(taskExecutionRunnable);
-                    verify(taskExecutionRunnable.getWorkflowEventBus(), never())
+                    verify(taskExecutorClient, atLeast(2)).dispatch(taskExecution);
+                    verify(taskExecution.getWorkflowEventBus(), never())
                             .publish(any(TaskFailedLifecycleEvent.class));
                 });
     }
@@ -325,22 +325,22 @@ class WorkerGroupDispatcherTest {
 
         dispatcher = new WorkerGroupDispatcher("TestGroup", taskExecutorClient, taskDispatchPolicy);
 
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis() - 500);
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis() - 500);
         TaskDispatchException ex = new TaskDispatchException("generic dispatch error");
-        doThrow(ex).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        doThrow(ex).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         await()
                 .atMost(Duration.ofSeconds(2))
                 .untilAsserted(() -> {
-                    verify(taskExecutorClient, times(1)).dispatch(taskExecutionRunnable);
-                    verify(taskExecutionRunnable.getWorkflowEventBus()).publish(
+                    verify(taskExecutorClient, times(1)).dispatch(taskExecution);
+                    verify(taskExecution.getWorkflowEventBus()).publish(
                             argThat(event -> event instanceof TaskFailedLifecycleEvent &&
                                     ((TaskFailedLifecycleEvent) event)
-                                            .getTaskExecutionRunnable() == taskExecutionRunnable));
+                                            .getTaskExecution() == taskExecution));
                 });
     }
 
@@ -352,24 +352,24 @@ class WorkerGroupDispatcherTest {
 
         dispatcher = new WorkerGroupDispatcher("TestGroup", taskExecutorClient, taskDispatchPolicy);
 
-        ITaskExecutionRunnable taskExecutionRunnable =
-                mockTaskExecutionRunnableWithFirstDispatchTime(System.currentTimeMillis() - 100);
+        ITaskExecution taskExecution =
+                mockTaskExecutionWithFirstDispatchTime(System.currentTimeMillis() - 100);
         CountDownLatch countDownLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
             countDownLatch.countDown();
             throw new TaskDispatchException("Generic dispatch error");
-        }).when(taskExecutorClient).dispatch(taskExecutionRunnable);
+        }).when(taskExecutorClient).dispatch(taskExecution);
 
         dispatcher.start();
-        dispatcher.dispatchTask(taskExecutionRunnable, 0);
+        dispatcher.dispatchTask(taskExecution, 0);
 
         assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
-        verify(taskExecutionRunnable.getWorkflowEventBus(), never()).publish(any(TaskFailedLifecycleEvent.class));
+        verify(taskExecution.getWorkflowEventBus(), never()).publish(any(TaskFailedLifecycleEvent.class));
     }
 
-    // Helper to mock TaskExecutionRunnable with firstDispatchTime
-    private ITaskExecutionRunnable mockTaskExecutionRunnableWithFirstDispatchTime(long firstDispatchTime) {
-        ITaskExecutionRunnable taskExecutionRunnable = mock(ITaskExecutionRunnable.class);
+    // Helper to mock TaskExecution with firstDispatchTime
+    private ITaskExecution mockTaskExecutionWithFirstDispatchTime(long firstDispatchTime) {
+        ITaskExecution taskExecution = mock(ITaskExecution.class);
         TaskInstance taskInstance = mock(TaskInstance.class);
         WorkflowInstance workflowInstance = mock(WorkflowInstance.class);
         WorkflowEventBus eventBus = mock(WorkflowEventBus.class);
@@ -377,12 +377,12 @@ class WorkerGroupDispatcherTest {
         TaskExecutionContext context = mock(TaskExecutionContext.class);
         when(context.getFirstDispatchTime()).thenReturn(firstDispatchTime);
 
-        when(taskExecutionRunnable.getTaskInstance()).thenReturn(taskInstance);
-        when(taskExecutionRunnable.getWorkflowInstance()).thenReturn(workflowInstance);
-        when(taskExecutionRunnable.getWorkflowEventBus()).thenReturn(eventBus);
-        when(taskExecutionRunnable.getId()).thenReturn(ThreadLocalRandom.current().nextInt(1000, 9999));
-        when(taskExecutionRunnable.getTaskExecutionContext()).thenReturn(context);
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
+        when(taskExecution.getWorkflowInstance()).thenReturn(workflowInstance);
+        when(taskExecution.getWorkflowEventBus()).thenReturn(eventBus);
+        when(taskExecution.getId()).thenReturn(ThreadLocalRandom.current().nextInt(1000, 9999));
+        when(taskExecution.getTaskExecutionContext()).thenReturn(context);
 
-        return taskExecutionRunnable;
+        return taskExecution;
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, Claude Opus 4.6 (1M context)

## Purpose of the pull request

close #18137 

Align naming with workflow engine industry conventions (Temporal, Cadence, Camunda) where "Execution" represents a running instance, distinguishing from "Executor" (the component that performs the work). Also rename packages from `runnable` to `execution` for consistency.

## Brief change log

Renames:
- IWorkflowExecutionRunnable -> IWorkflowExecution
- WorkflowExecutionRunnable -> WorkflowExecution
- WorkflowExecutionRunnableBuilder -> WorkflowExecutionBuilder
- WorkflowExecutionRunnableFactory -> WorkflowExecutionFactory
- ITaskExecutionRunnable -> ITaskExecution
- TaskExecutionRunnable -> TaskExecution
- TaskExecutionRunnableBuilder -> TaskExecutionBuilder
- ITaskExecutionRunnableLifecycleListener -> ITaskExecutionLifecycleListener
- engine.workflow.runnable -> engine.workflow.execution
- engine.task.runnable -> engine.task.execution

## Verify this pull request

Verify by exist test case.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
