### PR TITLE
[Improvement-18224][API] Migrate small-service Map<String,Object> returns to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ProjectWorkerGroupController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ProjectWorkerGroupController.java
@@ -19,13 +19,16 @@ package org.apache.dolphinscheduler.api.controller;
 
 import static org.apache.dolphinscheduler.api.enums.Status.ASSIGN_WORKER_GROUP_TO_PROJECT_ERROR;
 
+import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.ProjectWorkerGroupRelationService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.dao.entity.ProjectWorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -98,7 +101,13 @@ public class ProjectWorkerGroupController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     public Map<String, Object> queryAssignedWorkerGroups(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
                                                          @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
-        return projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(loginUser, projectCode);
+        List<ProjectWorkerGroup> projectWorkerGroups =
+                projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(loginUser, projectCode);
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.STATUS, Status.SUCCESS);
+        result.put(Constants.MSG, Status.SUCCESS.getMsg());
+        result.put(Constants.DATA_LIST, projectWorkerGroups);
+        return result;
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskGroupController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskGroupController.java
@@ -29,8 +29,10 @@ import org.apache.dolphinscheduler.api.audit.enums.AuditType;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.TaskGroupQueueService;
 import org.apache.dolphinscheduler.api.service.TaskGroupService;
+import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.dao.entity.TaskGroupQueue;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.Map;
@@ -315,14 +317,14 @@ public class TaskGroupController extends BaseController {
     @GetMapping(value = "/query-list-by-group-id")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TASK_GROUP_QUEUE_LIST_ERROR)
-    public Result queryTaskGroupQueues(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestParam(value = "groupId", required = false, defaultValue = "-1") Integer groupId,
-                                       @RequestParam(value = "taskInstanceName", required = false) String taskName,
-                                       @RequestParam(value = "workflowInstanceName", required = false) String workflowInstanceName,
-                                       @RequestParam(value = "status", required = false) Integer status,
-                                       @RequestParam("pageNo") Integer pageNo,
-                                       @RequestParam("pageSize") Integer pageSize) {
-        Map<String, Object> result = taskGroupQueueService.queryTasksByGroupId(
+    public Result<PageInfo<TaskGroupQueue>> queryTaskGroupQueues(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                 @RequestParam(value = "groupId", required = false, defaultValue = "-1") Integer groupId,
+                                                                 @RequestParam(value = "taskInstanceName", required = false) String taskName,
+                                                                 @RequestParam(value = "workflowInstanceName", required = false) String workflowInstanceName,
+                                                                 @RequestParam(value = "status", required = false) Integer status,
+                                                                 @RequestParam("pageNo") Integer pageNo,
+                                                                 @RequestParam("pageSize") Integer pageSize) {
+        PageInfo<TaskGroupQueue> pageInfo = taskGroupQueueService.queryTasksByGroupId(
                 loginUser,
                 taskName,
                 workflowInstanceName,
@@ -330,7 +332,7 @@ public class TaskGroupController extends BaseController {
                 groupId,
                 pageNo,
                 pageSize);
-        return returnDataList(result);
+        return Result.success(pageInfo);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/UiPluginController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/UiPluginController.java
@@ -26,9 +26,10 @@ import org.apache.dolphinscheduler.api.service.UiPluginService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.PluginType;
+import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.entity.User;
 
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -67,11 +68,10 @@ public class UiPluginController extends BaseController {
     @GetMapping(value = "/query-by-type")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(QUERY_PLUGINS_ERROR)
-    public Result queryUiPluginsByType(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestParam(value = "pluginType") PluginType pluginType) {
-
-        Map<String, Object> result = uiPluginService.queryUiPluginsByType(pluginType);
-        return returnDataList(result);
+    public Result<List<PluginDefine>> queryUiPluginsByType(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                           @RequestParam(value = "pluginType") PluginType pluginType) {
+        List<PluginDefine> pluginDefines = uiPluginService.queryUiPluginsByType(pluginType);
+        return Result.success(pluginDefines);
     }
 
     @Operation(summary = "queryUiPluginDetailById", description = "QUERY_UI_PLUGIN_DETAIL_BY_ID")
@@ -81,11 +81,10 @@ public class UiPluginController extends BaseController {
     @GetMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(QUERY_PLUGINS_ERROR)
-    public Result queryUiPluginDetailById(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                          @PathVariable("id") Integer pluginId) {
-
-        Map<String, Object> result = uiPluginService.queryUiPluginDetailById(pluginId);
-        return returnDataList(result);
+    public Result<PluginDefine> queryUiPluginDetailById(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                        @PathVariable("id") Integer pluginId) {
+        PluginDefine pluginDefine = uiPluginService.queryUiPluginDetailById(pluginId);
+        return Result.success(pluginDefine);
     }
 
     @Operation(summary = "queryProductInfo", description = "QUERY_PRODUCT_INFO")

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -443,7 +443,7 @@ public class PythonGateway {
     }
 
     public Tenant queryTenantByCode(String tenantCode) {
-        return (Tenant) tenantService.queryByTenantCode(tenantCode).get(Constants.DATA_LIST);
+        return tenantService.queryByTenantCode(tenantCode);
     }
 
     public void updateTenant(String userName, int id, String tenantCode, int queueId, String desc) throws Exception {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/EnvironmentWorkerGroupRelationService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/EnvironmentWorkerGroupRelationService.java
@@ -17,7 +17,9 @@
 
 package org.apache.dolphinscheduler.api.service;
 
-import java.util.Map;
+import org.apache.dolphinscheduler.dao.entity.EnvironmentWorkerGroupRelation;
+
+import java.util.List;
 
 public interface EnvironmentWorkerGroupRelationService {
 
@@ -26,12 +28,12 @@ public interface EnvironmentWorkerGroupRelationService {
      *
      * @param environmentCode environment code
      */
-    Map<String, Object> queryEnvironmentWorkerGroupRelation(Long environmentCode);
+    List<EnvironmentWorkerGroupRelation> queryEnvironmentWorkerGroupRelation(Long environmentCode);
 
     /**
      * query all environment worker group relation
      *
      * @return all relation list
      */
-    Map<String, Object> queryAllEnvironmentWorkerGroupRelationList();
+    List<EnvironmentWorkerGroupRelation> queryAllEnvironmentWorkerGroupRelationList();
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationService.java
@@ -18,10 +18,10 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.dao.entity.ProjectWorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.List;
-import java.util.Map;
 
 public interface ProjectWorkerGroupRelationService {
 
@@ -39,7 +39,8 @@ public interface ProjectWorkerGroupRelationService {
      *
      * @param loginUser the login user
      * @param projectCode project code
+     * @return assigned worker group relations
      */
-    Map<String, Object> queryAssignedWorkerGroupsByProject(User loginUser, Long projectCode);
+    List<ProjectWorkerGroup> queryAssignedWorkerGroupsByProject(User loginUser, Long projectCode);
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupQueueService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupQueueService.java
@@ -17,10 +17,11 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.dao.entity.TaskGroupQueue;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.List;
-import java.util.Map;
 
 public interface TaskGroupQueueService {
 
@@ -33,12 +34,11 @@ public interface TaskGroupQueueService {
      * @param status      Task queue status
      * @param pageNo      page no
      * @param pageSize    page size
-    
-     * @return tasks list
+     * @return tasks list page
      */
-    Map<String, Object> queryTasksByGroupId(User loginUser, String taskName, String workflowInstanceName,
-                                            Integer status,
-                                            int groupId, int pageNo, int pageSize);
+    PageInfo<TaskGroupQueue> queryTasksByGroupId(User loginUser, String taskName, String workflowInstanceName,
+                                                 Integer status,
+                                                 int groupId, int pageNo, int pageSize);
 
     void deleteByWorkflowInstanceId(Integer workflowInstanceId);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TenantService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TenantService.java
@@ -22,7 +22,6 @@ import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.List;
-import java.util.Map;
 
 public interface TenantService {
 
@@ -98,9 +97,9 @@ public interface TenantService {
      * query tenant by tenant code
      *
      * @param tenantCode tenant code
-     * @return tenant list
+     * @return tenant if exists, otherwise {@code null}
      */
-    Map<String, Object> queryByTenantCode(String tenantCode);
+    Tenant queryByTenantCode(String tenantCode);
 
     /**
      * Make sure tenant with given name exists, and create the tenant if not exists

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UiPluginService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UiPluginService.java
@@ -19,14 +19,15 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.dto.ProductInfoDto;
 import org.apache.dolphinscheduler.common.enums.PluginType;
+import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 
-import java.util.Map;
+import java.util.List;
 
 public interface UiPluginService {
 
-    Map<String, Object> queryUiPluginsByType(PluginType pluginType);
+    List<PluginDefine> queryUiPluginsByType(PluginType pluginType);
 
-    Map<String, Object> queryUiPluginDetailById(int id);
+    PluginDefine queryUiPluginDetailById(int id);
 
     ProductInfoDto queryProductInfo();
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/EnvironmentWorkerGroupRelationServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/EnvironmentWorkerGroupRelationServiceImpl.java
@@ -17,15 +17,11 @@
 
 package org.apache.dolphinscheduler.api.service.impl;
 
-import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.EnvironmentWorkerGroupRelationService;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.dao.entity.EnvironmentWorkerGroupRelation;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
- * task definition service impl
+ * environment worker group relation service impl
  */
 @Service
 @Slf4j
@@ -50,13 +46,8 @@ public class EnvironmentWorkerGroupRelationServiceImpl extends BaseServiceImpl
      * @param environmentCode environment code
      */
     @Override
-    public Map<String, Object> queryEnvironmentWorkerGroupRelation(Long environmentCode) {
-        Map<String, Object> result = new HashMap<>();
-        List<EnvironmentWorkerGroupRelation> relations =
-                environmentWorkerGroupRelationMapper.queryByEnvironmentCode(environmentCode);
-        result.put(Constants.DATA_LIST, relations);
-        putMsg(result, Status.SUCCESS);
-        return result;
+    public List<EnvironmentWorkerGroupRelation> queryEnvironmentWorkerGroupRelation(Long environmentCode) {
+        return environmentWorkerGroupRelationMapper.queryByEnvironmentCode(environmentCode);
     }
 
     /**
@@ -65,13 +56,7 @@ public class EnvironmentWorkerGroupRelationServiceImpl extends BaseServiceImpl
      * @return all relation list
      */
     @Override
-    public Map<String, Object> queryAllEnvironmentWorkerGroupRelationList() {
-        Map<String, Object> result = new HashMap<>();
-
-        List<EnvironmentWorkerGroupRelation> relations = environmentWorkerGroupRelationMapper.selectList(null);
-
-        result.put(Constants.DATA_LIST, relations);
-        putMsg(result, Status.SUCCESS);
-        return result;
+    public List<EnvironmentWorkerGroupRelation> queryAllEnvironmentWorkerGroupRelationList() {
+        return environmentWorkerGroupRelationMapper.selectList(null);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
@@ -193,14 +193,16 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
     }
 
     @Override
-    public Map<String, Object> queryAssignedWorkerGroupsByProject(User loginUser, Long projectCode) {
-        Map<String, Object> result = new HashMap<>();
-
+    public List<ProjectWorkerGroup> queryAssignedWorkerGroupsByProject(User loginUser, Long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check project auth
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, null);
-        if (!hasProjectAndPerm) {
-            return result;
+        Map<String, Object> permResult = new HashMap<>();
+        if (!projectService.hasProjectAndPerm(loginUser, project, permResult, null)) {
+            Status status = (Status) permResult.get(Constants.STATUS);
+            if (status == null) {
+                throw new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM);
+            }
+            throw new ServiceException(status.getCode(), (String) permResult.get(Constants.MSG));
         }
 
         Set<String> assignedWorkerGroups = getAllUsedWorkerGroups(project);
@@ -208,16 +210,12 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
         projectWorkerGroupDao.queryByProjectCode(projectCode)
                 .forEach(projectWorkerGroup -> assignedWorkerGroups.add(projectWorkerGroup.getWorkerGroup()));
 
-        List<ProjectWorkerGroup> projectWorkerGroups = assignedWorkerGroups.stream().map(workerGroup -> {
+        return assignedWorkerGroups.stream().map(workerGroup -> {
             ProjectWorkerGroup projectWorkerGroup = new ProjectWorkerGroup();
             projectWorkerGroup.setProjectCode(projectCode);
             projectWorkerGroup.setWorkerGroup(workerGroup);
             return projectWorkerGroup;
         }).distinct().collect(Collectors.toList());
-
-        result.put(Constants.DATA_LIST, projectWorkerGroups);
-        putMsg(result, Status.SUCCESS);
-        return result;
     }
 
     private Set<String> getAllUsedWorkerGroups(Project project) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupQueueServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupQueueServiceImpl.java
@@ -17,10 +17,8 @@
 
 package org.apache.dolphinscheduler.api.service.impl;
 
-import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.TaskGroupQueueService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskGroupQueue;
@@ -30,9 +28,7 @@ import org.apache.dolphinscheduler.dao.mapper.TaskGroupQueueMapper;
 
 import org.apache.commons.collections4.CollectionUtils;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
@@ -63,24 +59,21 @@ public class TaskGroupQueueServiceImpl extends BaseServiceImpl implements TaskGr
      * @return tasks list
      */
     @Override
-    public Map<String, Object> queryTasksByGroupId(User loginUser,
-                                                   String taskName,
-                                                   String workflowInstanceName,
-                                                   Integer status,
-                                                   int groupId,
-                                                   int pageNo,
-                                                   int pageSize) {
-        Map<String, Object> result = new HashMap<>();
-        Page<TaskGroupQueue> page = new Page<>(pageNo, pageSize);
+    public PageInfo<TaskGroupQueue> queryTasksByGroupId(User loginUser,
+                                                        String taskName,
+                                                        String workflowInstanceName,
+                                                        Integer status,
+                                                        int groupId,
+                                                        int pageNo,
+                                                        int pageSize) {
         PageInfo<TaskGroupQueue> pageInfo = new PageInfo<>(pageNo, pageSize);
         Set<Integer> projectIds = resourcePermissionCheckService
                 .userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS, loginUser.getId(), log);
         if (projectIds.isEmpty()) {
-            result.put(Constants.DATA_LIST, pageInfo);
-            putMsg(result, Status.SUCCESS);
-            return result;
+            return pageInfo;
         }
         List<Project> projects = projectMapper.selectBatchIds(projectIds);
+        Page<TaskGroupQueue> page = new Page<>(pageNo, pageSize);
         IPage<TaskGroupQueue> taskGroupQueue = taskGroupQueueMapper.queryTaskGroupQueueByTaskGroupIdPaging(
                 page,
                 taskName,
@@ -91,10 +84,7 @@ public class TaskGroupQueueServiceImpl extends BaseServiceImpl implements TaskGr
 
         pageInfo.setTotal((int) taskGroupQueue.getTotal());
         pageInfo.setTotalList(taskGroupQueue.getRecords());
-
-        result.put(Constants.DATA_LIST, pageInfo);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return pageInfo;
     }
 
     @Override

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -46,9 +46,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -302,17 +300,11 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
      * query tenant by tenant code
      *
      * @param tenantCode tenant code
-     * @return tenant detail information
+     * @return tenant if exists, otherwise {@code null}
      */
     @Override
-    public Map<String, Object> queryByTenantCode(String tenantCode) {
-        Map<String, Object> result = new HashMap<>();
-        Tenant tenant = tenantMapper.queryByTenantCode(tenantCode);
-        if (tenant != null) {
-            result.put(Constants.DATA_LIST, tenant);
-            putMsg(result, Status.SUCCESS);
-        }
-        return result;
+    public Tenant queryByTenantCode(String tenantCode) {
+        return tenantMapper.queryByTenantCode(tenantCode);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UiPluginServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UiPluginServiceImpl.java
@@ -19,8 +19,8 @@ package org.apache.dolphinscheduler.api.service.impl;
 
 import org.apache.dolphinscheduler.api.dto.ProductInfoDto;
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.UiPluginService;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.PluginType;
 import org.apache.dolphinscheduler.dao.entity.DsVersion;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
@@ -29,9 +29,7 @@ import org.apache.dolphinscheduler.dao.repository.DsVersionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.PostConstruct;
 
@@ -58,40 +56,28 @@ public class UiPluginServiceImpl extends BaseServiceImpl implements UiPluginServ
     }
 
     @Override
-    public Map<String, Object> queryUiPluginsByType(PluginType pluginType) {
-        Map<String, Object> result = new HashMap<>();
+    public List<PluginDefine> queryUiPluginsByType(PluginType pluginType) {
         if (!pluginType.getHasUi()) {
             log.warn("Plugin does not have UI.");
-            putMsg(result, Status.PLUGIN_NOT_A_UI_COMPONENT);
-            return result;
+            throw new ServiceException(Status.PLUGIN_NOT_A_UI_COMPONENT);
         }
         List<PluginDefine> pluginDefines = pluginDefineMapper.queryByPluginType(pluginType.getDesc());
 
         if (CollectionUtils.isEmpty(pluginDefines)) {
             log.warn("Query plugins result is null, check status of plugins.");
-            putMsg(result, Status.QUERY_PLUGINS_RESULT_IS_NULL);
-            return result;
+            throw new ServiceException(Status.QUERY_PLUGINS_RESULT_IS_NULL);
         }
-        // pluginDefines=buildPluginParams(pluginDefines);
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, pluginDefines);
-        return result;
+        return pluginDefines;
     }
 
     @Override
-    public Map<String, Object> queryUiPluginDetailById(int id) {
-        Map<String, Object> result = new HashMap<>();
+    public PluginDefine queryUiPluginDetailById(int id) {
         PluginDefine pluginDefine = pluginDefineMapper.queryDetailById(id);
         if (null == pluginDefine) {
             log.warn("Query plugins result is empty, pluginId:{}.", id);
-            putMsg(result, Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL);
-            return result;
+            throw new ServiceException(Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL);
         }
-        // String params=pluginDefine.getPluginParams();
-        // pluginDefine.setPluginParams(parseParams(params));
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, pluginDefine);
-        return result;
+        return pluginDefine;
     }
 
     @Override

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UiPluginControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UiPluginControllerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.api.controller;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
@@ -29,9 +28,11 @@ import org.apache.dolphinscheduler.api.dto.ProductInfoDto;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.UiPluginService;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.PluginType;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.dao.entity.PluginDefine;
+
+import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -42,16 +43,10 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import com.google.common.collect.ImmutableMap;
-
 public class UiPluginControllerTest extends AbstractControllerTest {
 
     private static final PluginType pluginType = PluginType.ALERT;
     private static final int pluginId = 1;
-    private static final Result expectResponseContent = JSONUtils.parseObject(
-            "{\"code\":0,\"msg\":\"success\",\"data\":\"Test Data\",\"success\":true,\"failed\":false}", Result.class);
-    private static final ImmutableMap<String, Object> uiPluginServiceResult =
-            ImmutableMap.of(Constants.STATUS, Status.SUCCESS, Constants.DATA_LIST, "Test Data");
 
     @MockBean(name = "uiPluginService")
     private UiPluginService uiPluginService;
@@ -59,7 +54,7 @@ public class UiPluginControllerTest extends AbstractControllerTest {
     @Test
     public void testQueryUiPluginsByType() throws Exception {
         when(uiPluginService.queryUiPluginsByType(any(PluginType.class)))
-                .thenReturn(uiPluginServiceResult);
+                .thenReturn(Collections.singletonList(new PluginDefine("test", "alert", "[]")));
 
         final MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
         paramsMap.add("pluginType", String.valueOf(pluginType));
@@ -71,15 +66,14 @@ public class UiPluginControllerTest extends AbstractControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
 
-        final Result actualResponseContent =
-                JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
-        assertThat(actualResponseContent.toString()).isEqualTo(expectResponseContent.toString());
+        Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
+        Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
     }
 
     @Test
     public void testQueryUiPluginDetailById() throws Exception {
         when(uiPluginService.queryUiPluginDetailById(anyInt()))
-                .thenReturn(uiPluginServiceResult);
+                .thenReturn(new PluginDefine("test", "alert", "[]"));
 
         final MvcResult mvcResult = mockMvc.perform(get("/ui-plugins/{id}", pluginId)
                 .header(SESSION_ID, sessionId))
@@ -87,9 +81,8 @@ public class UiPluginControllerTest extends AbstractControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
 
-        final Result actualResponseContent =
-                JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
-        assertThat(actualResponseContent.toString()).isEqualTo(expectResponseContent.toString());
+        Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
+        Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/EnvironmentWorkerGroupRelationServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/EnvironmentWorkerGroupRelationServiceTest.java
@@ -17,13 +17,11 @@
 
 package org.apache.dolphinscheduler.api.service;
 
-import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.EnvironmentWorkerGroupRelationServiceImpl;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.dao.entity.EnvironmentWorkerGroupRelation;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
 
-import java.util.Map;
+import java.util.List;
 
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
@@ -54,18 +52,18 @@ public class EnvironmentWorkerGroupRelationServiceTest {
     public void testQueryEnvironmentWorkerGroupRelation() {
         Mockito.when(relationMapper.queryByEnvironmentCode(1L))
                 .thenReturn(Lists.newArrayList(new EnvironmentWorkerGroupRelation()));
-        Map<String, Object> result = relationService.queryEnvironmentWorkerGroupRelation(1L);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        List<EnvironmentWorkerGroupRelation> relations = relationService.queryEnvironmentWorkerGroupRelation(1L);
+        logger.info(relations.toString());
+        Assertions.assertEquals(1, relations.size());
     }
 
     @Test
     public void testQueryAllEnvironmentWorkerGroupRelationList() {
         Mockito.when(relationMapper.selectList(Mockito.any()))
                 .thenReturn(Lists.newArrayList(new EnvironmentWorkerGroupRelation()));
-        Map<String, Object> result = relationService.queryAllEnvironmentWorkerGroupRelationList();
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+        List<EnvironmentWorkerGroupRelation> relations = relationService.queryAllEnvironmentWorkerGroupRelationList();
+        logger.info(relations.toString());
+        Assertions.assertEquals(1, relations.size());
     }
 
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
@@ -38,7 +38,6 @@ import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -185,14 +184,17 @@ public class ProjectWorkerGroupRelationServiceTest {
 
     @Test
     public void testQueryAssignedWorkerGroupsByProject() {
-        // no permission
+        // no permission - hasProjectAndPerm should populate the status into the result map and return false
         Mockito.when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.anyMap(), Mockito.any()))
-                .thenReturn(false);
-
-        Map<String, Object> result =
-                projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(getGeneralUser(), projectCode);
-
-        Assertions.assertTrue(result.isEmpty());
+                .thenAnswer(invocation -> {
+                    Map<String, Object> permResult = invocation.getArgument(2);
+                    permResult.put(Constants.STATUS, Status.USER_NO_OPERATION_PROJECT_PERM);
+                    permResult.put(Constants.MSG, Status.USER_NO_OPERATION_PROJECT_PERM.getMsg());
+                    return false;
+                });
+        AssertionsHelper.assertThrowsServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
+                () -> projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(getGeneralUser(),
+                        projectCode));
 
         // success
         Mockito.when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.anyMap(), Mockito.any()))
@@ -210,12 +212,12 @@ public class ProjectWorkerGroupRelationServiceTest {
         Mockito.when(scheduleMapper.querySchedulerListByProjectName(Mockito.any()))
                 .thenReturn(Lists.newArrayList());
 
-        result = projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(getGeneralUser(), projectCode);
+        List<ProjectWorkerGroup> projectWorkerGroups =
+                projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(getGeneralUser(), projectCode);
 
-        ProjectWorkerGroup[] actualValue =
-                ((List<ProjectWorkerGroup>) result.get(Constants.DATA_LIST)).toArray(new ProjectWorkerGroup[0]);
-        System.out.println(Arrays.toString(actualValue));
-        Assertions.assertEquals(actualValue[0].getWorkerGroup(), getProjectWorkerGroup().getWorkerGroup());
+        Assertions.assertEquals(1, projectWorkerGroups.size());
+        Assertions.assertEquals(getProjectWorkerGroup().getWorkerGroup(),
+                projectWorkerGroups.get(0).getWorkerGroup());
     }
 
     private List<String> getWorkerGroups() {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UiPluginServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UiPluginServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import static org.apache.dolphinscheduler.api.AssertionsHelper.assertThrowsServiceException;
+
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.UiPluginServiceImpl;
 import org.apache.dolphinscheduler.common.enums.PluginType;
@@ -25,6 +27,7 @@ import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.mapper.PluginDefineMapper;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -58,33 +61,32 @@ public class UiPluginServiceTest {
 
     @Test
     public void testQueryPlugins1() {
-        Map<String, Object> result = uiPluginService.queryUiPluginsByType(PluginType.REGISTER);
-        Assertions.assertEquals(Status.PLUGIN_NOT_A_UI_COMPONENT, result.get("status"));
+        assertThrowsServiceException(Status.PLUGIN_NOT_A_UI_COMPONENT,
+                () -> uiPluginService.queryUiPluginsByType(PluginType.REGISTER));
     }
 
     @Test
     public void testQueryPlugins2() {
-        Map<String, Object> result = uiPluginService.queryUiPluginsByType(PluginType.ALERT);
         Mockito.when(pluginDefineMapper.queryByPluginType(PluginType.ALERT.getDesc())).thenReturn(null);
-        Assertions.assertEquals(Status.QUERY_PLUGINS_RESULT_IS_NULL, result.get("status"));
+        assertThrowsServiceException(Status.QUERY_PLUGINS_RESULT_IS_NULL,
+                () -> uiPluginService.queryUiPluginsByType(PluginType.ALERT));
 
         Mockito.when(pluginDefineMapper.queryByPluginType(PluginType.ALERT.getDesc()))
                 .thenReturn(Collections.singletonList(pluginDefine));
-        result = uiPluginService.queryUiPluginsByType(PluginType.ALERT);
-        Assertions.assertEquals(Status.SUCCESS, result.get("status"));
+        List<PluginDefine> pluginDefines = uiPluginService.queryUiPluginsByType(PluginType.ALERT);
+        Assertions.assertEquals(1, pluginDefines.size());
     }
 
     @Test
     public void testQueryPluginDetailById() {
         Mockito.when(pluginDefineMapper.queryDetailById(1)).thenReturn(null);
-        Map<String, Object> result = uiPluginService.queryUiPluginDetailById(1);
-        Assertions.assertEquals(Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL, result.get("status"));
+        assertThrowsServiceException(Status.QUERY_PLUGIN_DETAIL_RESULT_IS_NULL,
+                () -> uiPluginService.queryUiPluginDetailById(1));
 
         Mockito.when(pluginDefineMapper.queryDetailById(1)).thenReturn(pluginDefine);
-        result = uiPluginService.queryUiPluginDetailById(1);
-        Assertions.assertEquals(Status.SUCCESS, result.get("status"));
+        PluginDefine data = uiPluginService.queryUiPluginDetailById(1);
+        Assertions.assertNotNull(data);
 
-        PluginDefine data = (PluginDefine) result.get("data");
         String pluginParams = data.getPluginParams();
         ArrayNode arrayNode = JSONUtils.parseArray(pluginParams);
         String placeholder = arrayNode.path(0).path("props").path("placeholder").asText();


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

Batch-migrate seven Map<String, Object> methods across five small services to typed return / void + ServiceException, with cascading updates to the controllers, PythonGateway and unit tests:

TenantService
- queryByTenantCode(String): Tenant (nullable; only consumed by PythonGateway)

TaskGroupQueueService
- queryTasksByGroupId(...): PageInfo<TaskGroupQueue>

ProjectWorkerGroupRelationService
- queryAssignedWorkerGroupsByProject(User, Long): List<ProjectWorkerGroup>

UiPluginService
- queryUiPluginsByType(PluginType): List<PluginDefine>
- queryUiPluginDetailById(int): PluginDefine

EnvironmentWorkerGroupRelationService
- queryEnvironmentWorkerGroupRelation(Long): List<EnvironmentWorkerGroupRelation>
- queryAllEnvironmentWorkerGroupRelationList(): List<EnvironmentWorkerGroupRelation>

HTTP wire format is preserved:
* Standard endpoints (TaskGroup, UiPlugin) now wrap the typed return in Result.success(data); ApiExceptionHandler converts ServiceException to the same Result(code, msg) shape that BaseController.returnDataList(map) produced.
* The non-standard ProjectWorkerGroupController.queryAssignedWorkerGroups endpoint still returns a raw Map<String, Object>; the controller now builds the {STATUS, MSG, DATA_LIST} map from the typed service return so the JSON body remains byte-for-byte identical on success. Permission failures translate the legacy hasProjectAndPerm(Map) status into a ServiceException, so the error path now goes through ApiExceptionHandler (Result shape) instead of the raw Map.

Py4J boundary is preserved: PythonGateway.queryTenantByCode now returns the Tenant directly from the service (still null on miss, matching the previous behavior where DATA_LIST was unset).

ExecutorService.forceStartTaskInstance is intentionally deferred — its only caller is TaskGroupServiceImpl.forceStartTask, which itself returns Map<String, Object> and is part of the larger TaskGroupService migration. Migrating it now would require a temporary Map-rebuild in TaskGroupServiceImpl that the next PR would immediately undo.

Part of the migration series tracked by #18224.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
