### PR TITLE
[Improvement-18224][API] Migrate WorkflowDefinitionService Map<String,Object> returns to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowDefinitionController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowDefinitionController.java
@@ -37,7 +37,8 @@ import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_WORKFLOW_DEFIN
 
 import org.apache.dolphinscheduler.api.audit.OperatorLog;
 import org.apache.dolphinscheduler.api.audit.enums.AuditType;
-import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
+import org.apache.dolphinscheduler.api.dto.workflow.WorkflowDefinitionVariablesDTO;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.WorkflowDefinitionService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
@@ -45,10 +46,14 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionTypeEnum;
+import org.apache.dolphinscheduler.dao.entity.DagData;
+import org.apache.dolphinscheduler.dao.entity.DependentSimplifyDefinition;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 
+import java.util.List;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +70,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -107,21 +114,21 @@ public class WorkflowDefinitionController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     @ApiException(CREATE_WORKFLOW_DEFINITION_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_CREATE)
-    public Result createWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                           @RequestParam(value = "name", required = true) String name,
-                                           @RequestParam(value = "description", required = false) String description,
-                                           @RequestParam(value = "globalParams", required = false, defaultValue = "[]") String globalParams,
-                                           @RequestParam(value = "locations", required = false) String locations,
-                                           @RequestParam(value = "timeout", required = false, defaultValue = "0") int timeout,
-                                           @RequestParam(value = "taskRelationJson", required = true) String taskRelationJson,
-                                           @RequestParam(value = "taskDefinitionJson", required = true) String taskDefinitionJson,
-                                           @RequestParam(value = "otherParamsJson", required = false) String otherParamsJson,
-                                           @RequestParam(value = "executionType", defaultValue = "PARALLEL") WorkflowExecutionTypeEnum executionType) {
-        Map<String, Object> result = workflowDefinitionService.createWorkflowDefinition(loginUser, projectCode, name,
-                description, globalParams,
+    public Result<WorkflowDefinition> createWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                               @RequestParam(value = "name", required = true) String name,
+                                                               @RequestParam(value = "description", required = false) String description,
+                                                               @RequestParam(value = "globalParams", required = false, defaultValue = "[]") String globalParams,
+                                                               @RequestParam(value = "locations", required = false) String locations,
+                                                               @RequestParam(value = "timeout", required = false, defaultValue = "0") int timeout,
+                                                               @RequestParam(value = "taskRelationJson", required = true) String taskRelationJson,
+                                                               @RequestParam(value = "taskDefinitionJson", required = true) String taskDefinitionJson,
+                                                               @RequestParam(value = "otherParamsJson", required = false) String otherParamsJson,
+                                                               @RequestParam(value = "executionType", defaultValue = "PARALLEL") WorkflowExecutionTypeEnum executionType) {
+        WorkflowDefinition workflowDefinition = workflowDefinitionService.createWorkflowDefinition(loginUser,
+                projectCode, name, description, globalParams,
                 locations, timeout, taskRelationJson, taskDefinitionJson, otherParamsJson, executionType);
-        return returnDataList(result);
+        return Result.success(workflowDefinition);
     }
 
     /**
@@ -142,13 +149,12 @@ public class WorkflowDefinitionController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(BATCH_COPY_WORKFLOW_DEFINITION_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_COPY)
-    public Result copyWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                         @RequestParam(value = "codes", required = true) String codes,
-                                         @RequestParam(value = "targetProjectCode", required = true) long targetProjectCode) {
-        return returnDataList(
-                workflowDefinitionService.batchCopyWorkflowDefinition(loginUser, projectCode, codes,
-                        targetProjectCode));
+    public Result<Void> copyWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                               @RequestParam(value = "codes", required = true) String codes,
+                                               @RequestParam(value = "targetProjectCode", required = true) long targetProjectCode) {
+        workflowDefinitionService.batchCopyWorkflowDefinition(loginUser, projectCode, codes, targetProjectCode);
+        return Result.success();
     }
 
     /**
@@ -168,13 +174,12 @@ public class WorkflowDefinitionController extends BaseController {
     @PostMapping(value = "/batch-move")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(BATCH_MOVE_WORKFLOW_DEFINITION_ERROR)
-    public Result moveWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                         @RequestParam(value = "codes", required = true) String codes,
-                                         @RequestParam(value = "targetProjectCode", required = true) long targetProjectCode) {
-        return returnDataList(
-                workflowDefinitionService.batchMoveWorkflowDefinition(loginUser, projectCode, codes,
-                        targetProjectCode));
+    public Result<Void> moveWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                               @RequestParam(value = "codes", required = true) String codes,
+                                               @RequestParam(value = "targetProjectCode", required = true) long targetProjectCode) {
+        workflowDefinitionService.batchMoveWorkflowDefinition(loginUser, projectCode, codes, targetProjectCode);
+        return Result.success();
     }
 
     /**
@@ -193,14 +198,12 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/verify-name")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(VERIFY_WORKFLOW_DEFINITION_NAME_UNIQUE_ERROR)
-    public Result verifyWorkflowDefinitionName(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                               @RequestParam(value = "name", required = true) String name,
-                                               @RequestParam(value = "workflowDefinitionCode", required = false, defaultValue = "0") long workflowDefinitionCode) {
-        Map<String, Object> result =
-                workflowDefinitionService.verifyWorkflowDefinitionName(loginUser, projectCode, name,
-                        workflowDefinitionCode);
-        return returnDataList(result);
+    public Result<Void> verifyWorkflowDefinitionName(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                     @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                     @RequestParam(value = "name", required = true) String name,
+                                                     @RequestParam(value = "workflowDefinitionCode", required = false, defaultValue = "0") long workflowDefinitionCode) {
+        workflowDefinitionService.verifyWorkflowDefinitionName(loginUser, projectCode, name, workflowDefinitionCode);
+        return Result.success();
     }
 
     /**
@@ -230,32 +233,28 @@ public class WorkflowDefinitionController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UPDATE_WORKFLOW_DEFINITION_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_UPDATE)
-    public Result updateWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                           @RequestParam(value = "name", required = true) String name,
-                                           @PathVariable(value = "code", required = true) long code,
-                                           @RequestParam(value = "description", required = false) String description,
-                                           @RequestParam(value = "globalParams", required = false, defaultValue = "[]") String globalParams,
-                                           @RequestParam(value = "locations", required = false) String locations,
-                                           @RequestParam(value = "timeout", required = false, defaultValue = "0") int timeout,
-                                           @RequestParam(value = "taskRelationJson", required = true) String taskRelationJson,
-                                           @RequestParam(value = "taskDefinitionJson", required = true) String taskDefinitionJson,
-                                           @RequestParam(value = "executionType", defaultValue = "PARALLEL") WorkflowExecutionTypeEnum executionType,
-                                           @RequestParam(value = "releaseState", required = false, defaultValue = "OFFLINE") ReleaseState releaseState) {
+    public Result<WorkflowDefinition> updateWorkflowDefinition(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                               @RequestParam(value = "name", required = true) String name,
+                                                               @PathVariable(value = "code", required = true) long code,
+                                                               @RequestParam(value = "description", required = false) String description,
+                                                               @RequestParam(value = "globalParams", required = false, defaultValue = "[]") String globalParams,
+                                                               @RequestParam(value = "locations", required = false) String locations,
+                                                               @RequestParam(value = "timeout", required = false, defaultValue = "0") int timeout,
+                                                               @RequestParam(value = "taskRelationJson", required = true) String taskRelationJson,
+                                                               @RequestParam(value = "taskDefinitionJson", required = true) String taskDefinitionJson,
+                                                               @RequestParam(value = "executionType", defaultValue = "PARALLEL") WorkflowExecutionTypeEnum executionType,
+                                                               @RequestParam(value = "releaseState", required = false, defaultValue = "OFFLINE") ReleaseState releaseState) {
 
-        Map<String, Object> result = workflowDefinitionService.updateWorkflowDefinition(loginUser, projectCode, name,
-                code, description, globalParams,
+        WorkflowDefinition workflowDefinition = workflowDefinitionService.updateWorkflowDefinition(loginUser,
+                projectCode, name, code, description, globalParams,
                 locations, timeout, taskRelationJson, taskDefinitionJson, executionType);
-        // If the update fails, the result will be returned directly
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
-            return returnDataList(result);
-        }
 
         // Judge whether to go online after editing,0 means offline, 1 means online
         if (releaseState == ReleaseState.ONLINE) {
             workflowDefinitionService.onlineWorkflowDefinition(loginUser, projectCode, code);
         }
-        return returnDataList(result);
+        return Result.success(workflowDefinition);
     }
 
     /**
@@ -306,13 +305,12 @@ public class WorkflowDefinitionController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(SWITCH_WORKFLOW_DEFINITION_VERSION_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_SWITCH_VERSION)
-    public Result switchWorkflowDefinitionVersion(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                  @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                  @PathVariable(value = "code") long code,
-                                                  @PathVariable(value = "version") int version) {
-        Map<String, Object> result =
-                workflowDefinitionService.switchWorkflowDefinitionVersion(loginUser, projectCode, code, version);
-        return returnDataList(result);
+    public Result<Void> switchWorkflowDefinitionVersion(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                        @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                        @PathVariable(value = "code") long code,
+                                                        @PathVariable(value = "version") int version) {
+        workflowDefinitionService.switchWorkflowDefinitionVersion(loginUser, projectCode, code, version);
+        return Result.success();
     }
 
     /**
@@ -384,12 +382,11 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/{code}")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_DETAIL_OF_WORKFLOW_DEFINITION_ERROR)
-    public Result queryWorkflowDefinitionByCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                @PathVariable(value = "code", required = true) long code) {
-        Map<String, Object> result =
-                workflowDefinitionService.queryWorkflowDefinitionByCode(loginUser, projectCode, code);
-        return returnDataList(result);
+    public Result<DagData> queryWorkflowDefinitionByCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                         @PathVariable(value = "code", required = true) long code) {
+        DagData dagData = workflowDefinitionService.queryWorkflowDefinitionByCode(loginUser, projectCode, code);
+        return Result.success(dagData);
     }
 
     /**
@@ -407,12 +404,11 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/query-by-name")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_DETAIL_OF_WORKFLOW_DEFINITION_ERROR)
-    public Result<WorkflowDefinition> queryWorkflowDefinitionByName(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                                    @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                                    @RequestParam("name") String name) {
-        Map<String, Object> result =
-                workflowDefinitionService.queryWorkflowDefinitionByName(loginUser, projectCode, name);
-        return returnDataList(result);
+    public Result<DagData> queryWorkflowDefinitionByName(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                         @RequestParam("name") String name) {
+        DagData dagData = workflowDefinitionService.queryWorkflowDefinitionByName(loginUser, projectCode, name);
+        return Result.success(dagData);
     }
 
     /**
@@ -426,10 +422,9 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKFLOW_DEFINITION_LIST)
-    public Result queryWorkflowDefinitionList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                              @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
-        Map<String, Object> result = workflowDefinitionService.queryWorkflowDefinitionList(loginUser, projectCode);
-        return returnDataList(result);
+    public Result<List<DagData>> queryWorkflowDefinitionList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                             @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
+        return Result.success(workflowDefinitionService.queryWorkflowDefinitionList(loginUser, projectCode));
     }
 
     /**
@@ -443,11 +438,9 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/simple-list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKFLOW_DEFINITION_LIST)
-    public Result queryWorkflowDefinitionSimpleList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                    @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
-        Map<String, Object> result =
-                workflowDefinitionService.queryWorkflowDefinitionSimpleList(loginUser, projectCode);
-        return returnDataList(result);
+    public Result<ArrayNode> queryWorkflowDefinitionSimpleList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
+        return Result.success(workflowDefinitionService.queryWorkflowDefinitionSimpleList(loginUser, projectCode));
     }
 
     /**
@@ -508,12 +501,11 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/{code}/view-tree")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(ENCAPSULATION_TREEVIEW_STRUCTURE_ERROR)
-    public Result viewTree(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                           @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                           @PathVariable("code") long code,
-                           @RequestParam("limit") Integer limit) {
-        Map<String, Object> result = workflowDefinitionService.viewTree(loginUser, projectCode, code, limit);
-        return returnDataList(result);
+    public Result<TreeViewDto> viewTree(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                        @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                        @PathVariable("code") long code,
+                                        @RequestParam("limit") Integer limit) {
+        return Result.success(workflowDefinitionService.viewTree(loginUser, projectCode, code, limit));
     }
 
     /**
@@ -531,12 +523,11 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/{code}/tasks")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GET_TASKS_LIST_BY_WORKFLOW_DEFINITION_CODE_ERROR)
-    public Result getNodeListByDefinitionCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                              @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                              @PathVariable("code") long code) {
-        Map<String, Object> result =
-                workflowDefinitionService.getTaskNodeListByDefinitionCode(loginUser, projectCode, code);
-        return returnDataList(result);
+    public Result<List<TaskDefinition>> getNodeListByDefinitionCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                    @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                    @PathVariable("code") long code) {
+        return Result.success(
+                workflowDefinitionService.getTaskNodeListByDefinitionCode(loginUser, projectCode, code));
     }
 
     /**
@@ -554,12 +545,11 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/batch-query-tasks")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GET_TASKS_LIST_BY_WORKFLOW_DEFINITION_CODE_ERROR)
-    public Result getNodeListMapByDefinitionCodes(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                  @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                  @RequestParam("codes") String codes) {
-        Map<String, Object> result =
-                workflowDefinitionService.getNodeListMapByDefinitionCodes(loginUser, projectCode, codes);
-        return returnDataList(result);
+    public Result<Map<Long, List<TaskDefinition>>> getNodeListMapByDefinitionCodes(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                                   @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                                   @RequestParam("codes") String codes) {
+        return Result.success(
+                workflowDefinitionService.getNodeListMapByDefinitionCodes(loginUser, projectCode, codes));
     }
 
     /**
@@ -576,10 +566,9 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/query-workflow-definition-list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GET_TASKS_LIST_BY_WORKFLOW_DEFINITION_CODE_ERROR)
-    public Result getWorkflowListByProjectCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                               @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
-        Map<String, Object> result = workflowDefinitionService.queryWorkflowDefinitionListByProjectCode(projectCode);
-        return returnDataList(result);
+    public Result<List<DependentSimplifyDefinition>> getWorkflowListByProjectCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                                  @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
+        return Result.success(workflowDefinitionService.queryWorkflowDefinitionListByProjectCode(projectCode));
     }
 
     /**
@@ -597,12 +586,11 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/query-task-definition-list")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(GET_TASKS_LIST_BY_WORKFLOW_DEFINITION_CODE_ERROR)
-    public Result getTaskListByWorkflowDefinitionCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                      @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                      @RequestParam(value = "workflowDefinitionCode") Long workflowDefinitionCode) {
-        Map<String, Object> result = workflowDefinitionService
-                .queryTaskDefinitionListByWorkflowDefinitionCode(projectCode, workflowDefinitionCode);
-        return returnDataList(result);
+    public Result<List<DependentSimplifyDefinition>> getTaskListByWorkflowDefinitionCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                                         @RequestParam(value = "workflowDefinitionCode") Long workflowDefinitionCode) {
+        return Result.success(workflowDefinitionService
+                .queryTaskDefinitionListByWorkflowDefinitionCode(projectCode, workflowDefinitionCode));
     }
 
     @Operation(summary = "deleteByWorkflowDefinitionCode", description = "DELETE_WORKFLOW_DEFINITION_BY_ID_NOTES")
@@ -613,11 +601,11 @@ public class WorkflowDefinitionController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(DELETE_WORKFLOW_DEFINE_BY_CODE_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_DELETE)
-    public Result deleteWorkflowDefinitionByCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                 @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                 @PathVariable("code") long code) {
+    public Result<Void> deleteWorkflowDefinitionByCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                       @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                       @PathVariable("code") long code) {
         workflowDefinitionService.deleteWorkflowDefinitionByCode(loginUser, code);
-        return new Result(Status.SUCCESS);
+        return Result.success();
     }
 
     /**
@@ -636,13 +624,11 @@ public class WorkflowDefinitionController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     @ApiException(BATCH_DELETE_WORKFLOW_DEFINE_BY_CODES_ERROR)
     @OperatorLog(auditType = AuditType.WORKFLOW_BATCH_DELETE)
-    public Result batchDeleteWorkflowDefinitionByCodes(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                       @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                                       @RequestParam("codes") String codes) {
-
-        Map<String, Object> result =
-                workflowDefinitionService.batchDeleteWorkflowDefinitionByCodes(loginUser, projectCode, codes);
-        return returnDataList(result);
+    public Result<Void> batchDeleteWorkflowDefinitionByCodes(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                             @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                             @RequestParam("codes") String codes) {
+        workflowDefinitionService.batchDeleteWorkflowDefinitionByCodes(loginUser, projectCode, codes);
+        return Result.success();
     }
 
     /**
@@ -656,11 +642,10 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/all")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKFLOW_DEFINITION_LIST)
-    public Result queryAllWorkflowDefinitionByProjectCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                          @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
-        Map<String, Object> result =
-                workflowDefinitionService.queryAllWorkflowDefinitionByProjectCode(loginUser, projectCode);
-        return returnDataList(result);
+    public Result<List<DagData>> queryAllWorkflowDefinitionByProjectCode(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                         @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode) {
+        return Result.success(
+                workflowDefinitionService.queryAllWorkflowDefinitionByProjectCode(loginUser, projectCode));
     }
 
     /**
@@ -677,11 +662,10 @@ public class WorkflowDefinitionController extends BaseController {
     @GetMapping(value = "/{code}/view-variables")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(QUERY_WORKFLOW_DEFINITION_ALL_VARIABLES_ERROR)
-    public Result viewVariables(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
-                                @PathVariable("code") Long code) {
-        Map<String, Object> result = workflowDefinitionService.viewVariables(loginUser, projectCode, code);
-        return returnDataList(result);
+    public Result<WorkflowDefinitionVariablesDTO> viewVariables(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                @Parameter(name = "projectCode", description = "PROJECT_CODE", required = true) @PathVariable long projectCode,
+                                                                @PathVariable("code") Long code) {
+        return Result.success(workflowDefinitionService.viewVariables(loginUser, projectCode, code));
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflow/WorkflowDefinitionVariablesDTO.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/dto/workflow/WorkflowDefinitionVariablesDTO.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.dto.workflow;
+
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowDefinitionVariablesDTO {
+
+    private List<Property> globalParams;
+
+    private Map<String, Map<String, Object>> localParams;
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -263,15 +263,10 @@ public class PythonGateway {
                     null, timeout, taskRelationJson, taskDefinitionJson,
                     executionTypeEnum);
         } else {
-            Map<String, Object> result = workflowDefinitionService.createWorkflowDefinition(user, projectCode, name,
+            workflowDefinition = workflowDefinitionService.createWorkflowDefinition(user, projectCode, name,
                     description, globalParams,
                     null, timeout, taskRelationJson, taskDefinitionJson, otherParamsJson,
                     executionTypeEnum);
-            if (result.get(Constants.STATUS) != Status.SUCCESS) {
-                log.error(result.get(Constants.MSG).toString());
-                throw new ServiceException(result.get(Constants.MSG).toString());
-            }
-            workflowDefinition = (WorkflowDefinition) result.get(Constants.DATA_LIST);
             workflowDefinitionCode = workflowDefinition.getCode();
         }
 
@@ -297,21 +292,16 @@ public class PythonGateway {
      * @param workflowName workflow name
      */
     private WorkflowDefinition getWorkflow(User user, long projectCode, String workflowName) {
-        Map<String, Object> verifyWorkflowDefinitionExists =
-                workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, workflowName, 0);
-        Status verifyStatus = (Status) verifyWorkflowDefinitionExists.get(Constants.STATUS);
-
-        WorkflowDefinition workflowDefinition = null;
-        if (verifyStatus == Status.WORKFLOW_DEFINITION_NAME_EXIST) {
-            workflowDefinition = workflowDefinitionMapper.queryByDefineName(projectCode, workflowName);
-        } else if (verifyStatus != Status.SUCCESS) {
-            String msg =
-                    "Verify workflow exists status is invalid, neither SUCCESS or WORKFLOW_NAME_EXIST.";
-            log.error(msg);
-            throw new RuntimeException(msg);
+        try {
+            workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, workflowName, 0);
+            // name available -> workflow does not exist yet
+            return null;
+        } catch (ServiceException e) {
+            if (e.getCode() == Status.WORKFLOW_DEFINITION_NAME_EXIST.getCode()) {
+                return workflowDefinitionMapper.queryByDefineName(projectCode, workflowName);
+            }
+            throw e;
         }
-
-        return workflowDefinition;
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionService.java
@@ -17,9 +17,14 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
+import org.apache.dolphinscheduler.api.dto.workflow.WorkflowDefinitionVariablesDTO;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionTypeEnum;
+import org.apache.dolphinscheduler.dao.entity.DagData;
+import org.apache.dolphinscheduler.dao.entity.DependentSimplifyDefinition;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
@@ -28,66 +33,39 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
 public interface WorkflowDefinitionService {
 
     /**
      * create workflow definition
-     *
-     * @param loginUser          login user
-     * @param projectCode        project code
-     * @param name               workflow definition name
-     * @param description        description
-     * @param globalParams       global params
-     * @param locations          locations for nodes
-     * @param timeout            timeout
-     * @param taskRelationJson   relation json for nodes
-     * @param taskDefinitionJson taskDefinitionJson
-     * @param otherParamsJson    otherParamsJson handle other params
-     * @return create result code
      */
-    Map<String, Object> createWorkflowDefinition(User loginUser,
-                                                 long projectCode,
-                                                 String name,
-                                                 String description,
-                                                 String globalParams,
-                                                 String locations,
-                                                 int timeout,
-                                                 String taskRelationJson,
-                                                 String taskDefinitionJson,
-                                                 String otherParamsJson,
-                                                 WorkflowExecutionTypeEnum executionType);
+    WorkflowDefinition createWorkflowDefinition(User loginUser,
+                                                long projectCode,
+                                                String name,
+                                                String description,
+                                                String globalParams,
+                                                String locations,
+                                                int timeout,
+                                                String taskRelationJson,
+                                                String taskDefinitionJson,
+                                                String otherParamsJson,
+                                                WorkflowExecutionTypeEnum executionType);
 
     /**
-     * query workflow definition list
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @return definition list
+     * query workflow definition list (full DAG data)
      */
-    Map<String, Object> queryWorkflowDefinitionList(User loginUser,
-                                                    long projectCode);
+    List<DagData> queryWorkflowDefinitionList(User loginUser,
+                                              long projectCode);
 
     /**
-     * query workflow definition simple list
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @return definition simple list
+     * query workflow definition simple list (id / code / name / projectCode)
      */
-    Map<String, Object> queryWorkflowDefinitionSimpleList(User loginUser,
-                                                          long projectCode);
+    ArrayNode queryWorkflowDefinitionSimpleList(User loginUser,
+                                                long projectCode);
 
     /**
      * query workflow definition list paging
-     *
-     * @param loginUser       login user
-     * @param projectCode     project code
-     * @param searchVal       search value
-     * @param otherParamsJson otherParamsJson handle other params
-     * @param pageNo          page number
-     * @param pageSize        page size
-     * @param userId          user id
-     * @return workflow definition page
      */
     PageInfo<WorkflowDefinition> queryWorkflowDefinitionListPaging(User loginUser,
                                                                    long projectCode,
@@ -99,16 +77,10 @@ public interface WorkflowDefinitionService {
 
     /**
      * query detail of workflow definition
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param code        workflow definition code
-     * @return workflow definition detail
      */
-
-    Map<String, Object> queryWorkflowDefinitionByCode(User loginUser,
-                                                      long projectCode,
-                                                      long code);
+    DagData queryWorkflowDefinitionByCode(User loginUser,
+                                          long projectCode,
+                                          long code);
 
     Optional<WorkflowDefinition> queryWorkflowDefinition(long workflowDefinitionCode, int workflowDefinitionVersion);
 
@@ -116,190 +88,112 @@ public interface WorkflowDefinitionService {
                                                                        int workflowDefinitionVersion);
 
     /**
-     * query detail of workflow definition
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param name        workflow definition name
-     * @return workflow definition detail
+     * query detail of workflow definition by name
      */
-
-    Map<String, Object> queryWorkflowDefinitionByName(User loginUser,
-                                                      long projectCode,
-                                                      String name);
+    DagData queryWorkflowDefinitionByName(User loginUser,
+                                          long projectCode,
+                                          String name);
 
     /**
      * batch copy workflow definition
-     *
-     * @param loginUser         loginUser
-     * @param projectCode       projectCode
-     * @param codes             workflowDefinitionCodes
-     * @param targetProjectCode targetProjectCode
      */
-    Map<String, Object> batchCopyWorkflowDefinition(User loginUser,
-                                                    long projectCode,
-                                                    String codes,
-                                                    long targetProjectCode);
+    void batchCopyWorkflowDefinition(User loginUser,
+                                     long projectCode,
+                                     String codes,
+                                     long targetProjectCode);
 
     /**
      * batch move workflow definition
-     *
-     * @param loginUser         loginUser
-     * @param projectCode       projectCode
-     * @param codes             workflowDefinitionCodes
-     * @param targetProjectCode targetProjectCode
      */
-    Map<String, Object> batchMoveWorkflowDefinition(User loginUser,
-                                                    long projectCode,
-                                                    String codes,
-                                                    long targetProjectCode);
+    void batchMoveWorkflowDefinition(User loginUser,
+                                     long projectCode,
+                                     String codes,
+                                     long targetProjectCode);
 
     /**
      * update workflow definition, with whole workflow definition object including task definition, task relation and location.
-     *
-     * @param loginUser          login user
-     * @param projectCode        project code
-     * @param name               workflow definition name
-     * @param code               workflow definition code
-     * @param description        description
-     * @param globalParams       global params
-     * @param locations          locations for nodes
-     * @param timeout            timeout
-     * @param taskRelationJson   relation json for nodes
-     * @param taskDefinitionJson taskDefinitionJson
-     * @return update result code
      */
-    Map<String, Object> updateWorkflowDefinition(User loginUser,
-                                                 long projectCode,
-                                                 String name,
-                                                 long code,
-                                                 String description,
-                                                 String globalParams,
-                                                 String locations,
-                                                 int timeout,
-                                                 String taskRelationJson,
-                                                 String taskDefinitionJson,
-                                                 WorkflowExecutionTypeEnum executionType);
+    WorkflowDefinition updateWorkflowDefinition(User loginUser,
+                                                long projectCode,
+                                                String name,
+                                                long code,
+                                                String description,
+                                                String globalParams,
+                                                String locations,
+                                                int timeout,
+                                                String taskRelationJson,
+                                                String taskDefinitionJson,
+                                                WorkflowExecutionTypeEnum executionType);
 
     /**
-     * verify workflow definition name unique
-     *
-     * @param loginUser             login user
-     * @param projectCode           project code
-     * @param name                  name
-     * @param workflowDefinitionCode workflowDefinitionCode
-     * @return true if workflow definition name not exists, otherwise false
+     * verify workflow definition name unique. Throws {@link org.apache.dolphinscheduler.api.exceptions.ServiceException}
+     * with {@code WORKFLOW_DEFINITION_NAME_EXIST} when the name is already taken.
      */
-    Map<String, Object> verifyWorkflowDefinitionName(User loginUser,
-                                                     long projectCode,
-                                                     String name,
-                                                     long workflowDefinitionCode);
+    void verifyWorkflowDefinitionName(User loginUser,
+                                      long projectCode,
+                                      String name,
+                                      long workflowDefinitionCode);
 
     /**
-     * batch delete workflow definition by code
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param codes       workflow definition codes
-     * @return delete result code
+     * batch delete workflow definition by codes
      */
-    Map<String, Object> batchDeleteWorkflowDefinitionByCodes(User loginUser,
-                                                             long projectCode,
-                                                             String codes);
+    void batchDeleteWorkflowDefinitionByCodes(User loginUser,
+                                              long projectCode,
+                                              String codes);
 
     void deleteWorkflowDefinitionByCode(User loginUser, long workflowDefinitionCode);
 
     /**
-     * check the workflow task relation json
-     *
-     * @param workflowTaskRelationJson workflow task relation json
-     * @return check result code
+     * check the workflow task relation json (no return value: throws on validation failures)
      */
-    Map<String, Object> checkWorkflowNodeList(String workflowTaskRelationJson,
-                                              List<TaskDefinitionLog> taskDefinitionLogs);
+    void checkWorkflowNodeList(String workflowTaskRelationJson,
+                               List<TaskDefinitionLog> taskDefinitionLogs);
 
     /**
      * get task node details based on workflow definition
-     *
-     * @param loginUser   loginUser
-     * @param projectCode project code
-     * @param code        workflowDefinition code
-     * @return task node list
      */
-    Map<String, Object> getTaskNodeListByDefinitionCode(User loginUser,
-                                                        long projectCode,
-                                                        long code);
+    List<TaskDefinition> getTaskNodeListByDefinitionCode(User loginUser,
+                                                         long projectCode,
+                                                         long code);
 
     /**
-     * get task node details map based on workflow definition
-     *
-     * @param loginUser   loginUser
-     * @param projectCode project code
-     * @param codes       define code list
-     * @return task node list
+     * get task node details map based on workflow definition codes (workflow code -> task definition list)
      */
-    Map<String, Object> getNodeListMapByDefinitionCodes(User loginUser,
-                                                        long projectCode,
-                                                        String codes);
+    Map<Long, List<TaskDefinition>> getNodeListMapByDefinitionCodes(User loginUser,
+                                                                    long projectCode,
+                                                                    String codes);
 
     /**
      * query workflow definition all by project code
-     *
-     * @param projectCode project code
-     * @return workflow definitions in the project
      */
-    Map<String, Object> queryAllWorkflowDefinitionByProjectCode(User loginUser, long projectCode);
+    List<DagData> queryAllWorkflowDefinitionByProjectCode(User loginUser, long projectCode);
 
     /**
-     * query workflow definition list by project code
-     *
-     * @param projectCode project code
-     * @return workflow definitions in the project
+     * query workflow definition list by project code (simplified records used for dependent task picker)
      */
-    Map<String, Object> queryWorkflowDefinitionListByProjectCode(long projectCode);
+    List<DependentSimplifyDefinition> queryWorkflowDefinitionListByProjectCode(long projectCode);
 
     /**
-     * query workflow definition list by project code
-     *
-     * @param projectCode           project code
-     * @param workflowDefinitionCode workflow definition code
-     * @return workflow definitions in the project
+     * query task definition list (simplified records) by workflow definition code
      */
-    Map<String, Object> queryTaskDefinitionListByWorkflowDefinitionCode(long projectCode, Long workflowDefinitionCode);
+    List<DependentSimplifyDefinition> queryTaskDefinitionListByWorkflowDefinitionCode(long projectCode,
+                                                                                      Long workflowDefinitionCode);
 
     /**
      * Encapsulates the TreeView structure
-     *
-     * @param projectCode project code
-     * @param code        workflow definition code
-     * @param limit       limit
-     * @return tree view json data
      */
-    Map<String, Object> viewTree(User loginUser, long projectCode, long code, Integer limit);
+    TreeViewDto viewTree(User loginUser, long projectCode, long code, Integer limit);
 
     /**
      * switch the defined workflow definition version
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param code        workflow definition code
-     * @param version     the version user want to switch
-     * @return switch workflow definition version result code
      */
-    Map<String, Object> switchWorkflowDefinitionVersion(User loginUser,
-                                                        long projectCode,
-                                                        long code,
-                                                        int version);
+    void switchWorkflowDefinitionVersion(User loginUser,
+                                         long projectCode,
+                                         long code,
+                                         int version);
 
     /**
      * query the pagination versions info by one certain workflow definition code
-     *
-     * @param loginUser   login user info to check auth
-     * @param projectCode project code
-     * @param pageNo      page number
-     * @param pageSize    page size
-     * @param code        workflow definition code
-     * @return the pagination workflow definition versions info of the certain workflow definition
      */
     Result queryWorkflowDefinitionVersions(User loginUser,
                                            long projectCode,
@@ -309,11 +203,6 @@ public interface WorkflowDefinitionService {
 
     /**
      * delete one certain workflow definition by version number and workflow definition code
-     *
-     * @param loginUser                 login user info to check auth
-     * @param projectCode               project code
-     * @param workflowDefinitionCode    workflow definition code
-     * @param workflowDefinitionVersion version number
      */
     void deleteWorkflowDefinitionVersion(User loginUser,
                                          long projectCode,
@@ -331,14 +220,9 @@ public interface WorkflowDefinitionService {
     void offlineWorkflowDefinition(User loginUser, Long projectCode, Long workflowDefinitionCode);
 
     /**
-     * view workflow variables
-     *
-     * @param loginUser   login user
-     * @param projectCode project code
-     * @param code        workflow definition code
-     * @return variables data
+     * view workflow variables (globalParams + localParams)
      */
-    Map<String, Object> viewVariables(User loginUser, long projectCode, long code);
+    WorkflowDefinitionVariablesDTO viewVariables(User loginUser, long projectCode, long code);
 
     void saveWorkflowLineage(long projectCode,
                              long workflowDefinitionCode,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -29,8 +29,6 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import static org.apache.dolphinscheduler.api.enums.Status.WORKFLOW_DEFINITION_NOT_EXIST;
 import static org.apache.dolphinscheduler.common.constants.CommandKeyConstants.CMD_PARAM_SUB_WORKFLOW_DEFINITION_CODE;
 import static org.apache.dolphinscheduler.common.constants.Constants.COPY_SUFFIX;
-import static org.apache.dolphinscheduler.common.constants.Constants.DATA_LIST;
-import static org.apache.dolphinscheduler.common.constants.Constants.GLOBAL_PARAMS;
 import static org.apache.dolphinscheduler.common.constants.Constants.LOCAL_PARAMS;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.LOCAL_PARAMS_LIST;
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE;
@@ -39,6 +37,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager.chec
 import org.apache.dolphinscheduler.api.dto.TaskCodeVersionDto;
 import org.apache.dolphinscheduler.api.dto.treeview.Instance;
 import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
+import org.apache.dolphinscheduler.api.dto.workflow.WorkflowDefinitionVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.ProjectService;
@@ -230,25 +229,22 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     @Transactional
-    public Map<String, Object> createWorkflowDefinition(User loginUser,
-                                                        long projectCode,
-                                                        String name,
-                                                        String description,
-                                                        String globalParams,
-                                                        String locations,
-                                                        int timeout,
-                                                        String taskRelationJson,
-                                                        String taskDefinitionJson,
-                                                        String otherParamsJson,
-                                                        WorkflowExecutionTypeEnum executionType) {
+    public WorkflowDefinition createWorkflowDefinition(User loginUser,
+                                                       long projectCode,
+                                                       String name,
+                                                       String description,
+                                                       String globalParams,
+                                                       String locations,
+                                                       int timeout,
+                                                       String taskRelationJson,
+                                                       String taskDefinitionJson,
+                                                       String otherParamsJson,
+                                                       WorkflowExecutionTypeEnum executionType) {
         Project project = projectMapper.queryByCode(projectCode);
 
         // check if user have write perm for project
-        Map<String, Object> result = new HashMap<>();
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        requireProjectAndWritePerm(loginUser, project);
+
         if (checkDescriptionLength(description)) {
             log.warn("Parameter description is too long.");
             throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
@@ -272,15 +268,13 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                         globalParams, locations, timeout, loginUser.getId());
         workflowDefinition.setExecutionType(executionType);
 
-        result = createDagDefine(loginUser, taskRelationList, workflowDefinition, taskDefinitionLogs);
-        return result;
+        return createDagDefine(loginUser, taskRelationList, workflowDefinition, taskDefinitionLogs);
     }
 
-    protected Map<String, Object> createDagDefine(User loginUser,
-                                                  List<WorkflowTaskRelationLog> taskRelationList,
-                                                  WorkflowDefinition workflowDefinition,
-                                                  List<TaskDefinitionLog> taskDefinitionLogs) {
-        Map<String, Object> result = new HashMap<>();
+    protected WorkflowDefinition createDagDefine(User loginUser,
+                                                 List<WorkflowTaskRelationLog> taskRelationList,
+                                                 WorkflowDefinition workflowDefinition,
+                                                 List<TaskDefinitionLog> taskDefinitionLogs) {
         int saveTaskResult = processService.saveTaskDefine(loginUser, workflowDefinition.getProjectCode(),
                 taskDefinitionLogs, Boolean.TRUE);
         if (saveTaskResult == Constants.EXIT_CODE_SUCCESS) {
@@ -295,10 +289,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         if (insertVersion == 0) {
             log.error("Save workflow definition error, workflowDefinitionCode:{}.", workflowDefinition.getCode());
             throw new ServiceException(Status.CREATE_WORKFLOW_DEFINITION_ERROR);
-        } else {
-            log.info("Save workflow definition complete, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                    workflowDefinition.getCode(), insertVersion);
         }
+        log.info("Save workflow definition complete, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                workflowDefinition.getCode(), insertVersion);
         workflowDefinition.setVersion(insertVersion);
         int insertResult = processService.saveTaskRelation(loginUser, workflowDefinition.getProjectCode(),
                 workflowDefinition.getCode(),
@@ -308,18 +301,25 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     "Save workflow task relations error, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
                     workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
             throw new ServiceException(Status.CREATE_WORKFLOW_TASK_RELATION_ERROR);
-        } else {
-            log.info(
-                    "Save workflow task relations complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                    workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
         }
+        log.info(
+                "Save workflow task relations complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
 
         saveWorkflowLineage(workflowDefinition.getProjectCode(), workflowDefinition.getCode(),
                 insertVersion, taskDefinitionLogs);
+        return workflowDefinition;
+    }
 
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, workflowDefinition);
-        return result;
+    private void requireProjectAndWritePerm(User loginUser, Project project) {
+        Map<String, Object> permResult = new HashMap<>();
+        if (!projectService.hasProjectAndWritePerm(loginUser, project, permResult)) {
+            Status status = (Status) permResult.get(Constants.STATUS);
+            if (status == null) {
+                throw new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM);
+            }
+            throw new ServiceException(status.getCode(), (String) permResult.get(Constants.MSG));
+        }
     }
 
     @Override
@@ -454,17 +454,13 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return definition list
      */
     @Override
-    public Map<String, Object> queryWorkflowDefinitionList(User loginUser, long projectCode) {
+    public List<DagData> queryWorkflowDefinitionList(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> result = new HashMap<>();
         List<WorkflowDefinition> resourceList = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
-        List<DagData> dagDataList = resourceList.stream().map(processService::genDagData).collect(Collectors.toList());
-        result.put(Constants.DATA_LIST, dagDataList);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return resourceList.stream().map(processService::genDagData).collect(Collectors.toList());
     }
 
     /**
@@ -475,12 +471,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return definition simple list
      */
     @Override
-    public Map<String, Object> queryWorkflowDefinitionSimpleList(User loginUser, long projectCode) {
+    public ArrayNode queryWorkflowDefinitionSimpleList(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> result = new HashMap<>();
         List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
         ArrayNode arrayNode = JSONUtils.createArrayNode();
         for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
@@ -491,9 +486,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             workflowDefinitionNode.put("projectCode", workflowDefinition.getProjectCode());
             arrayNode.add(workflowDefinitionNode);
         }
-        result.put(Constants.DATA_LIST, arrayNode);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return arrayNode;
     }
 
     /**
@@ -561,22 +554,17 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return workflow definition detail
      */
     @Override
-    public Map<String, Object> queryWorkflowDefinitionByCode(User loginUser, long projectCode, long code) {
+    public DagData queryWorkflowDefinitionByCode(User loginUser, long projectCode, long code) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
-        } else {
-            DagData dagData = processService.genDagData(workflowDefinition);
-            result.put(Constants.DATA_LIST, dagData);
-            putMsg(result, Status.SUCCESS);
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
         }
-        return result;
+        return processService.genDagData(workflowDefinition);
     }
 
     @Override
@@ -599,23 +587,18 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     }
 
     @Override
-    public Map<String, Object> queryWorkflowDefinitionByName(User loginUser, long projectCode, String name) {
+    public DagData queryWorkflowDefinitionByName(User loginUser, long projectCode, String name) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByDefineName(projectCode, name);
 
         if (workflowDefinition == null) {
             log.error("workflow definition does not exist, projectCode:{}.", projectCode);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, name);
-        } else {
-            DagData dagData = processService.genDagData(workflowDefinition);
-            result.put(Constants.DATA_LIST, dagData);
-            putMsg(result, Status.SUCCESS);
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, name);
         }
-        return result;
+        return processService.genDagData(workflowDefinition);
     }
 
     /**
@@ -635,29 +618,24 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     @Transactional
-    public Map<String, Object> updateWorkflowDefinition(User loginUser,
-                                                        long projectCode,
-                                                        String name,
-                                                        long code,
-                                                        String description,
-                                                        String globalParams,
-                                                        String locations,
-                                                        int timeout,
-                                                        String taskRelationJson,
-                                                        String taskDefinitionJson,
-                                                        WorkflowExecutionTypeEnum executionType) {
+    public WorkflowDefinition updateWorkflowDefinition(User loginUser,
+                                                       long projectCode,
+                                                       String name,
+                                                       long code,
+                                                       String description,
+                                                       String globalParams,
+                                                       String locations,
+                                                       int timeout,
+                                                       String taskRelationJson,
+                                                       String taskDefinitionJson,
+                                                       WorkflowExecutionTypeEnum executionType) {
         Project project = projectMapper.queryByCode(projectCode);
         // check if user have write perm for project
-        Map<String, Object> result = new HashMap<>();
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        requireProjectAndWritePerm(loginUser, project);
 
         if (checkDescriptionLength(description)) {
             log.warn("Parameter description is too long.");
-            putMsg(result, Status.DESCRIPTION_TOO_LONG_ERROR);
-            return result;
+            throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
         }
 
         globalParamsValidator.validate(globalParams);
@@ -669,15 +647,13 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         // check workflow definition exists
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
         }
         if (workflowDefinition.getReleaseState() == ReleaseState.ONLINE) {
             // online can not permit edit
             log.warn("workflow definition is not allowed to be modified due to {}, workflowDefinitionCode:{}.",
                     ReleaseState.ONLINE.getDescp(), workflowDefinition.getCode());
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_ALLOWED_EDIT, workflowDefinition.getName());
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_ALLOWED_EDIT, workflowDefinition.getName());
         }
         if (!name.equals(workflowDefinition.getName())) {
             // check whether the new workflow define name exist
@@ -685,17 +661,15 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             if (definition != null) {
                 log.warn("workflow definition with the same name already exists, workflowDefinitionCode:{}.",
                         definition.getCode());
-                putMsg(result, Status.WORKFLOW_DEFINITION_NAME_EXIST, name);
-                return result;
+                throw new ServiceException(Status.WORKFLOW_DEFINITION_NAME_EXIST, name);
             }
         }
         WorkflowDefinition workflowDefinitionDeepCopy =
                 JSONUtils.parseObject(JSONUtils.toJsonString(workflowDefinition), WorkflowDefinition.class);
         workflowDefinition.set(projectCode, name, description, globalParams, locations, timeout);
         workflowDefinition.setExecutionType(executionType);
-        result = updateDagDefine(loginUser, taskRelationList, workflowDefinition, workflowDefinitionDeepCopy,
+        return updateDagDefine(loginUser, taskRelationList, workflowDefinition, workflowDefinitionDeepCopy,
                 taskDefinitionLogs);
-        return result;
     }
 
     /**
@@ -729,12 +703,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         }
     }
 
-    protected Map<String, Object> updateDagDefine(User loginUser,
-                                                  List<WorkflowTaskRelationLog> taskRelationList,
-                                                  WorkflowDefinition workflowDefinition,
-                                                  WorkflowDefinition workflowDefinitionDeepCopy,
-                                                  List<TaskDefinitionLog> taskDefinitionLogs) {
-        Map<String, Object> result = new HashMap<>();
+    protected WorkflowDefinition updateDagDefine(User loginUser,
+                                                 List<WorkflowTaskRelationLog> taskRelationList,
+                                                 WorkflowDefinition workflowDefinition,
+                                                 WorkflowDefinition workflowDefinitionDeepCopy,
+                                                 List<TaskDefinitionLog> taskDefinitionLogs) {
         int saveTaskResult = processService.saveTaskDefine(loginUser, workflowDefinition.getProjectCode(),
                 taskDefinitionLogs, Boolean.TRUE);
         if (saveTaskResult == Constants.EXIT_CODE_SUCCESS) {
@@ -743,7 +716,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         if (saveTaskResult == Constants.DEFINITION_FAILURE) {
             log.error("Update task definitions error, projectCode:{}, workflowDefinitionCode:{}.",
                     workflowDefinition.getProjectCode(), workflowDefinition.getCode());
-            putMsg(result, Status.UPDATE_TASK_DEFINITION_ERROR);
             throw new ServiceException(Status.UPDATE_TASK_DEFINITION_ERROR);
         }
         boolean isChange = false;
@@ -767,51 +739,43 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         } else {
             isChange = true;
         }
-        if (isChange) {
-            log.info(
-                    "workflow definition needs to be updated, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                    workflowDefinition.getProjectCode(), workflowDefinition.getCode(), workflowDefinition.getVersion());
-            workflowDefinition.setUpdateTime(new Date());
-            int insertVersion =
-                    processService.saveWorkflowDefine(loginUser, workflowDefinition, Boolean.TRUE, Boolean.TRUE);
-            if (insertVersion <= 0) {
-                log.error("Update workflow definition error, workflowDefinitionCode:{}.", workflowDefinition.getCode());
-                putMsg(result, Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
-                throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
-            } else {
-                log.info(
-                        "Update workflow definition complete, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                        workflowDefinition.getCode(), insertVersion);
-            }
-            workflowDefinition.setVersion(insertVersion);
-
-            taskUsedInOtherTaskValid(workflowDefinition, taskRelationList);
-            int insertResult = processService.saveTaskRelation(loginUser, workflowDefinition.getProjectCode(),
-                    workflowDefinition.getCode(), insertVersion, taskRelationList, taskDefinitionLogs, Boolean.TRUE);
-            if (insertResult == Constants.EXIT_CODE_SUCCESS) {
-                log.info(
-                        "Update workflow task relations complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                        workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
-                putMsg(result, Status.SUCCESS);
-                result.put(Constants.DATA_LIST, workflowDefinition);
-            } else {
-                log.error(
-                        "Update workflow task relations error, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
-                        workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
-                putMsg(result, Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
-                throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
-            }
-
-            saveWorkflowLineage(workflowDefinition.getProjectCode(), workflowDefinition.getCode(),
-                    insertVersion, taskDefinitionLogs);
-        } else {
+        if (!isChange) {
             log.info(
                     "workflow definition does not need to be updated because there is no change, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
                     workflowDefinition.getProjectCode(), workflowDefinition.getCode(), workflowDefinition.getVersion());
-            putMsg(result, Status.SUCCESS);
-            result.put(Constants.DATA_LIST, workflowDefinition);
+            return workflowDefinition;
         }
-        return result;
+        log.info(
+                "workflow definition needs to be updated, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                workflowDefinition.getProjectCode(), workflowDefinition.getCode(), workflowDefinition.getVersion());
+        workflowDefinition.setUpdateTime(new Date());
+        int insertVersion =
+                processService.saveWorkflowDefine(loginUser, workflowDefinition, Boolean.TRUE, Boolean.TRUE);
+        if (insertVersion <= 0) {
+            log.error("Update workflow definition error, workflowDefinitionCode:{}.", workflowDefinition.getCode());
+            throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
+        }
+        log.info(
+                "Update workflow definition complete, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                workflowDefinition.getCode(), insertVersion);
+        workflowDefinition.setVersion(insertVersion);
+
+        taskUsedInOtherTaskValid(workflowDefinition, taskRelationList);
+        int insertResult = processService.saveTaskRelation(loginUser, workflowDefinition.getProjectCode(),
+                workflowDefinition.getCode(), insertVersion, taskRelationList, taskDefinitionLogs, Boolean.TRUE);
+        if (insertResult != Constants.EXIT_CODE_SUCCESS) {
+            log.error(
+                    "Update workflow task relations error, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                    workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
+            throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
+        }
+        log.info(
+                "Update workflow task relations complete, projectCode:{}, workflowDefinitionCode:{}, workflowDefinitionVersion:{}.",
+                workflowDefinition.getProjectCode(), workflowDefinition.getCode(), insertVersion);
+
+        saveWorkflowLineage(workflowDefinition.getProjectCode(), workflowDefinition.getCode(),
+                insertVersion, taskDefinitionLogs);
+        return workflowDefinition;
     }
 
     /**
@@ -823,37 +787,31 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return true if workflow definition name not exists, otherwise false
      */
     @Override
-    public Map<String, Object> verifyWorkflowDefinitionName(User loginUser, long projectCode, String name,
-                                                            long workflowDefinitionCode) {
+    public void verifyWorkflowDefinitionName(User loginUser, long projectCode, String name,
+                                             long workflowDefinitionCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_CREATE);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition =
                 workflowDefinitionMapper.verifyByDefineName(project.getCode(), name.trim());
         if (workflowDefinition == null) {
-            putMsg(result, Status.SUCCESS);
-            return result;
+            return;
         }
         if (workflowDefinitionCode != 0 && workflowDefinitionCode == workflowDefinition.getCode()) {
-            putMsg(result, Status.SUCCESS);
-            return result;
+            return;
         }
         log.warn("workflow definition with the same name {} already exists, workflowDefinitionCode:{}.",
                 workflowDefinition.getName(), workflowDefinition.getCode());
-        putMsg(result, Status.WORKFLOW_DEFINITION_NAME_EXIST, name.trim());
-        return result;
+        throw new ServiceException(Status.WORKFLOW_DEFINITION_NAME_EXIST, name.trim());
     }
 
     @Override
     @Transactional
-    public Map<String, Object> batchDeleteWorkflowDefinitionByCodes(User loginUser, long projectCode, String codes) {
-        Map<String, Object> result = new HashMap<>();
+    public void batchDeleteWorkflowDefinitionByCodes(User loginUser, long projectCode, String codes) {
         if (StringUtils.isEmpty(codes)) {
             log.error("Parameter workflowDefinitionCodes is empty, projectCode is {}.", projectCode);
-            putMsg(result, Status.WORKFLOW_DEFINITION_CODES_IS_EMPTY);
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_CODES_IS_EMPTY);
         }
 
         Set<Long> definitionCodes = Lists.newArrayList(codes.split(Constants.COMMA)).stream().map(Long::parseLong)
@@ -881,8 +839,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                         e.getMessage());
             }
         }
-        putMsg(result, Status.SUCCESS);
-        return result;
     }
 
     /**
@@ -980,14 +936,12 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return check result code
      */
     @Override
-    public Map<String, Object> checkWorkflowNodeList(String workflowTaskRelationJson,
-                                                     List<TaskDefinitionLog> taskDefinitionLogsList) {
-        Map<String, Object> result = new HashMap<>();
+    public void checkWorkflowNodeList(String workflowTaskRelationJson,
+                                      List<TaskDefinitionLog> taskDefinitionLogsList) {
         try {
             if (workflowTaskRelationJson == null) {
                 log.error("workflow task relation data is null.");
-                putMsg(result, Status.DATA_IS_NOT_VALID, workflowTaskRelationJson);
-                return result;
+                throw new ServiceException(Status.DATA_IS_NOT_VALID, "null");
             }
 
             List<WorkflowTaskRelation> taskRelationList =
@@ -997,34 +951,30 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
             if (CollectionUtils.isEmpty(taskNodes)) {
                 log.error("Task node data is empty.");
-                putMsg(result, Status.WORKFLOW_DAG_IS_EMPTY);
-                return result;
+                throw new ServiceException(Status.WORKFLOW_DAG_IS_EMPTY);
             }
 
             // check has cycle
             if (graphHasCycle(taskNodes)) {
                 log.error("workflow DAG has cycle.");
-                putMsg(result, Status.WORKFLOW_NODE_HAS_CYCLE);
-                return result;
+                throw new ServiceException(Status.WORKFLOW_NODE_HAS_CYCLE);
             }
 
             // check whether the workflow definition json is normal
             for (TaskNode taskNode : taskNodes) {
                 if (!checkTaskParameters(taskNode.getType(), taskNode.getParams())) {
-                    putMsg(result, Status.WORKFLOW_NODE_S_PARAMETER_INVALID, taskNode.getName());
-                    return result;
+                    throw new ServiceException(Status.WORKFLOW_NODE_S_PARAMETER_INVALID, taskNode.getName());
                 }
 
                 // check extra params
                 CheckUtils.checkOtherParams(taskNode.getExtras());
             }
-            putMsg(result, Status.SUCCESS);
+        } catch (ServiceException e) {
+            throw e;
         } catch (Exception e) {
-            result.put(Constants.STATUS, Status.INTERNAL_SERVER_ERROR_ARGS);
-            putMsg(result, Status.INTERNAL_SERVER_ERROR_ARGS, e.getMessage());
             log.error(Status.INTERNAL_SERVER_ERROR_ARGS.getMsg(), e);
+            throw new ServiceException(Status.INTERNAL_SERVER_ERROR_ARGS, e.getMessage());
         }
-        return result;
     }
 
     /**
@@ -1036,23 +986,18 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return task node list
      */
     @Override
-    public Map<String, Object> getTaskNodeListByDefinitionCode(User loginUser, long projectCode, long code) {
+    public List<TaskDefinition> getTaskNodeListByDefinitionCode(User loginUser, long projectCode, long code) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
         }
         DagData dagData = processService.genDagData(workflowDefinition);
-        result.put(Constants.DATA_LIST, dagData.getTaskDefinitionList());
-        putMsg(result, Status.SUCCESS);
-
-        return result;
+        return dagData.getTaskDefinitionList();
     }
 
     /**
@@ -1064,19 +1009,18 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return task node list
      */
     @Override
-    public Map<String, Object> getNodeListMapByDefinitionCodes(User loginUser, long projectCode, String codes) {
+    public Map<Long, List<TaskDefinition>> getNodeListMapByDefinitionCodes(User loginUser, long projectCode,
+                                                                           String codes) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
-        Map<String, Object> result = new HashMap<>();
         Set<Long> defineCodeSet = Lists.newArrayList(codes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
         List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionMapper.queryByCodes(defineCodeSet);
         if (CollectionUtils.isEmpty(workflowDefinitionList)) {
             log.error("workflow definitions do not exist, codes:{}.", defineCodeSet);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, codes);
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, codes);
         }
         HashMap<Long, Project> userProjects = new HashMap<>(Constants.DEFAULT_HASH_MAP_SIZE);
         projectMapper.queryProjectCreatedAndAuthorizedByUserId(loginUser.getId())
@@ -1086,24 +1030,15 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         List<WorkflowDefinition> workflowDefinitionListInProject = workflowDefinitionList.stream()
                 .filter(o -> userProjects.containsKey(o.getProjectCode())).collect(Collectors.toList());
         if (CollectionUtils.isEmpty(workflowDefinitionListInProject)) {
-            Set<Long> codesInProject = workflowDefinitionListInProject.stream()
-                    .map(WorkflowDefinition::getCode).collect(Collectors.toSet());
-            log.error("workflow definitions do not exist in project, projectCode:{}, workflowDefinitionsCodes:{}.",
-                    workflowDefinitionListInProject.get(0).getProjectCode(), codesInProject);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, codes);
-            return result;
+            log.error("workflow definitions do not exist in project, codes:{}.", codes);
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, codes);
         }
         Map<Long, List<TaskDefinition>> taskNodeMap = new HashMap<>();
         for (WorkflowDefinition workflowDefinition : workflowDefinitionListInProject) {
             DagData dagData = processService.genDagData(workflowDefinition);
             taskNodeMap.put(workflowDefinition.getCode(), dagData.getTaskDefinitionList());
         }
-
-        result.put(Constants.DATA_LIST, taskNodeMap);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
-
+        return taskNodeMap;
     }
 
     /**
@@ -1114,18 +1049,13 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return workflow definitions in the project
      */
     @Override
-    public Map<String, Object> queryAllWorkflowDefinitionByProjectCode(User loginUser, long projectCode) {
+    public List<DagData> queryAllWorkflowDefinitionByProjectCode(User loginUser, long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> result = new HashMap<>();
         List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
-        List<DagData> dagDataList =
-                workflowDefinitions.stream().map(processService::genDagData).collect(Collectors.toList());
-        result.put(Constants.DATA_LIST, dagDataList);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return workflowDefinitions.stream().map(processService::genDagData).collect(Collectors.toList());
     }
 
     /**
@@ -1135,13 +1065,8 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return workflow definition list in the project
      */
     @Override
-    public Map<String, Object> queryWorkflowDefinitionListByProjectCode(long projectCode) {
-        Map<String, Object> result = new HashMap<>();
-        List<DependentSimplifyDefinition> workflowDefinitions =
-                workflowDefinitionMapper.queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(projectCode, null);
-        result.put(Constants.DATA_LIST, workflowDefinitions);
-        putMsg(result, Status.SUCCESS);
-        return result;
+    public List<DependentSimplifyDefinition> queryWorkflowDefinitionListByProjectCode(long projectCode) {
+        return workflowDefinitionMapper.queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(projectCode, null);
     }
 
     /**
@@ -1152,10 +1077,8 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return task definition list in the workflow definition
      */
     @Override
-    public Map<String, Object> queryTaskDefinitionListByWorkflowDefinitionCode(long projectCode,
-                                                                               Long workflowDefinitionCode) {
-        Map<String, Object> result = new HashMap<>();
-
+    public List<DependentSimplifyDefinition> queryTaskDefinitionListByWorkflowDefinitionCode(long projectCode,
+                                                                                             Long workflowDefinitionCode) {
         Set<Long> definitionCodesSet = new HashSet<>();
         definitionCodesSet.add(workflowDefinitionCode);
         List<DependentSimplifyDefinition> workflowDefinitions = workflowDefinitionMapper
@@ -1173,10 +1096,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             dependentSimplifyDefinition.setVersion(taskDefinitionLog.getVersion());
             taskDefinitionList.add(dependentSimplifyDefinition);
         }
-
-        result.put(Constants.DATA_LIST, taskDefinitionList);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return taskDefinitionList;
     }
 
     /**
@@ -1188,8 +1108,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return tree view json data
      */
     @Override
-    public Map<String, Object> viewTree(User loginUser, long projectCode, long code, Integer limit) {
-        Map<String, Object> result = new HashMap<>();
+    public TreeViewDto viewTree(User loginUser, long projectCode, long code, Integer limit) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_TREE_VIEW);
@@ -1197,8 +1116,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (null == workflowDefinition || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, code:{}.", code);
-            putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
-            return result;
+            throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
         }
         DAG<Long, TaskNode, TaskNodeRelation> dag = processService.genDagGraph(workflowDefinition);
         // nodes that are running
@@ -1219,8 +1137,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                 .collect(Collectors.toMap(TaskDefinitionLog::getCode, taskDefinitionLog -> taskDefinitionLog));
 
         if (limit < 0) {
-            putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR);
-            return result;
+            throw new ServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR);
         }
         if (limit > workflowInstanceList.size()) {
             limit = workflowInstanceList.size();
@@ -1312,10 +1229,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                 waitingRunningNodeMap.clear();
             }
         }
-        result.put(Constants.DATA_LIST, parentTreeViewDto);
-        result.put(Constants.STATUS, Status.SUCCESS);
-        result.put(Constants.MSG, Status.SUCCESS.getMsg());
-        return result;
+        return parentTreeViewDto;
     }
 
     /**
@@ -1354,15 +1268,14 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     @Transactional
-    public Map<String, Object> batchCopyWorkflowDefinition(User loginUser,
-                                                           long projectCode,
-                                                           String codes,
-                                                           long targetProjectCode) {
-        Map<String, Object> result = checkParams(loginUser, projectCode, codes, targetProjectCode, WORKFLOW_BATCH_COPY);
+    public void batchCopyWorkflowDefinition(User loginUser,
+                                            long projectCode,
+                                            String codes,
+                                            long targetProjectCode) {
+        checkParams(loginUser, projectCode, codes, targetProjectCode, WORKFLOW_BATCH_COPY);
         List<String> failedWorkflowList = new ArrayList<>();
-        doBatchOperateWorkflowDefinition(loginUser, targetProjectCode, failedWorkflowList, codes, result, true);
-        checkBatchOperateResult(projectCode, targetProjectCode, result, failedWorkflowList, true);
-        return result;
+        doBatchOperateWorkflowDefinition(loginUser, targetProjectCode, failedWorkflowList, codes, true);
+        checkBatchOperateResult(projectCode, targetProjectCode, failedWorkflowList, true);
     }
 
     /**
@@ -1376,27 +1289,25 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     @Transactional
-    public Map<String, Object> batchMoveWorkflowDefinition(User loginUser,
-                                                           long projectCode,
-                                                           String codes,
-                                                           long targetProjectCode) {
-        Map<String, Object> result =
-                checkParams(loginUser, projectCode, codes, targetProjectCode, TASK_DEFINITION_MOVE);
+    public void batchMoveWorkflowDefinition(User loginUser,
+                                            long projectCode,
+                                            String codes,
+                                            long targetProjectCode) {
+        checkParams(loginUser, projectCode, codes, targetProjectCode, TASK_DEFINITION_MOVE);
         if (projectCode == targetProjectCode) {
             log.warn("Project code is same as target project code, projectCode:{}.", projectCode);
-            return result;
+            return;
         }
 
         List<String> failedWorkflowList = new ArrayList<>();
-        doBatchOperateWorkflowDefinition(loginUser, targetProjectCode, failedWorkflowList, codes, result, false);
-        checkBatchOperateResult(projectCode, targetProjectCode, result, failedWorkflowList, false);
-        return result;
+        doBatchOperateWorkflowDefinition(loginUser, targetProjectCode, failedWorkflowList, codes, false);
+        checkBatchOperateResult(projectCode, targetProjectCode, failedWorkflowList, false);
     }
 
-    private Map<String, Object> checkParams(User loginUser,
-                                            long projectCode,
-                                            String workflowDefinitionCodes,
-                                            long targetProjectCode, String perm) {
+    private void checkParams(User loginUser,
+                             long projectCode,
+                             String workflowDefinitionCodes,
+                             long targetProjectCode, String perm) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, perm);
@@ -1411,16 +1322,12 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             // check user access for project
             projectService.checkProjectAndAuthThrowException(loginUser, targetProject, perm);
         }
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        return result;
     }
 
     protected void doBatchOperateWorkflowDefinition(User loginUser,
                                                     long targetProjectCode,
                                                     List<String> failedWorkflowList,
                                                     String workflowDefinitionCodes,
-                                                    Map<String, Object> result,
                                                     boolean isCopy) {
         Set<Long> definitionCodes = Arrays.stream(workflowDefinitionCodes.split(Constants.COMMA)).map(Long::parseLong)
                 .collect(Collectors.toSet());
@@ -1500,32 +1407,26 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     int insertResult = scheduleMapper.insert(scheduleObj);
                     if (insertResult != 1) {
                         log.error("Schedule create error, workflowDefinitionCode:{}.", workflowDefinition.getCode());
-                        putMsg(result, Status.CREATE_SCHEDULE_ERROR);
                         throw new ServiceException(Status.CREATE_SCHEDULE_ERROR);
                     }
                 }
                 try {
-                    result.putAll(createDagDefine(loginUser, taskRelationList, workflowDefinition, taskDefinitionLogs));
+                    createDagDefine(loginUser, taskRelationList, workflowDefinition, taskDefinitionLogs);
                 } catch (Exception e) {
                     log.error("Copy workflow definition error, workflowDefinitionCode from {} to {}.",
                             oldWorkflowDefinitionCode, workflowDefinition.getCode(), e);
-                    putMsg(result, Status.COPY_WORKFLOW_DEFINITION_ERROR);
-                    throw new ServiceException(Status.COPY_WORKFLOW_DEFINITION_ERROR);
+                    failedWorkflowList.add(workflowDefinition.getCode() + "[" + workflowDefinition.getName() + "]");
                 }
             } else {
                 log.info("Move workflow definition...");
                 try {
-                    result.putAll(updateDagDefine(loginUser, taskRelationList, workflowDefinition, null,
-                            Lists.newArrayList()));
+                    updateDagDefine(loginUser, taskRelationList, workflowDefinition, null,
+                            Lists.newArrayList());
                 } catch (Exception e) {
                     log.error("Move workflow definition error, workflowDefinitionCode:{}.",
                             workflowDefinition.getCode(), e);
-                    putMsg(result, Status.MOVE_WORKFLOW_DEFINITION_ERROR);
-                    throw new ServiceException(Status.MOVE_WORKFLOW_DEFINITION_ERROR);
+                    failedWorkflowList.add(workflowDefinition.getCode() + "[" + workflowDefinition.getName() + "]");
                 }
-            }
-            if (result.get(Constants.STATUS) != Status.SUCCESS) {
-                failedWorkflowList.add(workflowDefinition.getCode() + "[" + workflowDefinition.getName() + "]");
             }
         }
     }
@@ -1667,20 +1568,19 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     @Transactional
-    public Map<String, Object> switchWorkflowDefinitionVersion(User loginUser, long projectCode, long code,
-                                                               int version) {
+    public void switchWorkflowDefinitionVersion(User loginUser, long projectCode, long code,
+                                                int version) {
         Project project = projectMapper.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
         if (Objects.isNull(workflowDefinition) || projectCode != workflowDefinition.getProjectCode()) {
             log.error(
                     "Switch workflow definition error because it does not exist, projectCode:{}, workflowDefinitionCode:{}.",
                     projectCode, code);
-            putMsg(result, Status.SWITCH_WORKFLOW_DEFINITION_VERSION_NOT_EXIST_WORKFLOW_DEFINITION_ERROR, code);
-            return result;
+            throw new ServiceException(Status.SWITCH_WORKFLOW_DEFINITION_VERSION_NOT_EXIST_WORKFLOW_DEFINITION_ERROR,
+                    code);
         }
 
         WorkflowDefinitionLog workflowDefinitionLog =
@@ -1689,16 +1589,15 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             log.error(
                     "Switch workflow definition error because version does not exist, projectCode:{}, workflowDefinitionCode:{}, version:{}.",
                     projectCode, code, version);
-            putMsg(result, Status.SWITCH_WORKFLOW_DEFINITION_VERSION_NOT_EXIST_WORKFLOW_DEFINITION_VERSION_ERROR,
+            throw new ServiceException(
+                    Status.SWITCH_WORKFLOW_DEFINITION_VERSION_NOT_EXIST_WORKFLOW_DEFINITION_VERSION_ERROR,
                     workflowDefinition.getCode(), version);
-            return result;
         }
         int switchVersion = processService.switchVersion(workflowDefinition, workflowDefinitionLog);
         if (switchVersion <= 0) {
             log.error(
                     "Switch workflow definition version error, projectCode:{}, workflowDefinitionCode:{}, version:{}.",
                     projectCode, code, version);
-            putMsg(result, Status.SWITCH_WORKFLOW_DEFINITION_VERSION_ERROR);
             throw new ServiceException(Status.SWITCH_WORKFLOW_DEFINITION_VERSION_ERROR);
         }
 
@@ -1719,8 +1618,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
         log.info("Switch workflow definition version complete, projectCode:{}, workflowDefinitionCode:{}, version:{}.",
                 projectCode, code, version);
-        putMsg(result, Status.SUCCESS);
-        return result;
     }
 
     private static @NotNull List<TaskCodeVersionDto> getTaskCodeVersionDtos(List<WorkflowTaskRelation> workflowTaskRelationList) {
@@ -1752,27 +1649,24 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @param isCopy            isCopy
      */
     private void checkBatchOperateResult(long srcProjectCode, long targetProjectCode,
-                                         Map<String, Object> result, List<String> failedWorkflowList, boolean isCopy) {
+                                         List<String> failedWorkflowList, boolean isCopy) {
         if (!failedWorkflowList.isEmpty()) {
             String failedWorkflow = String.join(",", failedWorkflowList);
             if (isCopy) {
                 log.error(
                         "Copy workflow definition error, srcProjectCode:{}, targetProjectCode:{}, failedWorkflowList:{}.",
                         srcProjectCode, targetProjectCode, failedWorkflow);
-                putMsg(result, Status.COPY_WORKFLOW_DEFINITION_ERROR, srcProjectCode, targetProjectCode,
-                        failedWorkflow);
-            } else {
-                log.error(
-                        "Move workflow definition error, srcProjectCode:{}, targetProjectCode:{}, failedWorkflowList:{}.",
-                        srcProjectCode, targetProjectCode, failedWorkflow);
-                putMsg(result, Status.MOVE_WORKFLOW_DEFINITION_ERROR, srcProjectCode, targetProjectCode,
+                throw new ServiceException(Status.COPY_WORKFLOW_DEFINITION_ERROR, srcProjectCode, targetProjectCode,
                         failedWorkflow);
             }
-        } else {
-            log.info("Batch {} workflow definition complete, srcProjectCode:{}, targetProjectCode:{}.",
-                    isCopy ? "copy" : "move", srcProjectCode, targetProjectCode);
-            putMsg(result, Status.SUCCESS);
+            log.error(
+                    "Move workflow definition error, srcProjectCode:{}, targetProjectCode:{}, failedWorkflowList:{}.",
+                    srcProjectCode, targetProjectCode, failedWorkflow);
+            throw new ServiceException(Status.MOVE_WORKFLOW_DEFINITION_ERROR, srcProjectCode, targetProjectCode,
+                    failedWorkflow);
         }
+        log.info("Batch {} workflow definition complete, srcProjectCode:{}, targetProjectCode:{}.",
+                isCopy ? "copy" : "move", srcProjectCode, targetProjectCode);
     }
 
     /**
@@ -1896,21 +1790,19 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      * @return variables data
      */
     @Override
-    public Map<String, Object> viewVariables(User loginUser, long projectCode, long code) {
+    public WorkflowDefinitionVariablesDTO viewVariables(User loginUser, long projectCode, long code) {
 
         Project project = projectMapper.queryByCode(projectCode);
 
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        Map<String, Object> result = new HashMap<>();
         WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
 
         if (Objects.isNull(workflowDefinition) || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                     code);
-            putMsg(result, WORKFLOW_DEFINITION_NOT_EXIST, code);
-            return result;
+            throw new ServiceException(WORKFLOW_DEFINITION_NOT_EXIST, code);
         }
 
         // global params
@@ -1918,19 +1810,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
         Map<String, Map<String, Object>> localUserDefParams = getLocalParams(workflowDefinition);
 
-        Map<String, Object> resultMap = new HashMap<>();
-
-        if (Objects.nonNull(globalParams)) {
-            resultMap.put(GLOBAL_PARAMS, globalParams);
-        }
-
-        if (Objects.nonNull(localUserDefParams)) {
-            resultMap.put(LOCAL_PARAMS, localUserDefParams);
-        }
-
-        result.put(DATA_LIST, resultMap);
-        putMsg(result, Status.SUCCESS);
-        return result;
+        return new WorkflowDefinitionVariablesDTO(globalParams, localUserDefParams);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -488,13 +488,8 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
                 workflowDefinitionMapper.queryByCode(workflowInstance.getWorkflowDefinitionCode());
         List<WorkflowTaskRelationLog> taskRelationList =
                 JSONUtils.toList(taskRelationJson, WorkflowTaskRelationLog.class);
-        // check workflow json is valid
-        Map<String, Object> checkResult =
-                workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs);
-        Status checkStatus = (Status) checkResult.get(Constants.STATUS);
-        if (checkStatus != Status.SUCCESS) {
-            throw new ServiceException(checkStatus.getCode(), (String) checkResult.get(Constants.MSG));
-        }
+        // check workflow json is valid (throws ServiceException on validation failures)
+        workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs);
 
         workflowDefinition.set(projectCode, workflowDefinition.getName(), workflowDefinition.getDescription(),
                 globalParams, locations, timeout);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkflowDefinitionControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkflowDefinitionControllerTest.java
@@ -19,23 +19,26 @@ package org.apache.dolphinscheduler.api.controller;
 
 import static org.mockito.Mockito.doNothing;
 
+import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
+import org.apache.dolphinscheduler.api.dto.workflow.WorkflowDefinitionVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.impl.WorkflowDefinitionServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionTypeEnum;
+import org.apache.dolphinscheduler.dao.entity.DagData;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,9 +49,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-/**
- * process definition controller test
- */
 @ExtendWith(MockitoExtension.class)
 public class WorkflowDefinitionControllerTest {
 
@@ -71,49 +71,27 @@ public class WorkflowDefinitionControllerTest {
 
     @Test
     public void testCreateWorkflowDefinition() {
-        String relationJson =
-                "[{\"name\":\"\",\"pre_task_code\":0,\"pre_task_version\":0,\"post_task_code\":123456789,\"post_task_version\":1,"
-                        + "\"condition_type\":0,\"condition_params\":\"{}\"},{\"name\":\"\",\"pre_task_code\":123456789,\"pre_task_version\":1,"
-                        + "\"post_task_code\":123451234,\"post_task_version\":1,\"condition_type\":0,\"condition_params\":\"{}\"}]";
-        String taskDefinitionJson =
-                "[{\"name\":\"detail_up\",\"description\":\"\",\"taskType\":\"SHELL\",\"taskParams\":"
-                        + "\"{\\\"resourceList\\\":[],\\\"localParams\\\":[{\\\"prop\\\":\\\"datetime\\\",\\\"direct\\\":\\\"IN\\\","
-                        + "\\\"type\\\":\\\"VARCHAR\\\",\\\"value\\\":\\\"${system.datetime}\\\"}],\\\"rawScript\\\":"
-                        + "\\\"echo ${datetime}\\\",\\\"conditionResult\\\":\\\"{\\\\\\\"successNode\\\\\\\":[\\\\\\\"\\\\\\\"],"
-                        + "\\\\\\\"failedNode\\\\\\\":[\\\\\\\"\\\\\\\"]}\\\",\\\"dependence\\\":{}}\",\"flag\":0,\"taskPriority\":0,"
-                        + "\"workerGroup\":\"default\",\"failRetryTimes\":0,\"failRetryInterval\":0,\"timeoutFlag\":0,"
-                        + "\"timeoutNotifyStrategy\":0,\"timeout\":0,\"delayTime\":0,\"resourceIds\":\"\"}]";
         long projectCode = 1L;
         String name = "dag_test";
         String description = "desc test";
         String globalParams = "[]";
         String locations = "[]";
         int timeout = 0;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, 1);
+        String relationJson = "[]";
+        String taskDefinitionJson = "[]";
 
-        Mockito.when(
-                processDefinitionService.createWorkflowDefinition(user, projectCode, name, description, globalParams,
-                        locations, timeout, relationJson, taskDefinitionJson, "",
-                        WorkflowExecutionTypeEnum.PARALLEL))
-                .thenReturn(result);
+        WorkflowDefinition workflowDefinition = new WorkflowDefinition();
+        workflowDefinition.setName(name);
 
-        Result response =
-                workflowDefinitionController.createWorkflowDefinition(user, projectCode, name, description,
-                        globalParams,
-                        locations, timeout, relationJson, taskDefinitionJson, "",
-                        WorkflowExecutionTypeEnum.PARALLEL);
+        Mockito.when(processDefinitionService.createWorkflowDefinition(user, projectCode, name, description,
+                globalParams, locations, timeout, relationJson, taskDefinitionJson, "",
+                WorkflowExecutionTypeEnum.PARALLEL))
+                .thenReturn(workflowDefinition);
+
+        Result<WorkflowDefinition> response = workflowDefinitionController.createWorkflowDefinition(user, projectCode,
+                name, description, globalParams, locations, timeout, relationJson, taskDefinitionJson, "",
+                WorkflowExecutionTypeEnum.PARALLEL);
         Assertions.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
-    }
-
-    private void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
-        result.put(Constants.STATUS, status);
-        if (statusParams != null && statusParams.length > 0) {
-            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
-        } else {
-            result.put(Constants.MSG, status.getMsg());
-        }
     }
 
     public void putMsg(Result result, Status status, Object... statusParams) {
@@ -127,52 +105,38 @@ public class WorkflowDefinitionControllerTest {
 
     @Test
     public void testVerifyWorkflowDefinitionName() {
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.WORKFLOW_DEFINITION_NAME_EXIST);
         long projectCode = 1L;
         String name = "dag_test";
 
-        Mockito.when(processDefinitionService.verifyWorkflowDefinitionName(user, projectCode, name, 0))
-                .thenReturn(result);
+        Mockito.doThrow(new ServiceException(Status.WORKFLOW_DEFINITION_NAME_EXIST, name))
+                .when(processDefinitionService).verifyWorkflowDefinitionName(user, projectCode, name, 0);
 
-        Result response = workflowDefinitionController.verifyWorkflowDefinitionName(user, projectCode, name, 0);
-        Assertions.assertTrue(response.isStatus(Status.WORKFLOW_DEFINITION_NAME_EXIST));
+        Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionController.verifyWorkflowDefinitionName(user, projectCode, name, 0));
     }
 
     @Test
     public void updateWorkflowDefinition() {
-        String relationJson =
-                "[{\"name\":\"\",\"pre_task_code\":0,\"pre_task_version\":0,\"post_task_code\":123456789,\"post_task_version\":1,"
-                        + "\"condition_type\":0,\"condition_params\":\"{}\"},{\"name\":\"\",\"pre_task_code\":123456789,\"pre_task_version\":1,"
-                        + "\"post_task_code\":123451234,\"post_task_version\":1,\"condition_type\":0,\"condition_params\":\"{}\"}]";
-        String taskDefinitionJson =
-                "[{\"name\":\"detail_up\",\"description\":\"\",\"taskType\":\"SHELL\",\"taskParams\":"
-                        + "\"{\\\"resourceList\\\":[],\\\"localParams\\\":[{\\\"prop\\\":\\\"datetime\\\",\\\"direct\\\":\\\"IN\\\","
-                        + "\\\"type\\\":\\\"VARCHAR\\\",\\\"value\\\":\\\"${system.datetime}\\\"}],\\\"rawScript\\\":"
-                        + "\\\"echo ${datetime}\\\",\\\"conditionResult\\\":\\\"{\\\\\\\"successNode\\\\\\\":[\\\\\\\"\\\\\\\"],"
-                        + "\\\\\\\"failedNode\\\\\\\":[\\\\\\\"\\\\\\\"]}\\\",\\\"dependence\\\":{}}\",\"flag\":0,\"taskPriority\":0,"
-                        + "\"workerGroup\":\"default\",\"failRetryTimes\":0,\"failRetryInterval\":0,\"timeoutFlag\":0,"
-                        + "\"timeoutNotifyStrategy\":0,\"timeout\":0,\"delayTime\":0,\"resourceIds\":\"\"}]";
-        String locations = "{\"tasks-36196\":{\"name\":\"ssh_test1\",\"targetarr\":\"\",\"x\":141,\"y\":70}}";
+        String relationJson = "[]";
+        String taskDefinitionJson = "[]";
+        String locations = "{}";
         long projectCode = 1L;
         String name = "dag_test";
         String description = "desc test";
         String globalParams = "[]";
         int timeout = 0;
         long code = 123L;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put("processDefinitionId", 1);
+
+        WorkflowDefinition workflowDefinition = new WorkflowDefinition();
+        workflowDefinition.setCode(code);
 
         Mockito.when(processDefinitionService.updateWorkflowDefinition(user, projectCode, name, code, description,
-                globalParams,
-                locations, timeout, relationJson, taskDefinitionJson,
-                WorkflowExecutionTypeEnum.PARALLEL)).thenReturn(result);
+                globalParams, locations, timeout, relationJson, taskDefinitionJson,
+                WorkflowExecutionTypeEnum.PARALLEL)).thenReturn(workflowDefinition);
 
-        Result response = workflowDefinitionController.updateWorkflowDefinition(user, projectCode, name, code,
-                description, globalParams,
-                locations, timeout, relationJson, taskDefinitionJson, WorkflowExecutionTypeEnum.PARALLEL,
-                ReleaseState.OFFLINE);
+        Result<WorkflowDefinition> response = workflowDefinitionController.updateWorkflowDefinition(user, projectCode,
+                name, code, description, globalParams, locations, timeout, relationJson, taskDefinitionJson,
+                WorkflowExecutionTypeEnum.PARALLEL, ReleaseState.OFFLINE);
         Assertions.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }
 
@@ -180,8 +144,6 @@ public class WorkflowDefinitionControllerTest {
     public void testReleaseWorkflowDefinition() {
         long projectCode = 1L;
         long id = 1L;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
 
         doNothing().when(processDefinitionService)
                 .offlineWorkflowDefinition(user, projectCode, id);
@@ -192,26 +154,16 @@ public class WorkflowDefinitionControllerTest {
 
     @Test
     public void testQueryWorkflowDefinitionByCode() {
-        String locations = "{\"tasks-36196\":{\"name\":\"ssh_test1\",\"targetarr\":\"\",\"x\":141,\"y\":70}}";
         long projectCode = 1L;
-        String name = "dag_test";
-        String description = "desc test";
         long code = 1L;
 
         WorkflowDefinition workflowDefinition = new WorkflowDefinition();
-        workflowDefinition.setProjectCode(projectCode);
-        workflowDefinition.setDescription(description);
         workflowDefinition.setCode(code);
-        workflowDefinition.setLocations(locations);
-        workflowDefinition.setName(name);
-
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, workflowDefinition);
+        DagData dagData = new DagData(workflowDefinition, Collections.emptyList(), Collections.emptyList());
 
         Mockito.when(processDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, code))
-                .thenReturn(result);
-        Result response = workflowDefinitionController.queryWorkflowDefinitionByCode(user, projectCode, code);
+                .thenReturn(dagData);
+        Result<DagData> response = workflowDefinitionController.queryWorkflowDefinitionByCode(user, projectCode, code);
 
         Assertions.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
     }
@@ -222,12 +174,9 @@ public class WorkflowDefinitionControllerTest {
         long targetProjectCode = 2L;
         String code = "1";
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-
-        Mockito.when(processDefinitionService.batchCopyWorkflowDefinition(user, projectCode, code, targetProjectCode))
-                .thenReturn(result);
-        Result response =
+        doNothing().when(processDefinitionService)
+                .batchCopyWorkflowDefinition(user, projectCode, code, targetProjectCode);
+        Result<Void> response =
                 workflowDefinitionController.copyWorkflowDefinition(user, projectCode, code, targetProjectCode);
 
         Assertions.assertTrue(response != null && response.isSuccess());
@@ -239,12 +188,10 @@ public class WorkflowDefinitionControllerTest {
         long targetProjectCode = 2L;
         String id = "1";
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-
-        Mockito.when(processDefinitionService.batchMoveWorkflowDefinition(user, projectCode, id, targetProjectCode))
-                .thenReturn(result);
-        Result response = workflowDefinitionController.moveWorkflowDefinition(user, projectCode, id, targetProjectCode);
+        doNothing().when(processDefinitionService)
+                .batchMoveWorkflowDefinition(user, projectCode, id, targetProjectCode);
+        Result<Void> response =
+                workflowDefinitionController.moveWorkflowDefinition(user, projectCode, id, targetProjectCode);
 
         Assertions.assertTrue(response != null && response.isSuccess());
     }
@@ -252,46 +199,20 @@ public class WorkflowDefinitionControllerTest {
     @Test
     public void testQueryWorkflowDefinitionList() {
         long projectCode = 1L;
-        List<WorkflowDefinition> resourceList = getDefinitionList();
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-        result.put(Constants.DATA_LIST, resourceList);
-
-        Mockito.when(processDefinitionService.queryWorkflowDefinitionList(user, projectCode)).thenReturn(result);
-        Result response = workflowDefinitionController.queryWorkflowDefinitionList(user, projectCode);
+        Mockito.when(processDefinitionService.queryWorkflowDefinitionList(user, projectCode))
+                .thenReturn(Collections.emptyList());
+        Result<List<DagData>> response = workflowDefinitionController.queryWorkflowDefinitionList(user, projectCode);
 
         Assertions.assertTrue(response != null && response.isSuccess());
     }
 
     public List<WorkflowDefinition> getDefinitionList() {
         List<WorkflowDefinition> resourceList = new ArrayList<>();
-        String locations = "{\"tasks-36196\":{\"name\":\"ssh_test1\",\"targetarr\":\"\",\"x\":141,\"y\":70}}";
-        String projectName = "test";
-        String name = "dag_test";
-        String description = "desc test";
-        int id = 1;
-
         WorkflowDefinition workflowDefinition = new WorkflowDefinition();
-        workflowDefinition.setProjectName(projectName);
-        workflowDefinition.setDescription(description);
-        workflowDefinition.setId(id);
-        workflowDefinition.setLocations(locations);
-        workflowDefinition.setName(name);
-
-        String name2 = "dag_test";
-        int id2 = 2;
-
-        WorkflowDefinition workflowDefinition2 = new WorkflowDefinition();
-        workflowDefinition2.setProjectName(projectName);
-        workflowDefinition2.setDescription(description);
-        workflowDefinition2.setId(id2);
-        workflowDefinition2.setLocations(locations);
-        workflowDefinition2.setName(name2);
-
+        workflowDefinition.setName("dag_test");
+        workflowDefinition.setId(1);
         resourceList.add(workflowDefinition);
-        resourceList.add(workflowDefinition2);
-
         return resourceList;
     }
 
@@ -299,7 +220,6 @@ public class WorkflowDefinitionControllerTest {
     public void testDeleteWorkflowDefinitionByCode() {
         long projectCode = 1L;
         long code = 1L;
-        // not throw error mean pass
         Assertions.assertDoesNotThrow(
                 () -> workflowDefinitionController.deleteWorkflowDefinitionByCode(user, projectCode, code));
     }
@@ -309,11 +229,8 @@ public class WorkflowDefinitionControllerTest {
         long projectCode = 1L;
         Long code = 1L;
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-
         Mockito.when(processDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, code))
-                .thenReturn(result);
+                .thenReturn(Collections.emptyList());
         Result response = workflowDefinitionController.getNodeListByDefinitionCode(user, projectCode, code);
 
         Assertions.assertTrue(response != null && response.isSuccess());
@@ -324,11 +241,8 @@ public class WorkflowDefinitionControllerTest {
         long projectCode = 1L;
         String codeList = "1,2,3";
 
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
-
         Mockito.when(processDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, codeList))
-                .thenReturn(result);
+                .thenReturn(new HashMap<>());
         Result response = workflowDefinitionController.getNodeListMapByDefinitionCodes(user, projectCode, codeList);
 
         Assertions.assertTrue(response != null && response.isSuccess());
@@ -337,11 +251,9 @@ public class WorkflowDefinitionControllerTest {
     @Test
     public void testQueryProcessDefinitionAllByProjectId() {
         long projectCode = 1L;
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
 
         Mockito.when(processDefinitionService.queryAllWorkflowDefinitionByProjectCode(user, projectCode))
-                .thenReturn(result);
+                .thenReturn(Collections.emptyList());
         Result response = workflowDefinitionController.queryAllWorkflowDefinitionByProjectCode(user, projectCode);
 
         Assertions.assertTrue(response != null && response.isSuccess());
@@ -353,10 +265,9 @@ public class WorkflowDefinitionControllerTest {
         int processId = 1;
         int limit = 2;
         User user = new User();
-        Map<String, Object> result = new HashMap<>();
-        putMsg(result, Status.SUCCESS);
 
-        Mockito.when(processDefinitionService.viewTree(user, projectCode, processId, limit)).thenReturn(result);
+        Mockito.when(processDefinitionService.viewTree(user, projectCode, processId, limit))
+                .thenReturn(new TreeViewDto());
         Result response = workflowDefinitionController.viewTree(user, projectCode, processId, limit);
 
         Assertions.assertTrue(response != null && response.isSuccess());
@@ -401,10 +312,7 @@ public class WorkflowDefinitionControllerTest {
     @Test
     public void testSwitchWorkflowDefinitionVersion() {
         long projectCode = 1L;
-        Map<String, Object> resultMap = new HashMap<>();
-        putMsg(resultMap, Status.SUCCESS);
-        Mockito.when(processDefinitionService.switchWorkflowDefinitionVersion(user, projectCode, 1, 10))
-                .thenReturn(resultMap);
+        doNothing().when(processDefinitionService).switchWorkflowDefinitionVersion(user, projectCode, 1, 10);
         Result result = workflowDefinitionController.switchWorkflowDefinitionVersion(user, projectCode, 1, 10);
 
         Assertions.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
@@ -423,11 +331,9 @@ public class WorkflowDefinitionControllerTest {
     @Test
     public void testViewVariables() {
         long projectCode = 1L;
-        Map<String, Object> resultMap = new HashMap<>();
-        putMsg(resultMap, Status.SUCCESS);
 
-        Mockito.when(processDefinitionService.viewVariables(user, projectCode, 1))
-                .thenReturn(resultMap);
+        Mockito.when(processDefinitionService.viewVariables(user, projectCode, 1L))
+                .thenReturn(new WorkflowDefinitionVariablesDTO());
 
         Result result = workflowDefinitionController.viewVariables(user, projectCode, 1L);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -298,10 +298,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(taskDefinitionLogDao.queryTaskDefineLogList(workflowTaskRelations)).thenReturn(taskDefinitionLogs);
         when(processService.saveTaskDefine(user, projectCode, taskDefinitionLogs, true)).thenReturn(1);
         when(processService.saveWorkflowDefine(user, workflowDefinition, true, true)).thenReturn(1);
-        Map<String, Object> successRes =
-                workflowDefinitionService.batchCopyWorkflowDefinition(user, projectCode, codes, targetProjectCode);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
-
+        Assertions.assertDoesNotThrow(
+                () -> workflowDefinitionService.batchCopyWorkflowDefinition(user, projectCode, codes,
+                        targetProjectCode));
     }
     @Test
     public void testQueryWorkflowDefinitionList() {
@@ -321,9 +320,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         List<WorkflowDefinition> resourceList = new ArrayList<>();
         resourceList.add(getWorkflowDefinition());
         when(workflowDefinitionMapper.queryAllDefinitionList(project.getCode())).thenReturn(resourceList);
-        Map<String, Object> checkSuccessRes =
-                workflowDefinitionService.queryWorkflowDefinitionList(user, projectCode);
-        Assertions.assertEquals(Status.SUCCESS, checkSuccessRes.get(Constants.STATUS));
+        List<DagData> dagDataList = workflowDefinitionService.queryWorkflowDefinitionList(user, projectCode);
+        Assertions.assertNotNull(dagDataList);
     }
 
     @Test
@@ -414,15 +412,14 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         DagData dagData = new DagData(getWorkflowDefinition(), null, null);
         when(processService.genDagData(any())).thenReturn(dagData);
 
-        Map<String, Object> instanceNotexitRes =
-                workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 1L);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, instanceNotexitRes.get(Constants.STATUS));
+        ServiceException notFound = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 1L));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFound.getCode());
 
         // instance exit
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(getWorkflowDefinition());
-        Map<String, Object> successRes =
-                workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 46L);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        DagData successRes = workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 46L);
+        Assertions.assertNotNull(successRes);
     }
 
     @Test
@@ -442,16 +439,16 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         when(workflowDefinitionMapper.queryByDefineName(project.getCode(), "test_def")).thenReturn(null);
 
-        Map<String, Object> instanceNotExitRes =
-                workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test_def");
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, instanceNotExitRes.get(Constants.STATUS));
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test_def"));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // instance exit
         when(workflowDefinitionMapper.queryByDefineName(project.getCode(), "test"))
                 .thenReturn(getWorkflowDefinition());
-        Map<String, Object> successRes =
-                workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test");
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        when(processService.genDagData(any())).thenReturn(new DagData(getWorkflowDefinition(), null, null));
+        DagData successRes = workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test");
+        Assertions.assertNotNull(successRes);
     }
 
     @Test
@@ -498,9 +495,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         }
         when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         when(processService.saveWorkflowDefine(user, definition, Boolean.TRUE, Boolean.TRUE)).thenReturn(2);
-        Map<String, Object> map3 = workflowDefinitionService.batchCopyWorkflowDefinition(
-                user, projectCodeOther, String.valueOf(processDefinitionCode), projectCode);
-        Assertions.assertEquals(Status.SUCCESS, map3.get(Constants.STATUS));
+        Assertions.assertDoesNotThrow(() -> workflowDefinitionService.batchCopyWorkflowDefinition(
+                user, projectCodeOther, String.valueOf(processDefinitionCode), projectCode));
     }
 
     @Test
@@ -535,9 +531,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(workflowTaskRelationMapper.queryByWorkflowDefinitionCode(processDefinitionCode))
                 .thenReturn(getProcessTaskRelation());
 
-        Map<String, Object> successRes = workflowDefinitionService.batchMoveWorkflowDefinition(
-                user, projectCode, String.valueOf(processDefinitionCode), projectCodeOther);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertDoesNotThrow(() -> workflowDefinitionService.batchMoveWorkflowDefinition(
+                user, projectCode, String.valueOf(processDefinitionCode), projectCodeOther));
     }
 
     @Test
@@ -672,10 +667,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(process));
         when(workflowLineageService.taskDependentMsg(project.getCode(), process.getCode(), 0))
                 .thenReturn(Optional.empty());
-        putMsg(result, Status.SUCCESS, projectCode);
-        Map<String, Object> deleteSuccess =
-                workflowDefinitionService.batchDeleteWorkflowDefinitionByCodes(user, projectCode, singleCodes);
-        Assertions.assertEquals(Status.SUCCESS, deleteSuccess.get(Constants.STATUS));
+        Assertions.assertDoesNotThrow(
+                () -> workflowDefinitionService.batchDeleteWorkflowDefinitionByCodes(user, projectCode, singleCodes));
     }
 
     @Test
@@ -694,28 +687,28 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_CREATE);
         when(workflowDefinitionMapper.verifyByDefineName(project.getCode(), "test_pdf")).thenReturn(null);
-        Map<String, Object> processNotExistRes =
-                workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0);
-        Assertions.assertEquals(Status.SUCCESS, processNotExistRes.get(Constants.STATUS));
+        Assertions.assertDoesNotThrow(
+                () -> workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0));
 
         // process exist
         when(workflowDefinitionMapper.verifyByDefineName(project.getCode(), "test_pdf"))
                 .thenReturn(getWorkflowDefinition());
-        Map<String, Object> processExistRes = workflowDefinitionService.verifyWorkflowDefinitionName(user,
-                projectCode, "test_pdf", 0);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NAME_EXIST, processExistRes.get(Constants.STATUS));
+        ServiceException existsEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NAME_EXIST.getCode(), existsEx.getCode());
     }
 
     @Test
     public void testCheckWorkflowNodeList() {
-        Map<String, Object> dataNotValidRes = workflowDefinitionService.checkWorkflowNodeList(null, null);
-        Assertions.assertEquals(Status.DATA_IS_NOT_VALID, dataNotValidRes.get(Constants.STATUS));
+        ServiceException nullJsonEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.checkWorkflowNodeList(null, null));
+        Assertions.assertEquals(Status.DATA_IS_NOT_VALID.getCode(), nullJsonEx.getCode());
 
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionJson, TaskDefinitionLog.class);
 
-        Map<String, Object> taskEmptyRes =
-                workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs);
-        Assertions.assertEquals(Status.WORKFLOW_DAG_IS_EMPTY, taskEmptyRes.get(Constants.STATUS));
+        ServiceException emptyDagEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs));
+        Assertions.assertEquals(Status.WORKFLOW_DAG_IS_EMPTY.getCode(), emptyDagEx.getCode());
     }
 
     @Test
@@ -726,17 +719,17 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         // process definition not exist
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(null);
-        Map<String, Object> processDefinitionNullRes =
-                workflowDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, 46L);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, processDefinitionNullRes.get(Constants.STATUS));
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, 46L));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // success
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
-        when(processService.genDagData(any())).thenReturn(new DagData(workflowDefinition, null, null));
+        when(processService.genDagData(any()))
+                .thenReturn(new DagData(workflowDefinition, null, Collections.emptyList()));
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
-        Map<String, Object> dataNotValidRes =
-                workflowDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, 46L);
-        Assertions.assertEquals(Status.SUCCESS, dataNotValidRes.get(Constants.STATUS));
+        Assertions.assertNotNull(
+                workflowDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, 46L));
     }
 
     @Test
@@ -750,9 +743,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Set<Long> defineCodeSet = Lists.newArrayList(defineCodes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
         when(workflowDefinitionMapper.queryByCodes(defineCodeSet)).thenReturn(null);
-        Map<String, Object> processNotExistRes =
-                workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, processNotExistRes.get(Constants.STATUS));
+        ServiceException notExistEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notExistEx.getCode());
 
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
@@ -765,9 +758,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         projects.add(project1);
         when(projectMapper.queryProjectCreatedAndAuthorizedByUserId(user.getId())).thenReturn(projects);
 
-        Map<String, Object> successRes =
-                workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertNotNull(
+                workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes));
     }
 
     @Test
@@ -780,9 +772,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(workflowDefinition);
         when(workflowDefinitionMapper.queryAllDefinitionList(projectCode)).thenReturn(workflowDefinitionList);
-        Map<String, Object> successRes =
-                workflowDefinitionService.queryAllWorkflowDefinitionByProjectCode(user, projectCode);
-        Assertions.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+        Assertions.assertNotNull(
+                workflowDefinitionService.queryAllWorkflowDefinitionByProjectCode(user, projectCode));
     }
 
     @Test
@@ -793,21 +784,19 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 .checkProjectAndAuthThrowException(user, project1, WORKFLOW_TREE_VIEW);
         // process definition not exist
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
-        Map<String, Object> processDefinitionNullRes =
-                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10);
-        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST, processDefinitionNullRes.get(Constants.STATUS));
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10));
+        Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // task instance not existproject
         when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
         when(processService.genDagGraph(workflowDefinition)).thenReturn(new DAG<>());
-        Map<String, Object> taskNullRes =
-                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10);
-        Assertions.assertEquals(Status.SUCCESS, taskNullRes.get(Constants.STATUS));
+        Assertions.assertNotNull(
+                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10));
 
         // task instance exist
-        Map<String, Object> taskNotNuLLRes =
-                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10);
-        Assertions.assertEquals(Status.SUCCESS, taskNotNuLLRes.get(Constants.STATUS));
+        Assertions.assertNotNull(
+                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10));
     }
 
     @Test
@@ -820,9 +809,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project1, WORKFLOW_TREE_VIEW);
         when(processService.genDagGraph(workflowDefinition)).thenReturn(new DAG<>());
-        Map<String, Object> taskNotNuLLRes =
-                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10);
-        Assertions.assertEquals(Status.SUCCESS, taskNotNuLLRes.get(Constants.STATUS));
+        Assertions.assertNotNull(
+                workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10));
     }
 
     @Test
@@ -855,12 +843,11 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(processService.saveTaskRelation(eq(user), eq(projectCode), anyLong(), eq(1), anyList(), anyList(),
                 eq(Boolean.TRUE))).thenReturn(Constants.EXIT_CODE_SUCCESS);
 
-        Map<String, Object> result = workflowDefinitionService.createWorkflowDefinition(
+        WorkflowDefinition workflowDefinition = workflowDefinitionService.createWorkflowDefinition(
                 user, projectCode, name, description, "[]", "[]", timeout,
                 taskRelationJson, taskDefinitionJson, null, WorkflowExecutionTypeEnum.PARALLEL);
 
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        WorkflowDefinition workflowDefinition = (WorkflowDefinition) result.get(Constants.DATA_LIST);
+        Assertions.assertNotNull(workflowDefinition);
         Assertions.assertEquals(1, workflowDefinition.getVersion());
     }
 
@@ -882,12 +869,11 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         when(processService.saveTaskRelation(eq(user), eq(projectCode), eq(processDefinitionCode), eq(2), anyList(),
                 anyList(), eq(Boolean.TRUE))).thenReturn(Constants.EXIT_CODE_SUCCESS);
 
-        Map<String, Object> result = workflowDefinitionService.updateWorkflowDefinition(
+        WorkflowDefinition resultDefinition = workflowDefinitionService.updateWorkflowDefinition(
                 user, projectCode, name, processDefinitionCode, description, "[]", "[]", timeout,
                 taskRelationJson, taskDefinitionJson, WorkflowExecutionTypeEnum.PARALLEL);
 
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        WorkflowDefinition resultDefinition = (WorkflowDefinition) result.get(Constants.DATA_LIST);
+        Assertions.assertNotNull(resultDefinition);
         Assertions.assertEquals(2, resultDefinition.getVersion());
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -82,7 +82,6 @@ import org.apache.dolphinscheduler.service.process.ProcessService;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -539,8 +538,6 @@ public class WorkflowInstanceServiceTest {
         long projectCode = 1L;
         User loginUser = getAdminUser();
         Project project = getProject(projectCode);
-        Map<String, Object> result = new HashMap<>();
-        result.put(Constants.STATUS, Status.SUCCESS);
 
         // project auth fail
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
@@ -589,7 +586,7 @@ public class WorkflowInstanceServiceTest {
                 .thenReturn(1);
 
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionJson, TaskDefinitionLog.class);
-        when(workflowDefinitionService.checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs)).thenReturn(result);
+        Mockito.doNothing().when(workflowDefinitionService).checkWorkflowNodeList(taskRelationJson, taskDefinitionLogs);
 
         try (
                 MockedStatic<TaskPluginManager> taskPluginManagerMockedStatic =


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Migrate 19 methods from Map<String, Object> returns to typed returns or void with ServiceException, following the established pattern.

Methods migrated:
- createWorkflowDefinition / updateWorkflowDefinition -> WorkflowDefinition
- queryWorkflowDefinitionList / queryAllWorkflowDefinitionByProjectCode -> List<DagData>
- queryWorkflowDefinitionSimpleList -> ArrayNode
- queryWorkflowDefinitionByCode / queryWorkflowDefinitionByName -> DagData
- getTaskNodeListByDefinitionCode -> List<TaskDefinition>
- getNodeListMapByDefinitionCodes -> Map<Long, List<TaskDefinition>>
- queryWorkflowDefinitionListByProjectCode -> List<DependentSimplifyDefinition>
- queryTaskDefinitionListByWorkflowDefinitionCode -> List<DependentSimplifyDefinition>
- viewTree -> TreeViewDto
- viewVariables -> WorkflowDefinitionVariablesDTO (new DTO)
- verifyWorkflowDefinitionName -> void (throws on NAME_EXIST)
- checkWorkflowNodeList -> void (throws on validation failure)
- switchWorkflowDefinitionVersion -> void
- batchCopyWorkflowDefinition / batchMoveWorkflowDefinition -> void
- batchDeleteWorkflowDefinitionByCodes -> void

A new private requireProjectAndWritePerm helper unwraps the Map-style permission check from ProjectService into ServiceException.

Cascading caller updates:
- WorkflowDefinitionController: 25+ endpoints updated to forward typed returns via Result.success / Result.success(...)
- PythonGateway.createWorkflowDefinition: simplified to direct typed return; errors auto-throw via ServiceException
- PythonGateway.getWorkflow: replaced Map status check with try/catch on ServiceException to detect WORKFLOW_DEFINITION_NAME_EXIST
- WorkflowInstanceServiceImpl.updateWorkflowInstance: drops Map result check around checkWorkflowNodeList - validation failures propagate via ServiceException
- doBatchOperateWorkflowDefinition: switches per-workflow Map status inspection to try/catch + failedWorkflowList accumulation

Full module test suite: 682 tests, 0 failures.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
