### PR TITLE
[Chore][API] Remove deprecated ProjectService#checkProjectAndAuth

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
@@ -54,19 +54,6 @@ public interface ProjectService {
      */
     Map<String, Object> queryByName(User loginUser, String projectName);
 
-    /**
-     * check project and authorization
-     *
-     * @param loginUser login user
-     * @param project project
-     * @param projectCode project code
-     * @param perm String
-     * @return true if the login user have permission to see the project
-     * @deprecated use {@link #checkProjectAndAuthThrowException(User, Long, String)} instead
-     */
-    @Deprecated
-    Map<String, Object> checkProjectAndAuth(User loginUser, Project project, long projectCode, String perm);
-
     void checkProjectAndAuthThrowException(User loginUser, Project project, String permission) throws ServiceException;
 
     void checkProjectAndAuthThrowException(User loginUser, Long projectCode, String permission) throws ServiceException;
@@ -194,20 +181,6 @@ public interface ProjectService {
      * @return project list
      */
     Result queryProjectCreatedAndAuthorizedByUser(User loginUser);
-
-    /**
-     * check project and authorization
-     *
-     * @param result result
-     * @param loginUser login user
-     * @param project project
-     * @param projectCode project code
-     * @param perm String
-     * @return true if the login user have permission to see the project
-     * @deprecated use {@link #checkProjectAndAuthThrowException(User, Long, String)} instead
-     */
-    @Deprecated
-    void checkProjectAndAuth(Result result, User loginUser, Project project, long projectCode, String perm);
 
     /**
      * the project list in dependent node's permissions should not be restricted

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -192,34 +192,6 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         return result;
     }
 
-    /**
-     * check project and authorization
-     *
-     * @param loginUser   login user
-     * @param project     project
-     * @param projectCode project code
-     * @return true if the login user have permission to see the project
-     */
-    @Deprecated
-    @Override
-    public Map<String, Object> checkProjectAndAuth(User loginUser, Project project, long projectCode,
-                                                   String permission) {
-        Map<String, Object> result = new HashMap<>();
-        if (project == null) {
-            log.error("Project does not exist, projectCode:{}.", projectCode);
-            putMsg(result, Status.PROJECT_NOT_EXIST);
-        } else if (!canOperatorPermissions(loginUser, new Object[]{project.getId()}, AuthorizationType.PROJECTS,
-                permission)) {
-            // check read permission
-            log.error("User does not have {} permission to operate project, userName:{}, projectCode:{}.",
-                    permission, loginUser.getUserName(), projectCode);
-            putMsg(result, Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(), projectCode);
-        } else {
-            putMsg(result, Status.SUCCESS);
-        }
-        return result;
-    }
-
     public void checkProjectAndAuthThrowException(@NonNull User loginUser, @Nullable Project project,
                                                   String permission) {
         // todo: throw a permission exception
@@ -478,12 +450,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return result;
         }
 
-        checkProjectAndAuth(result, loginUser, project, project == null ? 0L : project.getCode(), PROJECT_DELETE);
-        if (result.getCode() != Status.SUCCESS.getCode()) {
-            return result;
-        }
-
-        assert project != null;
+        checkProjectAndAuthThrowException(loginUser, project, PROJECT_DELETE);
 
         List<WorkflowDefinition> workflowDefinitionList =
                 workflowDefinitionMapper.queryAllDefinitionList(project.getCode());
@@ -506,23 +473,6 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             putMsg(result, Status.DELETE_PROJECT_ERROR);
         }
         return result;
-    }
-
-    /**
-     * get check result
-     *
-     * @param loginUser login user
-     * @param project   project
-     * @return check result
-     */
-    private Map<String, Object> getCheckResult(User loginUser, Project project, String perm) {
-        Map<String, Object> checkResult =
-                checkProjectAndAuth(loginUser, project, project == null ? 0L : project.getCode(), perm);
-        Status status = (Status) checkResult.get(Constants.STATUS);
-        if (status != Status.SUCCESS) {
-            return checkResult;
-        }
-        return null;
     }
 
     /**
@@ -809,31 +759,6 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         result.setData(projects);
         putMsg(result, Status.SUCCESS);
         return result;
-    }
-
-    /**
-     * check project and authorization
-     *
-     * @param result      result
-     * @param loginUser   login user
-     * @param project     project
-     * @param projectCode project code
-     * @return true if the login user have permission to see the project
-     */
-    @Deprecated
-    @Override
-    public void checkProjectAndAuth(Result result, User loginUser, Project project, long projectCode,
-                                    String permission) {
-        if (project == null) {
-            log.error("Project does not exist, project code:{}.", projectCode);
-            putMsg(result, Status.PROJECT_NOT_EXIST);
-        } else if (!canOperatorPermissions(loginUser, new Object[]{project.getId()}, AuthorizationType.PROJECTS,
-                permission)) {
-            // check read permission
-            putMsg(result, Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(), projectCode);
-        } else {
-            putMsg(result, Status.SUCCESS);
-        }
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -483,10 +483,9 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                                                                       long environmentCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result = projectService.checkProjectAndAuth(loginUser, project, projectCode, null);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
+
+        Map<String, Object> result = new HashMap<>();
         // check schedule exists
         Schedule schedule = scheduleMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         if (schedule == null) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -134,12 +134,9 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                                                          String taskName) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, TASK_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_DEFINITION);
 
+        Map<String, Object> result = new HashMap<>();
         TaskDefinition taskDefinition =
                 taskDefinitionMapper.queryByName(project.getCode(), workflowDefinitionCode, taskName);
         if (taskDefinition == null) {
@@ -526,11 +523,9 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     public Map<String, Object> switchVersion(User loginUser, long projectCode, long taskCode, int version) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_SWITCH_TO_THIS_VERSION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
+
+        Map<String, Object> result = new HashMap<>();
         if (processService.isTaskOnline(taskCode)) {
             log.warn(
                     "Task definition version can not be switched due to workflow definition is {}, taskDefinitionCode:{}.",
@@ -584,13 +579,8 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         Result result = new Result();
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> checkResult =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, TASK_VERSION_VIEW);
-        Status resultStatus = (Status) checkResult.get(Constants.STATUS);
-        if (resultStatus != Status.SUCCESS) {
-            putMsg(result, resultStatus);
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_VERSION_VIEW);
+
         PageInfo<TaskDefinitionLog> pageInfo = new PageInfo<>(pageNo, pageSize);
         Page<TaskDefinitionLog> page = new Page<>(pageNo, pageSize);
         IPage<TaskDefinitionLog> taskDefinitionVersionsPaging =
@@ -645,12 +635,9 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     public Map<String, Object> queryTaskDefinitionDetail(User loginUser, long projectCode, long taskCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, TASK_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_DEFINITION);
 
+        Map<String, Object> result = new HashMap<>();
         TaskDefinition taskDefinition = taskDefinitionMapper.queryByCode(taskCode);
         if (taskDefinition == null || projectCode != taskDefinition.getProjectCode()) {
             log.error("Task definition does not exist, taskDefinitionCode:{}.", taskCode);
@@ -705,11 +692,9 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                                                      ReleaseState releaseState) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result = projectService.checkProjectAndAuth(loginUser, project, projectCode, null);
-        Status resultStatus = (Status) result.get(Constants.STATUS);
-        if (resultStatus != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
+
+        Map<String, Object> result = new HashMap<>();
         if (null == releaseState) {
             putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.RELEASE_STATE);
             return result;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
@@ -28,7 +28,6 @@ import org.apache.dolphinscheduler.api.service.TaskInstanceService;
 import org.apache.dolphinscheduler.api.service.UsersService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.TaskExecuteType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.dao.entity.Project;
@@ -241,13 +240,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
 
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> checkResult =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, FORCED_SUCCESS);
-        Status status = (Status) checkResult.get(Constants.STATUS);
-        if (status != Status.SUCCESS) {
-            putMsg(result, status);
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, FORCED_SUCCESS);
 
         TaskInstance taskInstance = taskInstanceMapper.selectById(taskInstanceId);
         if (taskInstance == null) {
@@ -271,13 +264,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
 
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> checkResult =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, FORCED_SUCCESS);
-        Status status = (Status) checkResult.get(Constants.STATUS);
-        if (status != Status.SUCCESS) {
-            putMsg(result, status);
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, FORCED_SUCCESS);
 
         TaskInstance taskInstance = taskInstanceMapper.selectById(taskInstanceId);
         if (taskInstance == null) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -457,11 +457,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> queryWorkflowDefinitionList(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
+
+        Map<String, Object> result = new HashMap<>();
         List<WorkflowDefinition> resourceList = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
         List<DagData> dagDataList = resourceList.stream().map(processService::genDagData).collect(Collectors.toList());
         result.put(Constants.DATA_LIST, dagDataList);
@@ -480,11 +478,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> queryWorkflowDefinitionSimpleList(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
+
+        Map<String, Object> result = new HashMap<>();
         List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
         ArrayNode arrayNode = JSONUtils.createArrayNode();
         for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
@@ -568,12 +564,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> queryWorkflowDefinitionByCode(User loginUser, long projectCode, long code) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
+        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
@@ -609,11 +602,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> queryWorkflowDefinitionByName(User loginUser, long projectCode, String name) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
+
+        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByDefineName(projectCode, name);
 
         if (workflowDefinition == null) {
@@ -836,11 +827,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                             long workflowDefinitionCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_CREATE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_CREATE);
+
+        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition =
                 workflowDefinitionMapper.verifyByDefineName(project.getCode(), name.trim());
         if (workflowDefinition == null) {
@@ -1050,10 +1039,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> getTaskNodeListByDefinitionCode(User loginUser, long projectCode, long code) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result = projectService.checkProjectAndAuth(loginUser, project, projectCode, null);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
+
+        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
@@ -1079,11 +1067,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> getNodeListMapByDefinitionCodes(User loginUser, long projectCode, String codes) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result = projectService.checkProjectAndAuth(loginUser, project, projectCode, null);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
+        Map<String, Object> result = new HashMap<>();
         Set<Long> defineCodeSet = Lists.newArrayList(codes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
         List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionMapper.queryByCodes(defineCodeSet);
@@ -1131,11 +1117,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Map<String, Object> queryAllWorkflowDefinitionByProjectCode(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
+
+        Map<String, Object> result = new HashMap<>();
         List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
         List<DagData> dagDataList =
                 workflowDefinitions.stream().map(processService::genDagData).collect(Collectors.toList());
@@ -1208,10 +1192,8 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         Map<String, Object> result = new HashMap<>();
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        result = projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_TREE_VIEW);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_TREE_VIEW);
+
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (null == workflowDefinition || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, code:{}.", code);
@@ -1377,9 +1359,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                            String codes,
                                                            long targetProjectCode) {
         Map<String, Object> result = checkParams(loginUser, projectCode, codes, targetProjectCode, WORKFLOW_BATCH_COPY);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
         List<String> failedWorkflowList = new ArrayList<>();
         doBatchOperateWorkflowDefinition(loginUser, targetProjectCode, failedWorkflowList, codes, result, true);
         checkBatchOperateResult(projectCode, targetProjectCode, result, failedWorkflowList, true);
@@ -1403,9 +1382,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                            long targetProjectCode) {
         Map<String, Object> result =
                 checkParams(loginUser, projectCode, codes, targetProjectCode, TASK_DEFINITION_MOVE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
         if (projectCode == targetProjectCode) {
             log.warn("Project code is same as target project code, projectCode:{}.", projectCode);
             return result;
@@ -1423,26 +1399,20 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                             long targetProjectCode, String perm) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result = projectService.checkProjectAndAuth(loginUser, project, projectCode, perm);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, perm);
 
         if (StringUtils.isEmpty(workflowDefinitionCodes)) {
             log.error("Parameter workflowDefinitionCodes is empty, projectCode is {}.", projectCode);
-            putMsg(result, Status.WORKFLOW_DEFINITION_CODES_IS_EMPTY, workflowDefinitionCodes);
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_CODES_IS_EMPTY);
         }
 
         if (projectCode != targetProjectCode) {
             Project targetProject = projectMapper.queryByCode(targetProjectCode);
             // check user access for project
-            Map<String, Object> targetResult =
-                    projectService.checkProjectAndAuth(loginUser, targetProject, targetProjectCode, perm);
-            if (targetResult.get(Constants.STATUS) != Status.SUCCESS) {
-                return targetResult;
-            }
+            projectService.checkProjectAndAuthThrowException(loginUser, targetProject, perm);
         }
+        Map<String, Object> result = new HashMap<>();
+        putMsg(result, Status.SUCCESS);
         return result;
     }
 
@@ -1701,12 +1671,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                                int version) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_SWITCH_TO_THIS_VERSION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
 
+        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (Objects.isNull(workflowDefinition) || projectCode != workflowDefinition.getProjectCode()) {
             log.error(
@@ -1824,13 +1791,8 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         Result result = new Result();
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> checkResult =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, VERSION_LIST);
-        Status resultStatus = (Status) checkResult.get(Constants.STATUS);
-        if (resultStatus != Status.SUCCESS) {
-            putMsg(result, resultStatus);
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, VERSION_LIST);
+
         PageInfo<WorkflowDefinitionLog> pageInfo = new PageInfo<>(pageNo, pageSize);
         Page<WorkflowDefinitionLog> page = new Page<>(pageNo, pageSize);
         IPage<WorkflowDefinitionLog> workflowDefinitionLogIPage =
@@ -1939,12 +1901,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         Project project = projectMapper.queryByCode(projectCode);
 
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_DEFINITION);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
+        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
 
         if (Objects.isNull(workflowDefinition) || projectCode != workflowDefinition.getProjectCode()) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -185,13 +185,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
                                                                        String startTime, String endTime) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode,
-                        WORKFLOW_INSTANCE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
+        Map<String, Object> result = new HashMap<>();
         if (0 > size) {
             putMsg(result, Status.NEGTIVE_SIZE_NUMBER_ERROR, size);
             return result;
@@ -234,12 +230,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     public Map<String, Object> queryWorkflowInstanceById(User loginUser, long projectCode, Integer workflowInstanceId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode,
-                        WORKFLOW_INSTANCE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+
+        Map<String, Object> result = new HashMap<>();
         WorkflowInstance workflowInstance = processService.findWorkflowInstanceDetailById(workflowInstanceId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
 
@@ -356,12 +349,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
                                                                  Integer workflowInstanceId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode,
-                        WORKFLOW_INSTANCE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+
+        Map<String, Object> result = new HashMap<>();
         WorkflowInstance workflowInstance = processService.findWorkflowInstanceDetailById(workflowInstanceId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
         WorkflowDefinition workflowDefinition =
@@ -479,13 +469,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     public Map<String, Object> querySubWorkflowInstanceByTaskId(User loginUser, long projectCode, Integer taskId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode,
-                        WORKFLOW_INSTANCE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
+        Map<String, Object> result = new HashMap<>();
         TaskInstance taskInstance = taskInstanceDao.queryById(taskId);
         if (taskInstance == null) {
             log.error("Task instance does not exist, projectCode:{}, taskInstanceId{}.", projectCode, taskId);
@@ -689,13 +675,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     public Map<String, Object> queryParentInstanceBySubId(User loginUser, long projectCode, Integer subId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode,
-                        WORKFLOW_INSTANCE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
+        Map<String, Object> result = new HashMap<>();
         WorkflowInstance subInstance = processService.findWorkflowInstanceDetailById(subId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, subId));
         if (subInstance.getIsSubWorkflow() == Flag.NO) {
@@ -992,9 +974,11 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
-        Map<String, Object> result =
-                projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE);
-        if (result.get(Constants.STATUS) != Status.SUCCESS || triggerCode == null) {
+        projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+
+        Map<String, Object> result = new HashMap<>();
+        if (triggerCode == null) {
+            putMsg(result, Status.SUCCESS);
             return result;
         }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.ResourcePermissionCheckService;
 import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
@@ -130,20 +131,19 @@ public class ProjectServiceTest {
 
     @Test
     public void testCheckProjectAndAuth() {
-        long projectCode = 1L;
         User loginUser = getLoginUser();
 
         // PROJECT_NOT_EXIST
-        Map<String, Object> result = projectService.checkProjectAndAuth(loginUser, null, projectCode, PROJECT);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.PROJECT_NOT_EXIST, result.get(Constants.STATUS));
+        ServiceException notExistEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.checkProjectAndAuthThrowException(loginUser, (Project) null, PROJECT));
+        Assertions.assertEquals(Status.PROJECT_NOT_EXIST.getCode(), notExistEx.getCode());
 
         // USER_NO_OPERATION_PROJECT_PERM
         Project project = getProject();
         project.setUserId(2);
-        result = projectService.checkProjectAndAuth(loginUser, project, projectCode, PROJECT);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM, result.get(Constants.STATUS));
+        ServiceException noPermEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT));
+        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), noPermEx.getCode());
 
         // success
         project.setUserId(1);
@@ -153,9 +153,8 @@ public class ProjectServiceTest {
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS,
                 new Object[]{project.getId()},
                 0, baseServiceLogger)).thenReturn(true);
-        result = projectService.checkProjectAndAuth(loginUser, project, projectCode, PROJECT);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assertions.assertDoesNotThrow(
+                () -> projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT));
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -140,11 +140,8 @@ public class TaskDefinitionServiceImplTest {
         String taskName = "task";
         Project project = getProject();
         when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
-
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, PROJECT_CODE);
-        when(projectService.checkProjectAndAuth(user, project, PROJECT_CODE, TASK_DEFINITION))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, TASK_DEFINITION);
 
         when(taskDefinitionMapper.queryByName(project.getCode(), PROCESS_DEFINITION_CODE, taskName))
                 .thenReturn(new TaskDefinition());
@@ -159,13 +156,8 @@ public class TaskDefinitionServiceImplTest {
     public void switchVersion() {
         Project project = getProject();
         when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
-
-        Map<String, Object> result = new HashMap<>();
-
-        putMsg(result, Status.SUCCESS, PROJECT_CODE);
-        when(
-                projectService.checkProjectAndAuth(user, project, PROJECT_CODE, WORKFLOW_SWITCH_TO_THIS_VERSION))
-                        .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
 
         when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(TASK_CODE, VERSION))
                 .thenReturn(new TaskDefinitionLog());
@@ -262,17 +254,14 @@ public class TaskDefinitionServiceImplTest {
     public void testReleaseTaskDefinition() {
         when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(getProject());
         Project project = getProject();
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, project, null);
 
         // check task dose not exist
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.TASK_DEFINE_NOT_EXIST, TASK_CODE);
-        when(projectService.checkProjectAndAuth(user, project, PROJECT_CODE, null)).thenReturn(result);
         Map<String, Object> map =
                 taskDefinitionService.releaseTaskDefinition(user, PROJECT_CODE, TASK_CODE, ReleaseState.OFFLINE);
         assertEquals(Status.TASK_DEFINE_NOT_EXIST, map.get(Constants.STATUS));
 
         // process definition offline
-        putMsg(result, Status.SUCCESS);
         TaskDefinition taskDefinition = new TaskDefinition();
         taskDefinition.setProjectCode(PROJECT_CODE);
         taskDefinition.setVersion(1);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskInstanceServiceTest.java
@@ -124,9 +124,8 @@ public class TaskInstanceServiceTest {
                 20));
 
         // data parameter check
-        putMsg(result, Status.SUCCESS, projectCode);
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, TASK_INSTANCE)).thenReturn(result);
+        doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, projectCode, TASK_INSTANCE);
         Assertions.assertThrows(ServiceException.class, () -> taskInstanceService.queryTaskListPaging(loginUser,
                 projectCode,
                 1,

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -290,7 +290,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionLogJson, TaskDefinitionLog.class);
 
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_BATCH_COPY)).thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
         when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         when(workflowTaskRelationMapper.queryByWorkflowDefinitionCode(Long.parseLong(codes)))
                 .thenReturn(workflowTaskRelations);
@@ -304,23 +305,19 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     }
     @Test
     public void testQueryWorkflowDefinitionList() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-
         Project project = getProject(projectCode);
-
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
 
         // project not found
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
-        Map<String, Object> map = workflowDefinitionService.queryWorkflowDefinitionList(user, projectCode);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, map.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
+        ServiceException ex = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.queryWorkflowDefinitionList(user, projectCode));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project check auth success
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         List<WorkflowDefinition> resourceList = new ArrayList<>();
         resourceList.add(getWorkflowDefinition());
         when(workflowDefinitionMapper.queryAllDefinitionList(project.getCode())).thenReturn(resourceList);
@@ -401,23 +398,19 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testQueryWorkflowDefinitionByCode() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-
         Project project = getProject(projectCode);
-
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
 
         // project check auth fail
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
-        Map<String, Object> map = workflowDefinitionService.queryWorkflowDefinitionByCode(user, 1L, 1L);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, map.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
+        ServiceException ex = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 1L));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project check auth success, instance not exist
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         DagData dagData = new DagData(getWorkflowDefinition(), null, null);
         when(processService.genDagData(any())).thenReturn(dagData);
 
@@ -427,9 +420,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         // instance exit
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(getWorkflowDefinition());
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
         Map<String, Object> successRes =
                 workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 46L);
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
@@ -437,24 +427,19 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testQueryWorkflowDefinitionByName() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-
         Project project = getProject(projectCode);
-
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
 
         // project check auth fail
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
-        Map<String, Object> map =
-                workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test_def");
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, map.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
+        ServiceException ex = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test_def"));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project check auth success, instance not exist
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         when(workflowDefinitionMapper.queryByDefineName(project.getCode(), "test_def")).thenReturn(null);
 
         Map<String, Object> instanceNotExitRes =
@@ -464,9 +449,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         // instance exit
         when(workflowDefinitionMapper.queryByDefineName(project.getCode(), "test"))
                 .thenReturn(getWorkflowDefinition());
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
         Map<String, Object> successRes =
                 workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test");
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
@@ -476,34 +458,31 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     public void testBatchCopyWorkflowDefinition() {
         Project project = getProject(projectCode);
 
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, projectCode);
-        Mockito.doReturn(result)
-                .when(projectService)
-                .checkProjectAndAuth(user, project, projectCode, WORKFLOW_BATCH_COPY);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
 
         // copy project definition ids empty test
-        Map<String, Object> map =
-                workflowDefinitionService.batchCopyWorkflowDefinition(user, projectCode, StringUtils.EMPTY, 2L);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_CODES_IS_EMPTY, map.get(Constants.STATUS));
+        ServiceException emptyEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.batchCopyWorkflowDefinition(user, projectCode, StringUtils.EMPTY, 2L));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_CODES_IS_EMPTY.getCode(), emptyEx.getCode());
 
         // project check auth fail
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_BATCH_COPY))
-                .thenReturn(result);
-        Map<String, Object> map1 = workflowDefinitionService.batchCopyWorkflowDefinition(
-                user, projectCode, String.valueOf(project.getId()), 2L);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, map1.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
+        ServiceException ex = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.batchCopyWorkflowDefinition(
+                        user, projectCode, String.valueOf(project.getId()), 2L));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
-        // project check auth success, target project name not equal project name, check auth target project fail
+        // project check auth success, target project name not equal project name
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
         Project project1 = getProject(projectCodeOther);
         when(projectMapper.queryByCode(projectCodeOther)).thenReturn(project1);
-        Mockito.doReturn(result)
-                .when(projectService)
-                .checkProjectAndAuth(user, project1, projectCodeOther, WORKFLOW_BATCH_COPY);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project1, WORKFLOW_BATCH_COPY);
 
-        putMsg(result, Status.SUCCESS, projectCodeOther);
         WorkflowDefinition definition = getWorkflowDefinition();
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(definition);
@@ -532,13 +511,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Project project2 = getProject(projectCodeOther);
         when(projectMapper.queryByCode(projectCodeOther)).thenReturn(project2);
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, projectCode);
-
-        when(projectService.checkProjectAndAuth(user, project1, projectCode, TASK_DEFINITION_MOVE))
-                .thenReturn(result);
-        when(projectService.checkProjectAndAuth(user, project2, projectCodeOther, TASK_DEFINITION_MOVE))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project1, TASK_DEFINITION_MOVE);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project2, TASK_DEFINITION_MOVE);
 
         WorkflowDefinition definition = getWorkflowDefinition();
         definition.setVersion(1);
@@ -558,7 +534,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(processService.saveWorkflowDefine(user, definition, Boolean.TRUE, Boolean.TRUE)).thenReturn(2);
         when(workflowTaskRelationMapper.queryByWorkflowDefinitionCode(processDefinitionCode))
                 .thenReturn(getProcessTaskRelation());
-        putMsg(result, Status.SUCCESS);
 
         Map<String, Object> successRes = workflowDefinitionService.batchMoveWorkflowDefinition(
                 user, projectCode, String.valueOf(processDefinitionCode), projectCodeOther);
@@ -705,20 +680,19 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testVerifyWorkflowDefinitionName() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         Project project = getProject(projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
 
         // project check auth fail
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_CREATE))
-                .thenReturn(result);
-        Map<String, Object> map = workflowDefinitionService.verifyWorkflowDefinitionName(user,
-                projectCode, "test_pdf", 0);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, map.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(user, project, WORKFLOW_CREATE);
+        ServiceException ex = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project check auth success, process not exist
-        putMsg(result, Status.SUCCESS, projectCode);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_CREATE);
         when(workflowDefinitionMapper.verifyByDefineName(project.getCode(), "test_pdf")).thenReturn(null);
         Map<String, Object> processNotExistRes =
                 workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0);
@@ -746,13 +720,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testGetTaskNodeListByDefinitionCode() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         Project project = getProject(projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, project, null);
 
-        // project check auth fail
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, null)).thenReturn(result);
         // process definition not exist
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(null);
         Map<String, Object> processDefinitionNullRes =
@@ -761,7 +732,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         // success
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
-        putMsg(result, Status.SUCCESS, projectCode);
         when(processService.genDagData(any())).thenReturn(new DagData(workflowDefinition, null, null));
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
         Map<String, Object> dataNotValidRes =
@@ -771,13 +741,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testGetTaskNodeListByDefinitionCodes() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         Project project = getProject(projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, project, null);
 
-        // project check auth fail
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, null)).thenReturn(result);
         // process definition not exist
         String defineCodes = "46";
         Set<Long> defineCodeSet = Lists.newArrayList(defineCodes.split(Constants.COMMA)).stream().map(Long::parseLong)
@@ -787,7 +754,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes);
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, processNotExistRes.get(Constants.STATUS));
 
-        putMsg(result, Status.SUCCESS, projectCode);
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(workflowDefinition);
@@ -806,12 +772,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testQueryAllWorkflowDefinitionByProjectCode() {
-        Map<String, Object> result = new HashMap<>();
         Project project = getProject(projectCode);
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(workflowDefinition);
@@ -824,11 +788,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testViewTree() {
         Project project1 = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS, projectCode);
         when(projectMapper.queryByCode(1)).thenReturn(project1);
-        when(projectService.checkProjectAndAuth(user, project1, projectCode, WORKFLOW_TREE_VIEW))
-                .thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project1, WORKFLOW_TREE_VIEW);
         // process definition not exist
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         Map<String, Object> processDefinitionNullRes =
@@ -836,9 +798,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, processDefinitionNullRes.get(Constants.STATUS));
 
         // task instance not existproject
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectMapper.queryByCode(1)).thenReturn(project1);
-        when(projectService.checkProjectAndAuth(user, project1, 1, WORKFLOW_TREE_VIEW)).thenReturn(result);
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
         when(processService.genDagGraph(workflowDefinition)).thenReturn(new DAG<>());
         Map<String, Object> taskNullRes =
@@ -857,10 +816,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
 
         Project project1 = getProject(1);
-        Map<String, Object> result = new HashMap<>();
-        result.put(Constants.STATUS, Status.SUCCESS);
         when(projectMapper.queryByCode(1)).thenReturn(project1);
-        when(projectService.checkProjectAndAuth(user, project1, 1, WORKFLOW_TREE_VIEW)).thenReturn(result);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project1, WORKFLOW_TREE_VIEW);
         when(processService.genDagGraph(workflowDefinition)).thenReturn(new DAG<>());
         Map<String, Object> taskNotNuLLRes =
                 workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10);
@@ -948,24 +906,19 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testViewVariables() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-
         Project project = getProject(projectCode);
+        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
 
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
-
         // project check auth fail
-        when(projectService.checkProjectAndAuth(user, project, projectCode, WORKFLOW_DEFINITION))
-                .thenReturn(result);
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> map =
-                workflowDefinitionService.viewVariables(user, workflowDefinition.getProjectCode(),
-                        workflowDefinition.getCode());
-
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, map.get(Constants.STATUS));
+        ServiceException ex = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.viewVariables(user, workflowDefinition.getProjectCode(),
+                        workflowDefinition.getCode()));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.api.service;
 
-import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.INSTANCE_DELETE;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.INSTANCE_UPDATE;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -313,19 +312,19 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 666L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        Map<String, Object> projectAuthFailMap =
-                workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, projectAuthFailMap.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
         // project auth success
-        putMsg(result, Status.SUCCESS, projectCode);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
         when(workflowInstanceMapper.queryByTriggerCode(projectCode)).thenReturn(new ArrayList());
-        projectAuthFailMap =
+        Map<String, Object> projectAuthFailMap =
                 workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L);
         Assertions.assertEquals(Status.SUCCESS, projectAuthFailMap.get(Constants.STATUS));
     }
@@ -335,34 +334,26 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>(5);
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
         int size = 10;
         String startTime = "2020-01-01 00:00:00";
         String endTime = "2020-08-02 00:00:00";
-        Date start = DateUtils.stringToDate(startTime);
-        Date end = DateUtils.stringToDate(endTime);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        Map<String, Object> projectAuthFailRes = workflowInstanceService
-                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, startTime, endTime);
-
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, projectAuthFailRes.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+        ServiceException ex = assertThrows(ServiceException.class, () -> workflowInstanceService
+                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, startTime, endTime));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project auth success
-        putMsg(result, Status.SUCCESS, projectCode);
         WorkflowInstance workflowInstance = getProcessInstance();
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        projectAuthFailRes = workflowInstanceService
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
+        Map<String, Object> projectAuthFailRes = workflowInstanceService
                 .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, -1, startTime, endTime);
         Assertions.assertEquals(Status.NEGTIVE_SIZE_NUMBER_ERROR, projectAuthFailRes.get(Constants.STATUS));
 
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
         when(usersService.queryUser(loginUser.getId())).thenReturn(loginUser);
         when(usersService.getUserIdByName(loginUser.getUserName())).thenReturn(loginUser.getId());
         when(usersService.queryUser(workflowInstance.getExecutorId())).thenReturn(loginUser);
@@ -377,30 +368,23 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>(5);
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
         int size = 10;
         String startTime = "2020-01-01 00:00:00";
         String endTime = "2020-08-02 00:00:00";
 
-        putMsg(result, Status.SUCCESS, projectCode);
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
+
         Map<String, Object> startTimeBiggerFailRes = workflowInstanceService
                 .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, endTime, startTime);
         Assertions.assertEquals(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR,
                 startTimeBiggerFailRes.get(Constants.STATUS));
 
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
         Map<String, Object> dataNullFailRes = workflowInstanceService
                 .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, null, endTime);
         Assertions.assertEquals(Status.DATA_IS_NULL, dataNullFailRes.get(Constants.STATUS));
 
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
         dataNullFailRes = workflowInstanceService
                 .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, startTime, null);
         Assertions.assertEquals(Status.DATA_IS_NULL, dataNullFailRes.get(Constants.STATUS));
@@ -411,23 +395,21 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        Map<String, Object> projectAuthFailRes =
-                workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, projectAuthFailRes.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project auth success
         WorkflowInstance workflowInstance = getProcessInstance();
-        putMsg(result, Status.SUCCESS, projectCode);
         WorkflowDefinition workflowDefinition = getProcessDefinition();
         workflowDefinition.setProjectCode(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
         when(processService.findWorkflowInstanceDetailById(workflowInstance.getId()))
                 .thenReturn(Optional.of(workflowInstance));
         when(processService.findWorkflowDefinition(workflowInstance.getWorkflowDefinitionCode(),
@@ -457,18 +439,18 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        Map<String, Object> projectAuthFailRes =
-                workflowInstanceService.queryTaskListByWorkflowInstanceId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, projectAuthFailRes.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.queryTaskListByWorkflowInstanceId(loginUser, projectCode, 1));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project auth success
-        putMsg(result, Status.SUCCESS, projectCode);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setState(WorkflowExecutionStatus.SUCCESS);
         TaskInstance taskInstance = new TaskInstance();
@@ -492,8 +474,6 @@ public class WorkflowInstanceServiceTest {
         Result res = new Result();
         res.setCode(Status.SUCCESS.ordinal());
         res.setData("xxx");
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
         when(processService.findWorkflowInstanceDetailById(workflowInstance.getId()))
                 .thenReturn(Optional.of(workflowInstance));
         when(taskInstanceDao.queryValidTaskListByWorkflowInstanceId(workflowInstance.getId()))
@@ -512,20 +492,18 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        Map<String, Object> projectAuthFailRes =
-                workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, projectAuthFailRes.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // task null
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
         when(taskInstanceDao.queryById(1)).thenReturn(null);
         Map<String, Object> taskNullRes =
                 workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
@@ -535,7 +513,6 @@ public class WorkflowInstanceServiceTest {
         TaskInstance taskInstance = getTaskInstance();
         taskInstance.setTaskType("HTTP");
         taskInstance.setWorkflowInstanceId(1);
-        putMsg(result, Status.SUCCESS, projectCode);
         when(taskInstanceDao.queryById(1)).thenReturn(taskInstance);
         TaskDefinition taskDefinition = new TaskDefinition();
         taskDefinition.setProjectCode(projectCode);
@@ -544,7 +521,6 @@ public class WorkflowInstanceServiceTest {
                 workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.TASK_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE, notSubprocessRes.get(Constants.STATUS));
 
-        putMsg(result, Status.SUCCESS, projectCode);
         taskDefinition.setProjectCode(0L);
         notSubprocessRes = workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.TASK_INSTANCE_NOT_EXISTS, notSubprocessRes.get(Constants.STATUS));
@@ -555,7 +531,6 @@ public class WorkflowInstanceServiceTest {
         TaskInstance subTask = getTaskInstance();
         subTask.setTaskType("SUB_WORKFLOW");
         subTask.setWorkflowInstanceId(1);
-        putMsg(result, Status.SUCCESS, projectCode);
         when(taskInstanceDao.queryById(subTask.getId())).thenReturn(subTask);
         when(processService.findSubWorkflowInstance(subTask.getWorkflowInstanceId(), subTask.getId())).thenReturn(null);
         Map<String, Object> subprocessNotExistRes =
@@ -564,7 +539,6 @@ public class WorkflowInstanceServiceTest {
 
         // sub process exist
         WorkflowInstance workflowInstance = getProcessInstance();
-        putMsg(result, Status.SUCCESS, projectCode);
         when(processService.findSubWorkflowInstance(taskInstance.getWorkflowInstanceId(), taskInstance.getId()))
                 .thenReturn(workflowInstance);
         Map<String, Object> subprocessExistRes =
@@ -677,20 +651,18 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
-        Map<String, Object> projectAuthFailRes =
-                workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND, projectAuthFailRes.get(Constants.STATUS));
+        Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
+                .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // process instance null
-        putMsg(result, Status.SUCCESS, projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, WORKFLOW_INSTANCE)).thenReturn(result);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
+                WORKFLOW_INSTANCE);
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.empty());
         assertThrows(ServiceException.class, () -> {
             workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
@@ -699,7 +671,6 @@ public class WorkflowInstanceServiceTest {
         // not sub process
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setIsSubWorkflow(Flag.NO);
-        putMsg(result, Status.SUCCESS, projectCode);
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.ofNullable(workflowInstance));
         Map<String, Object> notSubProcessRes =
                 workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
@@ -708,14 +679,12 @@ public class WorkflowInstanceServiceTest {
 
         // sub process
         workflowInstance.setIsSubWorkflow(Flag.YES);
-        putMsg(result, Status.SUCCESS, projectCode);
         when(processService.findParentWorkflowInstance(1)).thenReturn(null);
         Map<String, Object> subProcessNullRes =
                 workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, subProcessNullRes.get(Constants.STATUS));
 
         // success
-        putMsg(result, Status.SUCCESS, projectCode);
         when(processService.findParentWorkflowInstance(1)).thenReturn(workflowInstance);
         Map<String, Object> successRes = workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
         Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
@@ -726,13 +695,9 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
-        // project auth fail
+        // workflow instance not exist
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.checkProjectAndAuth(loginUser, project, projectCode, INSTANCE_DELETE)).thenReturn(result);
-
         assertThrows(ServiceException.class,
                 () -> workflowInstanceService.deleteWorkflowInstanceById(loginUser, 1));
 
@@ -740,7 +705,6 @@ public class WorkflowInstanceServiceTest {
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setIsSubWorkflow(Flag.NO);
         workflowInstance.setState(WorkflowExecutionStatus.RUNNING_EXECUTION);
-        putMsg(result, Status.SUCCESS, projectCode);
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.ofNullable(workflowInstance));
         when(workflowDefinitionLogMapper.queryByDefinitionCodeAndVersion(Mockito.anyLong(), Mockito.anyInt()))
                 .thenReturn(new WorkflowDefinitionLog());


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Migrate all internal callers to checkProjectAndAuthThrowException and drop the two @Deprecated overloads (Map-returning and Result-mutating) along with the unused private getCheckResult helper. Tests are updated to mock the new throwing API via doThrow / doNothing and assert exceptions instead of inspecting result-map status codes. Permission failures now flow through ApiExceptionHandler, preserving the wire format.


## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
