### PR TITLE
[Improvement-18224][API] Migrate TaskGroupService and ExecutorServiceforceStartTaskInstance to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskGroupController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TaskGroupController.java
@@ -32,10 +32,9 @@ import org.apache.dolphinscheduler.api.service.TaskGroupService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.TaskGroupQueue;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -61,16 +60,6 @@ public class TaskGroupController extends BaseController {
     @Autowired
     private TaskGroupService taskGroupService;
 
-    /**
-     * query task group list
-     *
-     * @param loginUser   login user
-     * @param name        name
-     * @param description description
-     * @param groupSize   group size
-     * @param name        project id
-     * @return result and msg code
-     */
     @Operation(summary = "create", description = "CREATE_TASK_GROUP_NOTE")
     @Parameters({
             @Parameter(name = "name", description = "NAME", schema = @Schema(implementation = String.class)),
@@ -83,26 +72,15 @@ public class TaskGroupController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_TASK_GROUP_ERROR)
     @OperatorLog(auditType = AuditType.TASK_GROUP_CREATE)
-    public Result createTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                  @RequestParam("name") String name,
-                                  @RequestParam(value = "projectCode", required = false, defaultValue = "0") Long projectCode,
-                                  @RequestParam("description") String description,
-                                  @RequestParam("groupSize") Integer groupSize) {
-        Map<String, Object> result =
-                taskGroupService.createTaskGroup(loginUser, projectCode, name, description, groupSize);
-        return returnDataList(result);
+    public Result<TaskGroup> createTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                             @RequestParam("name") String name,
+                                             @RequestParam(value = "projectCode", required = false, defaultValue = "0") Long projectCode,
+                                             @RequestParam("description") String description,
+                                             @RequestParam("groupSize") Integer groupSize) {
+        TaskGroup taskGroup = taskGroupService.createTaskGroup(loginUser, projectCode, name, description, groupSize);
+        return Result.success(taskGroup);
     }
 
-    /**
-     * update task group list
-     *
-     * @param loginUser   login user
-     * @param name        name
-     * @param description description
-     * @param groupSize   group size
-     * @param name        project id
-     * @return result and msg code
-     */
     @Operation(summary = "update", description = "UPDATE_TASK_GROUP_NOTE")
     @Parameters({
             @Parameter(name = "id", description = "TASK_GROUP_ID", schema = @Schema(implementation = int.class)),
@@ -115,23 +93,15 @@ public class TaskGroupController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(UPDATE_TASK_GROUP_ERROR)
     @OperatorLog(auditType = AuditType.TASK_GROUP_UPDATE)
-    public Result updateTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                  @RequestParam("id") Integer id,
-                                  @RequestParam("name") String name,
-                                  @RequestParam("description") String description,
-                                  @RequestParam("groupSize") Integer groupSize) {
-        Map<String, Object> result = taskGroupService.updateTaskGroup(loginUser, id, name, description, groupSize);
-        return returnDataList(result);
+    public Result<TaskGroup> updateTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                             @RequestParam("id") Integer id,
+                                             @RequestParam("name") String name,
+                                             @RequestParam("description") String description,
+                                             @RequestParam("groupSize") Integer groupSize) {
+        TaskGroup taskGroup = taskGroupService.updateTaskGroup(loginUser, id, name, description, groupSize);
+        return Result.success(taskGroup);
     }
 
-    /**
-     * query task group list paging
-     *
-     * @param loginUser login user
-     * @param pageNo    page number
-     * @param pageSize  page size
-     * @return queue list
-     */
     @Operation(summary = "list-paging", description = "QUERY_ALL_TASK_GROUP_NOTES")
     @Parameters({
             @Parameter(name = "pageNo", description = "PAGE_NO", required = true, schema = @Schema(implementation = int.class, example = "1")),
@@ -141,24 +111,15 @@ public class TaskGroupController extends BaseController {
     @GetMapping(value = "/list-paging")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TASK_GROUP_LIST_ERROR)
-    public Result queryAllTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                    @RequestParam(value = "name", required = false) String name,
-                                    @RequestParam(value = "status", required = false) Integer status,
-                                    @RequestParam("pageNo") Integer pageNo,
-                                    @RequestParam("pageSize") Integer pageSize) {
-        Map<String, Object> result = taskGroupService.queryAllTaskGroup(loginUser, name, status, pageNo, pageSize);
-        return returnDataList(result);
+    public Result<PageInfo<TaskGroup>> queryAllTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                         @RequestParam(value = "name", required = false) String name,
+                                                         @RequestParam(value = "status", required = false) Integer status,
+                                                         @RequestParam("pageNo") Integer pageNo,
+                                                         @RequestParam("pageSize") Integer pageSize) {
+        PageInfo<TaskGroup> pageInfo = taskGroupService.queryAllTaskGroup(loginUser, name, status, pageNo, pageSize);
+        return Result.success(pageInfo);
     }
 
-    /**
-     * query task group list paging
-     *
-     * @param loginUser login user
-     * @param pageNo    page number
-     * @param status    status
-     * @param pageSize  page size
-     * @return queue list
-     */
     @Operation(summary = "queryTaskGroupByStatus", description = "QUERY_TASK_GROUP_LIST_BY_STATUS_NOTES")
     @Parameters({
             @Parameter(name = "pageNo", description = "PAGE_NO", required = true, schema = @Schema(implementation = int.class, example = "1")),
@@ -168,23 +129,14 @@ public class TaskGroupController extends BaseController {
     @GetMapping(value = "/query-list-by-status")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TASK_GROUP_LIST_ERROR)
-    public Result queryTaskGroupByStatus(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                         @RequestParam("pageNo") Integer pageNo,
-                                         @RequestParam(value = "status", required = false) Integer status,
-                                         @RequestParam("pageSize") Integer pageSize) {
-        Map<String, Object> result = taskGroupService.queryTaskGroupByStatus(loginUser, pageNo, pageSize, status);
-        return returnDataList(result);
+    public Result<PageInfo<TaskGroup>> queryTaskGroupByStatus(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                              @RequestParam("pageNo") Integer pageNo,
+                                                              @RequestParam(value = "status", required = false) Integer status,
+                                                              @RequestParam("pageSize") Integer pageSize) {
+        PageInfo<TaskGroup> pageInfo = taskGroupService.queryTaskGroupByStatus(loginUser, pageNo, pageSize, status);
+        return Result.success(pageInfo);
     }
 
-    /**
-     * query task group list paging by project code
-     *
-     * @param loginUser   login user
-     * @param pageNo      page number
-     * @param projectCode project code
-     * @param pageSize    page size
-     * @return queue list
-     */
     @Operation(summary = "queryTaskGroupByName", description = "QUERY_TASK_GROUP_LIST_BY_PROJECT_ID_NOTES")
     @Parameters({
             @Parameter(name = "pageNo", description = "PAGE_NO", required = true, schema = @Schema(implementation = int.class, example = "1")),
@@ -194,22 +146,15 @@ public class TaskGroupController extends BaseController {
     @GetMapping(value = "/query-list-by-projectCode")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_TASK_GROUP_LIST_ERROR)
-    public Result queryTaskGroupByCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                       @RequestParam("pageNo") Integer pageNo,
-                                       @RequestParam(value = "projectCode", required = false) Long projectCode,
-                                       @RequestParam("pageSize") Integer pageSize) {
-        Map<String, Object> result =
+    public Result<PageInfo<TaskGroup>> queryTaskGroupByCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                            @RequestParam("pageNo") Integer pageNo,
+                                                            @RequestParam(value = "projectCode", required = false) Long projectCode,
+                                                            @RequestParam("pageSize") Integer pageSize) {
+        PageInfo<TaskGroup> pageInfo =
                 taskGroupService.queryTaskGroupByProjectCode(loginUser, pageNo, pageSize, projectCode);
-        return returnDataList(result);
+        return Result.success(pageInfo);
     }
 
-    /**
-     * close a task group
-     *
-     * @param loginUser login user
-     * @param id        id
-     * @return result
-     */
     @Operation(summary = "closeTaskGroup", description = "CLOSE_TASK_GROUP_NOTES")
     @Parameters({
             @Parameter(name = "id", description = "ID", required = true, schema = @Schema(implementation = int.class))
@@ -218,20 +163,12 @@ public class TaskGroupController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CLOSE_TASK_GROUP_ERROR)
     @OperatorLog(auditType = AuditType.TASK_GROUP_CLOSE)
-    public Result closeTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                 @RequestParam(value = "id", required = false) Integer id) {
-
-        Map<String, Object> result = taskGroupService.closeTaskGroup(loginUser, id);
-        return returnDataList(result);
+    public Result<Void> closeTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                       @RequestParam(value = "id", required = false) Integer id) {
+        taskGroupService.closeTaskGroup(loginUser, id);
+        return Result.success();
     }
 
-    /**
-     * start a task group
-     *
-     * @param loginUser login user
-     * @param id        id
-     * @return result
-     */
     @Operation(summary = "startTaskGroup", description = "START_TASK_GROUP_NOTES")
     @Parameters({
             @Parameter(name = "id", description = "TASK_GROUP_ID", required = true, schema = @Schema(implementation = int.class))
@@ -240,19 +177,12 @@ public class TaskGroupController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(START_TASK_GROUP_ERROR)
     @OperatorLog(auditType = AuditType.TASK_GROUP_START)
-    public Result startTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                 @RequestParam(value = "id", required = false) Integer id) {
-        Map<String, Object> result = taskGroupService.startTaskGroup(loginUser, id);
-        return returnDataList(result);
+    public Result<Void> startTaskGroup(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                       @RequestParam(value = "id", required = false) Integer id) {
+        taskGroupService.startTaskGroup(loginUser, id);
+        return Result.success();
     }
 
-    /**
-     * force start task without task group
-     *
-     * @param loginUser login user
-     * @param queueId   task group queue id
-     * @return result
-     */
     @Operation(summary = "forceStart", description = "FORCE_START_TASK_GROUP")
     @Parameters({
             @Parameter(name = "queueId", description = "TASK_GROUP_QUEUE_ID", required = true, schema = @Schema(implementation = int.class))
@@ -261,19 +191,12 @@ public class TaskGroupController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(START_TASK_GROUP_ERROR)
     @OperatorLog(auditType = AuditType.TASK_GROUP_START)
-    public Result forceStart(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                             @RequestParam(value = "queueId") Integer id) {
-        Map<String, Object> result = taskGroupService.forceStartTask(loginUser, id);
-        return returnDataList(result);
+    public Result<Void> forceStart(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                   @RequestParam(value = "queueId") Integer id) {
+        taskGroupService.forceStartTask(loginUser, id);
+        return Result.success();
     }
 
-    /**
-     * force start task without task group
-     *
-     * @param loginUser login user
-     * @param queueId   task group queue id
-     * @return result
-     */
     @Operation(summary = "modifyPriority", description = "MODIFY_TASK_GROUP_PRIORITY")
     @Parameters({
             @Parameter(name = "queueId", description = "TASK_GROUP_QUEUE_ID", required = true, schema = @Schema(implementation = int.class)),
@@ -283,28 +206,16 @@ public class TaskGroupController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(START_TASK_GROUP_ERROR)
     @OperatorLog(auditType = AuditType.TASK_GROUP_MODIFY)
-    public Result modifyPriority(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                 @RequestParam(value = "queueId") Integer queueId,
-                                 @RequestParam(value = "priority") Integer priority) {
-        Map<String, Object> result = taskGroupService.modifyPriority(loginUser, queueId, priority);
-        return returnDataList(result);
+    public Result<Void> modifyPriority(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                       @RequestParam(value = "queueId") Integer queueId,
+                                       @RequestParam(value = "priority") Integer priority) {
+        taskGroupService.modifyPriority(loginUser, queueId, priority);
+        return Result.success();
     }
 
     @Autowired
     private TaskGroupQueueService taskGroupQueueService;
 
-    /**
-     * query task group queue list paging
-     *
-     * @param groupId     ID for task group
-     * @param taskName    Task Name
-     * @param workflowInstanceName workflow instance name
-     * @param status      Task queue status
-     * @param loginUser   login user
-     * @param pageNo      page number
-     * @param pageSize    page size
-     * @return queue list
-     */
     @Operation(summary = "queryTaskGroupQueuesByGroupId", description = "QUERY_TASKS_GROUP_GROUP_QUEUES")
     @Parameters({
             @Parameter(name = "groupId", description = "GROUP_ID", required = false, schema = @Schema(implementation = int.class, example = "1", defaultValue = "-1")),

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/exceptions/ApiExceptionHandler.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/exceptions/ApiExceptionHandler.java
@@ -22,8 +22,11 @@ import org.apache.dolphinscheduler.api.utils.Result;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.HandlerMethod;
 
@@ -36,20 +39,37 @@ import org.springframework.web.method.HandlerMethod;
 public class ApiExceptionHandler {
 
     @ExceptionHandler(ServiceException.class)
-    public Result<Object> exceptionHandler(ServiceException e, HandlerMethod hm) {
+    public ResponseEntity<Result<Object>> exceptionHandler(ServiceException e, HandlerMethod hm) {
         log.error("{} Meet a ServiceException: {}", hm.getShortLogMessage(), e.getMessage());
-        return new Result<>(e.getCode(), e.getMessage());
+        return ResponseEntity.status(resolveResponseStatus(hm))
+                .body(new Result<>(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(Throwable.class)
-    public Result<Object> exceptionHandler(Throwable e, HandlerMethod hm) {
+    public ResponseEntity<Result<Object>> exceptionHandler(Throwable e, HandlerMethod hm) {
         ApiException ce = hm.getMethodAnnotation(ApiException.class);
         log.error("Meet an unknown exception: ", e);
+        Result<Object> body;
         if (ce == null) {
-            return Result.errorWithArgs(Status.INTERNAL_SERVER_ERROR_ARGS, e.getMessage());
+            body = Result.errorWithArgs(Status.INTERNAL_SERVER_ERROR_ARGS, e.getMessage());
+        } else {
+            Status st = ce.value();
+            body = new Result<>(st.getCode(), st.getMsg() + ":" + e.getMessage());
         }
-        Status st = ce.value();
-        return new Result<>(st.getCode(), st.getMsg() + ":" + e.getMessage());
+        return ResponseEntity.status(resolveResponseStatus(hm)).body(body);
+    }
+
+    /**
+     * Honour the {@link ResponseStatus} declared on the controller method so that error responses
+     * keep the same HTTP status code as success responses on the same endpoint. Falls back to 200
+     * OK when the handler method does not declare one.
+     */
+    private static HttpStatus resolveResponseStatus(HandlerMethod hm) {
+        ResponseStatus status = hm.getMethodAnnotation(ResponseStatus.class);
+        if (status == null) {
+            status = hm.getBeanType().getAnnotation(ResponseStatus.class);
+        }
+        return status == null ? HttpStatus.OK : status.value();
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
@@ -83,12 +83,8 @@ public interface ExecutorService {
 
     /**
      * force start Task Instance
-     *
-     * @param loginUser
-     * @param queueId
-     * @return
      */
-    Map<String, Object> forceStartTaskInstance(User loginUser, int queueId);
+    void forceStartTaskInstance(User loginUser, int queueId);
 
     /**
      * execute stream task instance

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TaskGroupService.java
@@ -17,117 +17,63 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.Map;
 
 public interface TaskGroupService {
 
     /**
      * create a Task group
-     *
-     * @param loginUser   login user
-     * @param name        task group name
-     * @param description task group description
-     * @param groupSize   task group total size
-     * @return the result code and msg
      */
-    Map<String, Object> createTaskGroup(User loginUser, Long projectCode, String name,
-                                        String description, int groupSize);
+    TaskGroup createTaskGroup(User loginUser, Long projectCode, String name, String description, int groupSize);
 
     /**
      * update the task group
-     *
-     * @param loginUser   login user
-     * @param name        task group name
-     * @param description task group description
-     * @param groupSize   task group total size
-     * @return the result code and msg
      */
-    Map<String, Object> updateTaskGroup(User loginUser, int id, String name,
-                                        String description, int groupSize);
+    TaskGroup updateTaskGroup(User loginUser, int id, String name, String description, int groupSize);
 
     /**
      * query all task group by user id
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @return the result code and msg
      */
-    Map<String, Object> queryAllTaskGroup(User loginUser, String name, Integer status, int pageNo, int pageSize);
+    PageInfo<TaskGroup> queryAllTaskGroup(User loginUser, String name, Integer status, int pageNo, int pageSize);
 
     /**
      * query all task group by status
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @param status    status
-     * @return the result code and msg
      */
-    Map<String, Object> queryTaskGroupByStatus(User loginUser, int pageNo, int pageSize, int status);
+    PageInfo<TaskGroup> queryTaskGroupByStatus(User loginUser, int pageNo, int pageSize, int status);
 
     /**
-     * query all task group by name
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @param projectCode  project code
-     * @return the result code and msg
+     * query all task group by project code
      */
-    Map<String, Object> queryTaskGroupByProjectCode(User loginUser, int pageNo, int pageSize, Long projectCode);
+    PageInfo<TaskGroup> queryTaskGroupByProjectCode(User loginUser, int pageNo, int pageSize, Long projectCode);
 
     /**
-     * query all task group by id
-     *
-     * @param loginUser login user
-     * @param id        id
-     * @return the result code and msg
+     * query task group by id (returns null if not found)
      */
-    Map<String, Object> queryTaskGroupById(User loginUser, int id);
+    TaskGroup queryTaskGroupById(User loginUser, int id);
 
     /**
-     * query
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @param userId    user id
-     * @param name      name
-     * @param status    status
-     * @return the result code and msg
+     * paginated query of task groups
      */
-    Map<String, Object> doQuery(User loginUser, int pageNo, int pageSize, int userId, String name, Integer status);
+    PageInfo<TaskGroup> doQuery(User loginUser, int pageNo, int pageSize, int userId, String name, Integer status);
 
     /**
      * close a task group
-     *
-     * @param loginUser login user
-     * @param id        task group id
-     * @return the result code and msg
      */
-    Map<String, Object> closeTaskGroup(User loginUser, int id);
+    void closeTaskGroup(User loginUser, int id);
 
     /**
      * start a task group
-     *
-     * @param loginUser login user
-     * @param id        task group id
-     * @return the result code and msg
      */
-    Map<String, Object> startTaskGroup(User loginUser, int id);
+    void startTaskGroup(User loginUser, int id);
 
     /**
      * wake a task manually
-     *
-     * @param taskId task id
-     * @return result
      */
-    Map<String, Object> forceStartTask(User loginUser, int taskId);
+    void forceStartTask(User loginUser, int taskId);
 
-    Map<String, Object> modifyPriority(User loginUser, Integer queueId, Integer priority);
+    void modifyPriority(User loginUser, Integer queueId, Integer priority);
 
     void deleteTaskGroupByProjectCode(long projectCode);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -38,7 +38,6 @@ import org.apache.dolphinscheduler.api.validator.workflow.BackfillWorkflowReques
 import org.apache.dolphinscheduler.api.validator.workflow.TriggerWorkflowDTO;
 import org.apache.dolphinscheduler.api.validator.workflow.TriggerWorkflowDTOValidator;
 import org.apache.dolphinscheduler.api.validator.workflow.TriggerWorkflowRequestTransformer;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
@@ -380,8 +379,7 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
     }
 
     @Override
-    public Map<String, Object> forceStartTaskInstance(User loginUser, int queueId) {
-        Map<String, Object> result = new HashMap<>();
+    public void forceStartTaskInstance(User loginUser, int queueId) {
         TaskGroupQueue taskGroupQueue = taskGroupQueueMapper.selectById(queueId);
         // check workflow instance exist
         workflowInstanceDao.queryOptionalById(taskGroupQueue.getWorkflowInstanceId())
@@ -395,9 +393,6 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
         taskGroupQueue.setForceStart(Flag.YES.getCode());
         taskGroupQueue.setUpdateTime(new Date());
         taskGroupQueueMapper.updateById(taskGroupQueue);
-
-        result.put(Constants.STATUS, Status.SUCCESS);
-        return result;
     }
 
     @Override

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.api.service.impl;
 
 import org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant;
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.ExecutorService;
 import org.apache.dolphinscheduler.api.service.TaskGroupQueueService;
 import org.apache.dolphinscheduler.api.service.TaskGroupService;
@@ -40,9 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -74,43 +73,26 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
     @Autowired
     private ExecutorService executorService;
 
-    /**
-     * create a Task group
-     *
-     * @param loginUser   login user
-     * @param name        task group name
-     * @param description task group description
-     * @param groupSize   task group total size
-     * @return the result code and msg
-     */
     @Override
     @Transactional
-    public Map<String, Object> createTaskGroup(User loginUser, Long projectCode, String name, String description,
-                                               int groupSize) {
-        Map<String, Object> result = new HashMap<>();
-        if (!hasProjectPerm(loginUser, projectCode, result, true)) {
-            return result;
-        }
+    public TaskGroup createTaskGroup(User loginUser, Long projectCode, String name, String description, int groupSize) {
+        requireProjectPerm(loginUser, projectCode, true);
         if (checkDescriptionLength(description)) {
             log.warn("Parameter description is too long.");
-            putMsg(result, Status.DESCRIPTION_TOO_LONG_ERROR);
-            return result;
+            throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
         }
         if (name == null) {
             log.warn("Parameter name can ot be null.");
-            putMsg(result, Status.NAME_NULL);
-            return result;
+            throw new ServiceException(Status.NAME_NULL);
         }
         if (groupSize <= 0) {
             log.warn("Parameter task group size is must bigger than 1.");
-            putMsg(result, Status.TASK_GROUP_SIZE_ERROR);
-            return result;
+            throw new ServiceException(Status.TASK_GROUP_SIZE_ERROR);
         }
-        TaskGroup taskGroup1 = taskGroupMapper.queryByName(loginUser.getId(), name);
-        if (taskGroup1 != null) {
-            log.warn("Task group with the same name already exists, taskGroupName:{}.", taskGroup1.getName());
-            putMsg(result, Status.TASK_GROUP_NAME_EXSIT);
-            return result;
+        TaskGroup duplicate = taskGroupMapper.queryByName(loginUser.getId(), name);
+        if (duplicate != null) {
+            log.warn("Task group with the same name already exists, taskGroupName:{}.", duplicate.getName());
+            throw new ServiceException(Status.TASK_GROUP_NAME_EXSIT);
         }
         Date now = new Date();
         TaskGroup taskGroup = TaskGroup.builder()
@@ -124,49 +106,29 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
                 .updateTime(now)
                 .build();
 
-        if (taskGroupMapper.insert(taskGroup) > 0) {
-            log.info("Create task group complete, taskGroupName:{}.", taskGroup.getName());
-            result.put(Constants.DATA_LIST, taskGroup);
-            putMsg(result, Status.SUCCESS);
-        } else {
+        if (taskGroupMapper.insert(taskGroup) <= 0) {
             log.error("Create task group error, taskGroupName:{}.", taskGroup.getName());
-            putMsg(result, Status.CREATE_TASK_GROUP_ERROR);
-            return result;
+            throw new ServiceException(Status.CREATE_TASK_GROUP_ERROR);
         }
-
-        return result;
+        log.info("Create task group complete, taskGroupName:{}.", taskGroup.getName());
+        return taskGroup;
     }
 
-    /**
-     * update the task group
-     *
-     * @param loginUser   login user
-     * @param name        task group name
-     * @param description task group description
-     * @param groupSize   task group total size
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> updateTaskGroup(User loginUser, int id, String name, String description, int groupSize) {
-        Map<String, Object> result = new HashMap<>();
+    public TaskGroup updateTaskGroup(User loginUser, int id, String name, String description, int groupSize) {
         TaskGroup taskGroup = taskGroupMapper.selectById(id);
-        if (!hasProjectPerm(loginUser, taskGroup.getProjectCode(), result, true)) {
-            return result;
-        }
+        requireProjectPerm(loginUser, taskGroup.getProjectCode(), true);
         if (checkDescriptionLength(description)) {
             log.warn("Parameter description is too long.");
-            putMsg(result, Status.DESCRIPTION_TOO_LONG_ERROR);
-            return result;
+            throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
         }
         if (name == null) {
             log.warn("Parameter name can ot be null.");
-            putMsg(result, Status.NAME_NULL);
-            return result;
+            throw new ServiceException(Status.NAME_NULL);
         }
         if (groupSize <= 0) {
             log.warn("Parameter task group size is must bigger than 1.");
-            putMsg(result, Status.TASK_GROUP_SIZE_ERROR);
-            return result;
+            throw new ServiceException(Status.TASK_GROUP_SIZE_ERROR);
         }
         Long exists = taskGroupMapper.selectCount(new QueryWrapper<TaskGroup>().lambda()
                 .eq(TaskGroup::getName, name)
@@ -175,13 +137,11 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
 
         if (exists > 0) {
             log.error("Task group with the same name already exists.");
-            putMsg(result, Status.TASK_GROUP_NAME_EXSIT);
-            return result;
+            throw new ServiceException(Status.TASK_GROUP_NAME_EXSIT);
         }
         if (taskGroup.getStatus() != Flag.YES) {
             log.warn("Task group has been closed, taskGroupId:{}.", id);
-            putMsg(result, Status.TASK_GROUP_STATUS_ERROR);
-            return result;
+            throw new ServiceException(Status.TASK_GROUP_STATUS_ERROR);
         }
         taskGroup.setGroupSize(groupSize);
         taskGroup.setDescription(description);
@@ -189,218 +149,115 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         if (StringUtils.isNotEmpty(name)) {
             taskGroup.setName(name);
         }
-        int i = taskGroupMapper.updateById(taskGroup);
-        if (i > 0) {
-            log.info("Update task group complete, taskGroupId:{}.", id);
-            result.put(Constants.DATA_LIST, taskGroup);
-            putMsg(result, Status.SUCCESS);
-        } else {
+        if (taskGroupMapper.updateById(taskGroup) <= 0) {
             log.error("Update task group error, taskGroupId:{}.", id);
-            putMsg(result, Status.UPDATE_TASK_GROUP_ERROR);
+            throw new ServiceException(Status.UPDATE_TASK_GROUP_ERROR);
         }
-        return result;
+        log.info("Update task group complete, taskGroupId:{}.", id);
+        return taskGroup;
     }
 
-    /**
-     * query all task group by user id
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> queryAllTaskGroup(User loginUser, String name, Integer status, int pageNo,
+    public PageInfo<TaskGroup> queryAllTaskGroup(User loginUser, String name, Integer status, int pageNo,
                                                  int pageSize) {
         return this.doQuery(loginUser, pageNo, pageSize, loginUser.getId(), name, status);
     }
 
-    /**
-     * query all task group by status
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @param status    status
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> queryTaskGroupByStatus(User loginUser, int pageNo, int pageSize, int status) {
+    public PageInfo<TaskGroup> queryTaskGroupByStatus(User loginUser, int pageNo, int pageSize, int status) {
         return this.doQuery(loginUser, pageNo, pageSize, loginUser.getId(), null, status);
     }
 
-    /**
-     * query all task group by name
-     *
-     * @param loginUser login user
-     * @param pageNo    page no
-     * @param pageSize  page size
-     * @param projectCode project code
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> queryTaskGroupByProjectCode(User loginUser, int pageNo, int pageSize, Long projectCode) {
-        Map<String, Object> result = new HashMap<>();
-        if (!hasProjectPerm(loginUser, projectCode, result, false)) {
-            return result;
-        }
+    public PageInfo<TaskGroup> queryTaskGroupByProjectCode(User loginUser, int pageNo, int pageSize, Long projectCode) {
+        requireProjectPerm(loginUser, projectCode, false);
         Page<TaskGroup> page = new Page<>(pageNo, pageSize);
         IPage<TaskGroup> taskGroupPaging =
                 taskGroupMapper.queryTaskGroupPagingByProjectCode(page, projectCode);
 
-        return getStringObjectMap(pageNo, pageSize, result, taskGroupPaging);
+        return buildPageInfo(pageNo, pageSize, taskGroupPaging);
     }
 
-    private Map<String, Object> getStringObjectMap(int pageNo, int pageSize, Map<String, Object> result,
-                                                   IPage<TaskGroup> taskGroupPaging) {
+    private PageInfo<TaskGroup> buildPageInfo(int pageNo, int pageSize, IPage<TaskGroup> taskGroupPaging) {
         PageInfo<TaskGroup> pageInfo = new PageInfo<>(pageNo, pageSize);
         int total = taskGroupPaging == null ? 0 : (int) taskGroupPaging.getTotal();
         List<TaskGroup> list = taskGroupPaging == null ? new ArrayList<TaskGroup>() : taskGroupPaging.getRecords();
         pageInfo.setTotal(total);
         pageInfo.setTotalList(list);
-
-        result.put(Constants.DATA_LIST, pageInfo);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return pageInfo;
     }
 
-    /**
-     * query all task group by id
-     *
-     * @param loginUser login user
-     * @param id        id
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> queryTaskGroupById(User loginUser, int id) {
-        Map<String, Object> result = new HashMap<>();
-        TaskGroup taskGroup = taskGroupMapper.selectById(id);
-        result.put(Constants.DATA_LIST, taskGroup);
-        putMsg(result, Status.SUCCESS);
-        return result;
+    public TaskGroup queryTaskGroupById(User loginUser, int id) {
+        return taskGroupMapper.selectById(id);
     }
 
-    /**
-     * query
-     *
-     * @param pageNo   page no
-     * @param pageSize page size
-     * @param userId   user id
-     * @param name     name
-     * @param status   status
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> doQuery(User loginUser, int pageNo, int pageSize, int userId, String name,
+    public PageInfo<TaskGroup> doQuery(User loginUser, int pageNo, int pageSize, int userId, String name,
                                        Integer status) {
-        Map<String, Object> result = new HashMap<>();
         Page<TaskGroup> page = new Page<>(pageNo, pageSize);
         IPage<TaskGroup> taskGroupPaging =
                 taskGroupMapper.queryTaskGroupPaging(page, name, status);
 
-        return getStringObjectMap(pageNo, pageSize, result, taskGroupPaging);
+        return buildPageInfo(pageNo, pageSize, taskGroupPaging);
     }
 
-    /**
-     * close a task group
-     *
-     * @param loginUser login user
-     * @param id        task group id
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> closeTaskGroup(User loginUser, int id) {
-        Map<String, Object> result = new HashMap<>();
-
-        boolean canOperatorPermissions = canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
-                ApiFuncIdentificationConstant.TASK_GROUP_CLOSE);
-        if (!canOperatorPermissions) {
-            putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);
-            return result;
+    public void closeTaskGroup(User loginUser, int id) {
+        if (!canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
+                ApiFuncIdentificationConstant.TASK_GROUP_CLOSE)) {
+            throw new ServiceException(Status.NO_CURRENT_OPERATING_PERMISSION);
         }
         TaskGroup taskGroup = taskGroupMapper.selectById(id);
         if (taskGroup.getStatus() == Flag.NO) {
             log.info("Task group has been closed, taskGroupId:{}.", id);
-            putMsg(result, Status.TASK_GROUP_STATUS_CLOSED);
-            return result;
+            throw new ServiceException(Status.TASK_GROUP_STATUS_CLOSED);
         }
         taskGroup.setStatus(Flag.NO);
-        int update = taskGroupMapper.updateById(taskGroup);
-        if (update > 0)
+        if (taskGroupMapper.updateById(taskGroup) > 0) {
             log.info("Task group close complete, taskGroupId:{}.", id);
-        else
+        } else {
             log.error("Task group close error, taskGroupId:{}.", id);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        }
     }
 
-    /**
-     * start a task group
-     *
-     * @param loginUser login user
-     * @param id        task group id
-     * @return the result code and msg
-     */
     @Override
-    public Map<String, Object> startTaskGroup(User loginUser, int id) {
-        Map<String, Object> result = new HashMap<>();
-
-        boolean canOperatorPermissions = canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
-                ApiFuncIdentificationConstant.TASK_GROUP_CLOSE);
-        if (!canOperatorPermissions) {
-            putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);
-            return result;
+    public void startTaskGroup(User loginUser, int id) {
+        if (!canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
+                ApiFuncIdentificationConstant.TASK_GROUP_CLOSE)) {
+            throw new ServiceException(Status.NO_CURRENT_OPERATING_PERMISSION);
         }
         TaskGroup taskGroup = taskGroupMapper.selectById(id);
         if (taskGroup.getStatus() == Flag.YES) {
             log.info("Task group has been started, taskGroupId:{}.", id);
-            putMsg(result, Status.TASK_GROUP_STATUS_OPENED);
-            return result;
+            throw new ServiceException(Status.TASK_GROUP_STATUS_OPENED);
         }
         taskGroup.setStatus(Flag.YES);
         taskGroup.setUpdateTime(new Date(System.currentTimeMillis()));
-        int update = taskGroupMapper.updateById(taskGroup);
-        if (update > 0)
+        if (taskGroupMapper.updateById(taskGroup) > 0) {
             log.info("Task group start complete, taskGroupId:{}.", id);
-        else
+        } else {
             log.error("Task group start error, taskGroupId:{}.", id);
-        putMsg(result, Status.SUCCESS);
-        return result;
-    }
-
-    /**
-     * wake a task manually
-     *
-     * @param loginUser
-     * @param queueId   task group queue id
-     * @return result
-     */
-    @Override
-    public Map<String, Object> forceStartTask(User loginUser, int queueId) {
-        Map<String, Object> result = new HashMap<>();
-        boolean canOperatorPermissions = canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
-                ApiFuncIdentificationConstant.TASK_GROUP_QUEUE_START);
-        if (!canOperatorPermissions) {
-            putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);
-            return result;
         }
-        return executorService.forceStartTaskInstance(loginUser, queueId);
     }
 
     @Override
-    public Map<String, Object> modifyPriority(User loginUser, Integer queueId, Integer priority) {
-        Map<String, Object> result = new HashMap<>();
+    public void forceStartTask(User loginUser, int queueId) {
+        if (!canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
+                ApiFuncIdentificationConstant.TASK_GROUP_QUEUE_START)) {
+            throw new ServiceException(Status.NO_CURRENT_OPERATING_PERMISSION);
+        }
+        executorService.forceStartTaskInstance(loginUser, queueId);
+    }
 
-        boolean canOperatorPermissions = canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
-                ApiFuncIdentificationConstant.TASK_GROUP_QUEUE_PRIORITY);
-        if (!canOperatorPermissions) {
-            putMsg(result, Status.NO_CURRENT_OPERATING_PERMISSION);
-            return result;
+    @Override
+    public void modifyPriority(User loginUser, Integer queueId, Integer priority) {
+        if (!canOperatorPermissions(loginUser, null, AuthorizationType.TASK_GROUP,
+                ApiFuncIdentificationConstant.TASK_GROUP_QUEUE_PRIORITY)) {
+            throw new ServiceException(Status.NO_CURRENT_OPERATING_PERMISSION);
         }
         taskGroupQueueService.modifyPriority(queueId, priority);
         log.info("Modify task group queue priority complete, queueId:{}, priority:{}.", queueId, priority);
-        putMsg(result, Status.SUCCESS);
-        return result;
     }
 
     @Override
@@ -416,37 +273,30 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         taskGroupMapper.deleteBatchIds(taskGroupIds);
     }
 
-    private boolean hasProjectPerm(User loginUser, long projectCode, Map<String, Object> result,
-                                   boolean writePermission) {
+    private void requireProjectPerm(User loginUser, long projectCode, boolean writePermission) {
+        if (loginUser.getUserType() == UserType.ADMIN_USER) {
+            return;
+        }
         Project project = projectMapper.queryByCode(projectCode);
         if (project == null) {
-            log.warn("Project does not exist");
-            putMsg(result, Status.PROJECT_NOT_FOUND, "");
+            log.warn("Project does not exist, projectCode:{}.", projectCode);
+            throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);
         }
-
-        if (loginUser.getUserType() == UserType.ADMIN_USER) {
-            return true;
-        }
-
         if (project.getUserId().equals(loginUser.getId())) {
-            return true;
+            return;
         }
-
         ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), loginUser.getId());
         if (projectUser == null) {
             log.warn("User {} does not have operation permission for project {}", loginUser.getUserName(),
                     project.getCode());
-            putMsg(result, Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(), project.getCode());
-            return false;
+            throw new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(),
+                    project.getCode());
         }
         if (writePermission && projectUser.getPerm() != Constants.DEFAULT_ADMIN_PERMISSION) {
             log.warn("User {} does not have write permission for project {}", loginUser.getUserName(),
                     project.getCode());
-            putMsg(result, Status.USER_NO_WRITE_PROJECT_PERM, loginUser.getUserName(), project.getCode());
-            return false;
+            throw new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM, loginUser.getUserName(),
+                    project.getCode());
         }
-
-        return true;
     }
-
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AccessTokenControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AccessTokenControllerTest.java
@@ -87,7 +87,7 @@ public class AccessTokenControllerTest extends AbstractControllerTest {
         MvcResult mvcResult = mockMvc.perform(post("/access-tokens")
                 .header("sessionId", sessionId)
                 .params(paramsMap))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
         Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UsersControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/UsersControllerTest.java
@@ -56,7 +56,7 @@ public class UsersControllerTest extends AbstractControllerTest {
         MvcResult mvcResult = mockMvc.perform(post("/users/create")
                 .header(SESSION_ID, sessionId)
                 .params(paramsMap))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/exceptions/ApiExceptionHandlerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/exceptions/ApiExceptionHandlerTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.HandlerMethod;
 
 public class ApiExceptionHandlerTest {
@@ -38,8 +39,8 @@ public class ApiExceptionHandlerTest {
         Method method =
                 controller.getClass().getMethod("createToken", User.class, int.class, String.class, String.class);
         HandlerMethod hm = new HandlerMethod(controller, method);
-        Result result = handler.exceptionHandler(new RuntimeException("test exception"), hm);
-        Assertions.assertEquals(Status.CREATE_ACCESS_TOKEN_ERROR.getCode(), result.getCode().intValue());
+        ResponseEntity<Result<Object>> response = handler.exceptionHandler(new RuntimeException("test exception"), hm);
+        Assertions.assertEquals(Status.CREATE_ACCESS_TOKEN_ERROR.getCode(), response.getBody().getCode().intValue());
     }
 
     @Test
@@ -49,7 +50,8 @@ public class ApiExceptionHandlerTest {
         Method method =
                 controller.getClass().getMethod("queryAllWorkflowDefinitionByProjectCode", User.class, long.class);
         HandlerMethod hm = new HandlerMethod(controller, method);
-        Result result = handler.exceptionHandler(new RuntimeException("test exception"), hm);
-        Assertions.assertEquals(Status.QUERY_WORKFLOW_DEFINITION_LIST.getCode(), result.getCode().intValue());
+        ResponseEntity<Result<Object>> response = handler.exceptionHandler(new RuntimeException("test exception"), hm);
+        Assertions.assertEquals(Status.QUERY_WORKFLOW_DEFINITION_LIST.getCode(),
+                response.getBody().getCode().intValue());
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskGroupServiceTest.java
@@ -17,13 +17,14 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import static org.apache.dolphinscheduler.api.AssertionsHelper.assertThrowsServiceException;
+
 import org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.permission.ResourcePermissionCheckService;
 import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.TaskGroupServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.enums.UserType;
@@ -35,7 +36,6 @@ import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -52,14 +52,9 @@ import org.slf4j.LoggerFactory;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
-/**
- * project service test
- **/
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class TaskGroupServiceTest {
-
-    private static final Logger logger = LoggerFactory.getLogger(TaskGroupServiceTest.class);
 
     @InjectMocks
     private TaskGroupServiceImpl taskGroupService;
@@ -83,9 +78,6 @@ public class TaskGroupServiceTest {
 
     private static final Logger serviceLogger = LoggerFactory.getLogger(BaseServiceImpl.class);
 
-    /**
-     * create admin user
-     */
     private User getLoginUser() {
         User loginUser = new User();
         loginUser.setUserType(UserType.ADMIN_USER);
@@ -104,7 +96,7 @@ public class TaskGroupServiceTest {
     }
 
     private TaskGroup getTaskGroup() {
-        TaskGroup taskGroup = TaskGroup.builder()
+        return TaskGroup.builder()
                 .name(taskGroupName)
                 .projectCode(0)
                 .description(taskGroupDesc)
@@ -112,8 +104,6 @@ public class TaskGroupServiceTest {
                 .userId(1)
                 .status(Flag.YES)
                 .build();
-
-        return taskGroup;
     }
 
     private List<TaskGroup> getList() {
@@ -128,8 +118,8 @@ public class TaskGroupServiceTest {
         Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TASK_GROUP,
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_QUEUE_START, serviceLogger))
                 .thenReturn(false);
-        Map<String, Object> objectMap = taskGroupService.forceStartTask(loginUser, 1);
-        Assertions.assertEquals(Status.NO_CURRENT_OPERATING_PERMISSION, objectMap.get(Constants.STATUS));
+        assertThrowsServiceException(Status.NO_CURRENT_OPERATING_PERMISSION,
+                () -> taskGroupService.forceStartTask(loginUser, 1));
     }
 
     @Test
@@ -138,8 +128,8 @@ public class TaskGroupServiceTest {
         Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TASK_GROUP,
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_QUEUE_PRIORITY, serviceLogger))
                 .thenReturn(false);
-        Map<String, Object> objectMap = taskGroupService.modifyPriority(loginUser, 1, 1);
-        Assertions.assertEquals(Status.NO_CURRENT_OPERATING_PERMISSION, objectMap.get(Constants.STATUS));
+        assertThrowsServiceException(Status.NO_CURRENT_OPERATING_PERMISSION,
+                () -> taskGroupService.modifyPriority(loginUser, 1, 1));
     }
 
     @Test
@@ -148,12 +138,12 @@ public class TaskGroupServiceTest {
         TaskGroup taskGroup = getTaskGroup();
         Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TASK_GROUP,
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_CREATE, serviceLogger)).thenReturn(true);
-        Mockito.when(taskGroupMapper.insert(taskGroup)).thenReturn(1);
+        Mockito.when(taskGroupMapper.insert(Mockito.any(TaskGroup.class))).thenReturn(1);
         Mockito.when(taskGroupMapper.queryByName(loginUser.getId(), taskGroupName)).thenReturn(null);
         Mockito.when(projectMapper.queryByCode(taskGroup.getProjectCode())).thenReturn(getProject());
-        Map<String, Object> result = taskGroupService.createTaskGroup(loginUser, 0L, taskGroupName, taskGroupDesc, 100);
-        Assertions.assertNotNull(result);
-
+        TaskGroup created = taskGroupService.createTaskGroup(loginUser, 0L, taskGroupName, taskGroupDesc, 100);
+        Assertions.assertNotNull(created);
+        Assertions.assertEquals(taskGroupName, created.getName());
     }
 
     @Test
@@ -161,8 +151,8 @@ public class TaskGroupServiceTest {
         User loginUser = getLoginUser();
         TaskGroup taskGroup = getTaskGroup();
         Mockito.when(taskGroupMapper.selectById(1)).thenReturn(taskGroup);
-        Map<String, Object> result = taskGroupService.queryTaskGroupById(loginUser, 1);
-        Assertions.assertNotNull(result.get(Constants.DATA_LIST));
+        TaskGroup result = taskGroupService.queryTaskGroupById(loginUser, 1);
+        Assertions.assertNotNull(result);
     }
 
     @Test
@@ -175,13 +165,13 @@ public class TaskGroupServiceTest {
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_VIEW, serviceLogger)).thenReturn(true);
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.TASK_GROUP, null,
                 0, serviceLogger)).thenReturn(true);
-        Mockito.when(taskGroupMapper.queryTaskGroupPaging(Mockito.any(Page.class), Mockito.eq(null), Mockito.eq(0)))
+        Mockito.when(taskGroupMapper.queryTaskGroupPaging(Mockito.any(Page.class), Mockito.eq(null), Mockito.eq(null)))
                 .thenReturn(page);
 
         // query all
-        Map<String, Object> result = taskGroupService.queryAllTaskGroup(loginUser, null, null, 1, 10);
-        PageInfo<TaskGroup> pageInfo = (PageInfo<TaskGroup>) result.get(Constants.DATA_LIST);
+        PageInfo<TaskGroup> pageInfo = taskGroupService.queryAllTaskGroup(loginUser, null, null, 1, 10);
         Assertions.assertNotNull(pageInfo.getTotalList());
+        Assertions.assertEquals(1, pageInfo.getTotalList().size());
     }
 
     @Test
@@ -190,7 +180,6 @@ public class TaskGroupServiceTest {
         User loginUser = getLoginUser();
         TaskGroup taskGroup = getTaskGroup();
         taskGroup.setStatus(Flag.YES);
-        // Task group status error
 
         Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TASK_GROUP,
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_EDIT, serviceLogger)).thenReturn(true);
@@ -199,10 +188,9 @@ public class TaskGroupServiceTest {
         Mockito.when(taskGroupMapper.selectById(1)).thenReturn(taskGroup);
         Mockito.when(taskGroupMapper.updateById(taskGroup)).thenReturn(1);
         Mockito.when(projectMapper.queryByCode(taskGroup.getProjectCode())).thenReturn(getProject());
-        Map<String, Object> result = taskGroupService.updateTaskGroup(loginUser, 1, "newName", "desc", 100);
-        logger.info(result.toString());
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-
+        TaskGroup updated = taskGroupService.updateTaskGroup(loginUser, 1, "newName", "desc", 100);
+        Assertions.assertNotNull(updated);
+        Assertions.assertEquals("newName", updated.getName());
     }
 
     @Test
@@ -212,22 +200,24 @@ public class TaskGroupServiceTest {
         TaskGroup taskGroup = getTaskGroup();
         Mockito.when(taskGroupMapper.selectById(1)).thenReturn(taskGroup);
 
-        // close failed
         Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TASK_GROUP,
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_CLOSE, serviceLogger)).thenReturn(true);
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.TASK_GROUP, null,
                 0, serviceLogger)).thenReturn(true);
-        Map<String, Object> result = taskGroupService.closeTaskGroup(loginUser, 1);
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
 
+        // close success path
+        Assertions.assertDoesNotThrow(() -> taskGroupService.closeTaskGroup(loginUser, 1));
+
+        // close already closed
         taskGroup.setStatus(Flag.NO);
         Mockito.when(taskGroupMapper.selectById(1)).thenReturn(taskGroup);
-        result = taskGroupService.closeTaskGroup(loginUser, 1);
-        Assertions.assertEquals(Status.TASK_GROUP_STATUS_CLOSED, result.get(Constants.STATUS));
+        assertThrowsServiceException(Status.TASK_GROUP_STATUS_CLOSED,
+                () -> taskGroupService.closeTaskGroup(loginUser, 1));
 
+        // start already started
         taskGroup.setStatus(Flag.YES);
         Mockito.when(taskGroupMapper.selectById(1)).thenReturn(taskGroup);
-        result = taskGroupService.startTaskGroup(loginUser, 1);
-        Assertions.assertEquals(Status.TASK_GROUP_STATUS_OPENED, result.get(Constants.STATUS));
+        assertThrowsServiceException(Status.TASK_GROUP_STATUS_OPENED,
+                () -> taskGroupService.startTaskGroup(loginUser, 1));
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Migrate all 11 TaskGroupService methods from Map<String,Object> returns to typed returns or void with ServiceException, plus the coupled ExecutorService.forceStartTaskInstance which is only invoked from TaskGroupServiceImpl.forceStartTask.

TaskGroupService:
- createTaskGroup -> TaskGroup
- updateTaskGroup -> TaskGroup
- queryAllTaskGroup / queryTaskGroupByStatus / queryTaskGroupByProjectCode -> PageInfo<TaskGroup>
- queryTaskGroupById -> TaskGroup (nullable)
- doQuery -> PageInfo<TaskGroup>
- closeTaskGroup / startTaskGroup / forceStartTask / modifyPriority -> void

ExecutorService:
- forceStartTaskInstance -> void

The private hasProjectPerm helper is replaced with requireProjectPerm which throws ServiceException. Admin users still bypass the project existence check (preserving the prior admin-shortcut semantics) and the non-admin-on-missing-project NPE is replaced with a clean PROJECT_NOT_FOUND error.

ApiExceptionHandler now propagates the controller method's @ResponseStatus to the error response so error and success paths share the same HTTP status code (e.g. POST endpoints stay 201 Created on ServiceException). This is the byte-for-byte fix for putMsg/throw divergence the migration would otherwise introduce — confirmed against TaskGroupControllerTest's real SpringBootTest harness. Two pre-existing tests that asserted the legacy "errors always 200" behaviour are updated to the unified status:
- AccessTokenControllerTest.testExceptionHandler
- UsersControllerTest.testCreateUser

ApiExceptionHandlerTest is updated to reflect the new ResponseEntity<Result> return type.

No PythonGateway or cross-service callers exist for these methods, so the migration is contained within the api module.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
