### PR TITLE
[Fix-18074][Task-Plugin] Fix SQL task parameter passing and unsafe regex replacement

### DIFF
--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImpl.java
@@ -199,7 +199,8 @@ public class CuringParamsServiceImpl implements CuringParamsService {
             safePutAll(prepareParamsMap, commandParamsMap);
         }
 
-        // 6. VarPool: override values only for existing IN-direction parameters
+        // 6. VarPool: override values for existing IN-direction parameters,
+        // and inject new parameters that only exist in VarPool for placeholder resolution
         List<Property> varPools = parseVarPool(taskInstance);
         if (CollectionUtils.isNotEmpty(varPools)) {
             for (Property varPool : varPools) {
@@ -208,7 +209,11 @@ public class CuringParamsServiceImpl implements CuringParamsService {
                 }
                 Property targetParam = prepareParamsMap.get(varPool.getProp());
                 if (targetParam != null && Direct.IN.equals(targetParam.getDirect())) {
+                    // Existing IN parameter: override its value
                     targetParam.setValue(varPool.getValue());
+                } else if (targetParam == null) {
+                    // Parameter not in map: inject it for placeholder resolution
+                    prepareParamsMap.put(varPool.getProp(), varPool);
                 }
             }
         }

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImpl.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImpl.java
@@ -212,8 +212,13 @@ public class CuringParamsServiceImpl implements CuringParamsService {
                     // Existing IN parameter: override its value
                     targetParam.setValue(varPool.getValue());
                 } else if (targetParam == null) {
-                    // Parameter not in map: inject it for placeholder resolution
-                    prepareParamsMap.put(varPool.getProp(), varPool);
+                    // Parameter not in map: announce as IN parameter from varPool for placeholder resolution
+                    Property newParam = new Property();
+                    newParam.setProp(varPool.getProp());
+                    newParam.setValue(varPool.getValue());
+                    newParam.setType(varPool.getType());
+                    newParam.setDirect(Direct.IN);
+                    prepareParamsMap.put(varPool.getProp(), newParam);
                 }
             }
         }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImplTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImplTest.java
@@ -538,4 +538,81 @@ public class CuringParamsServiceImplTest {
         // Ensure no unintended side effects
         Assertions.assertEquals(4, paramsMap.size());
     }
+
+    @Test
+    public void testParamParsingPreparation_varPoolInjectionWhenParamNameNotInLocalParams() {
+        // Test scenario: upstream task outputs p1=111, downstream task has p2=${p1} but no local p1
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setTaskCode(1000001L);
+        taskInstance.setTaskDefinitionVersion(1);
+        taskInstance.setExecutePath("home/path/execute");
+
+        // VarPool from upstream: p1=111 (OUT direction)
+        taskInstance.setVarPool("[{\"prop\":\"p1\",\"direct\":\"OUT\",\"type\":\"VARCHAR\",\"value\":\"111\"}]");
+
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setName("TaskName-1");
+        taskDefinition.setCode(1000001L);
+        taskDefinition.setVersion(1);
+
+        WorkflowInstance workflowInstance = new WorkflowInstance();
+        workflowInstance.setId(2);
+        final BackfillWorkflowCommandParam backfillWorkflowCommandParam = BackfillWorkflowCommandParam.builder()
+                .timeZone("Asia/Shanghai")
+                .build();
+        workflowInstance.setCommandParam(JSONUtils.toJsonString(backfillWorkflowCommandParam));
+        workflowInstance.setHistoryCmd(CommandType.COMPLEMENT_DATA.toString());
+        workflowInstance.setGlobalParams("[]");
+        workflowInstance.setScheduleTime(DateUtils.stringToDate("2024-01-01 00:00:00"));
+
+        WorkflowDefinition workflowDefinition = new WorkflowDefinition();
+        workflowDefinition.setName("ProcessName-1");
+        workflowDefinition.setProjectName("ProjectName");
+        workflowDefinition.setProjectCode(3000001L);
+        workflowDefinition.setCode(200001L);
+
+        Project project = new Project();
+        project.setName("ProjectName");
+        project.setCode(3000001L);
+
+        workflowInstance.setWorkflowDefinitionCode(workflowDefinition.getCode());
+        workflowInstance.setProjectCode(workflowDefinition.getProjectCode());
+        taskInstance.setTaskCode(taskDefinition.getCode());
+        taskInstance.setTaskDefinitionVersion(taskDefinition.getVersion());
+        taskInstance.setProjectCode(workflowDefinition.getProjectCode());
+        taskInstance.setWorkflowInstanceId(workflowInstance.getId());
+
+        // Local params: p2=${p1} (references p1 which only exists in varPool, not in local params)
+        org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters sqlParameters =
+                new org.apache.dolphinscheduler.plugin.task.api.parameters.SqlParameters();
+        sqlParameters.setType("MYSQL");
+        sqlParameters.setSql("select 1");
+
+        Property p2 = new Property();
+        p2.setProp("p2");
+        p2.setDirect(Direct.IN);
+        p2.setType(DataType.VARCHAR);
+        p2.setValue("${p1}");
+        sqlParameters.setLocalParams(Collections.singletonList(p2));
+
+        taskInstance.setTaskParams(JSONUtils.toJsonString(sqlParameters));
+
+        Mockito.when(projectParameterMapper.queryByProjectCode(Mockito.anyLong())).thenReturn(Collections.emptyList());
+
+        Map<String, Property> propertyMap =
+                curingParamsServiceImpl.paramParsingPreparation(taskInstance, sqlParameters, workflowInstance,
+                        project.getName(), workflowDefinition.getName());
+
+        Assertions.assertNotNull(propertyMap);
+
+        // Assert: p1 should be injected from varPool
+        Assertions.assertTrue(propertyMap.containsKey("p1"), "p1 should be injected from varPool");
+        Assertions.assertEquals("111", propertyMap.get("p1").getValue());
+
+        // Assert: p2 should exist and its value should be resolved from ${p1} to 111
+        Assertions.assertTrue(propertyMap.containsKey("p2"));
+        Assertions.assertEquals("111", propertyMap.get("p2").getValue(),
+                "p2's value ${p1} should be resolved to 111 using injected varPool param");
+    }
 }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImplTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/expand/CuringParamsServiceImplTest.java
@@ -606,9 +606,11 @@ public class CuringParamsServiceImplTest {
 
         Assertions.assertNotNull(propertyMap);
 
-        // Assert: p1 should be injected from varPool
+        // Assert: p1 should be injected from varPool and announced as IN direction
         Assertions.assertTrue(propertyMap.containsKey("p1"), "p1 should be injected from varPool");
         Assertions.assertEquals("111", propertyMap.get("p1").getValue());
+        Assertions.assertEquals(Direct.IN, propertyMap.get("p1").getDirect(),
+                "injected varPool param should be announced as IN direction");
 
         // Assert: p2 should exist and its value should be resolved from ${p1} to 111
         Assertions.assertTrue(propertyMap.containsKey("p2"));

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/main/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTask.java
@@ -492,8 +492,12 @@ public class SqlTask extends AbstractTask {
                 break;
             }
             String paramName = m.group(1);
-            String paramValue = sqlParamsMap.get(paramName).getValue();
-            content = m.replaceFirst(paramValue);
+            Property prop = sqlParamsMap.get(paramName);
+            if (prop == null || prop.getValue() == null) {
+                log.warn("Cannot find parameter: {} for !{{}} replacement, skipping", paramName, paramName);
+                break;
+            }
+            content = m.replaceFirst(Matcher.quoteReplacement(prop.getValue()));
         }
         return content;
     }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-sql/src/test/java/org/apache/dolphinscheduler/plugin/task/sql/SqlTaskTest.java
@@ -489,4 +489,69 @@ class SqlTaskTest {
         return resourceParametersHelper;
     }
 
+    @Test
+    void testReplaceOriginalValue_withSpecialCharacters() throws Exception {
+        Map<String, Property> paramsMap = new HashMap<>();
+
+        Property p1 = new Property();
+        p1.setProp("price");
+        p1.setValue("$100");
+        paramsMap.put("price", p1);
+
+        Property p2 = new Property();
+        p2.setProp("path");
+        p2.setValue("C:\\Users\\test");
+        paramsMap.put("path", p2);
+
+        Property p3 = new Property();
+        p3.setProp("empty");
+        p3.setValue("");
+        paramsMap.put("empty", p3);
+
+        Method method = SqlTask.class.getDeclaredMethod("replaceOriginalValue", String.class, String.class, Map.class);
+        method.setAccessible(true);
+
+        // The regex pattern matches optional quotes around !{...}, so they are replaced too
+        String sql1 = "select * from items where price = '!{price}'";
+        String result1 = (String) method.invoke(sqlTask, sql1, "['\"]*\\!\\{(.*?)\\}['\"]*", paramsMap);
+        Assertions.assertEquals("select * from items where price = $100", result1);
+
+        String sql2 = "load data local inpath \"!{path}\" into table t";
+        String result2 = (String) method.invoke(sqlTask, sql2, "['\"]*\\!\\{(.*?)\\}['\"]*", paramsMap);
+        Assertions.assertEquals("load data local inpath C:\\Users\\test into table t", result2);
+
+        String sql3 = "select !{empty} as val";
+        String result3 = (String) method.invoke(sqlTask, sql3, "['\"]*\\!\\{(.*?)\\}['\"]*", paramsMap);
+        Assertions.assertEquals("select  as val", result3);
+    }
+
+    @Test
+    void testReplaceOriginalValue_paramNotFound_keepsOriginalText() throws Exception {
+        Map<String, Property> paramsMap = new HashMap<>();
+
+        Method method = SqlTask.class.getDeclaredMethod("replaceOriginalValue", String.class, String.class, Map.class);
+        method.setAccessible(true);
+
+        String sql = "select * from t where name = '!{unknownParam}'";
+        String result = (String) method.invoke(sqlTask, sql, "['\"]*\\!\\{(.*?)\\}['\"]*", paramsMap);
+        Assertions.assertEquals(sql, result);
+    }
+
+    @Test
+    void testReplaceOriginalValue_paramValueNull_keepsOriginalText() throws Exception {
+        Map<String, Property> paramsMap = new HashMap<>();
+
+        Property p = new Property();
+        p.setProp("name");
+        p.setValue(null);
+        paramsMap.put("name", p);
+
+        Method method = SqlTask.class.getDeclaredMethod("replaceOriginalValue", String.class, String.class, Map.class);
+        method.setAccessible(true);
+
+        String sql = "select * from t where name = '!{name}'";
+        String result = (String) method.invoke(sqlTask, sql, "['\"]*\\!\\{(.*?)\\}['\"]*", paramsMap);
+        Assertions.assertEquals(sql, result);
+    }
+
 }


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES, Opus 4.7

## Purpose of the pull request

close #18074 

## Brief change log

When an upstream SQL task outputs parameter `p1` and the downstream task references it via a different parameter name `p2` (with value `${p1}`), the workflow fails with:

```
java.lang.IllegalArgumentException: No group with name {p1}
    at java.util.regex.Matcher.appendReplacement(Matcher.java:849)
    at org.apache.dolphinscheduler.plugin.task.sql.SqlTask.replaceOriginalValue(SqlTask.java:496)
```

Two root causes:

1. **VarPool not injected**: `CuringParamsServiceImpl.paramParsingPreparation()` step 6 only overrides parameters with the same name. Since the downstream task only has `p2` and not `p1`, the upstream VarPool value (`p1=111`) gets dropped, causing `${p1}` to remain unresolved.

2. **Unsafe regex replacement**: `SqlTask.replaceOriginalValue()` uses `Matcher.replaceFirst(paramValue)` directly, which treats `$` as a regex group reference. When the unresolved placeholder `${p1}` contains `$`, it causes the regex engine to crash.

**Changes:**

- `CuringParamsServiceImpl`: Inject VarPool parameters that don't exist in `prepareParamsMap` for downstream placeholder resolution
- `SqlTask`: Use `Matcher.quoteReplacement()` to safely handle `$` in parameter values, and add null safety check

## Verify this pull request

This pull request is covered by new unit tests:

- `CuringParamsServiceImplTest.testParamParsingPreparation_varPoolInjectionWhenParamNameNotInLocalParams` — verifies upstream VarPool parameter `p1` is injected and downstream `p2=${p1}` is resolved to `111`
- `SqlTaskTest.testReplaceOriginalValue_withSpecialCharacters` — verifies `$`, `\` characters in values are safely replaced
- `SqlTaskTest.testReplaceOriginalValue_paramNotFound_keepsOriginalText` — verifies original text is preserved when parameter is not found
- `SqlTaskTest.testReplaceOriginalValue_paramValueNull_keepsOriginalText` — verifies original text is preserved when parameter value is null

## Screenshots

Before fix:
<img width="1132" height="930" alt="image" src="https://github.com/user-attachments/assets/ab41c3c2-60ee-4d3a-b727-fb155f945322" />
<img width="1784" height="574" alt="image" src="https://github.com/user-attachments/assets/a0d1b695-ad8f-4c33-8b63-01d12ef7b267" />

After fix:
<img width="1882" height="134" alt="image" src="https://github.com/user-attachments/assets/d60fbf41-2d0f-4943-9e48-106d1c966e7d" />
<img width="1974" height="166" alt="image" src="https://github.com/user-attachments/assets/13cdc119-82f4-4b87-ac28-f741d6dbf11f" />


## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
