### PR TITLE
[Fix-18211][API] Add missing project authorization on view-gantt/view-variables and trigger workflow APIs

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
@@ -127,6 +127,7 @@ public class ExecutorController extends BaseController {
     @ApiException(START_WORKFLOW_INSTANCE_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_START)
     public Result<List<Integer>> triggerWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
                                                            @RequestParam(value = "workflowDefinitionCode") long workflowDefinitionCode,
                                                            @RequestParam(value = "scheduleTime") String scheduleTime,
                                                            @RequestParam(value = "failureStrategy") FailureStrategy failureStrategy,
@@ -150,6 +151,7 @@ public class ExecutorController extends BaseController {
             case START_PROCESS:
                 final WorkflowTriggerRequest workflowTriggerRequest = WorkflowTriggerRequest.builder()
                         .loginUser(loginUser)
+                        .projectCode(projectCode)
                         .workflowDefinitionCode(workflowDefinitionCode)
                         .startNodes(startNodeList)
                         .failureStrategy(failureStrategy)
@@ -169,6 +171,7 @@ public class ExecutorController extends BaseController {
             case COMPLEMENT_DATA:
                 final WorkflowBackFillRequest workflowBackFillRequest = WorkflowBackFillRequest.builder()
                         .loginUser(loginUser)
+                        .projectCode(projectCode)
                         .workflowDefinitionCode(workflowDefinitionCode)
                         .startNodes(startNodeList)
                         .failureStrategy(failureStrategy)
@@ -243,6 +246,7 @@ public class ExecutorController extends BaseController {
     @ApiException(BATCH_START_WORKFLOW_INSTANCE_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_BATCH_START)
     public Result<List<Integer>> batchTriggerWorkflowDefinitions(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                 @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
                                                                  @RequestParam(value = "workflowDefinitionCodes") String workflowDefinitionCodes,
                                                                  @RequestParam(value = "scheduleTime") String scheduleTime,
                                                                  @RequestParam(value = "failureStrategy") FailureStrategy failureStrategy,
@@ -269,6 +273,7 @@ public class ExecutorController extends BaseController {
         List<Integer> result = new ArrayList<>();
         for (Long workflowDefinitionCode : workflowDefinitionCodeList) {
             Result<List<Integer>> workflowInstanceIds = triggerWorkflowDefinition(loginUser,
+                    projectCode,
                     workflowDefinitionCode,
                     scheduleTime,
                     failureStrategy,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceController.java
@@ -347,7 +347,7 @@ public class WorkflowInstanceController extends BaseController {
     public Result viewVariables(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                 @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
                                 @PathVariable("id") Integer id) {
-        Map<String, Object> result = workflowInstanceService.viewVariables(projectCode, id);
+        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, id);
         return returnDataList(result);
     }
 
@@ -369,7 +369,7 @@ public class WorkflowInstanceController extends BaseController {
     public Result viewTree(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                            @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
                            @PathVariable("id") Integer id) throws Exception {
-        Map<String, Object> result = workflowInstanceService.viewGantt(projectCode, id);
+        Map<String, Object> result = workflowInstanceService.viewGantt(loginUser, projectCode, id);
         return returnDataList(result);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflow/WorkflowBackFillRequest.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflow/WorkflowBackFillRequest.java
@@ -41,6 +41,8 @@ public class WorkflowBackFillRequest {
 
     private User loginUser;
 
+    private long projectCode;
+
     private long workflowDefinitionCode;
 
     private String startNodes;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflow/WorkflowTriggerRequest.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflow/WorkflowTriggerRequest.java
@@ -36,6 +36,8 @@ public class WorkflowTriggerRequest {
 
     private User loginUser;
 
+    private long projectCode;
+
     private long workflowDefinitionCode;
 
     private String startNodes;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -367,6 +367,7 @@ public class PythonGateway {
 
         WorkflowTriggerRequest workflowTriggerRequest = WorkflowTriggerRequest.builder()
                 .loginUser(user)
+                .projectCode(project.getCode())
                 .workflowDefinitionCode(workflowDefinition.getCode())
                 .workerGroup(workerGroup)
                 .warningType(WarningType.of(warningType))

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
@@ -62,6 +62,7 @@ public interface ProjectService {
      * @param projectCode project code
      * @param perm String
      * @return true if the login user have permission to see the project
+     * @deprecated use {@link #checkProjectAndAuthThrowException(User, Long, String)} instead
      */
     @Deprecated
     Map<String, Object> checkProjectAndAuth(User loginUser, Project project, long projectCode, String perm);
@@ -203,7 +204,9 @@ public interface ProjectService {
      * @param projectCode project code
      * @param perm String
      * @return true if the login user have permission to see the project
+     * @deprecated use {@link #checkProjectAndAuthThrowException(User, Long, String)} instead
      */
+    @Deprecated
     void checkProjectAndAuth(Result result, User loginUser, Project project, long projectCode, String perm);
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceService.java
@@ -159,21 +159,23 @@ public interface WorkflowInstanceService {
     /**
      * view workflow instance variables
      *
+     * @param loginUser         login user
      * @param projectCode       project code
      * @param workflowInstanceId workflow instance id
      * @return variables data
      */
-    Map<String, Object> viewVariables(long projectCode, Integer workflowInstanceId);
+    Map<String, Object> viewVariables(User loginUser, long projectCode, Integer workflowInstanceId);
 
     /**
      * encapsulation gantt structure
      *
+     * @param loginUser         login user
      * @param projectCode       project code
      * @param workflowInstanceId workflow instance id
      * @return gantt tree data
      * @throws Exception exception when json parse
      */
-    Map<String, Object> viewGantt(long projectCode, Integer workflowInstanceId) throws Exception;
+    Map<String, Object> viewGantt(User loginUser, long projectCode, Integer workflowInstanceId) throws Exception;
 
     /**
      * query workflow instance by workflowDefinitionCode and stateArray

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -126,7 +126,18 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
     @Override
     @Transactional
     public Integer triggerWorkflowDefinition(final WorkflowTriggerRequest triggerRequest) {
+        // check user access for project
+        projectService.checkProjectAndAuthThrowException(
+                triggerRequest.getLoginUser(),
+                triggerRequest.getProjectCode(),
+                ApiFuncIdentificationConstant.RERUN);
         final TriggerWorkflowDTO triggerWorkflowDTO = triggerWorkflowRequestTransformer.transform(triggerRequest);
+        // verify the workflow definition belongs to the URL's project
+        if (triggerWorkflowDTO.getWorkflowDefinition() == null
+                || triggerWorkflowDTO.getWorkflowDefinition().getProjectCode() != triggerRequest.getProjectCode()) {
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST,
+                    String.valueOf(triggerRequest.getWorkflowDefinitionCode()));
+        }
         // todo: use validator chain
         triggerWorkflowDTOValidator.validate(triggerWorkflowDTO);
         return executorClient.triggerWorkflowDefinition().execute(triggerWorkflowDTO);
@@ -135,8 +146,20 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
     @Override
     @Transactional
     public List<Integer> backfillWorkflowDefinition(final WorkflowBackFillRequest workflowBackFillRequest) {
+        // check user access for project
+        projectService.checkProjectAndAuthThrowException(
+                workflowBackFillRequest.getLoginUser(),
+                workflowBackFillRequest.getProjectCode(),
+                ApiFuncIdentificationConstant.RERUN);
         final BackfillWorkflowDTO backfillWorkflowDTO =
                 backfillWorkflowRequestTransformer.transform(workflowBackFillRequest);
+        // verify the workflow definition belongs to the URL's project
+        if (backfillWorkflowDTO.getWorkflowDefinition() == null
+                || backfillWorkflowDTO.getWorkflowDefinition().getProjectCode() != workflowBackFillRequest
+                        .getProjectCode()) {
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST,
+                    String.valueOf(workflowBackFillRequest.getWorkflowDefinitionCode()));
+        }
         backfillWorkflowDTOValidator.validate(backfillWorkflowDTO);
         return executorClient.backfillWorkflowDefinition().execute(backfillWorkflowDTO);
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -200,6 +200,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
      * @param projectCode project code
      * @return true if the login user have permission to see the project
      */
+    @Deprecated
     @Override
     public Map<String, Object> checkProjectAndAuth(User loginUser, Project project, long projectCode,
                                                    String permission) {
@@ -819,6 +820,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
      * @param projectCode project code
      * @return true if the login user have permission to see the project
      */
+    @Deprecated
     @Override
     public void checkProjectAndAuth(Result result, User loginUser, Project project, long projectCode,
                                     String permission) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -752,12 +752,15 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     /**
      * view workflow instance variables
      *
+     * @param loginUser         login user
      * @param projectCode       project code
      * @param workflowInstanceId workflow instance id
      * @return variables data
      */
     @Override
-    public Map<String, Object> viewVariables(long projectCode, Integer workflowInstanceId) {
+    public Map<String, Object> viewVariables(User loginUser, long projectCode, Integer workflowInstanceId) {
+        // check user access for project
+        projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
         Map<String, Object> result = new HashMap<>();
 
         WorkflowInstance workflowInstance = workflowInstanceMapper.queryDetailById(workflowInstanceId);
@@ -872,13 +875,17 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     /**
      * encapsulation gantt structure
      *
+     * @param loginUser         login user
      * @param projectCode       project code
      * @param workflowInstanceId workflow instance id
      * @return gantt tree data
      * @throws Exception exception when json parse
      */
     @Override
-    public Map<String, Object> viewGantt(long projectCode, Integer workflowInstanceId) throws Exception {
+    public Map<String, Object> viewGantt(User loginUser, long projectCode,
+                                         Integer workflowInstanceId) throws Exception {
+        // check user access for project
+        projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
         Map<String, Object> result = new HashMap<>();
         WorkflowInstance workflowInstance = workflowInstanceMapper.queryDetailById(workflowInstanceId);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceControllerTest.java
@@ -201,7 +201,8 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
     public void testViewVariables() throws Exception {
         Map<String, Object> mockResult = new HashMap<>();
         mockResult.put(Constants.STATUS, Status.SUCCESS);
-        Mockito.when(workflowInstanceService.viewVariables(1113L, 123)).thenReturn(mockResult);
+        Mockito.when(workflowInstanceService.viewVariables(Mockito.any(), Mockito.eq(1113L), Mockito.eq(123)))
+                .thenReturn(mockResult);
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/workflow-instances/{id}/view-variables", "1113", "123")
                         .header(SESSION_ID, sessionId))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorServiceTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.service;
+
+import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.RERUN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.dolphinscheduler.api.dto.workflow.WorkflowBackFillRequest;
+import org.apache.dolphinscheduler.api.dto.workflow.WorkflowTriggerRequest;
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.executor.workflow.BackfillWorkflowExecutorDelegate;
+import org.apache.dolphinscheduler.api.executor.workflow.ExecutorClient;
+import org.apache.dolphinscheduler.api.executor.workflow.TriggerWorkflowExecutorDelegate;
+import org.apache.dolphinscheduler.api.service.impl.ExecutorServiceImpl;
+import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
+import org.apache.dolphinscheduler.api.validator.workflow.BackfillWorkflowDTO;
+import org.apache.dolphinscheduler.api.validator.workflow.BackfillWorkflowDTOValidator;
+import org.apache.dolphinscheduler.api.validator.workflow.BackfillWorkflowRequestTransformer;
+import org.apache.dolphinscheduler.api.validator.workflow.TriggerWorkflowDTO;
+import org.apache.dolphinscheduler.api.validator.workflow.TriggerWorkflowDTOValidator;
+import org.apache.dolphinscheduler.api.validator.workflow.TriggerWorkflowRequestTransformer;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ExecutorServiceTest {
+
+    @InjectMocks
+    private ExecutorServiceImpl executorService;
+
+    @Mock
+    private ProjectServiceImpl projectService;
+
+    @Mock
+    private TriggerWorkflowRequestTransformer triggerWorkflowRequestTransformer;
+
+    @Mock
+    private TriggerWorkflowDTOValidator triggerWorkflowDTOValidator;
+
+    @Mock
+    private BackfillWorkflowRequestTransformer backfillWorkflowRequestTransformer;
+
+    @Mock
+    private BackfillWorkflowDTOValidator backfillWorkflowDTOValidator;
+
+    @Mock
+    private ExecutorClient executorClient;
+
+    @Mock
+    private TriggerWorkflowExecutorDelegate triggerWorkflowExecutorDelegate;
+
+    @Mock
+    private BackfillWorkflowExecutorDelegate backfillWorkflowExecutorDelegate;
+
+    private User getLoginUser() {
+        User user = new User();
+        user.setId(1);
+        user.setUserName("test");
+        user.setUserType(UserType.GENERAL_USER);
+        return user;
+    }
+
+    @Test
+    public void testTriggerWorkflowDefinition_userHasNoProjectPermission() {
+        long projectCode = 100L;
+        long workflowDefinitionCode = 200L;
+        User loginUser = getLoginUser();
+
+        WorkflowTriggerRequest request = WorkflowTriggerRequest.builder()
+                .loginUser(loginUser)
+                .projectCode(projectCode)
+                .workflowDefinitionCode(workflowDefinitionCode)
+                .build();
+
+        doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
+                loginUser.getUserName(), projectCode))
+                        .when(projectService)
+                        .checkProjectAndAuthThrowException(loginUser, projectCode, RERUN);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> executorService.triggerWorkflowDefinition(request));
+        assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), ex.getCode());
+
+        verify(triggerWorkflowRequestTransformer, never()).transform(Mockito.any());
+        verify(triggerWorkflowDTOValidator, never()).validate(Mockito.any());
+    }
+
+    @Test
+    public void testTriggerWorkflowDefinition_workflowNotInRequestProject() {
+        long projectCode = 100L;
+        long otherProjectCode = 999L;
+        long workflowDefinitionCode = 200L;
+        User loginUser = getLoginUser();
+
+        WorkflowTriggerRequest request = WorkflowTriggerRequest.builder()
+                .loginUser(loginUser)
+                .projectCode(projectCode)
+                .workflowDefinitionCode(workflowDefinitionCode)
+                .build();
+
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, RERUN);
+
+        WorkflowDefinition workflowDefinition = new WorkflowDefinition();
+        workflowDefinition.setCode(workflowDefinitionCode);
+        workflowDefinition.setProjectCode(otherProjectCode);
+        TriggerWorkflowDTO dto = TriggerWorkflowDTO.builder()
+                .loginUser(loginUser)
+                .workflowDefinition(workflowDefinition)
+                .build();
+        when(triggerWorkflowRequestTransformer.transform(request)).thenReturn(dto);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> executorService.triggerWorkflowDefinition(request));
+        assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), ex.getCode());
+
+        verify(triggerWorkflowDTOValidator, never()).validate(Mockito.any());
+    }
+
+    @Test
+    public void testBackfillWorkflowDefinition_userHasNoProjectPermission() {
+        long projectCode = 100L;
+        long workflowDefinitionCode = 200L;
+        User loginUser = getLoginUser();
+
+        WorkflowBackFillRequest request = WorkflowBackFillRequest.builder()
+                .loginUser(loginUser)
+                .projectCode(projectCode)
+                .workflowDefinitionCode(workflowDefinitionCode)
+                .build();
+
+        doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
+                loginUser.getUserName(), projectCode))
+                        .when(projectService)
+                        .checkProjectAndAuthThrowException(loginUser, projectCode, RERUN);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> executorService.backfillWorkflowDefinition(request));
+        assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), ex.getCode());
+
+        verify(backfillWorkflowRequestTransformer, never()).transform(Mockito.any());
+        verify(backfillWorkflowDTOValidator, never()).validate(Mockito.any());
+    }
+
+    @Test
+    public void testBackfillWorkflowDefinition_workflowNotInRequestProject() {
+        long projectCode = 100L;
+        long otherProjectCode = 999L;
+        long workflowDefinitionCode = 200L;
+        User loginUser = getLoginUser();
+
+        WorkflowBackFillRequest request = WorkflowBackFillRequest.builder()
+                .loginUser(loginUser)
+                .projectCode(projectCode)
+                .workflowDefinitionCode(workflowDefinitionCode)
+                .build();
+
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, RERUN);
+
+        WorkflowDefinition workflowDefinition = new WorkflowDefinition();
+        workflowDefinition.setCode(workflowDefinitionCode);
+        workflowDefinition.setProjectCode(otherProjectCode);
+        BackfillWorkflowDTO dto = BackfillWorkflowDTO.builder()
+                .loginUser(loginUser)
+                .workflowDefinition(workflowDefinition)
+                .build();
+        when(backfillWorkflowRequestTransformer.transform(request)).thenReturn(dto);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> executorService.backfillWorkflowDefinition(request));
+        assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), ex.getCode());
+
+        verify(backfillWorkflowDTOValidator, never()).validate(Mockito.any());
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -773,23 +773,42 @@ public class WorkflowInstanceServiceTest {
 
     @Test
     public void testViewVariables() {
+        long projectCode = 1L;
+        User loginUser = getAdminUser();
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+
         // process instance not null
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setCommandType(CommandType.SCHEDULER);
         workflowInstance.setScheduleTime(new Date());
         workflowInstance.setGlobalParams("");
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
-        Map<String, Object> successRes = workflowInstanceService.viewVariables(1L, 1);
+        Map<String, Object> successRes = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
 
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
 
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
-        Map<String, Object> processNotExist = workflowInstanceService.viewVariables(1L, 1);
+        Map<String, Object> processNotExist = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, processNotExist.get(Constants.STATUS));
+
+        // project auth fail
+        doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
+                loginUser.getUserName(), projectCode))
+                        .when(projectService)
+                        .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+        ServiceException exception = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.viewVariables(loginUser, projectCode, 1));
+        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), exception.getCode());
     }
 
     @Test
     public void testViewVariables_WithTimePlaceholders() {
+        long projectCode = 1L;
+        User loginUser = getAdminUser();
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+
         String globalParamsJson = "[{\"prop\":\"biz_date\",\"value\":\"$[yyyyMMdd]\",\"type\":\"VARCHAR\"}," +
                 "{\"prop\":\"env\",\"value\":\"${ENV_TYPE}\",\"type\":\"VARCHAR\"}]";
 
@@ -810,7 +829,7 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setProjectCode(1L);
         when(workflowDefinitionMapper.queryByCode(100L)).thenReturn(workflowDefinition);
 
-        Map<String, Object> result = workflowInstanceService.viewVariables(1L, 1);
+        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
 
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
 
@@ -838,9 +857,14 @@ public class WorkflowInstanceServiceTest {
 
     @Test
     public void testViewVariables_InstanceNotFound() {
+        long projectCode = 1L;
+        User loginUser = getAdminUser();
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+
         when(workflowInstanceMapper.queryDetailById(999)).thenReturn(null);
 
-        Map<String, Object> result = workflowInstanceService.viewVariables(1L, 999);
+        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, 999);
 
         Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, result.get(Constants.STATUS));
         Assertions.assertNull(result.get(Constants.DATA_LIST));
@@ -848,6 +872,11 @@ public class WorkflowInstanceServiceTest {
 
     @Test
     public void testViewVariables_EmptyGlobalParams() {
+        long projectCode = 1L;
+        User loginUser = getAdminUser();
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setId(2);
         workflowInstance.setCommandType(CommandType.START_PROCESS);
@@ -862,7 +891,7 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setProjectCode(1L);
         when(workflowDefinitionMapper.queryByCode(101L)).thenReturn(workflowDefinition);
 
-        Map<String, Object> result = workflowInstanceService.viewVariables(1L, 2);
+        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, 2);
 
         Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
 
@@ -873,6 +902,11 @@ public class WorkflowInstanceServiceTest {
 
     @Test
     public void testViewGantt() throws Exception {
+        long projectCode = 0L;
+        User loginUser = getAdminUser();
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+
         WorkflowInstance workflowInstance = getProcessInstance();
         TaskInstance taskInstance = getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.RUNNING_EXECUTION);
@@ -890,16 +924,30 @@ public class WorkflowInstanceServiceTest {
         when(processService.genDagGraph(Mockito.any(WorkflowDefinition.class)))
                 .thenReturn(graph);
 
-        Map<String, Object> successRes = workflowInstanceService.viewGantt(0L, 1);
+        Map<String, Object> successRes = workflowInstanceService.viewGantt(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
 
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
-        Map<String, Object> processNotExist = workflowInstanceService.viewVariables(1L, 1);
+        Map<String, Object> processNotExist = workflowInstanceService.viewGantt(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, processNotExist.get(Constants.STATUS));
+
+        // project auth fail
+        doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
+                loginUser.getUserName(), projectCode))
+                        .when(projectService)
+                        .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+        ServiceException exception = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.viewGantt(loginUser, projectCode, 1));
+        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), exception.getCode());
     }
 
     @Test
     public void testViewVariablesWithStartingParam() {
+        long projectCode = 1L;
+        User loginUser = getAdminUser();
+        doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
+
         final RunWorkflowCommandParam runWorkflowCommandParam = RunWorkflowCommandParam.builder()
                 .commandParams(Lists.newArrayList(Property.builder()
                         .prop("name")
@@ -915,7 +963,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
 
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
-        Map<String, Object> successRes = workflowInstanceService.viewVariables(1L, 1);
+        Map<String, Object> successRes = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
 
         final RunWorkflowCommandParam commandParamWithEmptyTimeZone = RunWorkflowCommandParam.builder()
@@ -929,7 +977,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setCommandType(CommandType.SCHEDULER);
         workflowInstance.setScheduleTime(new Date());
         workflowInstance.setCommandParam(JSONUtils.toJsonString(commandParamWithEmptyTimeZone));
-        Map<String, Object> successRes2 = workflowInstanceService.viewVariables(1L, 1);
+        Map<String, Object> successRes2 = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.SUCCESS, successRes2.get(Constants.STATUS));
 
     }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

close #18211

The view-gantt / view-variables endpoints on WorkflowInstanceController and the start-workflow-instance / batch-start-workflow-instance endpoints on ExecutorController did not verify that the login user had permission on the URL projectCode, allowing any authenticated user to read another project's workflow instance details or trigger another project's online workflows.

* WorkflowInstanceServiceImpl#viewVariables/viewGantt now require loginUser and check projectService.checkProjectAndAuth with WORKFLOW_INSTANCE before reading the instance.
* WorkflowTriggerRequest / WorkflowBackFillRequest carry the URL projectCode. ExecutorServiceImpl#triggerWorkflowDefinition / backfillWorkflowDefinition gate the call with checkProjectAndAuthThrowException(RERUN) and reject when the resolved workflowDefinition does not belong to that projectCode.
* ExecutorController and PythonGateway propagate projectCode into the request builders. batchTriggerWorkflowDefinitions also accepts the path variable so the inner per-code call inherits it.
* New ExecutorServiceTest covers the unauthorized and cross-project trigger/backfill paths; existing WorkflowInstance tests are updated to the new viewVariables/viewGantt signatures.


## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
