### PR TITLE
[Improvement-18224][API] Migrate SchedulerService Map<String,Object> returns to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/SchedulerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/SchedulerController.java
@@ -33,13 +33,15 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.SchedulerService;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.ScheduleVO;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Priority;
 import org.apache.dolphinscheduler.common.enums.WarningType;
+import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -104,18 +106,18 @@ public class SchedulerController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_SCHEDULE_ERROR)
     @OperatorLog(auditType = AuditType.SCHEDULE_CREATE)
-    public Result createSchedule(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
-                                 @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                 @RequestParam(value = "workflowDefinitionCode") long workflowDefinitionCode,
-                                 @RequestParam(value = "schedule") String schedule,
-                                 @RequestParam(value = "warningType", required = false, defaultValue = DEFAULT_WARNING_TYPE) WarningType warningType,
-                                 @RequestParam(value = "warningGroupId", required = false, defaultValue = DEFAULT_NOTIFY_GROUP_ID) int warningGroupId,
-                                 @RequestParam(value = "failureStrategy", required = false, defaultValue = DEFAULT_FAILURE_POLICY) FailureStrategy failureStrategy,
-                                 @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
-                                 @RequestParam(value = "tenantCode", required = false, defaultValue = "default") String tenantCode,
-                                 @RequestParam(value = "environmentCode", required = false, defaultValue = "-1") Long environmentCode,
-                                 @RequestParam(value = "workflowInstancePriority", required = false, defaultValue = DEFAULT_WORKFLOW_INSTANCE_PRIORITY) Priority workflowInstancePriority) {
-        Map<String, Object> result = schedulerService.insertSchedule(
+    public Result<Schedule> createSchedule(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
+                                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                           @RequestParam(value = "workflowDefinitionCode") long workflowDefinitionCode,
+                                           @RequestParam(value = "schedule") String schedule,
+                                           @RequestParam(value = "warningType", required = false, defaultValue = DEFAULT_WARNING_TYPE) WarningType warningType,
+                                           @RequestParam(value = "warningGroupId", required = false, defaultValue = DEFAULT_NOTIFY_GROUP_ID) int warningGroupId,
+                                           @RequestParam(value = "failureStrategy", required = false, defaultValue = DEFAULT_FAILURE_POLICY) FailureStrategy failureStrategy,
+                                           @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
+                                           @RequestParam(value = "tenantCode", required = false, defaultValue = "default") String tenantCode,
+                                           @RequestParam(value = "environmentCode", required = false, defaultValue = "-1") Long environmentCode,
+                                           @RequestParam(value = "workflowInstancePriority", required = false, defaultValue = DEFAULT_WORKFLOW_INSTANCE_PRIORITY) Priority workflowInstancePriority) {
+        Schedule createdSchedule = schedulerService.insertSchedule(
                 loginUser,
                 projectCode,
                 workflowDefinitionCode,
@@ -127,8 +129,7 @@ public class SchedulerController extends BaseController {
                 workerGroup,
                 tenantCode,
                 environmentCode);
-
-        return returnDataList(result);
+        return Result.success(createdSchedule);
     }
 
     /**
@@ -162,22 +163,21 @@ public class SchedulerController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_SCHEDULE_ERROR)
     @OperatorLog(auditType = AuditType.SCHEDULE_UPDATE)
-    public Result updateSchedule(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
-                                 @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                 @PathVariable(value = "id") Integer id,
-                                 @RequestParam(value = "schedule") String schedule,
-                                 @RequestParam(value = "warningType", required = false, defaultValue = DEFAULT_WARNING_TYPE) WarningType warningType,
-                                 @RequestParam(value = "warningGroupId", required = false, defaultValue = DEFAULT_NOTIFY_GROUP_ID) int warningGroupId,
-                                 @RequestParam(value = "failureStrategy", required = false, defaultValue = "END") FailureStrategy failureStrategy,
-                                 @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
-                                 @RequestParam(value = "tenantCode", required = false, defaultValue = "default") String tenantCode,
-                                 @RequestParam(value = "environmentCode", required = false, defaultValue = "-1") Long environmentCode,
-                                 @RequestParam(value = "workflowInstancePriority", required = false, defaultValue = DEFAULT_WORKFLOW_INSTANCE_PRIORITY) Priority workflowInstancePriority) {
-
-        Map<String, Object> result = schedulerService.updateSchedule(loginUser, projectCode, id, schedule,
+    public Result<Schedule> updateSchedule(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
+                                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                           @PathVariable(value = "id") Integer id,
+                                           @RequestParam(value = "schedule") String schedule,
+                                           @RequestParam(value = "warningType", required = false, defaultValue = DEFAULT_WARNING_TYPE) WarningType warningType,
+                                           @RequestParam(value = "warningGroupId", required = false, defaultValue = DEFAULT_NOTIFY_GROUP_ID) int warningGroupId,
+                                           @RequestParam(value = "failureStrategy", required = false, defaultValue = "END") FailureStrategy failureStrategy,
+                                           @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
+                                           @RequestParam(value = "tenantCode", required = false, defaultValue = "default") String tenantCode,
+                                           @RequestParam(value = "environmentCode", required = false, defaultValue = "-1") Long environmentCode,
+                                           @RequestParam(value = "workflowInstancePriority", required = false, defaultValue = DEFAULT_WORKFLOW_INSTANCE_PRIORITY) Priority workflowInstancePriority) {
+        Schedule updatedSchedule = schedulerService.updateSchedule(loginUser, projectCode, id, schedule,
                 warningType, warningGroupId, failureStrategy, workflowInstancePriority, workerGroup, tenantCode,
                 environmentCode);
-        return returnDataList(result);
+        return Result.success(updatedSchedule);
     }
 
     @Operation(summary = "online", description = "ONLINE_SCHEDULE_NOTES")
@@ -274,10 +274,10 @@ public class SchedulerController extends BaseController {
     @Operation(summary = "queryScheduleList", description = "QUERY_SCHEDULE_LIST_NOTES")
     @PostMapping("/list")
     @ApiException(QUERY_SCHEDULE_LIST_ERROR)
-    public Result queryScheduleList(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
-                                    @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
-        Map<String, Object> result = schedulerService.queryScheduleList(loginUser, projectCode);
-        return returnDataList(result);
+    public Result<List<ScheduleVO>> queryScheduleList(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
+                                                      @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
+        List<ScheduleVO> scheduleList = schedulerService.queryScheduleList(loginUser, projectCode);
+        return Result.success(scheduleList);
     }
 
     /**
@@ -294,10 +294,10 @@ public class SchedulerController extends BaseController {
     @PostMapping("/preview")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(PREVIEW_SCHEDULE_ERROR)
-    public Result previewSchedule(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
-                                  @RequestParam(value = "schedule") String schedule) {
-        Map<String, Object> result = schedulerService.previewSchedule(loginUser, schedule);
-        return returnDataList(result);
+    public Result<List<String>> previewSchedule(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
+                                                @RequestParam(value = "schedule") String schedule) {
+        List<String> previewDateList = schedulerService.previewSchedule(loginUser, schedule);
+        return Result.success(previewDateList);
     }
 
     /**
@@ -330,21 +330,21 @@ public class SchedulerController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_SCHEDULE_ERROR)
     @OperatorLog(auditType = AuditType.SCHEDULE_UPDATE)
-    public Result updateScheduleByWorkflowDefinitionCode(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
-                                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                         @PathVariable(value = "code") long workflowDefinitionCode,
-                                                         @RequestParam(value = "schedule") String schedule,
-                                                         @RequestParam(value = "warningType", required = false, defaultValue = DEFAULT_WARNING_TYPE) WarningType warningType,
-                                                         @RequestParam(value = "warningGroupId", required = false) int warningGroupId,
-                                                         @RequestParam(value = "failureStrategy", required = false, defaultValue = "END") FailureStrategy failureStrategy,
-                                                         @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
-                                                         @RequestParam(value = "tenantCode", required = false, defaultValue = "default") String tenantCode,
-                                                         @RequestParam(value = "environmentCode", required = false, defaultValue = "-1") long environmentCode,
-                                                         @RequestParam(value = "workflowInstancePriority", required = false) Priority workflowInstancePriority) {
-        Map<String, Object> result = schedulerService.updateScheduleByWorkflowDefinitionCode(loginUser, projectCode,
+    public Result<Schedule> updateScheduleByWorkflowDefinitionCode(@Parameter(hidden = true) @RequestAttribute(value = SESSION_USER) User loginUser,
+                                                                   @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                   @PathVariable(value = "code") long workflowDefinitionCode,
+                                                                   @RequestParam(value = "schedule") String schedule,
+                                                                   @RequestParam(value = "warningType", required = false, defaultValue = DEFAULT_WARNING_TYPE) WarningType warningType,
+                                                                   @RequestParam(value = "warningGroupId", required = false) int warningGroupId,
+                                                                   @RequestParam(value = "failureStrategy", required = false, defaultValue = "END") FailureStrategy failureStrategy,
+                                                                   @RequestParam(value = "workerGroup", required = false, defaultValue = "default") String workerGroup,
+                                                                   @RequestParam(value = "tenantCode", required = false, defaultValue = "default") String tenantCode,
+                                                                   @RequestParam(value = "environmentCode", required = false, defaultValue = "-1") long environmentCode,
+                                                                   @RequestParam(value = "workflowInstancePriority", required = false) Priority workflowInstancePriority) {
+        Schedule updatedSchedule = schedulerService.updateScheduleByWorkflowDefinitionCode(loginUser, projectCode,
                 workflowDefinitionCode, schedule,
                 warningType, warningGroupId, failureStrategy, workflowInstancePriority, workerGroup, tenantCode,
                 environmentCode);
-        return returnDataList(result);
+        return Result.success(updatedSchedule);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -331,11 +331,11 @@ public class PythonGateway {
         int scheduleId;
         if (scheduleObj == null) {
             workflowDefinitionService.onlineWorkflowDefinition(user, projectCode, workflowCode);
-            Map<String, Object> result = schedulerService.insertSchedule(user, projectCode, workflowCode,
+            Schedule createdSchedule = schedulerService.insertSchedule(user, projectCode, workflowCode,
                     schedule, WarningType.valueOf(warningType),
                     warningGroupId, DEFAULT_FAILURE_STRATEGY, DEFAULT_PRIORITY, workerGroup, user.getTenantCode(),
                     DEFAULT_ENVIRONMENT_CODE);
-            scheduleId = (int) result.get("scheduleId");
+            scheduleId = createdSchedule.getId();
         } else {
             scheduleId = scheduleObj.getId();
             workflowDefinitionService.offlineWorkflowDefinition(user, projectCode, workflowCode);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/SchedulerService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/SchedulerService.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.ScheduleVO;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Priority;
 import org.apache.dolphinscheduler.common.enums.WarningType;
@@ -25,7 +26,6 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.List;
-import java.util.Map;
 
 public interface SchedulerService {
 
@@ -43,19 +43,18 @@ public interface SchedulerService {
      * @param workerGroup worker group
      * @param tenantCode tenant code
      * @param environmentCode environment code
-     * @return create result code
      */
-    Map<String, Object> insertSchedule(User loginUser,
-                                       long projectCode,
-                                       long workflowDefinitionCode,
-                                       String schedule,
-                                       WarningType warningType,
-                                       int warningGroupId,
-                                       FailureStrategy failureStrategy,
-                                       Priority workflowInstancePriority,
-                                       String workerGroup,
-                                       String tenantCode,
-                                       Long environmentCode);
+    Schedule insertSchedule(User loginUser,
+                            long projectCode,
+                            long workflowDefinitionCode,
+                            String schedule,
+                            WarningType warningType,
+                            int warningGroupId,
+                            FailureStrategy failureStrategy,
+                            Priority workflowInstancePriority,
+                            String workerGroup,
+                            String tenantCode,
+                            Long environmentCode);
 
     /**
      * updateWorkflowInstance schedule
@@ -71,19 +70,18 @@ public interface SchedulerService {
      * @param tenantCode tenant code
      * @param environmentCode environment code
      * @param workflowInstancePriority workflow instance priority
-     * @return update result code
      */
-    Map<String, Object> updateSchedule(User loginUser,
-                                       long projectCode,
-                                       Integer id,
-                                       String scheduleExpression,
-                                       WarningType warningType,
-                                       int warningGroupId,
-                                       FailureStrategy failureStrategy,
-                                       Priority workflowInstancePriority,
-                                       String workerGroup,
-                                       String tenantCode,
-                                       Long environmentCode);
+    Schedule updateSchedule(User loginUser,
+                            long projectCode,
+                            Integer id,
+                            String scheduleExpression,
+                            WarningType warningType,
+                            int warningGroupId,
+                            FailureStrategy failureStrategy,
+                            Priority workflowInstancePriority,
+                            String workerGroup,
+                            String tenantCode,
+                            Long environmentCode);
 
     /**
      * query schedule
@@ -108,7 +106,7 @@ public interface SchedulerService {
      * @param projectCode project code
      * @return schedule list
      */
-    Map<String, Object> queryScheduleList(User loginUser, long projectCode);
+    List<ScheduleVO> queryScheduleList(User loginUser, long projectCode);
 
     /**
      * delete schedule by id
@@ -125,7 +123,7 @@ public interface SchedulerService {
      * @param schedule schedule expression
      * @return the next five fire time
      */
-    Map<String, Object> previewSchedule(User loginUser, String schedule);
+    List<String> previewSchedule(User loginUser, String schedule);
 
     /**
      * update workflow definition schedule
@@ -140,19 +138,18 @@ public interface SchedulerService {
      * @param workerGroup worker group
      * @param tenantCode tenant code
      * @param workflowInstancePriority workflow instance priority
-     * @return update result code
      */
-    Map<String, Object> updateScheduleByWorkflowDefinitionCode(User loginUser,
-                                                               long projectCode,
-                                                               long workflowDefinitionCode,
-                                                               String scheduleExpression,
-                                                               WarningType warningType,
-                                                               int warningGroupId,
-                                                               FailureStrategy failureStrategy,
-                                                               Priority workflowInstancePriority,
-                                                               String workerGroup,
-                                                               String tenantCode,
-                                                               long environmentCode);
+    Schedule updateScheduleByWorkflowDefinitionCode(User loginUser,
+                                                    long projectCode,
+                                                    long workflowDefinitionCode,
+                                                    String scheduleExpression,
+                                                    WarningType warningType,
+                                                    int warningGroupId,
+                                                    FailureStrategy failureStrategy,
+                                                    Priority workflowInstancePriority,
+                                                    String workerGroup,
+                                                    String tenantCode,
+                                                    long environmentCode);
 
     /**
      * Online the scheduler by scheduler id, if the related workflow definition is not online will throw exception.

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -57,9 +57,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -113,31 +111,25 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      * @param workerGroup             worker group
      * @param tenantCode              tenant code
      * @param environmentCode         environment code
-     * @return create result code
      */
     @Override
     @Transactional
-    public Map<String, Object> insertSchedule(User loginUser,
-                                              long projectCode,
-                                              long workflowDefinitionCode,
-                                              String schedule,
-                                              WarningType warningType,
-                                              int warningGroupId,
-                                              FailureStrategy failureStrategy,
-                                              Priority workflowInstancePriority,
-                                              String workerGroup,
-                                              String tenantCode,
-                                              Long environmentCode) {
-
-        Map<String, Object> result = new HashMap<>();
+    public Schedule insertSchedule(User loginUser,
+                                   long projectCode,
+                                   long workflowDefinitionCode,
+                                   String schedule,
+                                   WarningType warningType,
+                                   int warningGroupId,
+                                   FailureStrategy failureStrategy,
+                                   Priority workflowInstancePriority,
+                                   String workerGroup,
+                                   String tenantCode,
+                                   Long environmentCode) {
 
         Project project = projectMapper.queryByCode(projectCode);
 
         // check project auth
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, null);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         // check workflow define release state
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
@@ -149,8 +141,8 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         if (scheduleExists != null) {
             log.error("Schedule already exist, scheduleId:{}, workflowDefinitionCode:{}", scheduleExists.getId(),
                     workflowDefinitionCode);
-            putMsg(result, Status.SCHEDULE_ALREADY_EXISTS, workflowDefinitionCode, scheduleExists.getId());
-            return result;
+            throw new ServiceException(Status.SCHEDULE_ALREADY_EXISTS, workflowDefinitionCode,
+                    scheduleExists.getId());
         }
 
         Schedule scheduleObj = new Schedule();
@@ -166,21 +158,18 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         ScheduleParam scheduleParam = JSONUtils.parseObject(schedule, ScheduleParam.class);
         if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
             log.warn("The start time must not be the same as the end or time can not be null.");
-            putMsg(result, Status.SCHEDULE_START_TIME_END_TIME_SAME);
-            return result;
+            throw new ServiceException(Status.SCHEDULE_START_TIME_END_TIME_SAME);
         }
         if (scheduleParam.getStartTime().getTime() > scheduleParam.getEndTime().getTime()) {
             log.warn("The start time must smaller than end time");
-            putMsg(result, Status.START_TIME_BIGGER_THAN_END_TIME_ERROR);
-            return result;
+            throw new ServiceException(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR);
         }
 
         scheduleObj.setStartTime(scheduleParam.getStartTime());
         scheduleObj.setEndTime(scheduleParam.getEndTime());
         if (!CronUtils.isValidExpression(scheduleParam.getCrontab())) {
             log.error("Schedule crontab verify failure, crontab:{}.", scheduleParam.getCrontab());
-            putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR, scheduleParam.getCrontab());
-            return result;
+            throw new ServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR, scheduleParam.getCrontab());
         }
         scheduleObj.setCrontab(scheduleParam.getCrontab());
         scheduleObj.setTimezoneId(scheduleParam.getTimezoneId());
@@ -203,13 +192,9 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         workflowDefinition.setWarningGroupId(warningGroupId);
         workflowDefinitionMapper.updateById(workflowDefinition);
 
-        // return scheduler object with ID
-        result.put(Constants.DATA_LIST, scheduleMapper.selectById(scheduleObj.getId()));
-        putMsg(result, Status.SUCCESS);
         log.info("Schedule create complete, projectCode:{}, workflowDefinitionCode:{}, scheduleId:{}.",
                 projectCode, workflowDefinitionCode, scheduleObj.getId());
-        result.put("scheduleId", scheduleObj.getId());
-        return result;
+        return scheduleMapper.selectById(scheduleObj.getId());
     }
 
     protected void projectPermCheckByWorkflowCode(User loginUser, long workflowDefinitionCode) {
@@ -236,38 +221,32 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      * @param tenantCode              tenant code
      * @param environmentCode         environment code
      * @param workflowInstancePriority workflow instance priority
-     * @return update result code
      */
     @Override
     @Transactional
-    public Map<String, Object> updateSchedule(User loginUser,
-                                              long projectCode,
-                                              Integer id,
-                                              String scheduleExpression,
-                                              WarningType warningType,
-                                              int warningGroupId,
-                                              FailureStrategy failureStrategy,
-                                              Priority workflowInstancePriority,
-                                              String workerGroup,
-                                              String tenantCode,
-                                              Long environmentCode) {
-        Map<String, Object> result = new HashMap<>();
+    public Schedule updateSchedule(User loginUser,
+                                   long projectCode,
+                                   Integer id,
+                                   String scheduleExpression,
+                                   WarningType warningType,
+                                   int warningGroupId,
+                                   FailureStrategy failureStrategy,
+                                   Priority workflowInstancePriority,
+                                   String workerGroup,
+                                   String tenantCode,
+                                   Long environmentCode) {
 
         Project project = projectMapper.queryByCode(projectCode);
 
         // check project auth
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, null);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         // check schedule exists
         Schedule schedule = scheduleMapper.selectById(id);
 
         if (schedule == null) {
             log.error("Schedule does not exist, scheduleId:{}.", id);
-            putMsg(result, Status.SCHEDULE_NOT_EXISTS, id);
-            return result;
+            throw new ServiceException(Status.SCHEDULE_NOT_EXISTS, id);
         }
 
         WorkflowDefinition workflowDefinition =
@@ -275,13 +254,12 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.",
                     schedule.getWorkflowDefinitionCode());
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(schedule.getWorkflowDefinitionCode()));
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST,
+                    String.valueOf(schedule.getWorkflowDefinitionCode()));
         }
 
-        updateSchedule(result, schedule, workflowDefinition, scheduleExpression, warningType, warningGroupId,
+        return updateSchedule(schedule, workflowDefinition, scheduleExpression, warningType, warningGroupId,
                 failureStrategy, workflowInstancePriority, workerGroup, tenantCode, environmentCode);
-        return result;
     }
 
     /**
@@ -351,43 +329,18 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      * @return schedule list
      */
     @Override
-    public Map<String, Object> queryScheduleList(User loginUser, long projectCode) {
-        Map<String, Object> result = new HashMap<>();
+    public List<ScheduleVO> queryScheduleList(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
 
         // check project auth
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, null);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         List<Schedule> schedules = scheduleMapper.querySchedulerListByProjectName(project.getName());
         List<ScheduleVO> scheduleList = new ArrayList<>();
         for (Schedule schedule : schedules) {
             scheduleList.add(new ScheduleVO(schedule));
         }
-
-        result.put(Constants.DATA_LIST, scheduleList);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
-    }
-
-    /**
-     * check valid
-     *
-     * @param result result
-     * @param bool   bool
-     * @param status status
-     * @return check result code
-     */
-    private boolean checkValid(Map<String, Object> result, boolean bool, Status status) {
-        // timeout is valid
-        if (bool) {
-            putMsg(result, status);
-            return true;
-        }
-        return false;
+        return scheduleList;
     }
 
     /**
@@ -426,8 +379,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      * @return the next five fire time
      */
     @Override
-    public Map<String, Object> previewSchedule(User loginUser, String schedule) {
-        Map<String, Object> result = new HashMap<>();
+    public List<String> previewSchedule(User loginUser, String schedule) {
         Cron cron;
         ScheduleParam scheduleParam = JSONUtils.parseObject(schedule, ScheduleParam.class);
 
@@ -442,16 +394,13 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
             cron = CronUtils.parse2Cron(scheduleParam.getCrontab());
         } catch (CronParseException e) {
             log.error("Parse cron to cron expression error, crontab:{}.", scheduleParam.getCrontab(), e);
-            putMsg(result, Status.PARSE_TO_CRON_EXPRESSION_ERROR);
-            return result;
+            throw new ServiceException(Status.PARSE_TO_CRON_EXPRESSION_ERROR);
         }
         List<ZonedDateTime> selfFireDateList =
                 CronUtils.getSelfFireDateList(startTime, endTime, cron, Constants.PREVIEW_SCHEDULE_EXECUTE_COUNT);
-        List<String> previewDateList =
-                selfFireDateList.stream().map(t -> DateUtils.dateToString(t, zoneId)).collect(Collectors.toList());
-        result.put(Constants.DATA_LIST, previewDateList);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return selfFireDateList.stream()
+                .map(t -> DateUtils.dateToString(t, zoneId))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -467,44 +416,40 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      * @param workerGroup             worker group
      * @param tenantCode              tenant code
      * @param workflowInstancePriority workflow instance priority
-     * @return update result code
      */
     @Override
-    public Map<String, Object> updateScheduleByWorkflowDefinitionCode(User loginUser,
-                                                                      long projectCode,
-                                                                      long workflowDefinitionCode,
-                                                                      String scheduleExpression,
-                                                                      WarningType warningType,
-                                                                      int warningGroupId,
-                                                                      FailureStrategy failureStrategy,
-                                                                      Priority workflowInstancePriority,
-                                                                      String workerGroup,
-                                                                      String tenantCode,
-                                                                      long environmentCode) {
+    public Schedule updateScheduleByWorkflowDefinitionCode(User loginUser,
+                                                           long projectCode,
+                                                           long workflowDefinitionCode,
+                                                           String scheduleExpression,
+                                                           WarningType warningType,
+                                                           int warningGroupId,
+                                                           FailureStrategy failureStrategy,
+                                                           Priority workflowInstancePriority,
+                                                           String workerGroup,
+                                                           String tenantCode,
+                                                           long environmentCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
-        Map<String, Object> result = new HashMap<>();
         // check schedule exists
         Schedule schedule = scheduleMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         if (schedule == null) {
             log.error("Schedule of workflow definition does not exist, workflowDefinitionCode:{}.",
                     workflowDefinitionCode);
-            putMsg(result, Status.SCHEDULE_CRON_NOT_EXISTS, workflowDefinitionCode);
-            return result;
+            throw new ServiceException(Status.SCHEDULE_CRON_NOT_EXISTS, workflowDefinitionCode);
         }
 
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", workflowDefinitionCode);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(workflowDefinitionCode));
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST,
+                    String.valueOf(workflowDefinitionCode));
         }
 
-        updateSchedule(result, schedule, workflowDefinition, scheduleExpression, warningType, warningGroupId,
+        return updateSchedule(schedule, workflowDefinition, scheduleExpression, warningType, warningGroupId,
                 failureStrategy, workflowInstancePriority, workerGroup, tenantCode, environmentCode);
-        return result;
     }
 
     @Transactional
@@ -576,16 +521,14 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         schedulerApi.deleteScheduleTask(project.getId(), schedule.getId());
     }
 
-    private void updateSchedule(Map<String, Object> result, Schedule schedule, WorkflowDefinition workflowDefinition,
-                                String scheduleExpression, WarningType warningType, int warningGroupId,
-                                FailureStrategy failureStrategy, Priority workflowInstancePriority, String workerGroup,
-                                String tenantCode,
-                                long environmentCode) {
-        if (checkValid(result, schedule.getReleaseState() == ReleaseState.ONLINE,
-                Status.SCHEDULE_CRON_ONLINE_FORBID_UPDATE)) {
+    private Schedule updateSchedule(Schedule schedule, WorkflowDefinition workflowDefinition,
+                                    String scheduleExpression, WarningType warningType, int warningGroupId,
+                                    FailureStrategy failureStrategy, Priority workflowInstancePriority,
+                                    String workerGroup, String tenantCode, long environmentCode) {
+        if (schedule.getReleaseState() == ReleaseState.ONLINE) {
             log.warn("Schedule can not be updated due to schedule is {}, scheduleId:{}.",
                     ReleaseState.ONLINE.getDescp(), schedule.getId());
-            return;
+            throw new ServiceException(Status.SCHEDULE_CRON_ONLINE_FORBID_UPDATE);
         }
 
         Date now = new Date();
@@ -598,26 +541,22 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
             ScheduleParam scheduleParam = JSONUtils.parseObject(scheduleExpression, ScheduleParam.class);
             if (scheduleParam == null) {
                 log.warn("Parameter scheduleExpression is invalid, so parse cron error.");
-                putMsg(result, Status.PARSE_TO_CRON_EXPRESSION_ERROR);
-                return;
+                throw new ServiceException(Status.PARSE_TO_CRON_EXPRESSION_ERROR);
             }
             if (DateUtils.differSec(scheduleParam.getStartTime(), scheduleParam.getEndTime()) == 0) {
                 log.warn("The start time must not be the same as the end or time can not be null.");
-                putMsg(result, Status.SCHEDULE_START_TIME_END_TIME_SAME);
-                return;
+                throw new ServiceException(Status.SCHEDULE_START_TIME_END_TIME_SAME);
             }
             if (scheduleParam.getStartTime().getTime() > scheduleParam.getEndTime().getTime()) {
                 log.warn("The start time must smaller than end time");
-                putMsg(result, Status.START_TIME_BIGGER_THAN_END_TIME_ERROR);
-                return;
+                throw new ServiceException(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR);
             }
 
             schedule.setStartTime(scheduleParam.getStartTime());
             schedule.setEndTime(scheduleParam.getEndTime());
             if (!CronUtils.isValidExpression(scheduleParam.getCrontab())) {
                 log.error("Schedule crontab verify failure, crontab:{}.", scheduleParam.getCrontab());
-                putMsg(result, Status.SCHEDULE_CRON_CHECK_FAILED, scheduleParam.getCrontab());
-                return;
+                throw new ServiceException(Status.SCHEDULE_CRON_CHECK_FAILED, scheduleParam.getCrontab());
             }
             schedule.setCrontab(scheduleParam.getCrontab());
             schedule.setTimezoneId(scheduleParam.getTimezoneId());
@@ -645,8 +584,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
 
         log.info("Schedule update complete, projectCode:{}, workflowDefinitionCode:{}, scheduleId:{}.",
                 workflowDefinition.getProjectCode(), workflowDefinition.getCode(), schedule.getId());
-        result.put(Constants.DATA_LIST, schedule);
-        putMsg(result, Status.SUCCESS);
+        return schedule;
     }
 
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/SchedulerControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/SchedulerControllerTest.java
@@ -30,13 +30,14 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.SchedulerService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Priority;
 import org.apache.dolphinscheduler.common.enums.WarningType;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
+
+import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,16 +51,11 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import com.google.common.collect.ImmutableMap;
-
 public class SchedulerControllerTest extends AbstractControllerTest {
 
     private static Schedule scheduleObj = new Schedule();
 
     private static final Logger logger = LoggerFactory.getLogger(SchedulerControllerTest.class);
-
-    final ImmutableMap<String, Object> result =
-            ImmutableMap.of(Constants.STATUS, Status.SUCCESS, Constants.DATA_LIST, scheduleObj);
 
     @MockBean(name = "schedulerService")
     private SchedulerService schedulerService;
@@ -86,7 +82,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         Mockito.when(schedulerService.insertSchedule(isA(User.class), isA(Long.class), isA(Long.class),
                 isA(String.class), isA(WarningType.class), isA(int.class), isA(FailureStrategy.class),
-                isA(Priority.class), isA(String.class), isA(String.class), isA(Long.class))).thenReturn(result);
+                isA(Priority.class), isA(String.class), isA(String.class), isA(Long.class))).thenReturn(scheduleObj);
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/", 123)
                 .header(SESSION_ID, sessionId)
@@ -117,7 +113,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
         Mockito.when(schedulerService.updateSchedule(isA(User.class), isA(Long.class), isA(Integer.class),
                 isA(String.class), isA(WarningType.class), isA(Integer.class), isA(FailureStrategy.class),
-                isA(Priority.class), isA(String.class), isA(String.class), isA(Long.class))).thenReturn(result);
+                isA(Priority.class), isA(String.class), isA(String.class), isA(Long.class))).thenReturn(scheduleObj);
 
         MvcResult mvcResult = mockMvc.perform(put("/projects/{projectCode}/schedules/{id}", 123, 37)
                 .header(SESSION_ID, sessionId)
@@ -197,7 +193,8 @@ public class SchedulerControllerTest extends AbstractControllerTest {
 
     @Test
     public void testQueryScheduleList() throws Exception {
-        Mockito.when(schedulerService.queryScheduleList(isA(User.class), isA(Long.class))).thenReturn(success());
+        Mockito.when(schedulerService.queryScheduleList(isA(User.class), isA(Long.class)))
+                .thenReturn(Collections.emptyList());
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/list", 123)
                 .header(SESSION_ID, sessionId))
@@ -213,7 +210,7 @@ public class SchedulerControllerTest extends AbstractControllerTest {
     @Test
     public void testPreviewSchedule() throws Exception {
         Mockito.when(schedulerService.previewSchedule(isA(User.class), isA(String.class)))
-                .thenReturn(success());
+                .thenReturn(Collections.emptyList());
 
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/schedules/preview", 123)
                 .header(SESSION_ID, sessionId)


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

<!--(Please answer YES or NO. If YES, please specify which parts were generated or assisted by AI)-->

## Purpose of the pull request

Refactor 5 SchedulerService methods from Map<String, Object> to typed return + ServiceException, with cascading updates to the controller, controller test and PythonGateway:

- insertSchedule(...): Schedule
- updateSchedule(...): Schedule
- queryScheduleList(User, long): List<ScheduleVO>
- previewSchedule(User, String): List<String>
- updateScheduleByWorkflowDefinitionCode(...): Schedule

HTTP wire format is preserved: ApiExceptionHandler converts ServiceException to the same Result(code, msg) shape that BaseController.returnDataList(map) produced; success paths use Result.success(data) matching the prior JSON body byte-for-byte. The private updateSchedule helper now throws on validation failure and returns the persisted Schedule on success, replacing the Map-mutation contract.

Py4J boundary is preserved: PythonGateway.createOrUpdateSchedule reads the new scheduleId via Schedule#getId() instead of result.get("scheduleId"), so Python SDK clients see no behavior change.

Part of the migration series tracked by #18224.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
