### PR TITLE
[Improvement-18224][API] Migrate ProjectService Map<String,Object> returns to typed returns

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/BaseController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/BaseController.java
@@ -80,25 +80,6 @@ public class BaseController {
     }
 
     /**
-     * return data list
-     *
-     * @param result result code
-     * @return result code
-     */
-    public Result returnDataList(Map<String, Object> result) {
-        Status status = (Status) result.get(Constants.STATUS);
-        if (status == Status.SUCCESS) {
-            String msg = Status.SUCCESS.getMsg();
-            Object datalist = result.get(Constants.DATA_LIST);
-            return success(msg, datalist);
-        } else {
-            Integer code = status.getCode();
-            String msg = (String) result.get(Constants.MSG);
-            return error(code, msg);
-        }
-    }
-
-    /**
      * success
      *
      * @return success result code
@@ -194,22 +175,6 @@ public class BaseController {
         result.setCode(code);
         result.setMsg(msg);
         return result;
-    }
-
-    /**
-     * put message to map
-     *
-     * @param result result
-     * @param status status
-     * @param statusParams object messages
-     */
-    protected void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
-        result.put(Constants.STATUS, status);
-        if (statusParams != null && statusParams.length > 0) {
-            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
-        } else {
-            result.put(Constants.MSG, status.getMsg());
-        }
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -415,7 +415,7 @@ public class PythonGateway {
 
     public Project queryProjectByName(String userName, String projectName) {
         User user = usersService.queryUser(userName);
-        return (Project) projectService.queryByName(user, projectName).get(Constants.DATA_LIST);
+        return projectService.queryByName(user, projectName);
     }
 
     public void updateProject(String userName, Long projectCode, String projectName, String desc) {
@@ -522,7 +522,7 @@ public class PythonGateway {
         Map<String, Object> result = new HashMap<>();
 
         User user = usersService.queryUser(userName);
-        Project project = (Project) projectService.queryByName(user, projectName).get(Constants.DATA_LIST);
+        Project project = projectService.queryByName(user, projectName);
         long projectCode = project.getCode();
         WorkflowDefinition workflowDefinition = getWorkflow(user, projectCode, workflowName);
         // get workflow info

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/BaseService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/BaseService.java
@@ -24,7 +24,6 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.Date;
-import java.util.Map;
 
 public interface BaseService {
 
@@ -46,15 +45,6 @@ public interface BaseService {
     boolean isNotAdmin(User loginUser);
 
     /**
-     * put message to map
-     *
-     * @param result result code
-     * @param status status
-     * @param statusParams status message
-     */
-    void putMsg(Map<String, Object> result, Status status, Object... statusParams);
-
-    /**
      * put message to result object
      *
      * @param result result code
@@ -62,16 +52,6 @@ public interface BaseService {
      * @param statusParams status message
      */
     void putMsg(Result<Object> result, Status status, Object... statusParams);
-
-    /**
-     * check
-     *
-     * @param result result
-     * @param bool bool
-     * @param userNoOperationPerm status
-     * @return check result
-     */
-    boolean check(Map<String, Object> result, boolean bool, Status userNoOperationPerm);
 
     /**
      * Verify that the operator has permissions

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProjectService.java
@@ -23,7 +23,6 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 
 import java.util.List;
-import java.util.Map;
 
 public interface ProjectService {
 
@@ -50,33 +49,13 @@ public interface ProjectService {
      *
      * @param loginUser login user
      * @param projectName project name
-     * @return project detail information
+     * @return project (throws {@link ServiceException} on not-found or no-perm)
      */
-    Map<String, Object> queryByName(User loginUser, String projectName);
+    Project queryByName(User loginUser, String projectName);
 
     void checkProjectAndAuthThrowException(User loginUser, Project project, String permission) throws ServiceException;
 
     void checkProjectAndAuthThrowException(User loginUser, Long projectCode, String permission) throws ServiceException;
-
-    boolean hasProjectAndPerm(User loginUser, Project project, Map<String, Object> result, String perm);
-
-    /**
-     * has project and permission
-     *
-     * @param loginUser  login user
-     * @param project    project
-     * @param result     result
-     * @param permission String
-     * @return true if the login user have permission to the project
-     */
-    @Deprecated
-    boolean hasProjectAndPerm(User loginUser, Project project, Result result, String permission);
-
-    @Deprecated
-    boolean hasProjectAndWritePerm(User loginUser, Project project, Result result);
-
-    @Deprecated
-    boolean hasProjectAndWritePerm(User loginUser, Project project, Map<String, Object> result);
 
     void checkHasProjectWritePermissionThrowException(User loginUser, long projectCode);
 
@@ -161,12 +140,12 @@ public interface ProjectService {
     Result queryAuthorizedUser(User loginUser, Long projectCode);
 
     /**
-     * query authorized project
+     * query authorized project list created by the login user
      *
      * @param loginUser login user
      * @return projects which the user have permission to see, Except for items created by this user
      */
-    Map<String, Object> queryProjectCreatedByUser(User loginUser);
+    List<Project> queryProjectCreatedByUser(User loginUser);
 
     /**
      * query all project list that have one or more workflow definitions.

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/BaseServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/BaseServiceImpl.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.text.MessageFormat;
 import java.util.Date;
-import java.util.Map;
 import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
@@ -69,23 +68,6 @@ public class BaseServiceImpl implements BaseService {
     }
 
     /**
-     * put message to map
-     *
-     * @param result result code
-     * @param status status
-     * @param statusParams status message
-     */
-    @Override
-    public void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
-        result.put(Constants.STATUS, status);
-        if (statusParams != null && statusParams.length > 0) {
-            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
-        } else {
-            result.put(Constants.MSG, status.getMsg());
-        }
-    }
-
-    /**
      * put message to result object
      *
      * @param result result code
@@ -100,25 +82,6 @@ public class BaseServiceImpl implements BaseService {
         } else {
             result.setMsg(status.getMsg());
         }
-    }
-
-    /**
-     * check
-     *
-     * @param result result
-     * @param bool bool
-     * @param userNoOperationPerm status
-     * @return check result
-     */
-    @Override
-    public boolean check(Map<String, Object> result, boolean bool, Status userNoOperationPerm) {
-        // only admin can operate
-        if (bool) {
-            result.put(Constants.STATUS, userNoOperationPerm);
-            result.put(Constants.MSG, userNoOperationPerm.getMsg());
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectParameterServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectParameterServiceImpl.java
@@ -73,10 +73,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
 
         // check if user have write perm for project
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         // check if project parameter name exists
         ProjectParameter projectParameter = projectParameterMapper.selectOne(new QueryWrapper<ProjectParameter>()
@@ -123,10 +120,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
 
         // check if user have write perm for project
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectParameter projectParameter = projectParameterMapper.queryByCode(code);
         // check project parameter exists
@@ -172,10 +166,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
 
         // check if user have write perm for project
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectParameter projectParameter = projectParameterMapper.queryByCode(code);
         // check project parameter exists
@@ -237,10 +228,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
         Result result = new Result();
 
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         PageInfo<ProjectParameter> pageInfo = new PageInfo<>(pageNo, pageSize);
         Page<ProjectParameter> page = new Page<>(pageNo, pageSize);
@@ -263,10 +251,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
         Result result = new Result();
 
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         ProjectParameter projectParameter = projectParameterMapper.queryByCode(code);
         if (projectParameter == null || projectCode != projectParameter.getProjectCode()) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectPreferenceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectPreferenceServiceImpl.java
@@ -61,10 +61,7 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
 
         // check if the user has the writing permission for project
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectPreference projectPreference = projectPreferenceMapper
                 .selectOne(new QueryWrapper<ProjectPreference>().lambda().eq(ProjectPreference::getProjectCode,
@@ -110,10 +107,7 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
         Result result = new Result();
 
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         ProjectPreference projectPreference = projectPreferenceMapper
                 .selectOne(new QueryWrapper<ProjectPreference>().lambda().eq(ProjectPreference::getProjectCode,
@@ -131,10 +125,7 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
 
         // check if the user has the writing permission for project
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndWritePerm = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectPreference projectPreference = projectPreferenceMapper
                 .selectOne(new QueryWrapper<ProjectPreference>().lambda().eq(ProjectPreference::getProjectCode,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -47,7 +47,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -166,35 +165,22 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     public Result queryByCode(User loginUser, long projectCode) {
         Result result = new Result();
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndPerm = hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
-        if (project != null) {
-            result.setData(project);
-            putMsg(result, Status.SUCCESS);
-        }
+        checkProjectAndAuthThrowException(loginUser, project, PROJECT);
+        result.setData(project);
+        putMsg(result, Status.SUCCESS);
         return result;
     }
 
     @Override
-    public Map<String, Object> queryByName(User loginUser, String projectName) {
-        Map<String, Object> result = new HashMap<>();
+    public Project queryByName(User loginUser, String projectName) {
         Project project = projectMapper.queryByName(projectName);
-        boolean hasProjectAndPerm = hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
-        if (project != null) {
-            result.put(Constants.DATA_LIST, project);
-            putMsg(result, Status.SUCCESS);
-        }
-        return result;
+        checkProjectAndAuthThrowException(loginUser, project, PROJECT);
+        return project;
     }
 
+    @Override
     public void checkProjectAndAuthThrowException(@NonNull User loginUser, @Nullable Project project,
                                                   String permission) {
-        // todo: throw a permission exception
         if (project == null) {
             throw new ServiceException(Status.PROJECT_NOT_EXIST);
         }
@@ -211,77 +197,6 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         }
         Project project = projectMapper.queryByCode(projectCode);
         checkProjectAndAuthThrowException(loginUser, project, permission);
-    }
-
-    @Override
-    public boolean hasProjectAndPerm(User loginUser, Project project, Map<String, Object> result, String permission) {
-        boolean checkResult = false;
-        if (project == null) {
-            log.error("Project does not exist.");
-            putMsg(result, Status.PROJECT_NOT_FOUND, "");
-        } else if (!canOperatorPermissions(loginUser, new Object[]{project.getId()}, AuthorizationType.PROJECTS,
-                permission)) {
-            log.error("User does not have {} permission to operate project, userName:{}, projectCode:{}.",
-                    permission, loginUser.getUserName(), project.getCode());
-            putMsg(result, Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(), project.getCode());
-        } else {
-            checkResult = true;
-        }
-        return checkResult;
-    }
-
-    @Override
-    public boolean hasProjectAndWritePerm(User loginUser, Project project, Result result) {
-        boolean checkResult = false;
-        if (project == null) {
-            log.error("Project does not exist.");
-            putMsg(result, Status.PROJECT_NOT_FOUND, "");
-        } else {
-            // case 1: user is admin
-            if (loginUser.getUserType() == UserType.ADMIN_USER) {
-                return true;
-            }
-            // case 2: user is project owner
-            if (project.getUserId().equals(loginUser.getId())) {
-                return true;
-            }
-            // case 3: check user permission level
-            ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), loginUser.getId());
-            if (projectUser == null || projectUser.getPerm() != Constants.DEFAULT_ADMIN_PERMISSION) {
-                putMsg(result, Status.USER_NO_WRITE_PROJECT_PERM, loginUser.getUserName(), project.getCode());
-                checkResult = false;
-            } else {
-                checkResult = true;
-            }
-        }
-        return checkResult;
-    }
-
-    @Override
-    public boolean hasProjectAndWritePerm(User loginUser, Project project, Map<String, Object> result) {
-        boolean checkResult = false;
-        if (project == null) {
-            log.error("Project does not exist.");
-            putMsg(result, Status.PROJECT_NOT_FOUND, "");
-        } else {
-            // case 1: user is admin
-            if (loginUser.getUserType() == UserType.ADMIN_USER) {
-                return true;
-            }
-            // case 2: user is project owner
-            if (project.getUserId().equals(loginUser.getId())) {
-                return true;
-            }
-            // case 3: check user permission level
-            ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), loginUser.getId());
-            if (projectUser == null || projectUser.getPerm() != Constants.DEFAULT_ADMIN_PERMISSION) {
-                putMsg(result, Status.USER_NO_WRITE_PROJECT_PERM, loginUser.getUserName(), project.getCode());
-                checkResult = false;
-            } else {
-                checkResult = true;
-            }
-        }
-        return checkResult;
     }
 
     @Override
@@ -308,23 +223,6 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         if (projectUser == null || projectUser.getPerm() != Constants.DEFAULT_ADMIN_PERMISSION) {
             throw new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM, loginUser.getUserName(), project.getCode());
         }
-    }
-
-    @Override
-    public boolean hasProjectAndPerm(User loginUser, Project project, Result result, String permission) {
-        boolean checkResult = false;
-        if (project == null) {
-            log.error("Project does not exist.");
-            putMsg(result, Status.PROJECT_NOT_FOUND, "");
-        } else if (!canOperatorPermissions(loginUser, new Object[]{project.getId()}, AuthorizationType.PROJECTS,
-                permission)) {
-            log.error("User does not have {} permission to operate project, userName:{}, projectCode:{}.",
-                    permission, loginUser.getUserName(), project.getCode());
-            putMsg(result, Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(), project.getName());
-        } else {
-            checkResult = true;
-        }
-        return checkResult;
     }
 
     /**
@@ -445,11 +343,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         Result result = new Result();
         Project project = projectMapper.queryByCode(projectCode);
 
-        boolean hasProjectAndWritePerm = hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
-
+        checkHasProjectWritePermissionThrowException(loginUser, project);
         checkProjectAndAuthThrowException(loginUser, project, PROJECT_DELETE);
 
         List<WorkflowDefinition> workflowDefinitionList =
@@ -494,10 +388,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         }
 
         Project project = projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndWritePerm = hasProjectAndWritePerm(loginUser, project, result);
-        if (!hasProjectAndWritePerm) {
-            return result;
-        }
+        checkHasProjectWritePermissionThrowException(loginUser, project);
         Project tempProject = projectMapper.queryByName(projectName);
         if (tempProject != null && tempProject.getCode() != project.getCode()) {
             putMsg(result, Status.PROJECT_ALREADY_EXISTS, projectName);
@@ -652,10 +543,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
 
         // 1. check read permission
         Project project = this.projectMapper.queryByCode(projectCode);
-        boolean hasProjectAndPerm = this.hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        this.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         // 2. query authorized user list
         List<User> users = this.userMapper.queryAuthedUserListByProjectId(project.getId());
@@ -664,21 +552,9 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         return result;
     }
 
-    /**
-     * query authorized project
-     *
-     * @param loginUser login user
-     * @return projects which the user have permission to see, Except for items created by this user
-     */
     @Override
-    public Map<String, Object> queryProjectCreatedByUser(User loginUser) {
-        Map<String, Object> result = new HashMap<>();
-
-        List<Project> projects = projectMapper.queryProjectCreatedByUser(loginUser.getId());
-        result.put(Constants.DATA_LIST, projects);
-        putMsg(result, Status.SUCCESS);
-
-        return result;
+    public List<Project> queryProjectCreatedByUser(User loginUser) {
+        return projectMapper.queryProjectCreatedByUser(loginUser.getId());
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
@@ -23,7 +23,6 @@ import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.ProjectWorkerGroupRelationService;
 import org.apache.dolphinscheduler.api.service.WorkerGroupService;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectWorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -39,10 +38,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -196,14 +193,7 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
     public List<ProjectWorkerGroup> queryAssignedWorkerGroupsByProject(User loginUser, Long projectCode) {
         Project project = projectMapper.queryByCode(projectCode);
         // check project auth
-        Map<String, Object> permResult = new HashMap<>();
-        if (!projectService.hasProjectAndPerm(loginUser, project, permResult, null)) {
-            Status status = (Status) permResult.get(Constants.STATUS);
-            if (status == null) {
-                throw new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM);
-            }
-            throw new ServiceException(status.getCode(), (String) permResult.get(Constants.MSG));
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         Set<String> assignedWorkerGroups = getAllUsedWorkerGroups(project);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -281,10 +281,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         Project project = projectMapper.queryByCode(projectCode);
 
         // check project auth
-        boolean hasProjectAndPerm = projectService.hasProjectAndPerm(loginUser, project, result, PROJECT);
-        if (!hasProjectAndPerm) {
-            return result;
-        }
+        projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         if (workflowDefinitionCode != 0) {
             WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -145,20 +145,6 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         return taskDefinition;
     }
 
-    /**
-     * Resolve project + write permission; throws ServiceException with the
-     * status that {@link ProjectService#hasProjectAndWritePerm(User, Project, Map)}
-     * would otherwise have written into the legacy result map.
-     */
-    private void requireProjectAndWritePerm(User loginUser, Project project) {
-        Map<String, Object> permCheck = new HashMap<>();
-        if (!projectService.hasProjectAndWritePerm(loginUser, project, permCheck)) {
-            Status status = (Status) permCheck.get(Constants.STATUS);
-            String msg = (String) permCheck.get(Constants.MSG);
-            throw new ServiceException(status.getCode(), msg);
-        }
-    }
-
     public void updateDag(User loginUser, long workflowDefinitionCode,
                           List<WorkflowTaskRelation> workflowTaskRelationList,
                           List<TaskDefinitionLog> taskDefinitionLogs) {
@@ -224,7 +210,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         Project project = projectMapper.queryByCode(projectCode);
 
         // check if user have write perm for project
-        requireProjectAndWritePerm(loginUser, project);
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         TaskDefinition taskDefinition = taskDefinitionMapper.queryByCode(taskCode);
         if (taskDefinition == null) {
@@ -591,7 +577,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     public void deleteByCodeAndVersion(User loginUser, long projectCode, long taskCode, int version) {
         Project project = projectMapper.queryByCode(projectCode);
         // check if user have write perm for project
-        requireProjectAndWritePerm(loginUser, project);
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         TaskDefinition taskDefinition = taskDefinitionMapper.queryByCode(taskCode);
         if (taskDefinition == null || projectCode != taskDefinition.getProjectCode()) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -243,7 +243,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         Project project = projectMapper.queryByCode(projectCode);
 
         // check if user have write perm for project
-        requireProjectAndWritePerm(loginUser, project);
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         if (checkDescriptionLength(description)) {
             log.warn("Parameter description is too long.");
@@ -309,17 +309,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         saveWorkflowLineage(workflowDefinition.getProjectCode(), workflowDefinition.getCode(),
                 insertVersion, taskDefinitionLogs);
         return workflowDefinition;
-    }
-
-    private void requireProjectAndWritePerm(User loginUser, Project project) {
-        Map<String, Object> permResult = new HashMap<>();
-        if (!projectService.hasProjectAndWritePerm(loginUser, project, permResult)) {
-            Status status = (Status) permResult.get(Constants.STATUS);
-            if (status == null) {
-                throw new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM);
-            }
-            throw new ServiceException(status.getCode(), (String) permResult.get(Constants.MSG));
-        }
     }
 
     @Override
@@ -631,7 +620,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                        WorkflowExecutionTypeEnum executionType) {
         Project project = projectMapper.queryByCode(projectCode);
         // check if user have write perm for project
-        requireProjectAndWritePerm(loginUser, project);
+        projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         if (checkDescriptionLength(description)) {
             log.warn("Parameter description is too long.");

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/BaseServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/BaseServiceTest.java
@@ -20,12 +20,8 @@ package org.apache.dolphinscheduler.api.service;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.User;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,17 +54,6 @@ public class BaseServiceTest {
 
     @Test
     public void testPutMsg() {
-
-        Map<String, Object> result = new HashMap<>();
-        baseService.putMsg(result, Status.SUCCESS);
-        Assertions.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
-        // has params
-        baseService.putMsg(result, Status.PROJECT_NOT_FOUND, "test");
-
-    }
-
-    @Test
-    public void testPutMsgTwo() {
 
         Result result = new Result();
         baseService.putMsg(result, Status.SUCCESS);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectParameterServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectParameterServiceTest.java
@@ -20,14 +20,16 @@ package org.apache.dolphinscheduler.api.service;
 import static org.apache.dolphinscheduler.api.utils.ServiceTestUtil.getGeneralUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.AssertionsHelper;
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.impl.ProjectParameterServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
@@ -76,16 +78,13 @@ public class ProjectParameterServiceTest {
         User loginUser = getGeneralUser();
 
         // PERMISSION DENIED
-        when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(false);
-        Result result = projectParameterService.createProjectParameter(loginUser, projectCode, "key", "value",
-                DataType.VARCHAR.name());
-        assertNull(result.getData());
-        assertNull(result.getCode());
-        assertNull(result.getMsg());
+        doThrow(new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM))
+                .when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
+        assertThrows(ServiceException.class,
+                () -> projectParameterService.createProjectParameter(loginUser, projectCode, "key", "value",
+                        DataType.VARCHAR.name()));
 
-        when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(true);
+        doNothing().when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
 
         // CODE GENERATION ERROR
         try (MockedStatic<CodeGenerateUtils> ignored = Mockito.mockStatic(CodeGenerateUtils.class)) {
@@ -99,7 +98,7 @@ public class ProjectParameterServiceTest {
         // PROJECT_PARAMETER_ALREADY_EXISTS
         when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         when(projectParameterMapper.selectOne(Mockito.any())).thenReturn(getProjectParameter());
-        result = projectParameterService.createProjectParameter(loginUser, projectCode, "key", "value",
+        Result result = projectParameterService.createProjectParameter(loginUser, projectCode, "key", "value",
                 DataType.VARCHAR.name());
         assertEquals(Status.PROJECT_PARAMETER_ALREADY_EXISTS.getCode(), result.getCode());
 
@@ -125,20 +124,17 @@ public class ProjectParameterServiceTest {
         User loginUser = getGeneralUser();
 
         // NO PERMISSION
-        when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(false);
-        Result result = projectParameterService.updateProjectParameter(loginUser, projectCode, 1, "key", "value",
-                DataType.VARCHAR.name());
-        assertNull(result.getData());
-        assertNull(result.getCode());
-        assertNull(result.getMsg());
+        doThrow(new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM))
+                .when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
+        assertThrows(ServiceException.class,
+                () -> projectParameterService.updateProjectParameter(loginUser, projectCode, 1, "key", "value",
+                        DataType.VARCHAR.name()));
 
         // PROJECT_PARAMETER_NOT_EXISTS
         when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(true);
+        doNothing().when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
         when(projectParameterMapper.queryByCode(Mockito.anyLong())).thenReturn(null);
-        result = projectParameterService.updateProjectParameter(loginUser, projectCode, 1, "key", "value",
+        Result result = projectParameterService.updateProjectParameter(loginUser, projectCode, 1, "key", "value",
                 DataType.VARCHAR.name());
         assertEquals(Status.PROJECT_PARAMETER_NOT_EXISTS.getCode(), result.getCode());
 
@@ -172,19 +168,16 @@ public class ProjectParameterServiceTest {
         User loginUser = getGeneralUser();
 
         // NO PERMISSION
-        when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(false);
-        Result result = projectParameterService.deleteProjectParametersByCode(loginUser, projectCode, 1);
-        assertNull(result.getData());
-        assertNull(result.getCode());
-        assertNull(result.getMsg());
+        doThrow(new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM))
+                .when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
+        assertThrows(ServiceException.class,
+                () -> projectParameterService.deleteProjectParametersByCode(loginUser, projectCode, 1));
 
         // PROJECT_PARAMETER_NOT_EXISTS
         when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(true);
+        doNothing().when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
         when(projectParameterMapper.queryByCode(Mockito.anyLong())).thenReturn(null);
-        result = projectParameterService.deleteProjectParametersByCode(loginUser, projectCode, 1);
+        Result result = projectParameterService.deleteProjectParametersByCode(loginUser, projectCode, 1);
         assertEquals(Status.PROJECT_PARAMETER_NOT_EXISTS.getCode(), result.getCode());
 
         // DATABASE OPERATION ERROR
@@ -204,21 +197,17 @@ public class ProjectParameterServiceTest {
         User loginUser = getGeneralUser();
 
         // NO PERMISSION
-        when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class),
-                Mockito.any()))
-                        .thenReturn(false);
+        doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM))
+                .when(projectService).checkProjectAndAuthThrowException(any(), Mockito.<Project>any(), any());
 
-        Result result = projectParameterService.queryProjectParameterByCode(loginUser, projectCode, 1);
-        assertNull(result.getData());
-        assertNull(result.getCode());
-        assertNull(result.getMsg());
+        assertThrows(ServiceException.class,
+                () -> projectParameterService.queryProjectParameterByCode(loginUser, projectCode, 1));
 
         // PROJECT_PARAMETER_NOT_EXISTS
         when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class),
-                Mockito.any())).thenReturn(true);
+        doNothing().when(projectService).checkProjectAndAuthThrowException(any(), Mockito.<Project>any(), any());
         when(projectParameterMapper.queryByCode(Mockito.anyLong())).thenReturn(null);
-        result = projectParameterService.queryProjectParameterByCode(loginUser, projectCode, 1);
+        Result result = projectParameterService.queryProjectParameterByCode(loginUser, projectCode, 1);
         assertEquals(Status.PROJECT_PARAMETER_NOT_EXISTS.getCode(), result.getCode());
 
         // SUCCESS
@@ -234,27 +223,23 @@ public class ProjectParameterServiceTest {
         Integer pageNo = 1;
 
         // NO PERMISSION
-        when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class),
-                Mockito.any()))
-                        .thenReturn(false);
+        doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM))
+                .when(projectService).checkProjectAndAuthThrowException(any(), Mockito.<Project>any(), any());
 
-        Result result =
-                projectParameterService.queryProjectParameterListPaging(loginUser, projectCode, pageSize, pageNo, null,
-                        DataType.VARCHAR.name());
-        assertNull(result.getData());
-        assertNull(result.getCode());
-        assertNull(result.getMsg());
+        assertThrows(ServiceException.class,
+                () -> projectParameterService.queryProjectParameterListPaging(loginUser, projectCode, pageSize, pageNo,
+                        null, DataType.VARCHAR.name()));
 
         // SUCCESS
-        when(projectService.hasProjectAndPerm(any(), any(), any(Result.class), any()))
-                .thenReturn(true);
+        doNothing().when(projectService).checkProjectAndAuthThrowException(any(), Mockito.<Project>any(), any());
 
         Page<ProjectParameter> page = new Page<>(pageNo, pageSize);
         page.setRecords(Collections.singletonList(getProjectParameter()));
 
         when(projectParameterMapper.queryProjectParameterListPaging(any(), anyLong(), any(), any(), any()))
                 .thenReturn(page);
-        result = projectParameterService.queryProjectParameterListPaging(loginUser, projectCode, pageSize, pageNo,
+        Result result = projectParameterService.queryProjectParameterListPaging(loginUser, projectCode, pageSize,
+                pageNo,
                 null, null);
         assertEquals(Status.SUCCESS.getCode(), result.getCode());
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectPreferenceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectPreferenceServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.impl.ProjectPreferenceServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
@@ -61,24 +62,22 @@ public class ProjectPreferenceServiceTest {
         User loginUser = getGeneralUser();
 
         // no permission
-        Mockito.when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(false);
-        Result result = projectPreferenceService.updateProjectPreference(loginUser, projectCode, "value");
-        Assertions.assertNull(result.getCode());
-        Assertions.assertNull(result.getData());
-        Assertions.assertNull(result.getMsg());
+        Mockito.doThrow(new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM))
+                .when(projectService).checkHasProjectWritePermissionThrowException(Mockito.any(), Mockito.any());
+        Assertions.assertThrows(ServiceException.class,
+                () -> projectPreferenceService.updateProjectPreference(loginUser, projectCode, "value"));
 
         // when preference exists in project
         Mockito.when(projectPreferenceMapper.selectOne(Mockito.any())).thenReturn(null);
         Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
 
         // success
-        Mockito.when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(true);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(Mockito.any(),
+                Mockito.any());
 
         Mockito.when(projectPreferenceMapper.insert(Mockito.any())).thenReturn(1);
 
-        result = projectPreferenceService.updateProjectPreference(loginUser, projectCode, "value");
+        Result result = projectPreferenceService.updateProjectPreference(loginUser, projectCode, "value");
         Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode());
 
         // database operatation fail
@@ -105,20 +104,19 @@ public class ProjectPreferenceServiceTest {
         User loginUser = getGeneralUser();
 
         // no permission
-        Mockito.when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(false);
-        Result result = projectPreferenceService.queryProjectPreferenceByProjectCode(loginUser, projectCode);
-        Assertions.assertNull(result.getCode());
-        Assertions.assertNull(result.getData());
-        Assertions.assertNull(result.getMsg());
+        Mockito.doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM))
+                .when(projectService).checkProjectAndAuthThrowException(Mockito.any(), Mockito.<Project>any(),
+                        Mockito.any());
+        Assertions.assertThrows(ServiceException.class,
+                () -> projectPreferenceService.queryProjectPreferenceByProjectCode(loginUser, projectCode));
 
         // PROJECT_PARAMETER_NOT_EXISTS
         Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        Mockito.when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class),
-                Mockito.any())).thenReturn(true);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(Mockito.any(),
+                Mockito.<Project>any(), Mockito.any());
 
         Mockito.when(projectPreferenceMapper.selectOne(Mockito.any())).thenReturn(null);
-        result = projectPreferenceService.queryProjectPreferenceByProjectCode(loginUser, projectCode);
+        Result result = projectPreferenceService.queryProjectPreferenceByProjectCode(loginUser, projectCode);
         Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode());
 
         // SUCCESS
@@ -132,21 +130,19 @@ public class ProjectPreferenceServiceTest {
         User loginUser = getGeneralUser();
 
         // no permission
-        Mockito.when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(false);
-        Result result = projectPreferenceService.enableProjectPreference(loginUser, projectCode, 1);
-        Assertions.assertNull(result.getCode());
-        Assertions.assertNull(result.getData());
-        Assertions.assertNull(result.getMsg());
+        Mockito.doThrow(new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM))
+                .when(projectService).checkHasProjectWritePermissionThrowException(Mockito.any(), Mockito.any());
+        Assertions.assertThrows(ServiceException.class,
+                () -> projectPreferenceService.enableProjectPreference(loginUser, projectCode, 1));
 
         Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        Mockito.when(projectService.hasProjectAndWritePerm(Mockito.any(), Mockito.any(), Mockito.any(Result.class)))
-                .thenReturn(true);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(Mockito.any(),
+                Mockito.any());
 
         // success
         Mockito.when(projectPreferenceMapper.selectOne(Mockito.any())).thenReturn(getProjectPreference());
         Mockito.when(projectPreferenceMapper.updateById(Mockito.any())).thenReturn(1);
-        result = projectPreferenceService.enableProjectPreference(loginUser, projectCode, 2);
+        Result result = projectPreferenceService.enableProjectPreference(loginUser, projectCode, 2);
         Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode());
 
         // db operation fail

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -31,7 +31,6 @@ import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
@@ -45,10 +44,8 @@ import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
@@ -158,31 +155,31 @@ public class ProjectServiceTest {
     }
 
     @Test
-    public void testHasProjectAndPerm() {
+    public void testCheckHasProjectWritePermissionThrowException() {
         User loginUser = getLoginUser();
         Project project = getProject();
-        Map<String, Object> result = new HashMap<>();
-        // not exist user
-        User tempUser = new User();
-        tempUser.setId(Integer.MAX_VALUE);
-        tempUser.setUserType(UserType.GENERAL_USER);
-        Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.PROJECTS,
-                tempUser.getId(), null, baseServiceLogger)).thenReturn(true);
-        boolean checkResult = projectService.hasProjectAndPerm(tempUser, project, result, null);
-        logger.info(result.toString());
-        Assertions.assertFalse(checkResult);
 
-        // success
-        result = new HashMap<>();
-        project.setUserId(1);
-        Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.PROJECTS,
-                loginUser.getId(), null, baseServiceLogger)).thenReturn(true);
-        Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS,
-                new Object[]{project.getId()},
-                loginUser.getId(), baseServiceLogger)).thenReturn(true);
-        checkResult = projectService.hasProjectAndPerm(loginUser, project, result, null);
-        logger.info(result.toString());
-        Assertions.assertTrue(checkResult);
+        // PROJECT_NOT_FOUND
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.checkHasProjectWritePermissionThrowException(loginUser, (Project) null));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), notFoundEx.getCode());
+
+        // USER_NO_WRITE_PROJECT_PERM
+        project.setUserId(2);
+        ServiceException noWriteEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.checkHasProjectWritePermissionThrowException(loginUser, project));
+        Assertions.assertEquals(Status.USER_NO_WRITE_PROJECT_PERM.getCode(), noWriteEx.getCode());
+
+        // success: admin
+        loginUser.setUserType(UserType.ADMIN_USER);
+        Assertions.assertDoesNotThrow(
+                () -> projectService.checkHasProjectWritePermissionThrowException(loginUser, project));
+
+        // success: project owner
+        loginUser.setUserType(UserType.GENERAL_USER);
+        project.setUserId(loginUser.getId());
+        Assertions.assertDoesNotThrow(
+                () -> projectService.checkHasProjectWritePermissionThrowException(loginUser, project));
     }
 
     @Test
@@ -213,49 +210,20 @@ public class ProjectServiceTest {
     }
 
     @Test
-    public void testHasProjectAndWritePerm() {
-        User loginUser = getLoginUser();
-        Project project = getProject();
-        Map<String, Object> result = new HashMap<>();
-        // not exist user
-        User tempUser = new User();
-        tempUser.setId(Integer.MAX_VALUE);
-        tempUser.setUserType(UserType.GENERAL_USER);
-        Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.PROJECTS,
-                tempUser.getId(), null, baseServiceLogger)).thenReturn(true);
-        boolean checkResult = projectService.hasProjectAndWritePerm(tempUser, project, result);
-        logger.info(result.toString());
-        Assertions.assertFalse(checkResult);
-
-        // success
-        result = new HashMap<>();
-        project.setUserId(1);
-        loginUser.setUserType(UserType.ADMIN_USER);
-        Mockito.when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.PROJECTS,
-                loginUser.getId(), null, baseServiceLogger)).thenReturn(true);
-        Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS,
-                new Object[]{project.getId()},
-                loginUser.getId(), baseServiceLogger)).thenReturn(true);
-        checkResult = projectService.hasProjectAndWritePerm(loginUser, project, result);
-        logger.info(result.toString());
-        Assertions.assertTrue(checkResult);
-    }
-
-    @Test
     public void testDeleteProject() {
         User loginUser = getLoginUser();
         Mockito.when(projectMapper.queryByCode(1L)).thenReturn(getProject());
 
         // PROJECT_NOT_FOUND
-        Result result = projectService.deleteProject(loginUser, 11L);
-        logger.info(result.toString());
-        Assertions.assertTrue(Status.PROJECT_NOT_FOUND.getCode() == result.getCode());
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.deleteProject(loginUser, 11L));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), notFoundEx.getCode());
         loginUser.setId(2);
 
-        // USER_NO_OPERATION_PROJECT_PERM
-        result = projectService.deleteProject(loginUser, 1L);
-        logger.info(result.toString());
-        Assertions.assertTrue(Status.USER_NO_WRITE_PROJECT_PERM.getCode() == result.getCode());
+        // USER_NO_WRITE_PROJECT_PERM
+        ServiceException noWriteEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.deleteProject(loginUser, 1L));
+        Assertions.assertEquals(Status.USER_NO_WRITE_PROJECT_PERM.getCode(), noWriteEx.getCode());
 
         // DELETE_PROJECT_ERROR_DEFINES_NOT_NULL
         Mockito.when(workflowDefinitionMapper.queryAllDefinitionList(1L)).thenReturn(getProcessDefinitions());
@@ -269,16 +237,16 @@ public class ProjectServiceTest {
                 resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.PROJECTS, loginUser.getId(),
                         PROJECT_DELETE, baseServiceLogger))
                 .thenReturn(true);
-        result = projectService.deleteProject(loginUser, 1L);
+        Result result = projectService.deleteProject(loginUser, 1L);
         logger.info(result.toString());
-        Assertions.assertTrue(Status.DELETE_PROJECT_ERROR_DEFINES_NOT_NULL.getCode() == result.getCode());
+        Assertions.assertEquals(Status.DELETE_PROJECT_ERROR_DEFINES_NOT_NULL.getCode(), result.getCode().intValue());
 
         // success
         Mockito.when(projectMapper.deleteById(1)).thenReturn(1);
         Mockito.when(workflowDefinitionMapper.queryAllDefinitionList(1L)).thenReturn(new ArrayList<>());
         result = projectService.deleteProject(loginUser, 1L);
         logger.info(result.toString());
-        Assertions.assertTrue(Status.SUCCESS.getCode() == result.getCode());
+        Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
     }
 
     @Test
@@ -291,9 +259,9 @@ public class ProjectServiceTest {
         Mockito.when(projectMapper.queryByName(projectName)).thenReturn(project);
         Mockito.when(projectMapper.queryByCode(2L)).thenReturn(getProject());
         // PROJECT_NOT_FOUND
-        Result result = projectService.update(loginUser, 1L, projectName, "desc");
-        logger.info(result.toString());
-        Assertions.assertTrue(Status.PROJECT_NOT_FOUND.getCode() == result.getCode());
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> projectService.update(loginUser, 1L, projectName, "desc"));
+        Assertions.assertEquals(Status.PROJECT_NOT_FOUND.getCode(), notFoundEx.getCode());
 
         // PROJECT_ALREADY_EXISTS
         Mockito.when(
@@ -303,14 +271,14 @@ public class ProjectServiceTest {
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS, new Object[]{1},
                 loginUser.getId(),
                 baseServiceLogger)).thenReturn(true);
-        result = projectService.update(loginUser, 2L, projectName, "desc");
+        Result result = projectService.update(loginUser, 2L, projectName, "desc");
         logger.info(result.toString());
-        Assertions.assertTrue(Status.PROJECT_ALREADY_EXISTS.getCode() == result.getCode());
+        Assertions.assertEquals(Status.PROJECT_ALREADY_EXISTS.getCode(), result.getCode().intValue());
 
         // USER_NOT_EXIST
         Mockito.when(userMapper.selectById(Mockito.any())).thenReturn(null);
         result = projectService.update(loginUser, 2L, "test", "desc");
-        Assertions.assertTrue(Status.USER_NOT_EXIST.getCode() == result.getCode());
+        Assertions.assertEquals(Status.USER_NOT_EXIST.getCode(), result.getCode().intValue());
 
         // success
         Mockito.when(userMapper.selectById(Mockito.any())).thenReturn(new User());
@@ -318,7 +286,7 @@ public class ProjectServiceTest {
         Mockito.when(projectMapper.updateById(Mockito.any(Project.class))).thenReturn(1);
         result = projectService.update(loginUser, 2L, "test", "desc");
         logger.info(result.toString());
-        Assertions.assertTrue(Status.SUCCESS.getCode() == result.getCode());
+        Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
 
     }
 
@@ -347,16 +315,16 @@ public class ProjectServiceTest {
     public void testQueryAuthorizedUser() {
         final User loginUser = this.getLoginUser();
 
-        // Failure 1: PROJECT_NOT_FOUND
-        Result result = this.projectService.queryAuthorizedUser(loginUser, 3682329499136L);
-        logger.info("FAILURE 1: {}", result.toString());
-        Assertions.assertTrue(Status.PROJECT_NOT_FOUND.getCode() == result.getCode());
+        // Failure 1: PROJECT_NOT_EXIST
+        ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
+                () -> this.projectService.queryAuthorizedUser(loginUser, 3682329499136L));
+        Assertions.assertEquals(Status.PROJECT_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // Failure 2: USER_NO_OPERATION_PROJECT_PERM
         Mockito.when(this.projectMapper.queryByCode(Mockito.anyLong())).thenReturn(this.getProject());
-        result = this.projectService.queryAuthorizedUser(loginUser, 3682329499136L);
-        logger.info("FAILURE 2: {}", result.toString());
-        Assertions.assertTrue(Status.USER_NO_OPERATION_PROJECT_PERM.getCode() == result.getCode());
+        ServiceException noPermEx = Assertions.assertThrows(ServiceException.class,
+                () -> this.projectService.queryAuthorizedUser(loginUser, 3682329499136L));
+        Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), noPermEx.getCode());
 
         // SUCCESS
         loginUser.setUserType(UserType.ADMIN_USER);
@@ -367,7 +335,7 @@ public class ProjectServiceTest {
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS, new Object[]{1},
                 0, baseServiceLogger)).thenReturn(true);
         Mockito.when(this.userMapper.queryAuthedUserListByProjectId(1)).thenReturn(this.getUserList());
-        result = this.projectService.queryAuthorizedUser(loginUser, 3682329499136L);
+        Result result = this.projectService.queryAuthorizedUser(loginUser, 3682329499136L);
         logger.info("SUCCESS 1: {}", result.toString());
         List<User> users = (List<User>) result.getData();
         Assertions.assertTrue(CollectionUtils.isNotEmpty(users));
@@ -391,9 +359,8 @@ public class ProjectServiceTest {
 
         // success
         loginUser.setUserType(UserType.ADMIN_USER);
-        Map<String, Object> result = projectService.queryProjectCreatedByUser(loginUser);
-        logger.info(result.toString());
-        List<Project> projects = (List<Project>) result.get(Constants.DATA_LIST);
+        List<Project> projects = projectService.queryProjectCreatedByUser(loginUser);
+        logger.info("projects size {}", projects.size());
         Assertions.assertTrue(CollectionUtils.isNotEmpty(projects));
 
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
@@ -24,7 +24,6 @@ import org.apache.dolphinscheduler.api.AssertionsHelper;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.service.impl.ProjectWorkerGroupRelationServiceImpl;
 import org.apache.dolphinscheduler.api.utils.Result;
-import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectWorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
@@ -40,7 +39,6 @@ import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -184,21 +182,18 @@ public class ProjectWorkerGroupRelationServiceTest {
 
     @Test
     public void testQueryAssignedWorkerGroupsByProject() {
-        // no permission - hasProjectAndPerm should populate the status into the result map and return false
-        Mockito.when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.anyMap(), Mockito.any()))
-                .thenAnswer(invocation -> {
-                    Map<String, Object> permResult = invocation.getArgument(2);
-                    permResult.put(Constants.STATUS, Status.USER_NO_OPERATION_PROJECT_PERM);
-                    permResult.put(Constants.MSG, Status.USER_NO_OPERATION_PROJECT_PERM.getMsg());
-                    return false;
-                });
+        // no permission - checkProjectAndAuthThrowException throws ServiceException
+        Mockito.doThrow(new org.apache.dolphinscheduler.api.exceptions.ServiceException(
+                Status.USER_NO_OPERATION_PROJECT_PERM))
+                .when(projectService).checkProjectAndAuthThrowException(Mockito.any(), Mockito.<Project>any(),
+                        Mockito.any());
         AssertionsHelper.assertThrowsServiceException(Status.USER_NO_OPERATION_PROJECT_PERM,
                 () -> projectWorkerGroupRelationService.queryAssignedWorkerGroupsByProject(getGeneralUser(),
                         projectCode));
 
         // success
-        Mockito.when(projectService.hasProjectAndPerm(Mockito.any(), Mockito.any(), Mockito.anyMap(), Mockito.any()))
-                .thenReturn(true);
+        Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(Mockito.any(),
+                Mockito.<Project>any(), Mockito.any());
 
         Mockito.when(projectMapper.queryByCode(projectCode))
                 .thenReturn(getProject());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -175,7 +175,7 @@ public class TaskDefinitionServiceImplTest {
     public void deleteByCodeAndVersion() {
         Project project = getProject();
         when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
-        when(projectService.hasProjectAndWritePerm(eq(user), eq(project), any(Map.class))).thenReturn(true);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
 
         // cross-project privilege escalation: taskCode belongs to another project - must be rejected
         TaskDefinition otherProjectTask = new TaskDefinition();
@@ -349,7 +349,8 @@ public class TaskDefinitionServiceImplTest {
 
             user.setUserType(UserType.ADMIN_USER);
             when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(getProject());
-            when(projectService.hasProjectAndWritePerm(eq(user), eq(getProject()), any(Map.class))).thenReturn(true);
+            Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user),
+                    eq(getProject()));
             when(taskDefinitionMapper.queryByCode(TASK_CODE)).thenReturn(taskDefinition);
             when(taskDefinitionLogMapper.queryMaxVersionForDefinition(TASK_CODE)).thenReturn(1);
             when(taskDefinitionMapper.updateById(Mockito.any())).thenReturn(1);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -815,11 +815,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void testUpdateWorkflowDefinition() {
-        Map<String, Object> result = new HashMap<>();
-
         Project project = getProject(projectCode);
         when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
-        when(projectService.hasProjectAndWritePerm(user, project, result)).thenReturn(true);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(user, project);
 
         try {
             workflowDefinitionService.updateWorkflowDefinition(user, projectCode, "test", 1,
@@ -834,7 +832,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     public void testCreateWorkflowDefinitionShouldSyncVersionToResponse() {
         Project project = getProject(projectCode);
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.hasProjectAndWritePerm(eq(user), eq(project), any(Map.class))).thenReturn(true);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
         when(workflowDefinitionMapper.verifyByDefineName(projectCode, name)).thenReturn(null);
         when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
         when(processService.saveTaskDefine(eq(user), eq(projectCode), anyList(), eq(Boolean.TRUE))).thenReturn(1);
@@ -857,7 +855,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         workflowDefinition.setName("origin-name");
         when(projectMapper.queryByCode(projectCode)).thenReturn(project);
-        when(projectService.hasProjectAndWritePerm(eq(user), eq(project), any(Map.class))).thenReturn(true);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
         when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
         when(workflowDefinitionMapper.queryByCode(processDefinitionCode)).thenReturn(workflowDefinition);
         when(workflowDefinitionMapper.verifyByDefineName(projectCode, name)).thenReturn(null);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

close #18224

Final cleanup of the ProjectService migration: turn queryByName and queryProjectCreatedByUser into typed returns (Project / List<Project>) and remove the four legacy hasProjectAndPerm / hasProjectAndWritePerm overloads. All callers now route through the existing throwing helpers checkProjectAndAuthThrowException and
checkHasProjectWritePermissionThrowException. Permission failures remain wire-format compatible thanks to ApiExceptionHandler.

Removes the now-orphaned Map<String,Object> helpers from BaseService / BaseServiceImpl / BaseController (putMsg(Map), check(Map), returnDataList(Map)), which had no remaining callers in main code.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
