### PR TITLE
[Fix-18182][API] User can delete task definitions in unauthorized projects

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -615,7 +615,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         }
         TaskDefinition taskDefinition = taskDefinitionMapper.queryByCode(taskCode);
 
-        if (taskDefinition == null) {
+        if (taskDefinition == null || projectCode != taskDefinition.getProjectCode()) {
             log.error("Task definition does not exist, taskDefinitionCode:{}.", taskCode);
             putMsg(result, Status.TASK_DEFINE_NOT_EXIST, String.valueOf(taskCode));
         } else {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -180,6 +180,35 @@ public class TaskDefinitionServiceImplTest {
         assertEquals(Status.SUCCESS, relation.get(Constants.STATUS));
     }
 
+    @Test
+    public void deleteByCodeAndVersion() {
+        Project project = getProject();
+        when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
+        when(projectService.hasProjectAndWritePerm(user, project, new HashMap<>())).thenReturn(true);
+
+        // cross-project privilege escalation: taskCode belongs to another project - must be rejected
+        TaskDefinition otherProjectTask = new TaskDefinition();
+        otherProjectTask.setProjectCode(PROJECT_CODE + 1);
+        otherProjectTask.setCode(TASK_CODE);
+        otherProjectTask.setVersion(VERSION + 1);
+        when(taskDefinitionMapper.queryByCode(TASK_CODE)).thenReturn(otherProjectTask);
+        Map<String, Object> crossProjectResult =
+                taskDefinitionService.deleteByCodeAndVersion(user, PROJECT_CODE, TASK_CODE, VERSION);
+        assertEquals(Status.TASK_DEFINE_NOT_EXIST, crossProjectResult.get(Constants.STATUS));
+        Mockito.verify(taskDefinitionLogMapper, Mockito.never()).deleteByCodeAndVersion(TASK_CODE, VERSION);
+
+        // normal path: taskCode belongs to the project - should succeed
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setProjectCode(PROJECT_CODE);
+        taskDefinition.setCode(TASK_CODE);
+        taskDefinition.setVersion(VERSION + 1);
+        when(taskDefinitionMapper.queryByCode(TASK_CODE)).thenReturn(taskDefinition);
+        when(taskDefinitionLogMapper.deleteByCodeAndVersion(TASK_CODE, VERSION)).thenReturn(1);
+        Map<String, Object> successResult =
+                taskDefinitionService.deleteByCodeAndVersion(user, PROJECT_CODE, TASK_CODE, VERSION);
+        assertEquals(Status.SUCCESS, successResult.get(Constants.STATUS));
+    }
+
     private void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
         result.put(Constants.STATUS, status);
         if (statusParams != null && statusParams.length > 0) {


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YSE, generated by ops 4.7

## Purpose of the pull request

close #18182

## Brief change log

- Check if the task is belong to the given project.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
