### PR TITLE
[Doc-18239] Fix outdated Spark documentation links

### DIFF
--- a/docs/docs/en/guide/task/spark.md
+++ b/docs/docs/en/guide/task/spark.md
@@ -4,9 +4,9 @@
 
 Spark task type for executing Spark application. When executing the Spark task, the worker will submits a job to the Spark cluster by following commands:
 
-(1) `spark submit` method to submit tasks. See [spark-submit](https://archive.apache.org/dist/spark/docs/3.2.1/#running-the-examples-and-shell) for more details.
+(1) `spark submit` method to submit tasks. See [spark-submit](https://spark.apache.org/docs/latest/submitting-applications.html#launching-applications-with-spark-submit) for more details.
 
-(2) `spark sql` method to submit tasks. See [spark sql](https://archive.apache.org/dist/spark/docs/3.2.1/api/sql/index.html) for more details.
+(2) `spark sql` method to submit tasks. See [spark sql](https://spark.apache.org/docs/latest/sql-distributed-sql-engine-spark-sql-cli.html) for more details.
 
 ## Create Task
 

--- a/docs/docs/zh/guide/task/spark.md
+++ b/docs/docs/zh/guide/task/spark.md
@@ -4,9 +4,9 @@
 
 Spark  任务类型用于执行 Spark 应用。对于 Spark 节点，worker 支持两个不同类型的 spark 命令提交任务：
 
-(1) `spark submit` 方式提交任务。更多详情查看 [spark-submit](https://archive.apache.org/dist/spark/docs/3.2.1/#running-the-examples-and-shell)。
+(1) `spark submit` 方式提交任务。更多详情查看 [spark-submit](https://spark.apache.org/docs/latest/submitting-applications.html#launching-applications-with-spark-submit)。
 
-(2) `spark sql` 方式提交任务。更多详情查看 [spark sql](https://archive.apache.org/dist/spark/docs/3.2.1/api/sql/index.html)。
+(2) `spark sql` 方式提交任务。更多详情查看 [spark sql](https://spark.apache.org/docs/latest/sql-distributed-sql-engine-spark-sql-cli.html)。
 
 ## 创建任务
 


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

No

## Purpose of the pull request

Fix #18239 

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

- Update the `spark-submit` documentation link to the latest official Spark documentation.
- Update the `spark-sql` documentation link to the latest official Spark documentation.
- Apply the same link updates to both English and Chinese Spark task guides.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.


## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)