### PR TITLE
[Improvement-18224][API] Migrate WorkflowInstanceService Map<String,Object> returns to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceController.java
@@ -22,6 +22,9 @@ import static org.apache.dolphinscheduler.api.enums.Status.QUERY_WORKFLOW_INSTAN
 import org.apache.dolphinscheduler.api.audit.OperatorLog;
 import org.apache.dolphinscheduler.api.audit.enums.AuditType;
 import org.apache.dolphinscheduler.api.dto.DynamicSubWorkflowDto;
+import org.apache.dolphinscheduler.api.dto.gantt.GanttDto;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceTaskListDTO;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.WorkflowInstanceService;
@@ -29,15 +32,14 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -138,12 +140,12 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/{id}/tasks")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.QUERY_TASK_LIST_BY_WORKFLOW_INSTANCE_ID_ERROR)
-    public Result queryTaskListByWorkflowInstanceId(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                    @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                    @PathVariable("id") Integer id) throws IOException {
-        Map<String, Object> result =
+    public Result<WorkflowInstanceTaskListDTO> queryTaskListByWorkflowInstanceId(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                                 @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                                 @PathVariable("id") Integer id) {
+        WorkflowInstanceTaskListDTO taskList =
                 workflowInstanceService.queryTaskListByWorkflowInstanceId(loginUser, projectCode, id);
-        return returnDataList(result);
+        return Result.success(taskList);
     }
 
     /**
@@ -174,19 +176,19 @@ public class WorkflowInstanceController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.UPDATE_WORKFLOW_INSTANCE_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_INSTANCE_UPDATE)
-    public Result updateWorkflowInstance(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                         @RequestParam(value = "taskRelationJson", required = true) String taskRelationJson,
-                                         @RequestParam(value = "taskDefinitionJson", required = true) String taskDefinitionJson,
-                                         @PathVariable(value = "id") Integer id,
-                                         @RequestParam(value = "scheduleTime", required = false) String scheduleTime,
-                                         @RequestParam(value = "syncDefine", required = true) Boolean syncDefine,
-                                         @RequestParam(value = "globalParams", required = false, defaultValue = "[]") String globalParams,
-                                         @RequestParam(value = "locations", required = false) String locations,
-                                         @RequestParam(value = "timeout", required = false, defaultValue = "0") int timeout) {
-        Map<String, Object> result = workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, id,
-                taskRelationJson, taskDefinitionJson, scheduleTime, syncDefine, globalParams, locations, timeout);
-        return returnDataList(result);
+    public Result<WorkflowDefinition> updateWorkflowInstance(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                             @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                             @RequestParam(value = "taskRelationJson", required = true) String taskRelationJson,
+                                                             @RequestParam(value = "taskDefinitionJson", required = true) String taskDefinitionJson,
+                                                             @PathVariable(value = "id") Integer id,
+                                                             @RequestParam(value = "scheduleTime", required = false) String scheduleTime,
+                                                             @RequestParam(value = "syncDefine", required = true) Boolean syncDefine,
+                                                             @RequestParam(value = "globalParams", required = false, defaultValue = "[]") String globalParams,
+                                                             @RequestParam(value = "locations", required = false) String locations,
+                                                             @RequestParam(value = "timeout", required = false, defaultValue = "0") int timeout) {
+        WorkflowDefinition workflowDefinition = workflowInstanceService.updateWorkflowInstance(loginUser, projectCode,
+                id, taskRelationJson, taskDefinitionJson, scheduleTime, syncDefine, globalParams, locations, timeout);
+        return Result.success(workflowDefinition);
     }
 
     /**
@@ -204,11 +206,12 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.QUERY_WORKFLOW_INSTANCE_BY_ID_ERROR)
-    public Result queryWorkflowInstanceById(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                            @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                            @PathVariable("id") Integer id) {
-        Map<String, Object> result = workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, id);
-        return returnDataList(result);
+    public Result<WorkflowInstance> queryWorkflowInstanceById(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                              @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                              @PathVariable("id") Integer id) {
+        WorkflowInstance workflowInstance =
+                workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, id);
+        return Result.success(workflowInstance);
     }
 
     /**
@@ -230,14 +233,14 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/top-n")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.QUERY_WORKFLOW_INSTANCE_BY_ID_ERROR)
-    public Result<WorkflowInstance> queryTopNLongestRunningWorkflowInstance(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                                            @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                                            @RequestParam("size") Integer size,
-                                                                            @RequestParam(value = "startTime", required = true) String startTime,
-                                                                            @RequestParam(value = "endTime", required = true) String endTime) {
-        Map<String, Object> result = workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser,
-                projectCode, size, startTime, endTime);
-        return returnDataList(result);
+    public Result<List<WorkflowInstance>> queryTopNLongestRunningWorkflowInstance(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                                  @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                                  @RequestParam("size") Integer size,
+                                                                                  @RequestParam(value = "startTime", required = true) String startTime,
+                                                                                  @RequestParam(value = "endTime", required = true) String endTime) {
+        List<WorkflowInstance> workflowInstances = workflowInstanceService.queryTopNLongestRunningWorkflowInstance(
+                loginUser, projectCode, size, startTime, endTime);
+        return Result.success(workflowInstances);
     }
 
     /**
@@ -279,12 +282,12 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/query-sub-by-parent")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.QUERY_SUB_WORKFLOW_INSTANCE_DETAIL_INFO_BY_TASK_ID_ERROR)
-    public Result querySubWorkflowInstanceByTaskId(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                   @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                   @RequestParam("taskId") Integer taskId) {
-        Map<String, Object> result =
+    public Result<Map<String, Integer>> querySubWorkflowInstanceByTaskId(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                         @RequestParam("taskId") Integer taskId) {
+        Map<String, Integer> data =
                 workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, taskId);
-        return returnDataList(result);
+        return Result.success(data);
     }
 
     /**
@@ -302,11 +305,12 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/query-parent-by-sub")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.QUERY_PARENT_WORKFLOW_INSTANCE_DETAIL_INFO_BY_SUB_WORKFLOW_INSTANCE_ID_ERROR)
-    public Result queryParentInstanceBySubId(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                             @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                             @RequestParam("subId") Integer subId) {
-        Map<String, Object> result = workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, subId);
-        return returnDataList(result);
+    public Result<Map<String, Integer>> queryParentInstanceBySubId(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                   @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                   @RequestParam("subId") Integer subId) {
+        Map<String, Integer> data =
+                workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, subId);
+        return Result.success(data);
     }
 
     /**
@@ -344,11 +348,11 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/{id}/view-variables")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.QUERY_WORKFLOW_INSTANCE_ALL_VARIABLES_ERROR)
-    public Result viewVariables(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                @PathVariable("id") Integer id) {
-        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, id);
-        return returnDataList(result);
+    public Result<WorkflowInstanceVariablesDTO> viewVariables(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                              @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                              @PathVariable("id") Integer id) {
+        WorkflowInstanceVariablesDTO variables = workflowInstanceService.viewVariables(loginUser, projectCode, id);
+        return Result.success(variables);
     }
 
     /**
@@ -366,11 +370,11 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping(value = "/{id}/view-gantt")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.ENCAPSULATION_WORKFLOW_INSTANCE_GANTT_STRUCTURE_ERROR)
-    public Result viewTree(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                           @PathVariable("id") Integer id) throws Exception {
-        Map<String, Object> result = workflowInstanceService.viewGantt(loginUser, projectCode, id);
-        return returnDataList(result);
+    public Result<GanttDto> viewTree(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                     @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                     @PathVariable("id") Integer id) throws Exception {
+        GanttDto ganttDto = workflowInstanceService.viewGantt(loginUser, projectCode, id);
+        return Result.success(ganttDto);
     }
 
     /**
@@ -391,11 +395,9 @@ public class WorkflowInstanceController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(Status.BATCH_DELETE_WORKFLOW_INSTANCE_BY_IDS_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_INSTANCE_BATCH_DELETE)
-    public Result batchDeleteWorkflowInstanceByIds(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                   @PathVariable long projectCode,
-                                                   @RequestParam("workflowInstanceIds") String workflowInstanceIds) {
-        // task queue
-        Map<String, Object> result = new HashMap<>();
+    public Result<Void> batchDeleteWorkflowInstanceByIds(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                         @PathVariable long projectCode,
+                                                         @RequestParam("workflowInstanceIds") String workflowInstanceIds) {
         List<String> deleteFailedIdList = new ArrayList<>();
         if (!StringUtils.isEmpty(workflowInstanceIds)) {
             String[] workflowInstanceIdArray = workflowInstanceIds.split(Constants.COMMA);
@@ -412,11 +414,10 @@ public class WorkflowInstanceController extends BaseController {
             }
         }
         if (!deleteFailedIdList.isEmpty()) {
-            putMsg(result, Status.BATCH_DELETE_WORKFLOW_INSTANCE_BY_IDS_ERROR, String.join("\n", deleteFailedIdList));
-        } else {
-            putMsg(result, Status.SUCCESS);
+            return Result.errorWithArgs(Status.BATCH_DELETE_WORKFLOW_INSTANCE_BY_IDS_ERROR,
+                    String.join("\n", deleteFailedIdList));
         }
-        return returnDataList(result);
+        return Result.success();
     }
 
     // Todo: This is unstable, in some case the command trigger failed, we cannot get workflow instance
@@ -431,10 +432,11 @@ public class WorkflowInstanceController extends BaseController {
     @GetMapping("/trigger")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKFLOW_INSTANCE_LIST_PAGING_ERROR)
-    public Result queryWorkflowInstancesByTriggerCode(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                      @PathVariable long projectCode,
-                                                      @RequestParam(value = "triggerCode") Long triggerCode) {
-        Map<String, Object> result = workflowInstanceService.queryByTriggerCode(loginUser, projectCode, triggerCode);
-        return returnDataList(result);
+    public Result<List<WorkflowInstance>> queryWorkflowInstancesByTriggerCode(@RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                              @PathVariable long projectCode,
+                                                                              @RequestParam(value = "triggerCode") Long triggerCode) {
+        List<WorkflowInstance> workflowInstances =
+                workflowInstanceService.queryByTriggerCode(loginUser, projectCode, triggerCode);
+        return Result.success(workflowInstances);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflowInstance/WorkflowInstanceTaskListDTO.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflowInstance/WorkflowInstanceTaskListDTO.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.dto.workflowInstance;
+
+import org.apache.dolphinscheduler.dao.entity.AbstractTaskInstanceContext;
+import org.apache.dolphinscheduler.dao.entity.TaskInstanceDependentDetails;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowInstanceTaskListDTO {
+
+    private String workflowInstanceState;
+
+    private List<TaskInstanceDependentDetails<AbstractTaskInstanceContext>> taskList;
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflowInstance/WorkflowInstanceVariablesDTO.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflowInstance/WorkflowInstanceVariablesDTO.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.dto.workflowInstance;
+
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowInstanceVariablesDTO {
+
+    private List<Property> globalParams;
+
+    private Map<String, Map<String, Object>> localParams;
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceService.java
@@ -18,13 +18,16 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.dto.DynamicSubWorkflowDto;
+import org.apache.dolphinscheduler.api.dto.gantt.GanttDto;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceTaskListDTO;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -33,11 +36,11 @@ public interface WorkflowInstanceService {
     /**
      * return top n SUCCESS workflow instance order by running time which started between startTime and endTime
      */
-    Map<String, Object> queryTopNLongestRunningWorkflowInstance(User loginUser,
-                                                                long projectCode,
-                                                                int size,
-                                                                String startTime,
-                                                                String endTime);
+    List<WorkflowInstance> queryTopNLongestRunningWorkflowInstance(User loginUser,
+                                                                   long projectCode,
+                                                                   int size,
+                                                                   String startTime,
+                                                                   String endTime);
 
     /**
      * query workflow instance by id
@@ -47,9 +50,9 @@ public interface WorkflowInstanceService {
      * @param workflowInstanceId   workflow instance id
      * @return workflow instance detail
      */
-    Map<String, Object> queryWorkflowInstanceById(User loginUser,
-                                                  long projectCode,
-                                                  Integer workflowInstanceId);
+    WorkflowInstance queryWorkflowInstanceById(User loginUser,
+                                               long projectCode,
+                                               Integer workflowInstanceId);
 
     /**
      * paging query workflow instance list, filtering according to project, workflow definition, time range, keyword, workflow status
@@ -87,11 +90,10 @@ public interface WorkflowInstanceService {
      * @param projectCode project code
      * @param workflowInstanceId   workflow instance id
      * @return task list for the workflow instance
-     * @throws IOException io exception
      */
-    Map<String, Object> queryTaskListByWorkflowInstanceId(User loginUser,
-                                                          long projectCode,
-                                                          Integer workflowInstanceId) throws IOException;
+    WorkflowInstanceTaskListDTO queryTaskListByWorkflowInstanceId(User loginUser,
+                                                                  long projectCode,
+                                                                  Integer workflowInstanceId);
 
     /**
      * query sub workflow instance detail info by task id
@@ -99,11 +101,11 @@ public interface WorkflowInstanceService {
      * @param loginUser   login user
      * @param projectCode project code
      * @param taskId      task id
-     * @return sub workflow instance detail
+     * @return single-entry map keyed by {@code subWorkflowInstanceId}
      */
-    Map<String, Object> querySubWorkflowInstanceByTaskId(User loginUser,
-                                                         long projectCode,
-                                                         Integer taskId);
+    Map<String, Integer> querySubWorkflowInstanceByTaskId(User loginUser,
+                                                          long projectCode,
+                                                          Integer taskId);
 
     List<DynamicSubWorkflowDto> queryDynamicSubWorkflowInstances(User loginUser,
                                                                  Integer taskId);
@@ -121,18 +123,18 @@ public interface WorkflowInstanceService {
      * @param globalParams       global params
      * @param locations          locations for nodes
      * @param timeout            timeout
-     * @return update result code
+     * @return updated workflow definition
      */
-    Map<String, Object> updateWorkflowInstance(User loginUser,
-                                               long projectCode,
-                                               Integer workflowInstanceId,
-                                               String taskRelationJson,
-                                               String taskDefinitionJson,
-                                               String scheduleTime,
-                                               Boolean syncDefine,
-                                               String globalParams,
-                                               String locations,
-                                               int timeout);
+    WorkflowDefinition updateWorkflowInstance(User loginUser,
+                                              long projectCode,
+                                              Integer workflowInstanceId,
+                                              String taskRelationJson,
+                                              String taskDefinitionJson,
+                                              String scheduleTime,
+                                              Boolean syncDefine,
+                                              String globalParams,
+                                              String locations,
+                                              int timeout);
 
     /**
      * query parent workflow instance detail info by sub workflow instance id
@@ -140,18 +142,17 @@ public interface WorkflowInstanceService {
      * @param loginUser   login user
      * @param projectCode project code
      * @param subId       sub workflow id
-     * @return parent instance detail
+     * @return single-entry map keyed by {@code parentWorkflowInstance}
      */
-    Map<String, Object> queryParentInstanceBySubId(User loginUser,
-                                                   long projectCode,
-                                                   Integer subId);
+    Map<String, Integer> queryParentInstanceBySubId(User loginUser,
+                                                    long projectCode,
+                                                    Integer subId);
 
     /**
      * delete workflow instance by id, at the same time，delete task instance and their mapping relation data
      *
      * @param loginUser         login user
      * @param workflowInstanceId workflow instance id
-     * @return delete result code
      */
     void deleteWorkflowInstanceById(User loginUser,
                                     Integer workflowInstanceId);
@@ -164,7 +165,7 @@ public interface WorkflowInstanceService {
      * @param workflowInstanceId workflow instance id
      * @return variables data
      */
-    Map<String, Object> viewVariables(User loginUser, long projectCode, Integer workflowInstanceId);
+    WorkflowInstanceVariablesDTO viewVariables(User loginUser, long projectCode, Integer workflowInstanceId);
 
     /**
      * encapsulation gantt structure
@@ -175,7 +176,7 @@ public interface WorkflowInstanceService {
      * @return gantt tree data
      * @throws Exception exception when json parse
      */
-    Map<String, Object> viewGantt(User loginUser, long projectCode, Integer workflowInstanceId) throws Exception;
+    GanttDto viewGantt(User loginUser, long projectCode, Integer workflowInstanceId) throws Exception;
 
     /**
      * query workflow instance by workflowDefinitionCode and stateArray
@@ -210,14 +211,14 @@ public interface WorkflowInstanceService {
                                                          int size);
 
     /**
-     * query workflow instance list bt trigger code
+     * query workflow instance list by trigger code
      *
-     * @param loginUser
-     * @param projectCode
-     * @param triggerCode
-     * @return
+     * @param loginUser   login user
+     * @param projectCode project code
+     * @param triggerCode trigger code (nullable)
+     * @return workflow instances triggered by the given trigger code
      */
-    Map<String, Object> queryByTriggerCode(User loginUser, long projectCode, Long triggerCode);
+    List<WorkflowInstance> queryByTriggerCode(User loginUser, long projectCode, Long triggerCode);
 
     void deleteWorkflowInstanceByWorkflowDefinitionCode(long workflowDefinitionCode);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -20,11 +20,9 @@ package org.apache.dolphinscheduler.api.service.impl;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_INSTANCE;
 import static org.apache.dolphinscheduler.api.enums.Status.WORKFLOW_INSTANCE_NOT_EXIST;
 import static org.apache.dolphinscheduler.api.enums.Status.WORKFLOW_INSTANCE_STATE_OPERATION_ERROR;
-import static org.apache.dolphinscheduler.common.constants.Constants.DATA_LIST;
-import static org.apache.dolphinscheduler.common.constants.Constants.GLOBAL_PARAMS;
 import static org.apache.dolphinscheduler.common.constants.Constants.LOCAL_PARAMS;
-import static org.apache.dolphinscheduler.common.constants.Constants.TASK_LIST;
-import static org.apache.dolphinscheduler.common.constants.Constants.WORKFLOW_INSTANCE_STATE;
+import static org.apache.dolphinscheduler.common.constants.Constants.PARENT_WORKFLOW_INSTANCE;
+import static org.apache.dolphinscheduler.common.constants.Constants.SUBWORKFLOW_INSTANCE_ID;
 import static org.apache.dolphinscheduler.common.utils.JSONUtils.parseObject;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager.checkTaskParameters;
 
@@ -32,6 +30,8 @@ import org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant;
 import org.apache.dolphinscheduler.api.dto.DynamicSubWorkflowDto;
 import org.apache.dolphinscheduler.api.dto.gantt.GanttDto;
 import org.apache.dolphinscheduler.api.dto.gantt.Task;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceTaskListDTO;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.ProjectService;
@@ -177,62 +177,41 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     @Autowired
     private TaskInstanceContextDao taskInstanceContextDao;
 
-    /**
-     * return top n SUCCESS workflow instance order by running time which started between startTime and endTime
-     */
     @Override
-    public Map<String, Object> queryTopNLongestRunningWorkflowInstance(User loginUser, long projectCode, int size,
-                                                                       String startTime, String endTime) {
+    public List<WorkflowInstance> queryTopNLongestRunningWorkflowInstance(User loginUser, long projectCode, int size,
+                                                                          String startTime, String endTime) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
-        Map<String, Object> result = new HashMap<>();
         if (0 > size) {
-            putMsg(result, Status.NEGTIVE_SIZE_NUMBER_ERROR, size);
-            return result;
+            throw new ServiceException(Status.NEGTIVE_SIZE_NUMBER_ERROR, size);
         }
         if (Objects.isNull(startTime)) {
-            putMsg(result, Status.DATA_IS_NULL, Constants.START_TIME);
-            return result;
+            throw new ServiceException(Status.DATA_IS_NULL, Constants.START_TIME);
         }
         Date start = DateUtils.stringToDate(startTime);
         if (Objects.isNull(endTime)) {
-            putMsg(result, Status.DATA_IS_NULL, Constants.END_TIME);
-            return result;
+            throw new ServiceException(Status.DATA_IS_NULL, Constants.END_TIME);
         }
         Date end = DateUtils.stringToDate(endTime);
         if (start == null || end == null) {
-            putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.START_END_DATE);
-            return result;
+            throw new ServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR, Constants.START_END_DATE);
         }
         if (start.getTime() > end.getTime()) {
-            putMsg(result, Status.START_TIME_BIGGER_THAN_END_TIME_ERROR, startTime, endTime);
-            return result;
+            throw new ServiceException(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR, startTime, endTime);
         }
 
-        List<WorkflowInstance> workflowInstances = workflowInstanceMapper.queryTopNWorkflowInstance(size, start, end,
-                WorkflowExecutionStatus.SUCCESS, projectCode);
-        result.put(DATA_LIST, workflowInstances);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return workflowInstanceMapper.queryTopNWorkflowInstance(size, start, end, WorkflowExecutionStatus.SUCCESS,
+                projectCode);
     }
 
-    /**
-     * query workflow instance by id
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param workflowInstanceId   workflow instance id
-     * @return workflow instance detail
-     */
     @Override
-    public Map<String, Object> queryWorkflowInstanceById(User loginUser, long projectCode, Integer workflowInstanceId) {
+    public WorkflowInstance queryWorkflowInstanceById(User loginUser, long projectCode, Integer workflowInstanceId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowInstance workflowInstance = processService.findWorkflowInstanceDetailById(workflowInstanceId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
 
@@ -242,33 +221,13 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode: {}.", projectCode);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, workflowInstanceId);
-        } else {
-            workflowInstance.setLocations(workflowDefinition.getLocations());
-            workflowInstance.setDagData(processService.genDagData(workflowDefinition));
-            result.put(DATA_LIST, workflowInstance);
-            putMsg(result, Status.SUCCESS);
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, workflowInstanceId);
         }
-
-        return result;
+        workflowInstance.setLocations(workflowDefinition.getLocations());
+        workflowInstance.setDagData(processService.genDagData(workflowDefinition));
+        return workflowInstance;
     }
 
-    /**
-     * paging query workflow instance list, filtering according to project, workflow definition, time range, keyword, workflow status
-     *
-     * @param loginUser         login user
-     * @param projectCode       project code
-     * @param workflowDefinitionCode workflow definition code
-     * @param pageNo            page number
-     * @param pageSize          page size
-     * @param searchVal         search value
-     * @param stateType         state type
-     * @param host              host
-     * @param startDate         start time
-     * @param endDate           end time
-     * @param otherParamsJson   otherParamsJson handle other params
-     * @return workflow instance list
-     */
     @Override
     public Result<PageInfo<WorkflowInstance>> queryWorkflowInstanceList(User loginUser,
                                                                         long projectCode,
@@ -336,22 +295,13 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         return result;
     }
 
-    /**
-     * query task list by workflow instance id
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param workflowInstanceId   workflow instance id
-     * @return task list for the workflow instance
-     */
     @Override
-    public Map<String, Object> queryTaskListByWorkflowInstanceId(User loginUser, long projectCode,
-                                                                 Integer workflowInstanceId) {
+    public WorkflowInstanceTaskListDTO queryTaskListByWorkflowInstanceId(User loginUser, long projectCode,
+                                                                         Integer workflowInstanceId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowInstance workflowInstance = processService.findWorkflowInstanceDetailById(workflowInstanceId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
         WorkflowDefinition workflowDefinition =
@@ -359,21 +309,14 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (workflowDefinition != null && projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowInstanceId:{}.", projectCode,
                     workflowInstanceId);
-            putMsg(result, WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
-            return result;
+            throw new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
         }
         List<TaskInstance> taskInstanceList =
                 taskInstanceDao.queryValidTaskListByWorkflowInstanceId(workflowInstanceId);
         List<TaskInstanceDependentDetails<AbstractTaskInstanceContext>> taskInstanceDependentDetailsList =
                 setTaskInstanceDependentResult(taskInstanceList);
-
-        Map<String, Object> resultMap = new HashMap<>();
-        resultMap.put(WORKFLOW_INSTANCE_STATE, workflowInstance.getState().toString());
-        resultMap.put(TASK_LIST, taskInstanceDependentDetailsList);
-        result.put(DATA_LIST, resultMap);
-
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return new WorkflowInstanceTaskListDTO(workflowInstance.getState().toString(),
+                taskInstanceDependentDetailsList);
     }
 
     private List<TaskInstanceDependentDetails<AbstractTaskInstanceContext>> setTaskInstanceDependentResult(List<TaskInstance> taskInstanceList) {
@@ -404,15 +347,12 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     @Override
     public List<DynamicSubWorkflowDto> queryDynamicSubWorkflowInstances(User loginUser, Integer taskId) {
         TaskInstance taskInstance = taskInstanceDao.queryById(taskId);
-        Map<String, Object> result = new HashMap<>();
         if (taskInstance == null) {
-            putMsg(result, Status.TASK_INSTANCE_NOT_EXISTS, taskId);
             throw new ServiceException(Status.TASK_INSTANCE_NOT_EXISTS, taskId);
         }
 
         TaskDefinition taskDefinition = taskDefinitionMapper.queryByCode(taskInstance.getTaskCode());
         if (taskDefinition == null) {
-            putMsg(result, Status.TASK_INSTANCE_NOT_EXISTS, taskId);
             throw new ServiceException(Status.TASK_INSTANCE_NOT_EXISTS, taskId);
         }
 
@@ -424,7 +364,6 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         List<WorkflowInstance> allSubWorkflows = workflowInstanceDao.queryByIds(allSubWorkflowInstanceId);
 
         if (allSubWorkflows == null || allSubWorkflows.isEmpty()) {
-            putMsg(result, Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, taskId);
             throw new ServiceException(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, taskId);
         }
         Long subWorkflowCode = allSubWorkflows.get(0).getWorkflowDefinitionCode();
@@ -432,7 +371,6 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         WorkflowDefinition subWorkflowDefinition =
                 processService.findWorkflowDefinition(subWorkflowCode, subWorkflowVersion);
         if (subWorkflowDefinition == null) {
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, subWorkflowCode);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, subWorkflowCode);
         }
 
@@ -457,39 +395,27 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         return allDynamicSubWorkflowDtos;
     }
 
-    /**
-     * query sub workflow instance detail info by task id
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param taskId      task id
-     * @return sub workflow instance detail
-     */
     @Override
-    public Map<String, Object> querySubWorkflowInstanceByTaskId(User loginUser, long projectCode, Integer taskId) {
+    public Map<String, Integer> querySubWorkflowInstanceByTaskId(User loginUser, long projectCode, Integer taskId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
-        Map<String, Object> result = new HashMap<>();
         TaskInstance taskInstance = taskInstanceDao.queryById(taskId);
         if (taskInstance == null) {
             log.error("Task instance does not exist, projectCode:{}, taskInstanceId{}.", projectCode, taskId);
-            putMsg(result, Status.TASK_INSTANCE_NOT_EXISTS, taskId);
-            return result;
+            throw new ServiceException(Status.TASK_INSTANCE_NOT_EXISTS, taskId);
         }
 
         TaskDefinition taskDefinition = taskDefinitionMapper.queryByCode(taskInstance.getTaskCode());
         if (taskDefinition != null && projectCode != taskDefinition.getProjectCode()) {
             log.error("Task definition does not exist, projectCode:{}, taskDefinitionCode:{}.", projectCode,
                     taskInstance.getTaskCode());
-            putMsg(result, Status.TASK_INSTANCE_NOT_EXISTS, taskId);
-            return result;
+            throw new ServiceException(Status.TASK_INSTANCE_NOT_EXISTS, taskId);
         }
 
         if (!TaskTypeUtils.isSubWorkflowTask(taskInstance.getTaskType())) {
-            putMsg(result, Status.TASK_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE, taskInstance.getName());
-            return result;
+            throw new ServiceException(Status.TASK_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE, taskInstance.getName());
         }
 
         WorkflowInstance subWorkflowInstance = processService.findSubWorkflowInstance(
@@ -497,43 +423,22 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (subWorkflowInstance == null) {
             log.error("Sub workflow instance does not exist, projectCode:{}, taskInstanceId:{}.", projectCode,
                     taskInstance.getId());
-            putMsg(result, Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, taskId);
-            return result;
+            throw new ServiceException(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, taskId);
         }
-        Map<String, Object> dataMap = new HashMap<>();
-        dataMap.put(Constants.SUBWORKFLOW_INSTANCE_ID, subWorkflowInstance.getId());
-        result.put(DATA_LIST, dataMap);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return Collections.singletonMap(SUBWORKFLOW_INSTANCE_ID, subWorkflowInstance.getId());
     }
 
-    /**
-     * update workflow instance
-     *
-     * @param loginUser          login user
-     * @param projectCode        project code
-     * @param taskRelationJson   workflow task relation json
-     * @param taskDefinitionJson taskDefinitionJson
-     * @param workflowInstanceId  workflow instance id
-     * @param scheduleTime       schedule time
-     * @param syncDefine         sync define
-     * @param globalParams       global params
-     * @param locations          locations for nodes
-     * @param timeout            timeout
-     * @return update result code
-     */
     @Transactional
     @Override
-    public Map<String, Object> updateWorkflowInstance(User loginUser, long projectCode, Integer workflowInstanceId,
-                                                      String taskRelationJson,
-                                                      String taskDefinitionJson, String scheduleTime,
-                                                      Boolean syncDefine,
-                                                      String globalParams,
-                                                      String locations, int timeout) {
+    public WorkflowDefinition updateWorkflowInstance(User loginUser, long projectCode, Integer workflowInstanceId,
+                                                     String taskRelationJson,
+                                                     String taskDefinitionJson, String scheduleTime,
+                                                     Boolean syncDefine,
+                                                     String globalParams,
+                                                     String locations, int timeout) {
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode,
                 ApiFuncIdentificationConstant.INSTANCE_UPDATE);
-        Map<String, Object> result = new HashMap<>();
         // check workflow instance exists
         WorkflowInstance workflowInstance = processService.findWorkflowInstanceDetailById(workflowInstanceId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
@@ -543,16 +448,14 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (workflowDefinition0 != null && projectCode != workflowDefinition0.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                     workflowInstance.getWorkflowDefinitionCode());
-            putMsg(result, WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
-            return result;
+            throw new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
         }
         // check workflow instance status
         if (!workflowInstance.getState().isFinalState()) {
             log.warn("workflow Instance state is {} so can not update workflow instance, workflowInstanceId:{}.",
                     workflowInstance.getState().name(), workflowInstanceId);
-            putMsg(result, WORKFLOW_INSTANCE_STATE_OPERATION_ERROR,
+            throw new ServiceException(WORKFLOW_INSTANCE_STATE_OPERATION_ERROR,
                     workflowInstance.getName(), workflowInstance.getState().toString(), "update");
-            return result;
         }
 
         String timezoneId;
@@ -567,21 +470,18 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionJson, TaskDefinitionLog.class);
         if (taskDefinitionLogs.isEmpty()) {
             log.warn("Parameter taskDefinitionJson is empty");
-            putMsg(result, Status.DATA_IS_NOT_VALID, taskDefinitionJson);
-            return result;
+            throw new ServiceException(Status.DATA_IS_NOT_VALID, taskDefinitionJson);
         }
         for (TaskDefinitionLog taskDefinitionLog : taskDefinitionLogs) {
             if (!checkTaskParameters(taskDefinitionLog.getTaskType(), taskDefinitionLog.getTaskParams())) {
                 log.error("Task parameters are invalid,  taskDefinitionName:{}.", taskDefinitionLog.getName());
-                putMsg(result, Status.WORKFLOW_NODE_S_PARAMETER_INVALID, taskDefinitionLog.getName());
-                return result;
+                throw new ServiceException(Status.WORKFLOW_NODE_S_PARAMETER_INVALID, taskDefinitionLog.getName());
             }
         }
         int saveTaskResult = processService.saveTaskDefine(loginUser, projectCode, taskDefinitionLogs, syncDefine);
         if (saveTaskResult == Constants.DEFINITION_FAILURE) {
             log.error("Update task definition error, projectCode:{}, workflowInstanceId:{}", projectCode,
                     workflowInstanceId);
-            putMsg(result, Status.UPDATE_TASK_DEFINITION_ERROR);
             throw new ServiceException(Status.UPDATE_TASK_DEFINITION_ERROR);
         }
         WorkflowDefinition workflowDefinition =
@@ -589,9 +489,11 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         List<WorkflowTaskRelationLog> taskRelationList =
                 JSONUtils.toList(taskRelationJson, WorkflowTaskRelationLog.class);
         // check workflow json is valid
-        result = workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return result;
+        Map<String, Object> checkResult =
+                workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs);
+        Status checkStatus = (Status) checkResult.get(Constants.STATUS);
+        if (checkStatus != Status.SUCCESS) {
+            throw new ServiceException(checkStatus.getCode(), (String) checkResult.get(Constants.MSG));
         }
 
         workflowDefinition.set(projectCode, workflowDefinition.getName(), workflowDefinition.getDescription(),
@@ -601,11 +503,10 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (insertVersion == 0) {
             log.error("Update workflow definition error, projectCode:{}, workflowDefinitionName:{}.", projectCode,
                     workflowDefinition.getName());
-            putMsg(result, Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
             throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
-        } else
-            log.info("Update workflow definition complete, projectCode:{}, workflowDefinitionName:{}.", projectCode,
-                    workflowDefinition.getName());
+        }
+        log.info("Update workflow definition complete, projectCode:{}, workflowDefinitionName:{}.", projectCode,
+                workflowDefinition.getName());
 
         // save workflow lineage
         if (syncDefine) {
@@ -615,33 +516,27 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         int insertResult = processService.saveTaskRelation(loginUser, workflowDefinition.getProjectCode(),
                 workflowDefinition.getCode(), insertVersion, taskRelationList, taskDefinitionLogs, syncDefine);
-        if (insertResult == Constants.EXIT_CODE_SUCCESS) {
-            log.info(
-                    "Update task relations complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                    projectCode, workflowDefinition.getCode(), insertVersion);
-            putMsg(result, Status.SUCCESS);
-            result.put(DATA_LIST, workflowDefinition);
-        } else {
+        if (insertResult != Constants.EXIT_CODE_SUCCESS) {
             log.info(
                     "Update task relations error, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
                     projectCode, workflowDefinition.getCode(), insertVersion);
-            putMsg(result, Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
             throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
         }
+        log.info(
+                "Update task relations complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                projectCode, workflowDefinition.getCode(), insertVersion);
         workflowInstance.setWorkflowDefinitionVersion(insertVersion);
         boolean update = workflowInstanceDao.updateById(workflowInstance);
         if (!update) {
             log.error(
                     "Update workflow instance version error, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}",
                     projectCode, workflowDefinition.getCode(), insertVersion);
-            putMsg(result, Status.UPDATE_WORKFLOW_INSTANCE_ERROR);
             throw new ServiceException(Status.UPDATE_WORKFLOW_INSTANCE_ERROR);
         }
         log.info(
                 "Update workflow instance complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}, workflowInstanceId:{}",
                 projectCode, workflowDefinition.getCode(), insertVersion, workflowInstanceId);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return workflowDefinition;
     }
 
     /**
@@ -663,52 +558,30 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         workflowInstance.setGlobalParams(globalParams);
     }
 
-    /**
-     * query parent workflow instance detail info by sub workflow instance id
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param subId       sub workflow id
-     * @return parent instance detail
-     */
     @Override
-    public Map<String, Object> queryParentInstanceBySubId(User loginUser, long projectCode, Integer subId) {
+    public Map<String, Integer> queryParentInstanceBySubId(User loginUser, long projectCode, Integer subId) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowInstance subInstance = processService.findWorkflowInstanceDetailById(subId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, subId));
         if (subInstance.getIsSubWorkflow() == Flag.NO) {
             log.warn(
                     "workflow instance is not sub workflow instance type, workflowInstanceId:{}, workflowInstanceName:{}.",
                     subId, subInstance.getName());
-            putMsg(result, Status.WORKFLOW_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE, subInstance.getName());
-            return result;
+            throw new ServiceException(Status.WORKFLOW_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE, subInstance.getName());
         }
 
         WorkflowInstance parentWorkflowInstance = processService.findParentWorkflowInstance(subId);
         if (parentWorkflowInstance == null) {
             log.error("Parent workflow instance does not exist, projectCode:{}, subWorkflowInstanceId:{}.",
                     projectCode, subId);
-            putMsg(result, Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST);
-            return result;
+            throw new ServiceException(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST);
         }
-        Map<String, Object> dataMap = new HashMap<>();
-        dataMap.put(Constants.PARENT_WORKFLOW_INSTANCE, parentWorkflowInstance.getId());
-        result.put(DATA_LIST, dataMap);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return Collections.singletonMap(PARENT_WORKFLOW_INSTANCE, parentWorkflowInstance.getId());
     }
 
-    /**
-     * delete workflow instance by id, at the same time，delete task instance and their mapping relation data
-     *
-     * @param loginUser         login user
-     * @param workflowInstanceId workflow instance id
-     * @return delete result code
-     */
     @Override
     @Transactional
     public void deleteWorkflowInstanceById(User loginUser, Integer workflowInstanceId) {
@@ -731,27 +604,17 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         deleteWorkflowInstanceById(workflowInstanceId);
     }
 
-    /**
-     * view workflow instance variables
-     *
-     * @param loginUser         login user
-     * @param projectCode       project code
-     * @param workflowInstanceId workflow instance id
-     * @return variables data
-     */
     @Override
-    public Map<String, Object> viewVariables(User loginUser, long projectCode, Integer workflowInstanceId) {
+    public WorkflowInstanceVariablesDTO viewVariables(User loginUser, long projectCode, Integer workflowInstanceId) {
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
-        Map<String, Object> result = new HashMap<>();
 
         WorkflowInstance workflowInstance = workflowInstanceMapper.queryDetailById(workflowInstanceId);
 
         if (workflowInstance == null) {
             log.error("workflow instance does not exist, projectCode:{}, workflowInstanceId:{}.", projectCode,
                     workflowInstanceId);
-            putMsg(result, WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
-            return result;
+            throw new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
         }
 
         WorkflowDefinition workflowDefinition =
@@ -759,8 +622,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (workflowDefinition != null && projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                     workflowInstance.getWorkflowDefinitionCode());
-            putMsg(result, WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
-            return result;
+            throw new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
         }
 
         String timezone = null;
@@ -779,13 +641,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         // localUserDefParams
         Map<String, Map<String, Object>> localUserDefParams = processLocalParams(workflowInstance, parameterMap);
 
-        Map<String, Object> resultMap = new HashMap<>();
-        resultMap.put(GLOBAL_PARAMS, finalGlobalParams);
-        resultMap.put(LOCAL_PARAMS, localUserDefParams);
-
-        result.put(DATA_LIST, resultMap);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return new WorkflowInstanceVariablesDTO(finalGlobalParams, localUserDefParams);
     }
 
     /**
@@ -854,28 +710,16 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         return localUserDefParams;
     }
 
-    /**
-     * encapsulation gantt structure
-     *
-     * @param loginUser         login user
-     * @param projectCode       project code
-     * @param workflowInstanceId workflow instance id
-     * @return gantt tree data
-     * @throws Exception exception when json parse
-     */
     @Override
-    public Map<String, Object> viewGantt(User loginUser, long projectCode,
-                                         Integer workflowInstanceId) throws Exception {
+    public GanttDto viewGantt(User loginUser, long projectCode, Integer workflowInstanceId) throws Exception {
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
-        Map<String, Object> result = new HashMap<>();
         WorkflowInstance workflowInstance = workflowInstanceMapper.queryDetailById(workflowInstanceId);
 
         if (workflowInstance == null) {
             log.error("workflow instance does not exist, projectCode:{}, workflowInstanceId:{}.", projectCode,
                     workflowInstanceId);
-            putMsg(result, WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
-            return result;
+            throw new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
         }
 
         WorkflowDefinition workflowDefinition = workflowDefinitionLogMapper.queryByDefinitionCodeAndVersion(
@@ -884,8 +728,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                     workflowInstance.getWorkflowDefinitionCode());
-            putMsg(result, WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
-            return result;
+            throw new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId);
         }
         GanttDto ganttDto = new GanttDto();
         DAG<Long, TaskNode, TaskNodeRelation> dag = processService.genDagGraph(workflowDefinition);
@@ -924,19 +767,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
             }
         }
         ganttDto.setTasks(taskList);
-
-        result.put(DATA_LIST, ganttDto);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return ganttDto;
     }
 
-    /**
-     * query workflow instance by workflowDefinitionCode and stateArray
-     *
-     * @param workflowDefinitionCode workflowDefinitionCode
-     * @param states                states array
-     * @return workflow instance list
-     */
     @Override
     public List<WorkflowInstance> queryByWorkflowDefinitionCodeAndStatus(Long workflowDefinitionCode, int[] states) {
         return workflowInstanceMapper.queryByWorkflowDefinitionCodeAndStatus(workflowDefinitionCode, states);
@@ -949,44 +782,22 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
                 states);
     }
 
-    /**
-     * query workflow instance by workflowDefinitionCode
-     *
-     * @param workflowDefinitionCode workflowDefinitionCode
-     * @param size                  size
-     * @return workflow instance list
-     */
     @Override
     public List<WorkflowInstance> queryByWorkflowDefinitionCode(Long workflowDefinitionCode, int size) {
         return workflowInstanceMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode, size);
     }
 
-    /**
-     * query workflow instance list bt trigger code
-     *
-     * @param loginUser
-     * @param projectCode
-     * @param triggerCode
-     * @return
-     */
     @Override
-    public Map<String, Object> queryByTriggerCode(User loginUser, long projectCode, Long triggerCode) {
+    public List<WorkflowInstance> queryByTriggerCode(User loginUser, long projectCode, Long triggerCode) {
 
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
-        Map<String, Object> result = new HashMap<>();
         if (triggerCode == null) {
-            putMsg(result, Status.SUCCESS);
-            return result;
+            return Collections.emptyList();
         }
-
-        List<WorkflowInstance> workflowInstances = workflowInstanceMapper.queryByTriggerCode(
-                triggerCode);
-        result.put(DATA_LIST, workflowInstances);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return workflowInstanceMapper.queryByTriggerCode(triggerCode);
     }
 
     @Override

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkflowInstanceControllerTest.java
@@ -24,15 +24,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.WorkflowInstanceService;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -81,12 +84,10 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testQueryTaskListByWorkflowInstanceId() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.PROJECT_NOT_FOUND);
         Mockito
                 .when(workflowInstanceService.queryTaskListByWorkflowInstanceId(Mockito.any(), Mockito.anyLong(),
                         Mockito.any()))
-                .thenReturn(mockResult);
+                .thenThrow(new ServiceException(Status.PROJECT_NOT_FOUND));
 
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/workflow-instances/{id}/tasks", "1113", "123")
@@ -102,8 +103,7 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testUpdateWorkflowInstance() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.SUCCESS);
+        WorkflowDefinition mockResult = new WorkflowDefinition();
         Mockito.when(workflowInstanceService
                 .updateWorkflowInstance(Mockito.any(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyString(),
                         Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString(),
@@ -139,11 +139,9 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testQueryWorkflowInstanceById() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.SUCCESS);
         Mockito.when(
                 workflowInstanceService.queryWorkflowInstanceById(Mockito.any(), Mockito.anyLong(), Mockito.anyInt()))
-                .thenReturn(mockResult);
+                .thenReturn(new WorkflowInstance());
         MvcResult mvcResult = mockMvc.perform(get("/projects/{projectCode}/workflow-instances/{id}", "1113", "123")
                 .header(SESSION_ID, sessionId))
                 .andExpect(status().isOk())
@@ -157,10 +155,8 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testQuerySubWorkflowInstanceByTaskId() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.TASK_INSTANCE_NOT_EXISTS);
         Mockito.when(workflowInstanceService.querySubWorkflowInstanceByTaskId(Mockito.any(), Mockito.anyLong(),
-                Mockito.anyInt())).thenReturn(mockResult);
+                Mockito.anyInt())).thenThrow(new ServiceException(Status.TASK_INSTANCE_NOT_EXISTS));
 
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/workflow-instances/query-sub-by-parent", "1113")
@@ -177,11 +173,9 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testQueryParentInstanceBySubId() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.WORKFLOW_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE);
         Mockito.when(
                 workflowInstanceService.queryParentInstanceBySubId(Mockito.any(), Mockito.anyLong(), Mockito.anyInt()))
-                .thenReturn(mockResult);
+                .thenThrow(new ServiceException(Status.WORKFLOW_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE));
 
         MvcResult mvcResult = mockMvc
                 .perform(get("/projects/{projectCode}/workflow-instances/query-parent-by-sub", "1113")
@@ -199,8 +193,8 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testViewVariables() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.SUCCESS);
+        WorkflowInstanceVariablesDTO mockResult =
+                new WorkflowInstanceVariablesDTO(Collections.emptyList(), Collections.emptyMap());
         Mockito.when(workflowInstanceService.viewVariables(Mockito.any(), Mockito.eq(1113L), Mockito.eq(123)))
                 .thenReturn(mockResult);
         MvcResult mvcResult = mockMvc
@@ -216,8 +210,6 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testDeleteWorkflowInstanceById() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.SUCCESS);
         Mockito.doNothing().when(workflowInstanceService).deleteWorkflowInstanceById(Mockito.any(), Mockito.anyInt());
 
         MvcResult mvcResult = mockMvc.perform(delete("/projects/{projectCode}/workflow-instances/{id}", "1113", "123")
@@ -233,9 +225,6 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void testBatchDeleteWorkflowInstanceByIds() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.WORKFLOW_INSTANCE_NOT_EXIST);
-
         Mockito.doNothing().when(workflowInstanceService).deleteWorkflowInstanceById(Mockito.any(), Mockito.anyInt());
         MvcResult mvcResult = mockMvc.perform(post("/projects/{projectCode}/workflow-instances/batch-delete", "1113")
                 .header(SESSION_ID, sessionId)
@@ -251,12 +240,9 @@ public class WorkflowInstanceControllerTest extends AbstractControllerTest {
 
     @Test
     public void queryWorkflowInstancesByTriggerCode() throws Exception {
-        Map<String, Object> mockResult = new HashMap<>();
-        mockResult.put(Constants.STATUS, Status.SUCCESS);
-
         Mockito.when(workflowInstanceService
                 .queryByTriggerCode(Mockito.any(), Mockito.anyLong(), Mockito.anyLong()))
-                .thenReturn(mockResult);
+                .thenReturn(new ArrayList<>());
 
         MvcResult mvcResult = mockMvc.perform(get("/projects/1113/workflow-instances/trigger")
                 .header("sessionId", sessionId)

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import static org.apache.dolphinscheduler.api.AssertionsHelper.assertThrowsServiceException;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.INSTANCE_UPDATE;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,6 +26,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceTaskListDTO;
+import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.impl.LoggerServiceImpl;
@@ -76,8 +79,6 @@ import org.apache.dolphinscheduler.service.expand.CuringParamsService;
 import org.apache.dolphinscheduler.service.model.TaskNode;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
-import java.io.IOException;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -195,8 +196,6 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
 
         // project auth fail
         doThrow(new ServiceException())
@@ -227,7 +226,6 @@ public class WorkflowInstanceServiceTest {
         pageReturn.setRecords(workflowInstanceList);
 
         // data parameter check
-        putMsg(result, Status.SUCCESS, projectCode);
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(Mockito.any(),
                 Mockito.any(Project.class),
@@ -252,8 +250,6 @@ public class WorkflowInstanceServiceTest {
                 10));
 
         // project auth success
-        putMsg(result, Status.SUCCESS, projectCode);
-
         doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
         when(usersService.queryUser(loginUser.getId())).thenReturn(loginUser);
         when(usersService.getUserIdByName(loginUser.getUserName())).thenReturn(loginUser.getId());
@@ -317,16 +313,19 @@ public class WorkflowInstanceServiceTest {
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
-        ServiceException ex = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
                 () -> workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L));
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
-        // project auth success
+
+        // project auth success, trigger code null returns empty list
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
                 WORKFLOW_INSTANCE);
-        when(workflowInstanceMapper.queryByTriggerCode(projectCode)).thenReturn(new ArrayList());
-        Map<String, Object> projectAuthFailMap =
-                workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L);
-        Assertions.assertEquals(Status.SUCCESS, projectAuthFailMap.get(Constants.STATUS));
+        List<WorkflowInstance> nullTriggerRes =
+                workflowInstanceService.queryByTriggerCode(loginUser, projectCode, null);
+        Assertions.assertTrue(nullTriggerRes.isEmpty());
+
+        when(workflowInstanceMapper.queryByTriggerCode(999L)).thenReturn(new ArrayList<>());
+        List<WorkflowInstance> emptyRes = workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L);
+        Assertions.assertTrue(emptyRes.isEmpty());
     }
 
     @Test
@@ -342,25 +341,22 @@ public class WorkflowInstanceServiceTest {
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
-        ServiceException ex = assertThrows(ServiceException.class, () -> workflowInstanceService
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND, () -> workflowInstanceService
                 .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, startTime, endTime));
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project auth success
-        WorkflowInstance workflowInstance = getProcessInstance();
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
                 WORKFLOW_INSTANCE);
-        Map<String, Object> projectAuthFailRes = workflowInstanceService
-                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, -1, startTime, endTime);
-        Assertions.assertEquals(Status.NEGTIVE_SIZE_NUMBER_ERROR, projectAuthFailRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.NEGTIVE_SIZE_NUMBER_ERROR, () -> workflowInstanceService
+                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, -1, startTime, endTime));
 
-        when(usersService.queryUser(loginUser.getId())).thenReturn(loginUser);
-        when(usersService.getUserIdByName(loginUser.getUserName())).thenReturn(loginUser.getId());
-        when(usersService.queryUser(workflowInstance.getExecutorId())).thenReturn(loginUser);
-        Map<String, Object> successRes = workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser,
+        when(workflowInstanceMapper.queryTopNWorkflowInstance(Mockito.eq(size), Mockito.any(), Mockito.any(),
+                Mockito.eq(WorkflowExecutionStatus.SUCCESS), Mockito.eq(projectCode)))
+                        .thenReturn(new ArrayList<>());
+        List<WorkflowInstance> successRes = workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser,
                 projectCode, size, startTime, endTime);
 
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertNotNull(successRes);
     }
 
     @Test
@@ -376,18 +372,17 @@ public class WorkflowInstanceServiceTest {
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
                 WORKFLOW_INSTANCE);
 
-        Map<String, Object> startTimeBiggerFailRes = workflowInstanceService
-                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, endTime, startTime);
-        Assertions.assertEquals(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR,
-                startTimeBiggerFailRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR,
+                () -> workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size,
+                        endTime, startTime));
 
-        Map<String, Object> dataNullFailRes = workflowInstanceService
-                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, null, endTime);
-        Assertions.assertEquals(Status.DATA_IS_NULL, dataNullFailRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.DATA_IS_NULL,
+                () -> workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size,
+                        null, endTime));
 
-        dataNullFailRes = workflowInstanceService
-                .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size, startTime, null);
-        Assertions.assertEquals(Status.DATA_IS_NULL, dataNullFailRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.DATA_IS_NULL,
+                () -> workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, size,
+                        startTime, null));
     }
 
     @Test
@@ -400,9 +395,8 @@ public class WorkflowInstanceServiceTest {
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
-        ServiceException ex = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
                 () -> workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1));
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project auth success
         WorkflowInstance workflowInstance = getProcessInstance();
@@ -414,28 +408,26 @@ public class WorkflowInstanceServiceTest {
                 .thenReturn(Optional.of(workflowInstance));
         when(processService.findWorkflowDefinition(workflowInstance.getWorkflowDefinitionCode(),
                 workflowInstance.getWorkflowDefinitionVersion())).thenReturn(workflowDefinition);
-        Map<String, Object> successRes = workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        WorkflowInstance successRes = workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
+        Assertions.assertNotNull(successRes);
 
         // worker group null
-        Map<String, Object> workerNullRes =
-                workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, workerNullRes.get(Constants.STATUS));
+        WorkflowInstance workerNullRes = workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
+        Assertions.assertNotNull(workerNullRes);
 
         // worker group exist
         WorkerGroup workerGroup = getWorkGroup();
-        Map<String, Object> workerExistRes =
-                workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, workerExistRes.get(Constants.STATUS));
+        WorkflowInstance workerExistRes = workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
+        Assertions.assertNotNull(workerExistRes);
 
         when(processService.findWorkflowDefinition(workflowInstance.getWorkflowDefinitionCode(),
-                workflowInstance.getWorkflowDefinitionVersion())).thenReturn(null);;
-        workerExistRes = workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, workerExistRes.get(Constants.STATUS));
+                workflowInstance.getWorkflowDefinitionVersion())).thenReturn(null);
+        assertThrowsServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST,
+                () -> workflowInstanceService.queryWorkflowInstanceById(loginUser, projectCode, 1));
     }
 
     @Test
-    public void testQueryTaskListByWorkflowInstanceId() throws IOException {
+    public void testQueryTaskListByWorkflowInstanceId() {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
@@ -444,9 +436,8 @@ public class WorkflowInstanceServiceTest {
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
-        ServiceException ex = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
                 () -> workflowInstanceService.queryTaskListByWorkflowInstanceId(loginUser, projectCode, 1));
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // project auth success
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
@@ -458,7 +449,6 @@ public class WorkflowInstanceServiceTest {
         taskInstance.setTaskType("SHELL");
         List<TaskInstance> taskInstanceList = new ArrayList<>();
         taskInstanceList.add(taskInstance);
-        List<DependentResultTaskInstanceContext> dependentResultTaskInstanceContextList = new ArrayList<>();
         TaskInstanceContext taskInstanceContext = new TaskInstanceContext();
         taskInstanceContext.setTaskInstanceId(0);
         taskInstanceContext.setContextType(ContextType.DEPENDENT_RESULT_CONTEXT);
@@ -482,9 +472,10 @@ public class WorkflowInstanceServiceTest {
         when(taskInstanceContextDao.batchQueryByTaskInstanceIdsAndContextType(taskInstanceIdList,
                 ContextType.DEPENDENT_RESULT_CONTEXT))
                         .thenReturn(Lists.asList(taskInstanceContext, new TaskInstanceContext[0]));
-        Map<String, Object> successRes =
+        WorkflowInstanceTaskListDTO successRes =
                 workflowInstanceService.queryTaskListByWorkflowInstanceId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertEquals(WorkflowExecutionStatus.SUCCESS.toString(), successRes.getWorkflowInstanceState());
+        Assertions.assertEquals(1, successRes.getTaskList().size());
     }
 
     @Test
@@ -497,17 +488,15 @@ public class WorkflowInstanceServiceTest {
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
-        ServiceException ex = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
                 () -> workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1));
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // task null
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
                 WORKFLOW_INSTANCE);
         when(taskInstanceDao.queryById(1)).thenReturn(null);
-        Map<String, Object> taskNullRes =
-                workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.TASK_INSTANCE_NOT_EXISTS, taskNullRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.TASK_INSTANCE_NOT_EXISTS,
+                () -> workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1));
 
         // task not sub process
         TaskInstance taskInstance = getTaskInstance();
@@ -517,13 +506,12 @@ public class WorkflowInstanceServiceTest {
         TaskDefinition taskDefinition = new TaskDefinition();
         taskDefinition.setProjectCode(projectCode);
         when(taskDefinitionMapper.queryByCode(taskInstance.getTaskCode())).thenReturn(taskDefinition);
-        Map<String, Object> notSubprocessRes =
-                workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.TASK_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE, notSubprocessRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.TASK_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE,
+                () -> workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1));
 
         taskDefinition.setProjectCode(0L);
-        notSubprocessRes = workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.TASK_INSTANCE_NOT_EXISTS, notSubprocessRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.TASK_INSTANCE_NOT_EXISTS,
+                () -> workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1));
 
         taskDefinition.setProjectCode(projectCode);
         when(taskDefinitionMapper.queryByCode(taskInstance.getTaskCode())).thenReturn(taskDefinition);
@@ -533,17 +521,17 @@ public class WorkflowInstanceServiceTest {
         subTask.setWorkflowInstanceId(1);
         when(taskInstanceDao.queryById(subTask.getId())).thenReturn(subTask);
         when(processService.findSubWorkflowInstance(subTask.getWorkflowInstanceId(), subTask.getId())).thenReturn(null);
-        Map<String, Object> subprocessNotExistRes =
-                workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, subprocessNotExistRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1));
 
         // sub process exist
         WorkflowInstance workflowInstance = getProcessInstance();
         when(processService.findSubWorkflowInstance(taskInstance.getWorkflowInstanceId(), taskInstance.getId()))
                 .thenReturn(workflowInstance);
-        Map<String, Object> subprocessExistRes =
+        Map<String, Integer> subprocessExistRes =
                 workflowInstanceService.querySubWorkflowInstanceByTaskId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, subprocessExistRes.get(Constants.STATUS));
+        Assertions.assertEquals(workflowInstance.getId(),
+                subprocessExistRes.get(Constants.SUBWORKFLOW_INSTANCE_ID));
     }
 
     @Test
@@ -552,38 +540,34 @@ public class WorkflowInstanceServiceTest {
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
         Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.PROJECT_NOT_FOUND, projectCode);
+        result.put(Constants.STATUS, Status.SUCCESS);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         doThrow(new ServiceException(Status.PROJECT_NOT_FOUND, projectCode))
                 .when(projectService)
                 .checkProjectAndAuthThrowException(loginUser, projectCode, INSTANCE_UPDATE);
-        Assertions.assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
                 () -> workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
                         shellJson, taskJson, "2020-02-21 00:00:00", true, "", "", 0));
 
         // process instance null
-        putMsg(result, Status.SUCCESS, projectCode);
         WorkflowInstance workflowInstance = getProcessInstance();
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         doNothing()
                 .when(projectService)
                 .checkProjectAndAuthThrowException(loginUser, projectCode, INSTANCE_UPDATE);
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.empty());
-        assertThrows(ServiceException.class, () -> {
-            workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
-                    shellJson, taskJson, "2020-02-21 00:00:00", true, "", "", 0);
-        });
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
+                        shellJson, taskJson, "2020-02-21 00:00:00", true, "", "", 0));
+
         // process instance not finish
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.ofNullable(workflowInstance));
         workflowInstance.setState(WorkflowExecutionStatus.RUNNING_EXECUTION);
-        putMsg(result, Status.SUCCESS, projectCode);
-        Map<String, Object> processInstanceNotFinishRes =
-                workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
-                        shellJson, taskJson, "2020-02-21 00:00:00", true, "", "", 0);
-        Assertions.assertEquals(Status.WORKFLOW_INSTANCE_STATE_OPERATION_ERROR,
-                processInstanceNotFinishRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_STATE_OPERATION_ERROR,
+                () -> workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
+                        shellJson, taskJson, "2020-02-21 00:00:00", true, "", "", 0));
 
         // process instance finish
         workflowInstance.setState(WorkflowExecutionStatus.SUCCESS);
@@ -606,7 +590,6 @@ public class WorkflowInstanceServiceTest {
 
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionJson, TaskDefinitionLog.class);
         when(workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs)).thenReturn(result);
-        putMsg(result, Status.SUCCESS, projectCode);
 
         try (
                 MockedStatic<TaskPluginManager> taskPluginManagerMockedStatic =
@@ -614,10 +597,10 @@ public class WorkflowInstanceServiceTest {
             taskPluginManagerMockedStatic
                     .when(() -> TaskPluginManager.checkTaskParameters(Mockito.any(), Mockito.any()))
                     .thenReturn(true);
-            Map<String, Object> processInstanceFinishRes =
+            WorkflowDefinition processInstanceFinishRes =
                     workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
                             taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", true, "", "", 0);
-            Assertions.assertEquals(Status.SUCCESS, processInstanceFinishRes.get(Constants.STATUS));
+            Assertions.assertNotNull(processInstanceFinishRes);
 
             final RunWorkflowCommandParam runWorkflowCommandParam = RunWorkflowCommandParam.builder()
                     .commandParams(Lists.newArrayList(Property.builder()
@@ -629,20 +612,19 @@ public class WorkflowInstanceServiceTest {
                     .timeZone("Asia/Shanghai")
                     .build();
             workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
-            Map<String, Object> processInstanceFinishRes2 =
+            WorkflowDefinition processInstanceFinishRes2 =
                     workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
                             taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", true, "", "", 0);
-            Assertions.assertEquals(Status.SUCCESS, processInstanceFinishRes2.get(Constants.STATUS));
+            Assertions.assertNotNull(processInstanceFinishRes2);
 
             // success
             when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
-            putMsg(result, Status.SUCCESS, projectCode);
 
             when(processService.saveWorkflowDefine(loginUser, workflowDefinition, Boolean.FALSE, Boolean.FALSE))
                     .thenReturn(1);
-            Map<String, Object> successRes = workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
+            WorkflowDefinition successRes = workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
                     taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", Boolean.FALSE, "", "", 0);
-            Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+            Assertions.assertNotNull(successRes);
         }
     }
 
@@ -656,38 +638,33 @@ public class WorkflowInstanceServiceTest {
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
-        ServiceException ex = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
                 () -> workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1));
-        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), ex.getCode());
 
         // process instance null
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
                 WORKFLOW_INSTANCE);
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.empty());
-        assertThrows(ServiceException.class, () -> {
-            workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
-        });
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1));
 
         // not sub process
         WorkflowInstance workflowInstance = getProcessInstance();
         workflowInstance.setIsSubWorkflow(Flag.NO);
         when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.ofNullable(workflowInstance));
-        Map<String, Object> notSubProcessRes =
-                workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE,
-                notSubProcessRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_SUB_WORKFLOW_INSTANCE,
+                () -> workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1));
 
         // sub process
         workflowInstance.setIsSubWorkflow(Flag.YES);
         when(processService.findParentWorkflowInstance(1)).thenReturn(null);
-        Map<String, Object> subProcessNullRes =
-                workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST, subProcessNullRes.get(Constants.STATUS));
+        assertThrowsServiceException(Status.SUB_WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1));
 
         // success
         when(processService.findParentWorkflowInstance(1)).thenReturn(workflowInstance);
-        Map<String, Object> successRes = workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Map<String, Integer> successRes = workflowInstanceService.queryParentInstanceBySubId(loginUser, projectCode, 1);
+        Assertions.assertEquals(workflowInstance.getId(), successRes.get(Constants.PARENT_WORKFLOW_INSTANCE));
     }
 
     @Test
@@ -748,22 +725,20 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setScheduleTime(new Date());
         workflowInstance.setGlobalParams("");
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
-        Map<String, Object> successRes = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
-
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        WorkflowInstanceVariablesDTO successRes = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
+        Assertions.assertNotNull(successRes);
 
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
-        Map<String, Object> processNotExist = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, processNotExist.get(Constants.STATUS));
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.viewVariables(loginUser, projectCode, 1));
 
         // project auth fail
         doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
                 loginUser.getUserName(), projectCode))
                         .when(projectService)
                         .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
-        ServiceException exception = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
                 () -> workflowInstanceService.viewVariables(loginUser, projectCode, 1));
-        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), exception.getCode());
     }
 
     @Test
@@ -793,14 +768,9 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setProjectCode(1L);
         when(workflowDefinitionMapper.queryByCode(100L)).thenReturn(workflowDefinition);
 
-        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
+        WorkflowInstanceVariablesDTO result = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
 
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-
-        Map<String, Object> dataList = (Map<String, Object>) result.get(Constants.DATA_LIST);
-        Assertions.assertNotNull(dataList);
-
-        List<Property> globalParams = (List<Property>) dataList.get(Constants.GLOBAL_PARAMS);
+        List<Property> globalParams = result.getGlobalParams();
         Assertions.assertNotNull(globalParams);
         Assertions.assertEquals(2, globalParams.size());
 
@@ -828,10 +798,8 @@ public class WorkflowInstanceServiceTest {
 
         when(workflowInstanceMapper.queryDetailById(999)).thenReturn(null);
 
-        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, 999);
-
-        Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, result.get(Constants.STATUS));
-        Assertions.assertNull(result.get(Constants.DATA_LIST));
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.viewVariables(loginUser, projectCode, 999));
     }
 
     @Test
@@ -855,12 +823,9 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setProjectCode(1L);
         when(workflowDefinitionMapper.queryByCode(101L)).thenReturn(workflowDefinition);
 
-        Map<String, Object> result = workflowInstanceService.viewVariables(loginUser, projectCode, 2);
+        WorkflowInstanceVariablesDTO result = workflowInstanceService.viewVariables(loginUser, projectCode, 2);
 
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-
-        Map<String, Object> dataList = (Map<String, Object>) result.get(Constants.DATA_LIST);
-        List<Property> globalParams = (List<Property>) dataList.get(Constants.GLOBAL_PARAMS);
+        List<Property> globalParams = result.getGlobalParams();
         Assertions.assertTrue(globalParams.isEmpty(), "Global params list should be empty when input is empty string");
     }
 
@@ -888,21 +853,19 @@ public class WorkflowInstanceServiceTest {
         when(processService.genDagGraph(Mockito.any(WorkflowDefinition.class)))
                 .thenReturn(graph);
 
-        Map<String, Object> successRes = workflowInstanceService.viewGantt(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertNotNull(workflowInstanceService.viewGantt(loginUser, projectCode, 1));
 
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
-        Map<String, Object> processNotExist = workflowInstanceService.viewGantt(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.WORKFLOW_INSTANCE_NOT_EXIST, processNotExist.get(Constants.STATUS));
+        assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
+                () -> workflowInstanceService.viewGantt(loginUser, projectCode, 1));
 
         // project auth fail
         doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
                 loginUser.getUserName(), projectCode))
                         .when(projectService)
                         .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
-        ServiceException exception = assertThrows(ServiceException.class,
+        assertThrowsServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
                 () -> workflowInstanceService.viewGantt(loginUser, projectCode, 1));
-        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), exception.getCode());
     }
 
     @Test
@@ -927,8 +890,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
 
         when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
-        Map<String, Object> successRes = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertNotNull(workflowInstanceService.viewVariables(loginUser, projectCode, 1));
 
         final RunWorkflowCommandParam commandParamWithEmptyTimeZone = RunWorkflowCommandParam.builder()
                 .commandParams(Lists.newArrayList(Property.builder()
@@ -941,9 +903,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setCommandType(CommandType.SCHEDULER);
         workflowInstance.setScheduleTime(new Date());
         workflowInstance.setCommandParam(JSONUtils.toJsonString(commandParamWithEmptyTimeZone));
-        Map<String, Object> successRes2 = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
-        Assertions.assertEquals(Status.SUCCESS, successRes2.get(Constants.STATUS));
-
+        Assertions.assertNotNull(workflowInstanceService.viewVariables(loginUser, projectCode, 1));
     }
 
     /**
@@ -1037,14 +997,5 @@ public class WorkflowInstanceServiceTest {
         taskInstance.setEndTime(new Date());
         taskInstance.setExecutorId(-1);
         return taskInstance;
-    }
-
-    private void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
-        result.put(Constants.STATUS, status);
-        if (statusParams != null && statusParams.length > 0) {
-            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
-        } else {
-            result.put(Constants.MSG, status.getMsg());
-        }
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Migrate 9 service methods from Map<String,Object> returns to typed returns or void with ServiceException, following the EnvironmentService pattern.

Methods migrated:
- queryTopNLongestRunningWorkflowInstance -> List<WorkflowInstance>
- queryWorkflowInstanceById -> WorkflowInstance
- queryTaskListByWorkflowInstanceId -> WorkflowInstanceTaskListDTO (new)
- querySubWorkflowInstanceByTaskId -> Map<String,Integer> (single-key)
- updateWorkflowInstance -> WorkflowDefinition
- queryParentInstanceBySubId -> Map<String,Integer> (single-key)
- viewVariables -> WorkflowInstanceVariablesDTO (new)
- viewGantt -> GanttDto
- queryByTriggerCode -> List<WorkflowInstance>

Two new DTOs encapsulate the multi-field payloads:
- WorkflowInstanceTaskListDTO (workflowInstanceState + taskList)
- WorkflowInstanceVariablesDTO (globalParams + localParams)

The single-field nested-id payloads (subWorkflowInstanceId, parentWorkflowInstance) keep their wire shape via Map<String,Integer>.

Error paths uniformly throw ServiceException; the HTTP wire format is preserved by ApiExceptionHandler converting the exception to the same Result(code, msg) shape that putMsg produced.

WorkflowInstanceController forwards typed values through Result.success; batchDeleteWorkflowInstanceByIds uses Result.errorWithArgs for the deleteFailed branch.

WorkflowInstanceService and WorkflowInstanceController have no PythonGateway / cross-service callers, so the migration is fully contained within these files plus the two test updates.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
