### PR TITLE
[Improvement-18224][API] Migrate K8sNamespaceService Map<String,Object> returns to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/K8sNamespaceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/K8sNamespaceController.java
@@ -36,7 +36,6 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -107,12 +106,11 @@ public class K8sNamespaceController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_K8S_NAMESPACE_ERROR)
     @OperatorLog(auditType = AuditType.K8S_NAMESPACE_CREATE)
-    public Result createNamespace(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                  @RequestParam(value = "namespace") String namespace,
-                                  @RequestParam(value = "clusterCode") Long clusterCode) {
-        Map<String, Object> result =
-                k8sNamespaceService.registerK8sNamespace(loginUser, namespace, clusterCode);
-        return returnDataList(result);
+    public Result<K8sNamespace> createNamespace(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                @RequestParam(value = "namespace") String namespace,
+                                                @RequestParam(value = "clusterCode") Long clusterCode) {
+        K8sNamespace k8sNamespace = k8sNamespaceService.registerK8sNamespace(loginUser, namespace, clusterCode);
+        return Result.success(k8sNamespace);
     }
 
     /**
@@ -153,10 +151,10 @@ public class K8sNamespaceController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_K8S_NAMESPACE_BY_ID_ERROR)
     @OperatorLog(auditType = AuditType.K8S_NAMESPACE_DELETE)
-    public Result delNamespaceById(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                   @RequestParam(value = "id") int id) {
-        Map<String, Object> result = k8sNamespaceService.deleteNamespaceById(loginUser, id);
-        return returnDataList(result);
+    public Result<Void> delNamespaceById(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                         @RequestParam(value = "id") int id) {
+        k8sNamespaceService.deleteNamespaceById(loginUser, id);
+        return Result.success();
     }
 
     /**
@@ -173,10 +171,10 @@ public class K8sNamespaceController extends BaseController {
     @GetMapping(value = "/unauth-namespace")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_UNAUTHORIZED_NAMESPACE_ERROR)
-    public Result queryUnauthorizedNamespace(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                             @RequestParam("userId") Integer userId) {
-        Map<String, Object> result = k8sNamespaceService.queryUnauthorizedNamespace(loginUser, userId);
-        return returnDataList(result);
+    public Result<List<K8sNamespace>> queryUnauthorizedNamespace(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                 @RequestParam("userId") Integer userId) {
+        List<K8sNamespace> namespaces = k8sNamespaceService.queryUnauthorizedNamespace(loginUser, userId);
+        return Result.success(namespaces);
     }
 
     /**
@@ -193,10 +191,10 @@ public class K8sNamespaceController extends BaseController {
     @GetMapping(value = "/authed-namespace")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_AUTHORIZED_NAMESPACE_ERROR)
-    public Result queryAuthorizedNamespace(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                           @RequestParam("userId") Integer userId) {
-        Map<String, Object> result = k8sNamespaceService.queryAuthorizedNamespace(loginUser, userId);
-        return returnDataList(result);
+    public Result<List<K8sNamespace>> queryAuthorizedNamespace(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                               @RequestParam("userId") Integer userId) {
+        List<K8sNamespace> namespaces = k8sNamespaceService.queryAuthorizedNamespace(loginUser, userId);
+        return Result.success(namespaces);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/K8sNamespaceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/K8sNamespaceService.java
@@ -22,7 +22,6 @@ import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * k8s namespace service impl
@@ -46,9 +45,8 @@ public interface K8sNamespaceService {
      * @param loginUser    login user
      * @param namespace    namespace
      * @param clusterCode  k8s not null
-     * @return
      */
-    Map<String, Object> registerK8sNamespace(User loginUser, String namespace, Long clusterCode);
+    K8sNamespace registerK8sNamespace(User loginUser, String namespace, Long clusterCode);
 
     /**
      * verify namespace and k8s
@@ -64,9 +62,8 @@ public interface K8sNamespaceService {
      *
      * @param loginUser login user
      * @param id        namespace id
-     * @return
      */
-    Map<String, Object> deleteNamespaceById(User loginUser, int id);
+    void deleteNamespaceById(User loginUser, int id);
 
     /**
      * query unauthorized namespace
@@ -75,7 +72,7 @@ public interface K8sNamespaceService {
      * @param userId    user id
      * @return the namespaces which user have not permission to see
      */
-    Map<String, Object> queryUnauthorizedNamespace(User loginUser, Integer userId);
+    List<K8sNamespace> queryUnauthorizedNamespace(User loginUser, Integer userId);
 
     /**
      * query unauthorized namespace
@@ -84,7 +81,7 @@ public interface K8sNamespaceService {
      * @param userId    user id
      * @return namespaces which the user have permission to see
      */
-    Map<String, Object> queryAuthorizedNamespace(User loginUser, Integer userId);
+    List<K8sNamespace> queryAuthorizedNamespace(User loginUser, Integer userId);
 
     /**
      * query namespace can use

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/K8SNamespaceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/K8SNamespaceServiceImpl.java
@@ -35,8 +35,8 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -105,38 +105,32 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
      * @param loginUser    login user
      * @param namespace    namespace
      * @param clusterCode  k8s not null
-     * @return
      */
     @Override
-    public Map<String, Object> registerK8sNamespace(User loginUser, String namespace, Long clusterCode) {
-        Map<String, Object> result = new HashMap<>();
+    public K8sNamespace registerK8sNamespace(User loginUser, String namespace, Long clusterCode) {
         if (isNotAdmin(loginUser)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
         if (StringUtils.isEmpty(namespace)) {
             log.warn("Parameter namespace is empty.");
-            putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.NAMESPACE);
-            return result;
+            throw new ServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.NAMESPACE);
         }
 
         if (clusterCode == null) {
             log.warn("Parameter clusterCode is null.");
-            putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.CLUSTER);
-            return result;
+            throw new ServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.CLUSTER);
         }
 
         if (checkNamespaceExistInDb(namespace, clusterCode)) {
             log.warn("K8S namespace already exists.");
-            putMsg(result, Status.K8S_NAMESPACE_EXIST, namespace, clusterCode);
-            return result;
+            throw new ServiceException(Status.K8S_NAMESPACE_EXIST, namespace, clusterCode);
         }
 
         Cluster cluster = clusterMapper.queryByClusterCode(clusterCode);
         if (cluster == null) {
             log.error("Cluster does not exist, clusterCode:{}", clusterCode);
-            putMsg(result, Status.CLUSTER_NOT_EXISTS, namespace, clusterCode);
-            return result;
+            throw new ServiceException(Status.CLUSTER_NOT_EXISTS, namespace, clusterCode);
         }
 
         long code = CodeGenerateUtils.genCode();
@@ -157,17 +151,13 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
                 k8sClientService.upsertNamespaceAndResourceToK8s(k8sNamespaceObj);
             } catch (Exception e) {
                 log.error("Namespace create to k8s error", e);
-                putMsg(result, Status.K8S_CLIENT_OPS_ERROR, e.getMessage());
-                return result;
+                throw new ServiceException(Status.K8S_CLIENT_OPS_ERROR, e.getMessage());
             }
         }
 
         k8sNamespaceMapper.insert(k8sNamespaceObj);
         log.info("K8s namespace create complete, namespace:{}.", k8sNamespaceObj.getNamespace());
-        result.put(Constants.DATA_LIST, k8sNamespaceObj);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
+        return k8sNamespaceObj;
     }
 
     /**
@@ -207,11 +197,9 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
      *
      * @param loginUser login user
      * @param id        namespace id
-     * @return
      */
     @Override
-    public Map<String, Object> deleteNamespaceById(User loginUser, int id) {
-        Map<String, Object> result = new HashMap<>();
+    public void deleteNamespaceById(User loginUser, int id) {
         if (isNotAdmin(loginUser)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
@@ -219,14 +207,11 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
         K8sNamespace k8sNamespaceObj = k8sNamespaceMapper.selectById(id);
         if (k8sNamespaceObj == null) {
             log.error("K8s namespace does not exist, namespaceId:{}.", id);
-            putMsg(result, Status.K8S_NAMESPACE_NOT_EXIST, id);
-            return result;
+            throw new ServiceException(Status.K8S_NAMESPACE_NOT_EXIST, id);
         }
 
         k8sNamespaceMapper.deleteById(id);
         log.info("K8s namespace delete complete, namespace:{}.", k8sNamespaceObj.getNamespace());
-        putMsg(result, Status.SUCCESS);
-        return result;
     }
 
     /**
@@ -247,23 +232,18 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
      * @return the namespaces which user have not permission to see
      */
     @Override
-    public Map<String, Object> queryUnauthorizedNamespace(User loginUser, Integer userId) {
-        Map<String, Object> result = new HashMap<>();
+    public List<K8sNamespace> queryUnauthorizedNamespace(User loginUser, Integer userId) {
         if (loginUser.getId() != userId && isNotAdmin(loginUser)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
         // query all namespace list, this auth does not like project
         List<K8sNamespace> namespaceList = k8sNamespaceMapper.selectList(null);
-        List<K8sNamespace> resultList = new ArrayList<>();
-        Set<K8sNamespace> namespaceSet;
-        if (namespaceList != null && !namespaceList.isEmpty()) {
-            namespaceSet = new HashSet<>(namespaceList);
-            List<K8sNamespace> authedProjectList = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
-            resultList = getUnauthorizedNamespaces(namespaceSet, authedProjectList);
+        if (namespaceList == null || namespaceList.isEmpty()) {
+            return Collections.emptyList();
         }
-        result.put(Constants.DATA_LIST, resultList);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        Set<K8sNamespace> namespaceSet = new HashSet<>(namespaceList);
+        List<K8sNamespace> authedProjectList = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
+        return getUnauthorizedNamespaces(namespaceSet, authedProjectList);
     }
 
     /**
@@ -274,18 +254,11 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
      * @return namespaces which the user have permission to see
      */
     @Override
-    public Map<String, Object> queryAuthorizedNamespace(User loginUser, Integer userId) {
-        Map<String, Object> result = new HashMap<>();
-
+    public List<K8sNamespace> queryAuthorizedNamespace(User loginUser, Integer userId) {
         if (loginUser.getId() != userId && isNotAdmin(loginUser)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-
-        List<K8sNamespace> namespaces = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
-        result.put(Constants.DATA_LIST, namespaces);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
+        return k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/K8SNamespaceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/K8SNamespaceServiceTest.java
@@ -24,7 +24,6 @@ import org.apache.dolphinscheduler.api.k8s.K8sClientService;
 import org.apache.dolphinscheduler.api.service.impl.K8SNamespaceServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
 import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
@@ -37,7 +36,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -91,19 +89,17 @@ public class K8SNamespaceServiceTest {
     @Test
     public void createK8sNamespace() {
         // namespace is null
-        Map<String, Object> result =
-                k8sNamespaceService.registerK8sNamespace(getLoginUser(), null, clusterCode);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+        assertThrowsServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR,
+                () -> k8sNamespaceService.registerK8sNamespace(getLoginUser(), null, clusterCode));
         // k8s is null
-        result = k8sNamespaceService.registerK8sNamespace(getLoginUser(), namespace, null);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR, result.get(Constants.STATUS));
+        assertThrowsServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR,
+                () -> k8sNamespaceService.registerK8sNamespace(getLoginUser(), namespace, null));
         // correct
         Mockito.when(clusterMapper.queryByClusterCode(Mockito.anyLong())).thenReturn(getCluster());
-        result = k8sNamespaceService.registerK8sNamespace(getLoginUser(), namespace, clusterCode);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        K8sNamespace created = k8sNamespaceService.registerK8sNamespace(getLoginUser(), namespace, clusterCode);
+        Assertions.assertNotNull(created);
+        Assertions.assertEquals(namespace, created.getNamespace());
+        Assertions.assertEquals(clusterCode, created.getClusterCode());
     }
 
     @Test
@@ -137,9 +133,7 @@ public class K8SNamespaceServiceTest {
         Mockito.when(k8sNamespaceMapper.deleteById(Mockito.<Serializable>any())).thenReturn(1);
         Mockito.when(k8sNamespaceMapper.selectById(1)).thenReturn(getNamespace());
 
-        Map<String, Object> result = k8sNamespaceService.deleteNamespaceById(getLoginUser(), 1);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        Assertions.assertDoesNotThrow(() -> k8sNamespaceService.deleteNamespaceById(getLoginUser(), 1));
     }
 
     @Test
@@ -150,9 +144,7 @@ public class K8SNamespaceServiceTest {
 
         // test admin user
         loginUser.setUserType(UserType.ADMIN_USER);
-        Map<String, Object> result = k8sNamespaceService.queryAuthorizedNamespace(loginUser, 2);
-        logger.info(result.toString());
-        List<K8sNamespace> namespaces = (List<K8sNamespace>) result.get(Constants.DATA_LIST);
+        List<K8sNamespace> namespaces = k8sNamespaceService.queryAuthorizedNamespace(loginUser, 2);
         Assertions.assertTrue(CollectionUtils.isNotEmpty(namespaces));
 
         // test non-admin user
@@ -170,9 +162,7 @@ public class K8SNamespaceServiceTest {
         // test admin user
         User loginUser = new User();
         loginUser.setUserType(UserType.ADMIN_USER);
-        Map<String, Object> result = k8sNamespaceService.queryUnauthorizedNamespace(loginUser, 2);
-        logger.info(result.toString());
-        List<K8sNamespace> namespaces = (List<K8sNamespace>) result.get(Constants.DATA_LIST);
+        List<K8sNamespace> namespaces = k8sNamespaceService.queryUnauthorizedNamespace(loginUser, 2);
         Assertions.assertTrue(CollectionUtils.isNotEmpty(namespaces));
 
         // test non-admin user


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

<!--(Please answer YES or NO. If YES, please specify which parts were generated or assisted by AI)-->

## Purpose of the pull request

Refactor 4 K8sNamespaceService methods from Map<String, Object> to typed return / void + ServiceException, with cascading updates to the controller and unit test:

- registerK8sNamespace(User, String, Long): K8sNamespace
- deleteNamespaceById(User, int): void
- queryUnauthorizedNamespace(User, Integer): List<K8sNamespace>
- queryAuthorizedNamespace(User, Integer): List<K8sNamespace>

HTTP wire format is preserved: ApiExceptionHandler converts ServiceException to the same Result(code, msg) shape that BaseController.returnDataList(map) produced; success paths use Result.success(data) matching the prior JSON body byte-for-byte.

No Py4J impact: K8sNamespaceService is not exposed via PythonGateway.

Part of the migration series tracked by #18224.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
