### PR TITLE
[Improvement-18249][DAO] Route ProjectMapper and WorkflowDefinitionMapper access through repository Dao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/ProjectAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/ProjectAuditOperatorImpl.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.api.audit.operator.impl;
 
 import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.Project;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Service;
 public class ProjectAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Override
     protected String getObjectNameFromIdentity(Object identity) {
@@ -40,7 +40,7 @@ public class ProjectAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        Project obj = projectMapper.queryByCode(objId);
+        Project obj = projectDao.queryByCode(objId);
         return obj == null ? "" : obj.getName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/ScheduleAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/ScheduleAuditOperatorImpl.java
@@ -26,7 +26,7 @@ import org.apache.dolphinscheduler.dao.entity.AuditLog;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import java.util.List;
 import java.util.Map;
@@ -41,7 +41,7 @@ public class ScheduleAuditOperatorImpl extends BaseAuditOperator {
     private ScheduleMapper scheduleMapper;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Override
     public void modifyRequestParams(String[] paramNameArr, Map<String, Object> paramsMap, List<AuditLog> auditLogList) {
@@ -78,7 +78,7 @@ public class ScheduleAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        WorkflowDefinition obj = workflowDefinitionMapper.queryByCode(objId);
+        WorkflowDefinition obj = workflowDefinitionDao.queryByCode(objId).orElse(null);
         return obj == null ? "" : obj.getName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/WorkflowAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/WorkflowAuditOperatorImpl.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.common.enums.AuditOperationType;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import java.util.List;
 import java.util.Map;
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
 public class WorkflowAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Override
     public void modifyAuditOperationType(AuditType auditType, Map<String, Object> paramsMap,
@@ -71,7 +71,7 @@ public class WorkflowAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        WorkflowDefinition obj = workflowDefinitionMapper.queryByCode(objId);
+        WorkflowDefinition obj = workflowDefinitionDao.queryByCode(objId).orElse(null);
         return obj == null ? "" : obj.getName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -38,10 +38,10 @@ import org.apache.dolphinscheduler.dao.mapper.AlertPluginInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 
@@ -155,10 +155,10 @@ public class ResourcePermissionCheckServiceImpl
     @Component
     public static class ProjectsResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
-        private final ProjectMapper projectMapper;
+        private final ProjectDao projectDao;
 
-        public ProjectsResourcePermissionCheck(ProjectMapper projectMapper) {
-            this.projectMapper = projectMapper;
+        public ProjectsResourcePermissionCheck(ProjectDao projectDao) {
+            this.projectDao = projectDao;
         }
 
         @Override
@@ -174,7 +174,7 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
-            return projectMapper.listAuthorizedProjects(userId, null).stream().map(Project::getId).collect(toSet());
+            return projectDao.listAuthorizedProjects(userId, null).stream().map(Project::getId).collect(toSet());
         }
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -51,11 +51,11 @@ import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageEntity;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
@@ -93,7 +93,7 @@ public class PythonGateway {
     private static final int ADMIN_USER_ID = 1;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
     private ProjectService projectService;
@@ -120,7 +120,7 @@ public class PythonGateway {
     private ResourcesService resourceService;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private TaskDefinitionMapper taskDefinitionMapper;
@@ -172,7 +172,7 @@ public class PythonGateway {
 
     public Map<String, Long> getCodeAndVersion(String projectName, String workflowDefinitionName,
                                                String taskName) {
-        Project project = projectMapper.queryByName(projectName);
+        Project project = projectDao.queryByName(projectName);
         Map<String, Long> result = new HashMap<>();
         // project do not exists, mean task not exists too, so we should directly return init value
         if (project == null) {
@@ -182,7 +182,7 @@ public class PythonGateway {
         }
 
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByDefineName(project.getCode(), workflowDefinitionName);
+                workflowDefinitionDao.queryByDefineName(project.getCode(), workflowDefinitionName);
         // In the case project exists, but current workflow still not created, we should also return the init
         // version of it
         if (workflowDefinition == null) {
@@ -247,7 +247,7 @@ public class PythonGateway {
             throw new RuntimeException("Can not create or update workflow for user who not related to any tenant.");
         }
 
-        Project project = projectMapper.queryByName(projectName);
+        Project project = projectDao.queryByName(projectName);
         long projectCode = project.getCode();
 
         WorkflowDefinition workflowDefinition = getWorkflow(user, projectCode, name);
@@ -298,7 +298,7 @@ public class PythonGateway {
             return null;
         } catch (ServiceException e) {
             if (e.getCode() == Status.WORKFLOW_DEFINITION_NAME_EXIST.getCode()) {
-                return workflowDefinitionMapper.queryByDefineName(projectCode, workflowName);
+                return workflowDefinitionDao.queryByDefineName(projectCode, workflowName);
             }
             throw e;
         }
@@ -357,9 +357,9 @@ public class PythonGateway {
                                      String warningType,
                                      Integer warningGroupId) {
         User user = usersService.queryUser(userName);
-        Project project = projectMapper.queryByName(projectName);
+        Project project = projectDao.queryByName(projectName);
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByDefineName(project.getCode(), workflowName);
+                workflowDefinitionDao.queryByDefineName(project.getCode(), workflowName);
 
         // make sure workflow online
         workflowDefinitionService.onlineWorkflowDefinition(user, project.getCode(), workflowDefinition.getCode());
@@ -402,7 +402,7 @@ public class PythonGateway {
         User user = usersService.queryUser(userName);
 
         Project project;
-        project = projectMapper.queryByName(name);
+        project = projectDao.queryByName(name);
         if (project == null) {
             projectService.createProject(user, name, desc);
         } else if (project.getUserId() != user.getId()) {
@@ -552,7 +552,7 @@ public class PythonGateway {
     public Map<String, Object> getDependentInfo(String projectName, String workflowName, String taskName) {
         Map<String, Object> result = new HashMap<>();
 
-        Project project = projectMapper.queryByName(projectName);
+        Project project = projectDao.queryByName(projectName);
         if (project == null) {
             String msg = String.format("Can not find valid project by name %s", projectName);
             log.error(msg);
@@ -562,7 +562,7 @@ public class PythonGateway {
         result.put("projectCode", projectCode);
 
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByDefineName(projectCode, workflowName);
+                workflowDefinitionDao.queryByDefineName(projectCode, workflowName);
         if (workflowDefinition == null) {
             String msg = String.format("Can not find valid workflow by name %s", workflowName);
             log.error(msg);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
@@ -36,13 +36,13 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
 import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.model.TaskInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.model.WorkflowDefinitionCountDto;
 import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -70,7 +70,7 @@ import com.google.common.collect.Lists;
 public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnalysisService {
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private ProjectService projectService;
@@ -79,7 +79,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
     private WorkflowInstanceMapper workflowInstanceMapper;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
     private CommandMapper commandMapper;
@@ -151,7 +151,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
     public WorkflowDefinitionCountVO getWorkflowDefinitionCountByProject(User loginUser, Long projectCode) {
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, PROJECT_OVERVIEW);
         List<WorkflowDefinitionCountDto> workflowDefinitionCounts =
-                workflowDefinitionMapper.countDefinitionByProjectCodes(Lists.newArrayList(projectCode));
+                workflowDefinitionDao.countDefinitionByProjectCodes(Lists.newArrayList(projectCode));
         return WorkflowDefinitionCountVO.of(workflowDefinitionCounts);
     }
 
@@ -161,7 +161,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         if (CollectionUtils.isEmpty(projectCodes)) {
             return WorkflowDefinitionCountVO.empty();
         }
-        return WorkflowDefinitionCountVO.of(workflowDefinitionMapper.countDefinitionByProjectCodes(projectCodes));
+        return WorkflowDefinitionCountVO.of(workflowDefinitionDao.countDefinitionByProjectCodes(projectCodes));
     }
 
     @Override
@@ -250,7 +250,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         if (CollectionUtils.isEmpty(projectIds)) {
             return Collections.emptyList();
         }
-        List<Long> projectCodes = projectMapper.selectBatchIds(projectIds)
+        List<Long> projectCodes = projectDao.queryByIds(projectIds)
                 .stream()
                 .map(Project::getCode)
                 .collect(Collectors.toList());
@@ -263,7 +263,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
             projectCodes = Collections.singletonList(projectCode);
         }
 
-        return workflowDefinitionMapper.queryDefinitionCodeListByProjectCodes(projectCodes);
+        return workflowDefinitionDao.queryDefinitionCodeListByProjectCodes(projectCodes);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ExecutorServiceImpl.java
@@ -53,8 +53,8 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupQueueMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
 import org.apache.dolphinscheduler.service.command.CommandService;
@@ -83,7 +83,7 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
     private ProjectService projectService;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Lazy()
     @Autowired
@@ -217,7 +217,7 @@ public class ExecutorServiceImpl extends BaseServiceImpl implements ExecutorServ
         }
 
         // check sub releaseState
-        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryByCodes(workflowDefinitionCodeSet);
+        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionDao.queryByCodes(workflowDefinitionCodeSet);
         return workflowDefinitions.stream()
                 .filter(definition -> definition.getReleaseState().equals(ReleaseState.OFFLINE))
                 .collect(Collectors.toSet())

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -32,8 +32,8 @@ import org.apache.dolphinscheduler.dao.entity.ResponseTaskLog;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 
 import org.apache.commons.lang3.StringUtils;
@@ -57,7 +57,7 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
     private TaskInstanceDao taskInstanceDao;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private ProjectService projectService;
@@ -112,7 +112,7 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
         if (taskInstance == null || StringUtils.isBlank(taskInstance.getHost())) {
             throw new ServiceException("task instance is null or host is null");
         }
-        Project project = projectMapper.queryProjectByTaskInstanceId(taskInstId);
+        Project project = projectDao.queryProjectByTaskInstanceId(taskInstId);
         projectService.checkProjectAndAuthThrowException(loginUser, project, DOWNLOAD_LOG);
         return getLogBytes(taskInstance);
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectParameterServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectParameterServiceImpl.java
@@ -30,8 +30,8 @@ import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectParameter;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectParameterMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,7 +63,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
     private ProjectService projectService;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Override
     @Transactional
@@ -72,7 +72,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
         Result result = new Result();
 
         // check if user have write perm for project
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         // check if project parameter name exists
@@ -119,7 +119,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
         Result result = new Result();
 
         // check if user have write perm for project
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectParameter projectParameter = projectParameterMapper.queryByCode(code);
@@ -165,7 +165,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
         Result result = new Result();
 
         // check if user have write perm for project
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectParameter projectParameter = projectParameterMapper.queryByCode(code);
@@ -227,7 +227,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
                                                   String searchVal, String projectParameterDataType) {
         Result result = new Result();
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         PageInfo<ProjectParameter> pageInfo = new PageInfo<>(pageNo, pageSize);
@@ -250,7 +250,7 @@ public class ProjectParameterServiceImpl extends BaseServiceImpl implements Proj
     public Result queryProjectParameterByCode(User loginUser, long projectCode, long code) {
         Result result = new Result();
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         ProjectParameter projectParameter = projectParameterMapper.queryByCode(code);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectPreferenceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectPreferenceServiceImpl.java
@@ -27,8 +27,8 @@ import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectPreference;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectPreferenceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import java.util.Date;
 import java.util.Objects;
@@ -53,14 +53,14 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
     private ProjectService projectService;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Override
     public Result updateProjectPreference(User loginUser, long projectCode, String preferences) {
         Result result = new Result();
 
         // check if the user has the writing permission for project
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectPreference projectPreference = projectPreferenceMapper
@@ -106,7 +106,7 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
     public Result queryProjectPreferenceByProjectCode(User loginUser, long projectCode) {
         Result result = new Result();
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         ProjectPreference projectPreference = projectPreferenceMapper
@@ -124,7 +124,7 @@ public class ProjectPreferenceServiceImpl extends BaseServiceImpl
         Result result = new Result();
 
         // check if the user has the writing permission for project
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
         ProjectPreference projectPreference = projectPreferenceMapper

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -36,10 +36,10 @@ import org.apache.dolphinscheduler.dao.entity.ProjectUser;
 import org.apache.dolphinscheduler.dao.entity.ProjectWorkflowDefinitionCount;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -76,13 +76,13 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     private TaskGroupService taskGroupService;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private ProjectUserMapper projectUserMapper;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
     private UserMapper userMapper;
@@ -109,7 +109,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return result;
         }
 
-        Project project = projectMapper.queryByName(name);
+        Project project = projectDao.queryByName(name);
         if (project != null) {
             log.warn("Project {} already exists.", project.getName());
             putMsg(result, Status.PROJECT_ALREADY_EXISTS, name);
@@ -129,7 +129,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
                 .updateTime(now)
                 .build();
 
-        if (projectMapper.insert(project) > 0) {
+        if (projectDao.insert(project) > 0) {
             log.info("Project is created and id is :{}", project.getId());
             result.setData(project);
             putMsg(result, Status.SUCCESS);
@@ -164,7 +164,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     @Override
     public Result queryByCode(User loginUser, long projectCode) {
         Result result = new Result();
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         checkProjectAndAuthThrowException(loginUser, project, PROJECT);
         result.setData(project);
         putMsg(result, Status.SUCCESS);
@@ -173,7 +173,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
 
     @Override
     public Project queryByName(User loginUser, String projectName) {
-        Project project = projectMapper.queryByName(projectName);
+        Project project = projectDao.queryByName(projectName);
         checkProjectAndAuthThrowException(loginUser, project, PROJECT);
         return project;
     }
@@ -195,13 +195,13 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         if (projectCode == null) {
             throw new ServiceException(Status.PROJECT_NOT_EXIST);
         }
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         checkProjectAndAuthThrowException(loginUser, project, permission);
     }
 
     @Override
     public void checkHasProjectWritePermissionThrowException(User loginUser, long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         checkHasProjectWritePermissionThrowException(loginUser, project);
     }
 
@@ -247,7 +247,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return result;
         }
         IPage<Project> projectIPage =
-                projectMapper.queryProjectListPaging(page, new ArrayList<>(projectIds), searchVal);
+                projectDao.queryProjectListPaging(page, new ArrayList<>(projectIds), searchVal);
 
         List<Project> projectList = projectIPage.getRecords();
         if (loginUser.getUserType() != UserType.ADMIN_USER) {
@@ -264,7 +264,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
                 .map(Project::getUserId).distinct().collect(Collectors.toList()));
         Map<Integer, String> userMap = userList.stream().collect(Collectors.toMap(User::getId, User::getUserName));
         List<Long> projectCodes = projectList.stream().map(Project::getCode).distinct().collect(Collectors.toList());
-        Map<Long, Integer> projectWorkflowDefinitionCountMap = workflowDefinitionMapper
+        Map<Long, Integer> projectWorkflowDefinitionCountMap = workflowDefinitionDao
                 .queryProjectWorkflowDefinitionCountByProjectCodes(projectCodes)
                 .stream()
                 .collect(Collectors.toMap(ProjectWorkflowDefinitionCount::getProjectCode,
@@ -306,7 +306,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return result;
         }
         IPage<Project> projectIPage =
-                projectMapper.queryProjectListPaging(page, new ArrayList<>(allProjectIds), searchVal);
+                projectDao.queryProjectListPaging(page, new ArrayList<>(allProjectIds), searchVal);
 
         List<Project> projectList = projectIPage.getRecords();
 
@@ -341,13 +341,13 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     @Override
     public Result deleteProject(User loginUser, Long projectCode) {
         Result result = new Result();
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         checkHasProjectWritePermissionThrowException(loginUser, project);
         checkProjectAndAuthThrowException(loginUser, project, PROJECT_DELETE);
 
         List<WorkflowDefinition> workflowDefinitionList =
-                workflowDefinitionMapper.queryAllDefinitionList(project.getCode());
+                workflowDefinitionDao.queryAllDefinitionList(project.getCode());
 
         if (!workflowDefinitionList.isEmpty()) {
             log.warn("Please delete the workflow definitions in project first! project code:{}.", projectCode);
@@ -357,8 +357,8 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         // delete the task group
         taskGroupService.deleteTaskGroupByProjectCode(project.getCode());
 
-        int delete = projectMapper.deleteById(project.getId());
-        if (delete > 0) {
+        boolean delete = projectDao.deleteById(project.getId());
+        if (delete) {
             log.info("Project is deleted and id is :{}.", project.getId());
             result.setData(Boolean.TRUE);
             putMsg(result, Status.SUCCESS);
@@ -387,9 +387,9 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return result;
         }
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         checkHasProjectWritePermissionThrowException(loginUser, project);
-        Project tempProject = projectMapper.queryByName(projectName);
+        Project tempProject = projectDao.queryByName(projectName);
         if (tempProject != null && tempProject.getCode() != project.getCode()) {
             putMsg(result, Status.PROJECT_ALREADY_EXISTS, projectName);
             return result;
@@ -404,8 +404,8 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         project.setDescription(desc);
         project.setUpdateTime(new Date());
         project.setUserId(user.getId());
-        int update = projectMapper.updateById(project);
-        if (update > 0) {
+        boolean update = projectDao.updateById(project);
+        if (update) {
             log.info("Project is updated and id is :{}", project.getId());
             result.setData(project);
             putMsg(result, Status.SUCCESS);
@@ -428,7 +428,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
 
         Set<Integer> projectIds = resourcePermissionCheckService
                 .userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS, loginUser.getId(), log);
-        List<Project> projectList = projectMapper.listAuthorizedProjects(
+        List<Project> projectList = projectDao.listAuthorizedProjects(
                 loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : loginUser.getId(),
                 new ArrayList<>(projectIds));
 
@@ -437,7 +437,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         Set<Project> projectSet;
         if (projectList != null && !projectList.isEmpty()) {
             projectSet = new HashSet<>(projectList);
-            authedProjectList = projectMapper.queryAuthedProjectListByUserId(userId);
+            authedProjectList = projectDao.queryAuthedProjectListByUserId(userId);
             unauthorizedProjectsList = getUnauthorizedProjects(projectSet, authedProjectList);
         }
 
@@ -476,7 +476,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             putMsg(result, Status.SUCCESS);
             return result;
         }
-        List<Project> projectList = projectMapper.listAuthorizedProjects(
+        List<Project> projectList = projectDao.listAuthorizedProjects(
                 loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : loginUser.getId(),
                 new ArrayList<>(projectIds));
 
@@ -485,7 +485,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         if (projectList != null && !projectList.isEmpty()) {
             projectSet = new HashSet<>(projectList);
 
-            List<Project> authedProjectList = projectMapper.queryAuthedProjectListByUserId(userId);
+            List<Project> authedProjectList = projectDao.queryAuthedProjectListByUserId(userId);
 
             resultList = getUnauthorizedProjects(projectSet, authedProjectList);
         }
@@ -523,7 +523,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     public Result queryAuthorizedProject(User loginUser, Integer userId) {
         Result result = new Result();
 
-        List<Project> projects = projectMapper.queryAuthedProjectListByUserId(userId);
+        List<Project> projects = projectDao.queryAuthedProjectListByUserId(userId);
         result.setData(projects);
         putMsg(result, Status.SUCCESS);
 
@@ -542,7 +542,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         Result result = new Result();
 
         // 1. check read permission
-        Project project = this.projectMapper.queryByCode(projectCode);
+        Project project = this.projectDao.queryByCode(projectCode);
         this.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         // 2. query authorized user list
@@ -554,7 +554,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
 
     @Override
     public List<Project> queryProjectCreatedByUser(User loginUser) {
-        return projectMapper.queryProjectCreatedByUser(loginUser.getId());
+        return projectDao.queryProjectCreatedByUser(loginUser.getId());
     }
 
     /**
@@ -574,7 +574,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             putMsg(result, Status.SUCCESS);
             return result;
         }
-        List<Project> projects = projectMapper.selectBatchIds(projectIds);
+        List<Project> projects = projectDao.queryByIds(projectIds);
 
         result.setData(projects);
         putMsg(result, Status.SUCCESS);
@@ -630,7 +630,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     public Result queryAllProjectList(User user) {
         Result result = new Result();
         List<Project> projects =
-                projectMapper.queryAllProject(user.getUserType() == UserType.ADMIN_USER ? 0 : user.getId());
+                projectDao.queryAllProject(user.getUserType() == UserType.ADMIN_USER ? 0 : user.getId());
 
         result.setData(projects);
         putMsg(result, Status.SUCCESS);
@@ -646,7 +646,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     public Result queryAllProjectListForDependent() {
         Result result = new Result<>();
         List<Project> projects =
-                projectMapper.queryAllProjectForDependent();
+                projectDao.queryAllProjectForDependent();
         result.setData(projects);
         putMsg(result, Status.SUCCESS);
         return result;
@@ -662,7 +662,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         if (CollectionUtils.isEmpty(projectIds)) {
             return Collections.emptyList();
         }
-        return projectMapper.selectBatchIds(projectIds)
+        return projectDao.queryByIds(projectIds)
                 .stream()
                 .map(Project::getCode)
                 .collect(Collectors.toList());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
@@ -26,8 +26,8 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectWorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectWorkerGroupDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
@@ -60,7 +60,7 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
     private ProjectWorkerGroupDao projectWorkerGroupDao;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private TaskDefinitionDao taskDefinitionDao;
@@ -91,7 +91,7 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
             return result;
         }
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         if (Objects.isNull(project)) {
             putMsg(result, Status.PROJECT_NOT_EXIST);
             return result;
@@ -191,7 +191,7 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
 
     @Override
     public List<ProjectWorkerGroup> queryAssignedWorkerGroupsByProject(User loginUser, Long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check project auth
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -42,9 +42,9 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.scheduler.api.SchedulerApi;
 import org.apache.dolphinscheduler.service.cron.CronUtils;
 import org.apache.dolphinscheduler.service.exceptions.CronParseException;
@@ -86,10 +86,10 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
     private ScheduleMapper scheduleMapper;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
     private SchedulerApi schedulerApi;
@@ -126,13 +126,13 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                                    String tenantCode,
                                    Long environmentCode) {
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check project auth
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         // check workflow define release state
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
         executorService.checkWorkflowDefinitionValid(projectCode, workflowDefinition, workflowDefinitionCode,
                 workflowDefinition.getVersion());
 
@@ -190,7 +190,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
          * updateWorkflowInstance receivers and cc by workflow definition id
          */
         workflowDefinition.setWarningGroupId(warningGroupId);
-        workflowDefinitionMapper.updateById(workflowDefinition);
+        workflowDefinitionDao.updateById(workflowDefinition);
 
         log.info("Schedule create complete, projectCode:{}, workflowDefinitionCode:{}, scheduleId:{}.",
                 projectCode, workflowDefinitionCode, scheduleObj.getId());
@@ -198,11 +198,11 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
     }
 
     protected void projectPermCheckByWorkflowCode(User loginUser, long workflowDefinitionCode) {
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
         if (workflowDefinition == null) {
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, workflowDefinitionCode);
         }
-        Project project = projectMapper.queryByCode(workflowDefinition.getProjectCode());
+        Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
         // check project auth
         this.projectService.checkProjectAndAuthThrowException(loginUser, project, null);
     }
@@ -236,7 +236,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                                    String tenantCode,
                                    Long environmentCode) {
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check project auth
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
@@ -250,7 +250,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         }
 
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByCode(schedule.getWorkflowDefinitionCode());
+                workflowDefinitionDao.queryByCode(schedule.getWorkflowDefinitionCode()).orElse(null);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.",
                     schedule.getWorkflowDefinitionCode());
@@ -278,13 +278,14 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                                 Integer pageNo, Integer pageSize) {
         Result result = new Result();
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check project auth
         projectService.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         if (workflowDefinitionCode != 0) {
-            WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+            WorkflowDefinition workflowDefinition =
+                    workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
             if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
                 log.error("workflow definition does not exist, workflowDefinitionCode:{}.", workflowDefinitionCode);
                 putMsg(result, Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(workflowDefinitionCode));
@@ -327,7 +328,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      */
     @Override
     public List<ScheduleVO> queryScheduleList(User loginUser, long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check project auth
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
@@ -426,7 +427,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                                                            String workerGroup,
                                                            String tenantCode,
                                                            long environmentCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
@@ -438,7 +439,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
             throw new ServiceException(Status.SCHEDULE_CRON_NOT_EXISTS, workflowDefinitionCode);
         }
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", workflowDefinitionCode);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST,
@@ -473,7 +474,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
             return;
         }
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByCode(schedule.getWorkflowDefinitionCode());
+                workflowDefinitionDao.queryByCode(schedule.getWorkflowDefinitionCode()).orElse(null);
         if (!ReleaseState.ONLINE.equals(workflowDefinition.getReleaseState())) {
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_RELEASE, workflowDefinition.getName());
         }
@@ -482,7 +483,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         schedule.setUpdateTime(new Date());
         scheduleMapper.updateById(schedule);
 
-        Project project = projectMapper.queryByCode(workflowDefinition.getProjectCode());
+        Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
         schedulerApi.insertOrUpdateScheduleTask(project.getId(), schedule);
     }
 
@@ -513,8 +514,8 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         schedule.setReleaseState(ReleaseState.OFFLINE);
         scheduleMapper.updateById(schedule);
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByCode(schedule.getWorkflowDefinitionCode());
-        Project project = projectMapper.queryByCode(workflowDefinition.getProjectCode());
+                workflowDefinitionDao.queryByCode(schedule.getWorkflowDefinitionCode()).orElse(null);
+        Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
         schedulerApi.deleteScheduleTask(project.getId(), schedule.getId());
     }
 
@@ -577,7 +578,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
 
         workflowDefinition.setWarningGroupId(warningGroupId);
 
-        workflowDefinitionMapper.updateById(workflowDefinition);
+        workflowDefinitionDao.updateById(workflowDefinition);
 
         log.info("Schedule update complete, projectCode:{}, workflowDefinitionCode:{}, scheduleId:{}.",
                 workflowDefinition.getProjectCode(), workflowDefinition.getCode(), schedule.getId());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -48,13 +48,13 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowTaskRelationLogDao;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
@@ -89,7 +89,7 @@ import com.google.common.collect.Lists;
 public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDefinitionService {
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private ProjectService projectService;
@@ -113,7 +113,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     private WorkflowTaskRelationService workflowTaskRelationService;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
     private ProcessService processService;
@@ -132,7 +132,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     @Override
     public TaskDefinition queryTaskDefinitionByName(User loginUser, long projectCode, long workflowDefinitionCode,
                                                     String taskName) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_DEFINITION);
 
@@ -148,7 +148,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     public void updateDag(User loginUser, long workflowDefinitionCode,
                           List<WorkflowTaskRelation> workflowTaskRelationList,
                           List<TaskDefinitionLog> taskDefinitionLogs) {
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
         if (workflowDefinition == null) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", workflowDefinitionCode);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST);
@@ -193,7 +193,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         if (taskDefinition == null) {
             throw new ServiceException(Status.TASK_DEFINE_NOT_EXIST, taskCode);
         }
-        Project project = projectMapper.queryByCode(taskDefinition.getProjectCode());
+        Project project = projectDao.queryByCode(taskDefinition.getProjectCode());
         projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_DEFINITION);
         return taskDefinition;
     }
@@ -207,7 +207,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
      */
     private TaskDefinitionLog updateTask(User loginUser, long projectCode, long taskCode,
                                          String taskDefinitionJsonObj) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check if user have write perm for project
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
@@ -308,18 +308,19 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                         throw new ServiceException(Status.CREATE_WORKFLOW_TASK_RELATION_LOG_ERROR);
                     }
                 }
-                WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+                WorkflowDefinition workflowDefinition =
+                        workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
                 workflowDefinition.setVersion(workflowDefinitionVersion);
                 workflowDefinition.setUpdateTime(now);
                 workflowDefinition.setUserId(loginUser.getId());
                 // update workflow definition
-                int updateWorkflowDefinitionCount = workflowDefinitionMapper.updateById(workflowDefinition);
+                boolean updateWorkflowDefinitionSuccess = workflowDefinitionDao.updateById(workflowDefinition);
                 WorkflowDefinitionLog workflowDefinitionLog = new WorkflowDefinitionLog(workflowDefinition);
                 workflowDefinitionLog.setOperateTime(now);
                 workflowDefinitionLog.setId(null);
                 workflowDefinitionLog.setOperator(loginUser.getId());
                 int insertWorkflowDefinitionLogCount = workflowDefinitionLogMapper.insert(workflowDefinitionLog);
-                if ((updateWorkflowDefinitionCount & insertWorkflowDefinitionLogCount) != 1) {
+                if (!updateWorkflowDefinitionSuccess || insertWorkflowDefinitionLogCount != 1) {
                     throw new ServiceException(Status.UPDATE_WORKFLOW_DEFINITION_ERROR);
                 }
             }
@@ -452,7 +453,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         Map<Long, TaskDefinition> taskCodeMap = taskDefinitionList.stream().collect(Collectors
                 .toMap(TaskDefinition::getCode, Function.identity(), (a, b) -> a));
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(workflowDefinitionCode);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(workflowDefinitionCode).orElse(null);
         TaskDefinition taskDefinition = taskCodeMap.get(taskCode);
 
         for (Long preTaskCode : addPreTaskSet) {
@@ -506,7 +507,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     @Transactional
     @Override
     public void switchVersion(User loginUser, long projectCode, long taskCode, int version) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
 
@@ -556,7 +557,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                                               int pageNo,
                                               int pageSize) {
         Result result = new Result();
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_VERSION_VIEW);
 
@@ -575,7 +576,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
 
     @Override
     public void deleteByCodeAndVersion(User loginUser, long projectCode, long taskCode, int version) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check if user have write perm for project
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
@@ -603,7 +604,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
 
     @Override
     public TaskDefinitionVO queryTaskDefinitionDetail(User loginUser, long projectCode, long taskCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, TASK_DEFINITION);
 
@@ -647,7 +648,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
     @Transactional
     @Override
     public void releaseTaskDefinition(User loginUser, long projectCode, long code, ReleaseState releaseState) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupQueueServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupQueueServiceImpl.java
@@ -23,8 +23,8 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskGroupQueue;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupQueueMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -47,7 +47,7 @@ public class TaskGroupQueueServiceImpl extends BaseServiceImpl implements TaskGr
     TaskGroupQueueMapper taskGroupQueueMapper;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     /**
      * query tasks in task group queue by group id
@@ -72,7 +72,7 @@ public class TaskGroupQueueServiceImpl extends BaseServiceImpl implements TaskGr
         if (projectIds.isEmpty()) {
             return pageInfo;
         }
-        List<Project> projects = projectMapper.selectBatchIds(projectIds);
+        List<Project> projects = projectDao.queryByIds(projectIds);
         Page<TaskGroupQueue> page = new Page<>(pageNo, pageSize);
         IPage<TaskGroupQueue> taskGroupQueue = taskGroupQueueMapper.queryTaskGroupQueueByTaskGroupIdPaging(
                 page,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
@@ -32,9 +32,9 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectUser;
 import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -62,7 +62,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
     private TaskGroupMapper taskGroupMapper;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private ProjectUserMapper projectUserMapper;
@@ -277,7 +277,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         if (loginUser.getUserType() == UserType.ADMIN_USER) {
             return;
         }
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         if (project == null) {
             log.warn("Project does not exist, projectCode:{}.", projectCode);
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
@@ -34,8 +34,8 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.extract.base.client.Clients;
@@ -70,7 +70,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInstanceService {
 
     @Autowired
-    ProjectMapper projectMapper;
+    ProjectDao projectDao;
 
     @Autowired
     ProjectService projectService;
@@ -238,7 +238,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
     public Result taskSavePoint(User loginUser, long projectCode, Integer taskInstanceId) {
         Result result = new Result();
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, FORCED_SUCCESS);
 
@@ -262,7 +262,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
     public Result stopTask(User loginUser, long projectCode, Integer taskInstanceId) {
         Result result = new Result();
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, FORCED_SUCCESS);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -43,10 +43,10 @@ import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -95,7 +95,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     private AlertGroupMapper alertGroupMapper;
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private K8sNamespaceUserMapper k8sNamespaceUserMapper;
@@ -438,7 +438,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             throw new ServiceException(Status.USER_NOT_EXIST, id);
         }
         // check if is a project owner
-        List<Project> projects = projectMapper.queryProjectCreatedByUser(id);
+        List<Project> projects = projectDao.queryProjectCreatedByUser(id);
         if (CollectionUtils.isNotEmpty(projects)) {
             String projectNames = projects.stream().map(Project::getName).collect(Collectors.joining(","));
             log.warn("Please transfer the project ownership before deleting the user, userId:{}, projects:{}.", id,
@@ -482,7 +482,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
 
         Arrays.stream(projectIds.split(",")).distinct().forEach(projectId -> {
             // 3. check if project is existed
-            Project project = this.projectMapper.queryDetailById(Integer.parseInt(projectId));
+            Project project = this.projectDao.queryDetailById(Integer.parseInt(projectId));
             if (project != null) {
                 // 4. delete the relationship between project and user
                 this.projectUserMapper.deleteProjectRelation(project.getId(), user.getId());
@@ -590,7 +590,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // 2. check if project is existed
-        Project project = this.projectMapper.queryByCode(projectCode);
+        Project project = this.projectDao.queryByCode(projectCode);
         if (project == null) {
             log.error("Project does not exist, projectCode:{}.", projectCode);
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);
@@ -642,7 +642,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // 3. check if project is existed
-        Project project = this.projectMapper.queryByCode(projectCode);
+        Project project = this.projectDao.queryByCode(projectCode);
         if (project == null) {
             log.error("Project does not exist, projectCode:{}.", projectCode);
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -44,9 +44,9 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.extract.base.client.Clients;
 import org.apache.dolphinscheduler.extract.master.IMasterContainerService;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
@@ -96,7 +96,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
     private TaskDefinitionMapper taskDefinitionMapper;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     /**
      * create or update a worker group
@@ -174,8 +174,8 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
 
         if (CollectionUtils.isNotEmpty(schedules)) {
             List<String> workflowDefinitionNames = schedules.stream().limit(3)
-                    .map(schedule -> workflowDefinitionMapper.queryByCode(schedule.getWorkflowDefinitionCode())
-                            .getName())
+                    .map(schedule -> workflowDefinitionDao.queryByCode(schedule.getWorkflowDefinitionCode())
+                            .orElse(null).getName())
                     .collect(Collectors.toList());
             throw new ServiceException(Status.WORKER_GROUP_DEPENDENT_SCHEDULER_EXISTS, schedules.size(),
                     JSONUtils.toJsonString(workflowDefinitionNames));

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -77,17 +77,16 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskLineage;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
@@ -148,7 +147,7 @@ import com.google.common.collect.Lists;
 public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements WorkflowDefinitionService {
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private ProjectService projectService;
@@ -158,9 +157,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
     @Autowired
     private WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
-
-    @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
 
     @Autowired
     private WorkflowDefinitionDao workflowDefinitionDao;
@@ -240,7 +236,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                        String taskDefinitionJson,
                                                        String otherParamsJson,
                                                        WorkflowExecutionTypeEnum executionType) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check if user have write perm for project
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
@@ -250,7 +246,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
         }
         // check whether the new workflow definition name exist
-        WorkflowDefinition definition = workflowDefinitionMapper.verifyByDefineName(project.getCode(), name);
+        WorkflowDefinition definition = workflowDefinitionDao.verifyByDefineName(project.getCode(), name);
         if (definition != null) {
             log.warn("workflow definition with the same name {} already exists, workflowDefinitionCode:{}.",
                     definition.getName(), definition.getCode());
@@ -444,11 +440,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public List<DagData> queryWorkflowDefinitionList(User loginUser, long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        List<WorkflowDefinition> resourceList = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
+        List<WorkflowDefinition> resourceList = workflowDefinitionDao.queryAllDefinitionList(projectCode);
         return resourceList.stream().map(processService::genDagData).collect(Collectors.toList());
     }
 
@@ -461,11 +457,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public ArrayNode queryWorkflowDefinitionSimpleList(User loginUser, long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
+        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionDao.queryAllDefinitionList(projectCode);
         ArrayNode arrayNode = JSONUtils.createArrayNode();
         for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
             ObjectNode workflowDefinitionNode = JSONUtils.createObjectNode();
@@ -544,11 +540,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public DagData queryWorkflowDefinitionByCode(User loginUser, long projectCode, long code) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
@@ -577,11 +573,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
     @Override
     public DagData queryWorkflowDefinitionByName(User loginUser, long projectCode, String name) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByDefineName(projectCode, name);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByDefineName(projectCode, name);
 
         if (workflowDefinition == null) {
             log.error("workflow definition does not exist, projectCode:{}.", projectCode);
@@ -618,7 +614,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                        String taskRelationJson,
                                                        String taskDefinitionJson,
                                                        WorkflowExecutionTypeEnum executionType) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check if user have write perm for project
         projectService.checkHasProjectWritePermissionThrowException(loginUser, project);
 
@@ -632,7 +628,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         List<TaskDefinitionLog> taskDefinitionLogs = generateTaskDefinitionList(taskDefinitionJson);
         List<WorkflowTaskRelationLog> taskRelationList = generateTaskRelationList(taskRelationJson, taskDefinitionLogs);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
         // check workflow definition exists
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
@@ -646,7 +642,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         }
         if (!name.equals(workflowDefinition.getName())) {
             // check whether the new workflow define name exist
-            WorkflowDefinition definition = workflowDefinitionMapper.verifyByDefineName(project.getCode(), name);
+            WorkflowDefinition definition = workflowDefinitionDao.verifyByDefineName(project.getCode(), name);
             if (definition != null) {
                 log.warn("workflow definition with the same name already exists, workflowDefinitionCode:{}.",
                         definition.getCode());
@@ -778,12 +774,12 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     @Override
     public void verifyWorkflowDefinitionName(User loginUser, long projectCode, String name,
                                              long workflowDefinitionCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_CREATE);
 
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.verifyByDefineName(project.getCode(), name.trim());
+                workflowDefinitionDao.verifyByDefineName(project.getCode(), name.trim());
         if (workflowDefinition == null) {
             return;
         }
@@ -805,7 +801,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
 
         Set<Long> definitionCodes = Lists.newArrayList(codes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
-        List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionMapper.queryByCodes(definitionCodes);
+        List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionDao.queryByCodes(definitionCodes);
         Set<Long> queryCodes =
                 workflowDefinitionList.stream().map(WorkflowDefinition::getCode).collect(Collectors.toSet());
         // definitionCodes - queryCodes
@@ -865,7 +861,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code)));
 
-        Project project = projectMapper.queryByCode(workflowDefinition.getProjectCode());
+        Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION_DELETE);
 
@@ -976,11 +972,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public List<TaskDefinition> getTaskNodeListByDefinitionCode(User loginUser, long projectCode, long code) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, workflowDefinitionCode:{}.", code);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
@@ -1000,19 +996,19 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     @Override
     public Map<Long, List<TaskDefinition>> getNodeListMapByDefinitionCodes(User loginUser, long projectCode,
                                                                            String codes) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         Set<Long> defineCodeSet = Lists.newArrayList(codes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
-        List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionMapper.queryByCodes(defineCodeSet);
+        List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionDao.queryByCodes(defineCodeSet);
         if (CollectionUtils.isEmpty(workflowDefinitionList)) {
             log.error("workflow definitions do not exist, codes:{}.", defineCodeSet);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, codes);
         }
         HashMap<Long, Project> userProjects = new HashMap<>(Constants.DEFAULT_HASH_MAP_SIZE);
-        projectMapper.queryProjectCreatedAndAuthorizedByUserId(loginUser.getId())
+        projectDao.queryProjectCreatedAndAuthorizedByUserId(loginUser.getId())
                 .forEach(userProject -> userProjects.put(userProject.getCode(), userProject));
 
         // check workflowDefinition exist in project
@@ -1039,11 +1035,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public List<DagData> queryAllWorkflowDefinitionByProjectCode(User loginUser, long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryAllDefinitionList(projectCode);
+        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionDao.queryAllDefinitionList(projectCode);
         return workflowDefinitions.stream().map(processService::genDagData).collect(Collectors.toList());
     }
 
@@ -1055,7 +1051,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public List<DependentSimplifyDefinition> queryWorkflowDefinitionListByProjectCode(long projectCode) {
-        return workflowDefinitionMapper.queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(projectCode, null);
+        return workflowDefinitionDao.queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(projectCode, null);
     }
 
     /**
@@ -1070,7 +1066,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                                                              Long workflowDefinitionCode) {
         Set<Long> definitionCodesSet = new HashSet<>();
         definitionCodesSet.add(workflowDefinitionCode);
-        List<DependentSimplifyDefinition> workflowDefinitions = workflowDefinitionMapper
+        List<DependentSimplifyDefinition> workflowDefinitions = workflowDefinitionDao
                 .queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(projectCode, definitionCodesSet);
 
         // query task definition log
@@ -1098,11 +1094,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
      */
     @Override
     public TreeViewDto viewTree(User loginUser, long projectCode, long code, Integer limit) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_TREE_VIEW);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
         if (null == workflowDefinition || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, code:{}.", code);
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, String.valueOf(code));
@@ -1297,7 +1293,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                              long projectCode,
                              String workflowDefinitionCodes,
                              long targetProjectCode, String perm) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, perm);
 
@@ -1307,7 +1303,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         }
 
         if (projectCode != targetProjectCode) {
-            Project targetProject = projectMapper.queryByCode(targetProjectCode);
+            Project targetProject = projectDao.queryByCode(targetProjectCode);
             // check user access for project
             projectService.checkProjectAndAuthThrowException(loginUser, targetProject, perm);
         }
@@ -1320,7 +1316,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                     boolean isCopy) {
         Set<Long> definitionCodes = Arrays.stream(workflowDefinitionCodes.split(Constants.COMMA)).map(Long::parseLong)
                 .collect(Collectors.toSet());
-        List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionMapper.queryByCodes(definitionCodes);
+        List<WorkflowDefinition> workflowDefinitionList = workflowDefinitionDao.queryByCodes(definitionCodes);
         Set<Long> queryCodes =
                 workflowDefinitionList.stream().map(WorkflowDefinition::getCode).collect(Collectors.toSet());
         // definitionCodes - queryCodes
@@ -1559,11 +1555,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     @Transactional
     public void switchWorkflowDefinitionVersion(User loginUser, long projectCode, long code,
                                                 int version) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
         if (Objects.isNull(workflowDefinition) || projectCode != workflowDefinition.getProjectCode()) {
             log.error(
                     "Switch workflow definition error because it does not exist, projectCode:{}, workflowDefinitionCode:{}.",
@@ -1672,7 +1668,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     public Result queryWorkflowDefinitionVersions(User loginUser, long projectCode, int pageNo, int pageSize,
                                                   long code) {
         Result result = new Result();
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, VERSION_LIST);
 
@@ -1705,7 +1701,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                 int version) {
         projectService.checkHasProjectWritePermissionThrowException(loginUser, projectCode);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
         if (workflowDefinition == null || projectCode != workflowDefinition.getProjectCode()) {
             throw new ServiceException(Status.WORKFLOW_DEFINITION_NOT_EXIST, code);
         }
@@ -1781,12 +1777,12 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     @Override
     public WorkflowDefinitionVariablesDTO viewVariables(User loginUser, long projectCode, long code) {
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
 
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_DEFINITION);
 
-        WorkflowDefinition workflowDefinition = workflowDefinitionMapper.queryByCode(code);
+        WorkflowDefinition workflowDefinition = workflowDefinitionDao.queryByCode(code).orElse(null);
 
         if (Objects.isNull(workflowDefinition) || projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -64,16 +64,16 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.RelationSubWorkflowMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceContextDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceMapDao;
 import org.apache.dolphinscheduler.dao.utils.WorkflowUtils;
@@ -120,7 +120,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     public static final String LOCAL_PARAMS_LIST = "localParamsList";
 
     @Autowired
-    ProjectMapper projectMapper;
+    ProjectDao projectDao;
 
     @Autowired
     ProjectService projectService;
@@ -145,7 +145,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     private WorkflowInstanceMapDao workflowInstanceMapDao;
 
     @Autowired
-    WorkflowDefinitionMapper workflowDefinitionMapper;
+    WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
     WorkflowDefinitionService workflowDefinitionService;
@@ -180,7 +180,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     @Override
     public List<WorkflowInstance> queryTopNLongestRunningWorkflowInstance(User loginUser, long projectCode, int size,
                                                                           String startTime, String endTime) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
@@ -208,7 +208,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Override
     public WorkflowInstance queryWorkflowInstanceById(User loginUser, long projectCode, Integer workflowInstanceId) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
@@ -298,14 +298,14 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     @Override
     public WorkflowInstanceTaskListDTO queryTaskListByWorkflowInstanceId(User loginUser, long projectCode,
                                                                          Integer workflowInstanceId) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
         WorkflowInstance workflowInstance = processService.findWorkflowInstanceDetailById(workflowInstanceId)
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByCode(workflowInstance.getWorkflowDefinitionCode());
+                workflowDefinitionDao.queryByCode(workflowInstance.getWorkflowDefinitionCode()).orElse(null);
         if (workflowDefinition != null && projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowInstanceId:{}.", projectCode,
                     workflowInstanceId);
@@ -397,7 +397,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Override
     public Map<String, Integer> querySubWorkflowInstanceByTaskId(User loginUser, long projectCode, Integer taskId) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
@@ -444,7 +444,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
                 .orElseThrow(() -> new ServiceException(WORKFLOW_INSTANCE_NOT_EXIST, workflowInstanceId));
         // check workflow instance exists in project
         WorkflowDefinition workflowDefinition0 =
-                workflowDefinitionMapper.queryByCode(workflowInstance.getWorkflowDefinitionCode());
+                workflowDefinitionDao.queryByCode(workflowInstance.getWorkflowDefinitionCode()).orElse(null);
         if (workflowDefinition0 != null && projectCode != workflowDefinition0.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                     workflowInstance.getWorkflowDefinitionCode());
@@ -485,7 +485,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
             throw new ServiceException(Status.UPDATE_TASK_DEFINITION_ERROR);
         }
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByCode(workflowInstance.getWorkflowDefinitionCode());
+                workflowDefinitionDao.queryByCode(workflowInstance.getWorkflowDefinitionCode()).orElse(null);
         List<WorkflowTaskRelationLog> taskRelationList =
                 JSONUtils.toList(taskRelationJson, WorkflowTaskRelationLog.class);
         // check workflow json is valid (throws ServiceException on validation failures)
@@ -555,7 +555,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Override
     public Map<String, Integer> queryParentInstanceBySubId(User loginUser, long projectCode, Integer subId) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 
@@ -585,7 +585,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         WorkflowDefinition workflowDefinition = workflowDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                 workflowInstance.getWorkflowDefinitionCode(), workflowInstance.getWorkflowDefinitionVersion());
 
-        Project project = projectMapper.queryByCode(workflowDefinition.getProjectCode());
+        Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project,
                 ApiFuncIdentificationConstant.INSTANCE_DELETE);
@@ -613,7 +613,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         }
 
         WorkflowDefinition workflowDefinition =
-                workflowDefinitionMapper.queryByCode(workflowInstance.getWorkflowDefinitionCode());
+                workflowDefinitionDao.queryByCode(workflowInstance.getWorkflowDefinitionCode()).orElse(null);
         if (workflowDefinition != null && projectCode != workflowDefinition.getProjectCode()) {
             log.error("workflow definition does not exist, projectCode:{}, workflowDefinitionCode:{}.", projectCode,
                     workflowInstance.getWorkflowDefinitionCode());
@@ -785,7 +785,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     @Override
     public List<WorkflowInstance> queryByTriggerCode(User loginUser, long projectCode, Long triggerCode) {
 
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowLineageServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowLineageServiceImpl.java
@@ -31,9 +31,9 @@ import org.apache.dolphinscheduler.dao.entity.WorkFlowRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkFlowRelationDetail;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskLineage;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowTaskLineageDao;
 
 import java.text.MessageFormat;
@@ -64,7 +64,7 @@ import org.springframework.util.CollectionUtils;
 public class WorkflowLineageServiceImpl extends BaseServiceImpl implements WorkflowLineageService {
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Autowired
     private TaskDefinitionMapper taskDefinitionMapper;
@@ -73,11 +73,11 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
     private WorkflowTaskLineageDao workflowTaskLineageDao;
 
     @Autowired
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Override
     public List<WorkFlowRelationDetail> queryWorkFlowLineageByName(long projectCode, String workflowDefinitionName) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         if (project == null) {
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);
         }
@@ -86,7 +86,7 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
 
     @Override
     public WorkFlowLineage queryWorkFlowLineageByCode(long projectCode, long workflowDefinitionCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         if (project == null) {
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);
         }
@@ -118,7 +118,7 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
 
     @Override
     public WorkFlowLineage queryWorkFlowLineage(long projectCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         if (project == null) {
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);
         }
@@ -189,7 +189,8 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
 
         for (WorkflowTaskLineage workflowTaskLineage : dependentWorkflowList) {
             WorkflowDefinition workflowDefinition =
-                    workflowDefinitionMapper.queryByCode(workflowTaskLineage.getDeptWorkflowDefinitionCode());
+                    workflowDefinitionDao.queryByCode(workflowTaskLineage.getDeptWorkflowDefinitionCode())
+                            .orElse(null);
             String taskName = "";
             if (workflowTaskLineage.getTaskDefinitionCode() != 0) {
                 TaskDefinition taskDefinition =
@@ -245,7 +246,7 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
         }
 
         List<WorkflowDefinition> workflowDefinitionList =
-                workflowDefinitionMapper.queryByCodes(workflowTaskLineageList.stream()
+                workflowDefinitionDao.queryByCodes(workflowTaskLineageList.stream()
                         .map(WorkflowTaskLineage::getWorkflowDefinitionCode).distinct()
                         .collect(Collectors.toList()));
         List<TaskDefinition> taskDefinitionList = taskDefinitionMapper.queryByCodeList(workflowTaskLineageList.stream()
@@ -286,7 +287,7 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
     @Override
     public List<DependentLineageTask> queryDependentWorkflowDefinitions(long projectCode, long workflowDefinitionCode,
                                                                         Long taskCode) {
-        Project project = projectMapper.queryByCode(projectCode);
+        Project project = projectDao.queryByCode(projectCode);
         if (project == null) {
             throw new ServiceException(Status.PROJECT_NOT_FOUND, projectCode);
         }
@@ -298,7 +299,7 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
             return dependentLineageTaskList;
         }
         List<WorkflowDefinition> workflowDefinitionList =
-                workflowDefinitionMapper.queryByCodes(workflowTaskLineageList.stream()
+                workflowDefinitionDao.queryByCodes(workflowTaskLineageList.stream()
                         .map(WorkflowTaskLineage::getWorkflowDefinitionCode).distinct().collect(Collectors.toList()));
         List<TaskDefinition> taskDefinitionList = taskDefinitionMapper.queryByCodeList(workflowTaskLineageList.stream()
                 .map(WorkflowTaskLineage::getTaskDefinitionCode).filter(code -> code != 0).distinct()
@@ -423,7 +424,7 @@ public class WorkflowLineageServiceImpl extends BaseServiceImpl implements Workf
         if (CollectionUtils.isEmpty(missingCodes)) {
             return;
         }
-        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionMapper.queryByCodes(missingCodes);
+        List<WorkflowDefinition> workflowDefinitions = workflowDefinitionDao.queryByCodes(missingCodes);
         if (CollectionUtils.isEmpty(workflowDefinitions)) {
             return;
         }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/DataAnalysisControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/DataAnalysisControllerTest.java
@@ -28,7 +28,7 @@ import org.apache.dolphinscheduler.api.vo.TaskInstanceCountVO;
 import org.apache.dolphinscheduler.api.vo.WorkflowInstanceCountVO;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.Project;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import java.util.Date;
 
@@ -48,7 +48,7 @@ public class DataAnalysisControllerTest extends AbstractControllerTest {
     private static final Logger logger = LoggerFactory.getLogger(DataAnalysisControllerTest.class);
 
     @Autowired
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     private int createProject() {
         Project project = new Project();
@@ -56,7 +56,7 @@ public class DataAnalysisControllerTest extends AbstractControllerTest {
         project.setName("ut project");
         project.setUserId(1);
         project.setCreateTime(new Date());
-        projectMapper.insert(project);
+        projectDao.insert(project);
         return project.getId();
     }
 
@@ -80,7 +80,7 @@ public class DataAnalysisControllerTest extends AbstractControllerTest {
         assertThat(result.getCode())
                 .isNotNull()
                 .isEqualTo(Status.SUCCESS.getCode());
-        projectMapper.deleteById(projectId);
+        projectDao.deleteById(projectId);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class DataAnalysisControllerTest extends AbstractControllerTest {
         assertThat(result.getCode())
                 .isEqualTo(Status.SUCCESS.getCode());
 
-        projectMapper.deleteById(projectId);
+        projectDao.deleteById(projectId);
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProjectControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProjectControllerTest.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import java.text.MessageFormat;
 
@@ -52,7 +52,7 @@ public class ProjectControllerTest {
     private ProjectServiceImpl projectService;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @BeforeEach
     public void before() {
@@ -81,7 +81,7 @@ public class ProjectControllerTest {
         Result result = new Result();
         putMsg(result, Status.SUCCESS);
         long projectCode = 1L;
-        Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject());
+        Mockito.when(projectDao.queryByCode(projectCode)).thenReturn(getProject());
         Mockito.when(projectService.queryByCode(user, projectCode)).thenReturn(result);
         Result response = projectController.queryProjectByCode(user, projectCode);
         Assertions.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/ProjectsResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/ProjectsResourcePermissionCheckTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class ProjectsResourcePermissionCheckTest {
     private ResourcePermissionCheckServiceImpl.ProjectsResourcePermissionCheck projectsResourcePermissionCheck;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Test
     public void testPermissionCheck() {
@@ -69,7 +69,7 @@ public class ProjectsResourcePermissionCheckTest {
         ids.add(project.getId());
         List<Project> projects = Arrays.asList(project);
 
-        Mockito.when(projectMapper.listAuthorizedProjects(user.getId(), null)).thenReturn(projects);
+        Mockito.when(projectDao.listAuthorizedProjects(user.getId(), null)).thenReturn(projects);
 
         Assertions.assertEquals(ids, projectsResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceTest.java
@@ -22,7 +22,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import java.util.Arrays;
@@ -51,7 +51,7 @@ public class ResourcePermissionCheckServiceTest {
     private UserDao userDao;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @InjectMocks
     ResourcePermissionCheckServiceImpl resourcePermissionCheckService;
@@ -59,7 +59,7 @@ public class ResourcePermissionCheckServiceTest {
     @BeforeEach
     public void setup() {
         ResourcePermissionCheckServiceImpl.RESOURCE_LIST_MAP.put(AuthorizationType.PROJECTS,
-                new ResourcePermissionCheckServiceImpl.ProjectsResourcePermissionCheck(projectMapper));
+                new ResourcePermissionCheckServiceImpl.ProjectsResourcePermissionCheck(projectDao));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ResourcePermissionCheckServiceTest {
                 user.getId(), logger));
 
         List<Project> projects = Arrays.asList(getProject(1), getProject(2), getProject(3));
-        Mockito.when(projectMapper.listAuthorizedProjects(user.getId(), null)).thenReturn(projects);
+        Mockito.when(projectDao.listAuthorizedProjects(user.getId(), null)).thenReturn(projects);
 
         Assertions.assertTrue(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS,
                 new Object[]{}, user.getId(), logger));
@@ -107,14 +107,14 @@ public class ResourcePermissionCheckServiceTest {
         // GENERAL_USER
         List<Project> projects = Arrays.asList(getProject(1), getProject(2), getProject(3));
         Mockito.when(userDao.queryById(generalUser.getId())).thenReturn(generalUser);
-        Mockito.when(projectMapper.listAuthorizedProjects(generalUser.getId(), null)).thenReturn(projects);
+        Mockito.when(projectDao.listAuthorizedProjects(generalUser.getId(), null)).thenReturn(projects);
         Assertions.assertEquals(3, resourcePermissionCheckService
                 .userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS, generalUser.getId(), logger).size());
 
         // ADMIN_USER
         User adminUser = getAdminUser();
         Mockito.when(userDao.queryById(adminUser.getId())).thenReturn(adminUser);
-        Mockito.when(projectMapper.listAuthorizedProjects(0, null)).thenReturn(projects);
+        Mockito.when(projectDao.listAuthorizedProjects(0, null)).thenReturn(projects);
         Assertions.assertEquals(3, resourcePermissionCheckService
                 .userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS, adminUser.getId(), logger).size());
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/python/PythonGatewayTest.java
@@ -22,9 +22,9 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageEntity;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
 
@@ -49,10 +49,10 @@ public class PythonGatewayTest {
     private PythonGateway pythonGateway;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     private TaskDefinitionMapper taskDefinitionMapper;
@@ -63,10 +63,10 @@ public class PythonGatewayTest {
     @Test
     public void testGetCodeAndVersion() {
         Project project = getTestProject();
-        Mockito.when(projectMapper.queryByName(project.getName())).thenReturn(project);
+        Mockito.when(projectDao.queryByName(project.getName())).thenReturn(project);
 
         WorkflowDefinition workflowDefinition = getTestProcessDefinition();
-        Mockito.when(workflowDefinitionMapper.queryByDefineName(project.getCode(), workflowDefinition.getName()))
+        Mockito.when(workflowDefinitionDao.queryByDefineName(project.getCode(), workflowDefinition.getName()))
                 .thenReturn(workflowDefinition);
 
         TaskDefinition taskDefinition = getTestTaskDefinition();
@@ -81,10 +81,10 @@ public class PythonGatewayTest {
     @Test
     public void testGetDependentInfo() {
         Project project = getTestProject();
-        Mockito.when(projectMapper.queryByName(project.getName())).thenReturn(project);
+        Mockito.when(projectDao.queryByName(project.getName())).thenReturn(project);
 
         WorkflowDefinition workflowDefinition = getTestProcessDefinition();
-        Mockito.when(workflowDefinitionMapper.queryByDefineName(project.getCode(), workflowDefinition.getName()))
+        Mockito.when(workflowDefinitionDao.queryByDefineName(project.getCode(), workflowDefinition.getName()))
                 .thenReturn(workflowDefinition);
 
         TaskDefinition taskDefinition = getTestTaskDefinition();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
@@ -46,10 +46,10 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
 import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 
 import java.text.MessageFormat;
@@ -86,7 +86,7 @@ public class DataAnalysisServiceTest {
     private DataAnalysisServiceImpl dataAnalysisServiceImpl;
 
     @Mock
-    ProjectMapper projectMapper;
+    ProjectDao projectDao;
 
     @Mock
     ProjectService projectService;
@@ -95,7 +95,7 @@ public class DataAnalysisServiceTest {
     WorkflowInstanceMapper workflowInstanceMapper;
 
     @Mock
-    WorkflowDefinitionMapper workflowDefinitionMapper;
+    WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     CommandMapper commandMapper;
@@ -127,13 +127,13 @@ public class DataAnalysisServiceTest {
         project.setName("test");
         resultMap = new HashMap<>();
 
-        when(projectMapper.queryByCode(1L)).thenReturn(project);
+        when(projectDao.queryByCode(1L)).thenReturn(project);
     }
 
     @AfterEach
     public void after() {
         user = null;
-        projectMapper = null;
+        projectDao = null;
         resultMap = null;
     }
 
@@ -306,8 +306,8 @@ public class DataAnalysisServiceTest {
                         .thenReturn(projectIds());
         PageInfo<Command> list2 = dataAnalysisServiceImpl.listPendingCommands(user, 1L, 1, 10);
         assertThat(list2.getTotal()).isEqualTo(0);
-        when(projectMapper.selectBatchIds(any())).thenReturn(Collections.singletonList(project));
-        when(workflowDefinitionMapper.queryDefinitionCodeListByProjectCodes(any()))
+        when(projectDao.queryByIds(any())).thenReturn(Collections.singletonList(project));
+        when(workflowDefinitionDao.queryDefinitionCodeListByProjectCodes(any()))
                 .thenReturn(Collections.singletonList(1L));
         when(commandMapper.queryCommandPageByIds(any(), any())).thenReturn(page);
         PageInfo<Command> list3 = dataAnalysisServiceImpl.listPendingCommands(user, 1L, 1, 10);
@@ -328,8 +328,8 @@ public class DataAnalysisServiceTest {
                         .thenReturn(projectIds());
         PageInfo<ErrorCommand> list2 = dataAnalysisServiceImpl.listErrorCommand(user, 1L, 1, 10);
         assertThat(list2.getTotal()).isEqualTo(0);
-        when(projectMapper.selectBatchIds(any())).thenReturn(Collections.singletonList(project));
-        when(workflowDefinitionMapper.queryDefinitionCodeListByProjectCodes(any()))
+        when(projectDao.queryByIds(any())).thenReturn(Collections.singletonList(project));
+        when(workflowDefinitionDao.queryDefinitionCodeListByProjectCodes(any()))
                 .thenReturn(Collections.singletonList(1L));
         when(errorCommandMapper.queryErrorCommandPageByIds(any(), any())).thenReturn(page);
         PageInfo<ErrorCommand> list3 = dataAnalysisServiceImpl.listErrorCommand(user, 1L, 1, 10);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/LoggerServiceTest.java
@@ -40,8 +40,8 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 
 import java.text.MessageFormat;
@@ -72,7 +72,7 @@ public class LoggerServiceTest {
     private TaskInstanceDao taskInstanceDao;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectService projectService;
@@ -238,7 +238,7 @@ public class LoggerServiceTest {
     @Test
     public void testGetLogBytesInSpecifiedProject() {
         long projectCode = 1L;
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
 
         User loginUser = new User();
         loginUser.setId(-1);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectParameterServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectParameterServiceTest.java
@@ -37,8 +37,8 @@ import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectParameter;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectParameterMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 
 import java.util.Collections;
@@ -63,7 +63,7 @@ public class ProjectParameterServiceTest {
     private ProjectParameterServiceImpl projectParameterService;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectParameterMapper projectParameterMapper;
@@ -96,7 +96,7 @@ public class ProjectParameterServiceTest {
         }
 
         // PROJECT_PARAMETER_ALREADY_EXISTS
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         when(projectParameterMapper.selectOne(Mockito.any())).thenReturn(getProjectParameter());
         Result result = projectParameterService.createProjectParameter(loginUser, projectCode, "key", "value",
                 DataType.VARCHAR.name());
@@ -131,7 +131,7 @@ public class ProjectParameterServiceTest {
                         DataType.VARCHAR.name()));
 
         // PROJECT_PARAMETER_NOT_EXISTS
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         doNothing().when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
         when(projectParameterMapper.queryByCode(Mockito.anyLong())).thenReturn(null);
         Result result = projectParameterService.updateProjectParameter(loginUser, projectCode, 1, "key", "value",
@@ -174,7 +174,7 @@ public class ProjectParameterServiceTest {
                 () -> projectParameterService.deleteProjectParametersByCode(loginUser, projectCode, 1));
 
         // PROJECT_PARAMETER_NOT_EXISTS
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         doNothing().when(projectService).checkHasProjectWritePermissionThrowException(any(), any());
         when(projectParameterMapper.queryByCode(Mockito.anyLong())).thenReturn(null);
         Result result = projectParameterService.deleteProjectParametersByCode(loginUser, projectCode, 1);
@@ -204,7 +204,7 @@ public class ProjectParameterServiceTest {
                 () -> projectParameterService.queryProjectParameterByCode(loginUser, projectCode, 1));
 
         // PROJECT_PARAMETER_NOT_EXISTS
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         doNothing().when(projectService).checkProjectAndAuthThrowException(any(), Mockito.<Project>any(), any());
         when(projectParameterMapper.queryByCode(Mockito.anyLong())).thenReturn(null);
         Result result = projectParameterService.queryProjectParameterByCode(loginUser, projectCode, 1);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectPreferenceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectPreferenceServiceTest.java
@@ -26,8 +26,8 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectPreference;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectPreferenceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ public class ProjectPreferenceServiceTest {
     private ProjectPreferenceServiceImpl projectPreferenceService;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectPreferenceMapper projectPreferenceMapper;
@@ -69,7 +69,7 @@ public class ProjectPreferenceServiceTest {
 
         // when preference exists in project
         Mockito.when(projectPreferenceMapper.selectOne(Mockito.any())).thenReturn(null);
-        Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        Mockito.when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
 
         // success
         Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(Mockito.any(),
@@ -111,7 +111,7 @@ public class ProjectPreferenceServiceTest {
                 () -> projectPreferenceService.queryProjectPreferenceByProjectCode(loginUser, projectCode));
 
         // PROJECT_PARAMETER_NOT_EXISTS
-        Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        Mockito.when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(Mockito.any(),
                 Mockito.<Project>any(), Mockito.any());
 
@@ -135,7 +135,7 @@ public class ProjectPreferenceServiceTest {
         Assertions.assertThrows(ServiceException.class,
                 () -> projectPreferenceService.enableProjectPreference(loginUser, projectCode, 1));
 
-        Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        Mockito.when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(Mockito.any(),
                 Mockito.any());
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -36,10 +36,10 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -78,7 +78,7 @@ public class ProjectServiceTest {
     private ProjectServiceImpl projectService;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectUserMapper projectUserMapper;
@@ -87,7 +87,7 @@ public class ProjectServiceTest {
     private TaskGroupService taskGroupService;
 
     @Mock
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     private UserMapper userMapper;
@@ -113,13 +113,13 @@ public class ProjectServiceTest {
         Assertions.assertEquals(Status.REQUEST_PARAMS_NOT_VALID_ERROR.getCode(), 10001);
 
         // PROJECT_ALREADY_EXISTS
-        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject());
+        Mockito.when(projectDao.queryByName(projectName)).thenReturn(getProject());
         result = projectService.createProject(loginUser, projectName, projectName);
         logger.info(result.toString());
         Assertions.assertEquals(Status.PROJECT_ALREADY_EXISTS.getCode(), result.getCode().intValue());
 
         // success
-        Mockito.when(projectMapper.insert(Mockito.any(Project.class))).thenReturn(1);
+        Mockito.when(projectDao.insert(Mockito.any(Project.class))).thenReturn(1);
         result = projectService.createProject(loginUser, "test", "test");
         logger.info(result.toString());
         Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
@@ -193,7 +193,7 @@ public class ProjectServiceTest {
         Integer pageNo = 1;
         String searchVal = "testVal";
         Result result = new Result();
-        Mockito.when(projectMapper.queryProjectListPaging(any(Page.class), Mockito.anyList(), eq(searchVal)))
+        Mockito.when(projectDao.queryProjectListPaging(any(Page.class), Mockito.anyList(), eq(searchVal)))
                 .thenReturn(page);
 
         Set<Integer> allProjectIds = new HashSet();
@@ -212,7 +212,7 @@ public class ProjectServiceTest {
     @Test
     public void testDeleteProject() {
         User loginUser = getLoginUser();
-        Mockito.when(projectMapper.queryByCode(1L)).thenReturn(getProject());
+        Mockito.when(projectDao.queryByCode(1L)).thenReturn(getProject());
 
         // PROJECT_NOT_FOUND
         ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
@@ -226,7 +226,7 @@ public class ProjectServiceTest {
         Assertions.assertEquals(Status.USER_NO_WRITE_PROJECT_PERM.getCode(), noWriteEx.getCode());
 
         // DELETE_PROJECT_ERROR_DEFINES_NOT_NULL
-        Mockito.when(workflowDefinitionMapper.queryAllDefinitionList(1L)).thenReturn(getProcessDefinitions());
+        Mockito.when(workflowDefinitionDao.queryAllDefinitionList(1L)).thenReturn(getProcessDefinitions());
         loginUser.setUserType(UserType.ADMIN_USER);
         loginUser.setId(1);
         Mockito.when(
@@ -242,8 +242,8 @@ public class ProjectServiceTest {
         Assertions.assertEquals(Status.DELETE_PROJECT_ERROR_DEFINES_NOT_NULL.getCode(), result.getCode().intValue());
 
         // success
-        Mockito.when(projectMapper.deleteById(1)).thenReturn(1);
-        Mockito.when(workflowDefinitionMapper.queryAllDefinitionList(1L)).thenReturn(new ArrayList<>());
+        Mockito.when(projectDao.deleteById(1)).thenReturn(true);
+        Mockito.when(workflowDefinitionDao.queryAllDefinitionList(1L)).thenReturn(new ArrayList<>());
         result = projectService.deleteProject(loginUser, 1L);
         logger.info(result.toString());
         Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
@@ -256,8 +256,8 @@ public class ProjectServiceTest {
         loginUser.setId(1);
         Project project = getProject();
         project.setCode(2L);
-        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(project);
-        Mockito.when(projectMapper.queryByCode(2L)).thenReturn(getProject());
+        Mockito.when(projectDao.queryByName(projectName)).thenReturn(project);
+        Mockito.when(projectDao.queryByCode(2L)).thenReturn(getProject());
         // PROJECT_NOT_FOUND
         ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
                 () -> projectService.update(loginUser, 1L, projectName, "desc"));
@@ -283,7 +283,7 @@ public class ProjectServiceTest {
         // success
         Mockito.when(userMapper.selectById(Mockito.any())).thenReturn(new User());
         project.setUserId(1);
-        Mockito.when(projectMapper.updateById(Mockito.any(Project.class))).thenReturn(1);
+        Mockito.when(projectDao.updateById(Mockito.any(Project.class))).thenReturn(true);
         result = projectService.update(loginUser, 2L, "test", "desc");
         logger.info(result.toString());
         Assertions.assertEquals(Status.SUCCESS.getCode(), result.getCode().intValue());
@@ -292,7 +292,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testQueryAuthorizedProject() {
-        Mockito.when(projectMapper.queryAuthedProjectListByUserId(2)).thenReturn(getList());
+        Mockito.when(projectDao.queryAuthedProjectListByUserId(2)).thenReturn(getList());
 
         User loginUser = getLoginUser();
 
@@ -321,7 +321,7 @@ public class ProjectServiceTest {
         Assertions.assertEquals(Status.PROJECT_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // Failure 2: USER_NO_OPERATION_PROJECT_PERM
-        Mockito.when(this.projectMapper.queryByCode(Mockito.anyLong())).thenReturn(this.getProject());
+        Mockito.when(this.projectDao.queryByCode(Mockito.anyLong())).thenReturn(this.getProject());
         ServiceException noPermEx = Assertions.assertThrows(ServiceException.class,
                 () -> this.projectService.queryAuthorizedUser(loginUser, 3682329499136L));
         Assertions.assertEquals(Status.USER_NO_OPERATION_PROJECT_PERM.getCode(), noPermEx.getCode());
@@ -355,7 +355,7 @@ public class ProjectServiceTest {
 
         User loginUser = getLoginUser();
 
-        Mockito.when(projectMapper.queryProjectCreatedByUser(1)).thenReturn(getList());
+        Mockito.when(projectDao.queryProjectCreatedByUser(1)).thenReturn(getList());
 
         // success
         loginUser.setUserType(UserType.ADMIN_USER);
@@ -375,7 +375,7 @@ public class ProjectServiceTest {
         // not admin user
         Mockito.when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS,
                 loginUser.getId(), projectLogger)).thenReturn(set);
-        Mockito.when(projectMapper.selectBatchIds(set)).thenReturn(getList());
+        Mockito.when(projectDao.queryByIds(set)).thenReturn(getList());
         result = projectService.queryProjectCreatedAndAuthorizedByUser(loginUser);
         List<Project> notAdminUserResult = (List<Project>) result.getData();
         Assertions.assertTrue(CollectionUtils.isNotEmpty(notAdminUserResult));
@@ -384,7 +384,7 @@ public class ProjectServiceTest {
         loginUser.setUserType(UserType.ADMIN_USER);
         Mockito.when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS,
                 loginUser.getId(), projectLogger)).thenReturn(set);
-        Mockito.when(projectMapper.selectBatchIds(set)).thenReturn(getList());
+        Mockito.when(projectDao.queryByIds(set)).thenReturn(getList());
         result = projectService.queryProjectCreatedAndAuthorizedByUser(loginUser);
         List<Project> projects = (List<Project>) result.getData();
 
@@ -394,7 +394,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testQueryAllProjectList() {
-        Mockito.when(projectMapper.queryAllProject(0)).thenReturn(getList());
+        Mockito.when(projectDao.queryAllProject(0)).thenReturn(getList());
 
         User user = new User();
         user.setId(0);
@@ -406,7 +406,7 @@ public class ProjectServiceTest {
     }
     @Test
     public void queryAllProjectListForDependent() {
-        Mockito.when(projectMapper.queryAllProjectForDependent()).thenReturn(getList());
+        Mockito.when(projectDao.queryAllProjectForDependent()).thenReturn(getList());
 
         Result result = projectService.queryAllProjectListForDependent();
         logger.info(result.toString());
@@ -427,7 +427,7 @@ public class ProjectServiceTest {
         list.add(1);
         Mockito.when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS,
                 loginUser.getId(), projectLogger)).thenReturn(set);
-        Mockito.when(projectMapper.listAuthorizedProjects(
+        Mockito.when(projectDao.listAuthorizedProjects(
                 loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : loginUser.getId(), list))
                 .thenReturn(getList());
         Result result = projectService.queryProjectWithAuthorizedLevel(loginUser, 2);
@@ -440,7 +440,7 @@ public class ProjectServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
         Mockito.when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS,
                 loginUser.getId(), projectLogger)).thenReturn(set);
-        Mockito.when(projectMapper.listAuthorizedProjects(
+        Mockito.when(projectDao.listAuthorizedProjects(
                 loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : loginUser.getId(), list))
                 .thenReturn(getList());
         result = projectService.queryProjectWithAuthorizedLevel(loginUser, 3);
@@ -461,7 +461,7 @@ public class ProjectServiceTest {
         list.add(1);
         Mockito.when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS,
                 loginUser.getId(), projectLogger)).thenReturn(set);
-        Mockito.when(projectMapper.listAuthorizedProjects(
+        Mockito.when(projectDao.listAuthorizedProjects(
                 loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : loginUser.getId(), list))
                 .thenReturn(getList());
         Result result = projectService.queryUnauthorizedProject(loginUser, 2);
@@ -474,7 +474,7 @@ public class ProjectServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
         Mockito.when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS,
                 loginUser.getId(), projectLogger)).thenReturn(set);
-        Mockito.when(projectMapper.listAuthorizedProjects(
+        Mockito.when(projectDao.listAuthorizedProjects(
                 loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : loginUser.getId(), list))
                 .thenReturn(getList());
         result = projectService.queryUnauthorizedProject(loginUser, 3);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
@@ -30,8 +30,8 @@ import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroupPageDetail;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectWorkerGroupDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
@@ -64,7 +64,7 @@ public class ProjectWorkerGroupRelationServiceTest {
     private WorkerGroupService workerGroupService;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectWorkerGroupDao projectWorkerGroupDao;
@@ -99,7 +99,7 @@ public class ProjectWorkerGroupRelationServiceTest {
         Assertions.assertEquals(Status.PROJECT_NOT_EXIST.getCode(), result.getCode());
 
         // project not exists
-        Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(null);
+        Mockito.when(projectDao.queryByCode(projectCode)).thenReturn(null);
         result = projectWorkerGroupRelationService.assignWorkerGroupsToProject(loginUser, projectCode,
                 getWorkerGroups());
         Assertions.assertEquals(Status.PROJECT_NOT_EXIST.getCode(), result.getCode());
@@ -109,7 +109,7 @@ public class ProjectWorkerGroupRelationServiceTest {
         workerGroup.setName("test");
         WorkerGroupPageDetail workerGroupPageDetail = new WorkerGroupPageDetail();
         workerGroupPageDetail.setName("test1");
-        Mockito.when(projectMapper.queryByCode(Mockito.anyLong())).thenReturn(getProject());
+        Mockito.when(projectDao.queryByCode(Mockito.anyLong())).thenReturn(getProject());
         Mockito.when(workerGroupDao.queryAllWorkerGroup()).thenReturn(Collections.singletonList(workerGroup));
         Mockito.when(workerGroupService.getConfigWorkerGroupPageDetail())
                 .thenReturn(Collections.singletonList(workerGroupPageDetail));
@@ -195,7 +195,7 @@ public class ProjectWorkerGroupRelationServiceTest {
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(Mockito.any(),
                 Mockito.<Project>any(), Mockito.any());
 
-        Mockito.when(projectMapper.queryByCode(projectCode))
+        Mockito.when(projectDao.queryByCode(projectCode))
                 .thenReturn(getProject());
 
         Mockito.when(projectWorkerGroupDao.queryByProjectCode(Mockito.any()))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
@@ -25,9 +25,11 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,10 +53,10 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
     private ScheduleMapper scheduleMapper;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     private ProjectService projectService;
@@ -112,9 +114,9 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
                 ((ServiceException) exception).getCode());
 
         // error project permissions
-        Mockito.when(workflowDefinitionMapper.queryByCode(processDefinitionCode))
-                .thenReturn(this.getProcessDefinition());
-        Mockito.when(projectMapper.queryByCode(projectCode)).thenReturn(this.getProject());
+        Mockito.when(workflowDefinitionDao.queryByCode(processDefinitionCode))
+                .thenReturn(Optional.of(this.getProcessDefinition()));
+        Mockito.when(projectDao.queryByCode(projectCode)).thenReturn(this.getProject());
         Mockito.doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM)).when(projectService)
                 .checkProjectAndAuthThrowException(user, this.getProject(), null);
         exception = Assertions.assertThrows(ServiceException.class,

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -45,13 +45,14 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowTaskRelationLogDao;
 import org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager;
 import org.apache.dolphinscheduler.service.process.ProcessService;
@@ -61,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,7 +90,7 @@ public class TaskDefinitionServiceImplTest {
     private TaskDefinitionLogMapper taskDefinitionLogMapper;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectServiceImpl projectService;
@@ -110,6 +112,9 @@ public class TaskDefinitionServiceImplTest {
 
     @Mock
     private WorkflowDefinitionMapper workflowDefinitionMapper;
+
+    @Mock
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     private WorkflowTaskRelationLogDao workflowTaskRelationLogDao;
@@ -139,7 +144,7 @@ public class TaskDefinitionServiceImplTest {
     public void queryTaskDefinitionByName() {
         String taskName = "task";
         Project project = getProject();
-        when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, TASK_DEFINITION);
 
@@ -155,7 +160,7 @@ public class TaskDefinitionServiceImplTest {
     @Test
     public void switchVersion() {
         Project project = getProject();
-        when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
 
@@ -174,7 +179,7 @@ public class TaskDefinitionServiceImplTest {
     @Test
     public void deleteByCodeAndVersion() {
         Project project = getProject();
-        when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(project);
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
 
         // cross-project privilege escalation: taskCode belongs to another project - must be rejected
@@ -240,7 +245,7 @@ public class TaskDefinitionServiceImplTest {
 
     @Test
     public void testReleaseTaskDefinition() {
-        when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(getProject());
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(getProject());
         Project project = getProject();
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, project, null);
 
@@ -284,7 +289,7 @@ public class TaskDefinitionServiceImplTest {
         ArrayList<TaskDefinitionLog> taskDefinitionLogs = new ArrayList<>();
         taskDefinitionLogs.add(taskDefinitionLog);
         int version = 1;
-        when(workflowDefinitionMapper.queryByCode(isA(long.class))).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(isA(long.class))).thenReturn(Optional.of(workflowDefinition));
 
         // saveWorkflowDefine
         when(workflowDefinitionLogMapper.queryMaxVersionForDefinition(isA(long.class))).thenReturn(version);
@@ -320,7 +325,7 @@ public class TaskDefinitionServiceImplTest {
 
         // error task definition not exists
         when(taskDefinitionMapper.queryByCode(TASK_CODE)).thenReturn(getTaskDefinition());
-        when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(getProject());
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(getProject());
         doThrow(new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM)).when(projectService)
                 .checkProjectAndAuthThrowException(user, getProject(), TASK_DEFINITION);
         exception = Assertions.assertThrows(ServiceException.class,
@@ -348,7 +353,7 @@ public class TaskDefinitionServiceImplTest {
             taskDefinitionSecond.setCode(5);
 
             user.setUserType(UserType.ADMIN_USER);
-            when(projectMapper.queryByCode(PROJECT_CODE)).thenReturn(getProject());
+            when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(getProject());
             Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user),
                     eq(getProject()));
             when(taskDefinitionMapper.queryByCode(TASK_CODE)).thenReturn(taskDefinition);
@@ -361,8 +366,8 @@ public class TaskDefinitionServiceImplTest {
 
             when(workflowTaskRelationMapper.queryUpstreamByCode(PROJECT_CODE, TASK_CODE))
                     .thenReturn(getProcessTaskRelationListV2());
-            when(workflowDefinitionMapper.queryByCode(PROCESS_DEFINITION_CODE))
-                    .thenReturn(getProcessDefinition());
+            when(workflowDefinitionDao.queryByCode(PROCESS_DEFINITION_CODE))
+                    .thenReturn(Optional.of(getProcessDefinition()));
             when(workflowTaskRelationMapper.batchInsert(Mockito.anyList())).thenReturn(1);
             when(workflowTaskRelationMapper.updateById(Mockito.any())).thenReturn(1);
             when(workflowTaskRelationLogDao.batchInsert(Mockito.anyList())).thenReturn(2);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskGroupServiceTest.java
@@ -31,8 +31,8 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +63,7 @@ public class TaskGroupServiceTest {
     private TaskGroupMapper taskGroupMapper;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     private String taskGroupName = "TaskGroupServiceTest";
 
@@ -140,7 +140,7 @@ public class TaskGroupServiceTest {
                 loginUser.getId(), ApiFuncIdentificationConstant.TASK_GROUP_CREATE, serviceLogger)).thenReturn(true);
         Mockito.when(taskGroupMapper.insert(Mockito.any(TaskGroup.class))).thenReturn(1);
         Mockito.when(taskGroupMapper.queryByName(loginUser.getId(), taskGroupName)).thenReturn(null);
-        Mockito.when(projectMapper.queryByCode(taskGroup.getProjectCode())).thenReturn(getProject());
+        Mockito.when(projectDao.queryByCode(taskGroup.getProjectCode())).thenReturn(getProject());
         TaskGroup created = taskGroupService.createTaskGroup(loginUser, 0L, taskGroupName, taskGroupDesc, 100);
         Assertions.assertNotNull(created);
         Assertions.assertEquals(taskGroupName, created.getName());
@@ -187,7 +187,7 @@ public class TaskGroupServiceTest {
                 0, serviceLogger)).thenReturn(true);
         Mockito.when(taskGroupMapper.selectById(1)).thenReturn(taskGroup);
         Mockito.when(taskGroupMapper.updateById(taskGroup)).thenReturn(1);
-        Mockito.when(projectMapper.queryByCode(taskGroup.getProjectCode())).thenReturn(getProject());
+        Mockito.when(projectDao.queryByCode(taskGroup.getProjectCode())).thenReturn(getProject());
         TaskGroup updated = taskGroupService.updateTaskGroup(loginUser, 1, "newName", "desc", 100);
         Assertions.assertNotNull(updated);
         Assertions.assertEquals("newName", updated.getName());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskInstanceServiceTest.java
@@ -40,8 +40,8 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
@@ -75,7 +75,7 @@ public class TaskInstanceServiceTest {
     private TaskInstanceServiceImpl taskInstanceService;
 
     @Mock
-    ProjectMapper projectMapper;
+    ProjectDao projectDao;
 
     @Mock
     ProjectServiceImpl projectService;
@@ -124,7 +124,7 @@ public class TaskInstanceServiceTest {
                 20));
 
         // data parameter check
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, projectCode, TASK_INSTANCE);
         Assertions.assertThrows(ServiceException.class, () -> taskInstanceService.queryTaskListPaging(loginUser,
                 projectCode,

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -41,10 +41,10 @@ import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,7 +95,7 @@ public class UsersServiceTest {
     private K8sNamespaceUserMapper k8sNamespaceUserMapper;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -348,12 +348,12 @@ public class UsersServiceTest {
                 () -> usersService.deleteUserById(loginUser, 3));
 
         // user is project owner
-        Mockito.when(projectMapper.queryProjectCreatedByUser(1)).thenReturn(Lists.newArrayList(new Project()));
+        Mockito.when(projectDao.queryProjectCreatedByUser(1)).thenReturn(Lists.newArrayList(new Project()));
         assertThrowsServiceException(Status.TRANSFORM_PROJECT_OWNERSHIP,
                 () -> usersService.deleteUserById(loginUser, 1));
 
         // success
-        Mockito.when(projectMapper.queryProjectCreatedByUser(1)).thenReturn(null);
+        Mockito.when(projectDao.queryProjectCreatedByUser(1)).thenReturn(null);
         assertDoesNotThrow(() -> usersService.deleteUserById(loginUser, 1));
     }
 
@@ -415,7 +415,7 @@ public class UsersServiceTest {
         final int authorizer = 100;
         Mockito.when(this.userMapper.selectById(authorizer)).thenReturn(this.getUser());
         Mockito.when(this.userMapper.selectById(projectCreator)).thenReturn(this.getUser());
-        Mockito.when(this.projectMapper.queryByCode(projectCode)).thenReturn(this.getProject());
+        Mockito.when(this.projectDao.queryByCode(projectCode)).thenReturn(this.getProject());
 
         // ERROR: USER_NOT_EXIST
         User loginUser = new User();
@@ -463,7 +463,7 @@ public class UsersServiceTest {
         // success
         Project project = new Project();
         project.setId(0);
-        Mockito.when(this.projectMapper.queryByCode(Mockito.anyLong())).thenReturn(project);
+        Mockito.when(this.projectDao.queryByCode(Mockito.anyLong())).thenReturn(project);
         assertDoesNotThrow(() -> usersService.revokeProject(loginUser, 1, projectCode));
     }
 
@@ -484,7 +484,7 @@ public class UsersServiceTest {
                 () -> usersService.revokeProjectById(loginUser, 2, projectId));
 
         // success
-        Mockito.when(this.projectMapper.queryByCode(Mockito.anyLong())).thenReturn(new Project());
+        Mockito.when(this.projectDao.queryByCode(Mockito.anyLong())).thenReturn(new Project());
         assertDoesNotThrow(() -> usersService.revokeProjectById(loginUser, 1, projectId));
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -60,17 +60,16 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.UserWithWorkflowDefinitionCode;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
@@ -142,9 +141,6 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     private WorkflowDefinitionServiceImpl workflowDefinitionService;
 
     @Mock
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
-
-    @Mock
     private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
@@ -160,7 +156,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     private WorkflowTaskRelationLogMapper workflowTaskRelationLogMapper;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private ProjectServiceImpl projectService;
@@ -289,10 +285,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         List<TaskDefinitionLog> taskDefinitionLogs = JSONUtils.toList(taskDefinitionLogJson, TaskDefinitionLog.class);
 
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
-        when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         when(workflowTaskRelationMapper.queryByWorkflowDefinitionCode(Long.parseLong(codes)))
                 .thenReturn(workflowTaskRelations);
         when(taskDefinitionLogDao.queryTaskDefineLogList(workflowTaskRelations)).thenReturn(taskDefinitionLogs);
@@ -305,7 +301,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testQueryWorkflowDefinitionList() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
 
         // project not found
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
@@ -319,7 +315,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         List<WorkflowDefinition> resourceList = new ArrayList<>();
         resourceList.add(getWorkflowDefinition());
-        when(workflowDefinitionMapper.queryAllDefinitionList(project.getCode())).thenReturn(resourceList);
+        when(workflowDefinitionDao.queryAllDefinitionList(project.getCode())).thenReturn(resourceList);
         List<DagData> dagDataList = workflowDefinitionService.queryWorkflowDefinitionList(user, projectCode);
         Assertions.assertNotNull(dagDataList);
     }
@@ -397,7 +393,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testQueryWorkflowDefinitionByCode() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
 
         // project check auth fail
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
@@ -417,7 +413,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFound.getCode());
 
         // instance exit
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(getWorkflowDefinition());
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(getWorkflowDefinition()));
         DagData successRes = workflowDefinitionService.queryWorkflowDefinitionByCode(user, projectCode, 46L);
         Assertions.assertNotNull(successRes);
     }
@@ -425,7 +421,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testQueryWorkflowDefinitionByName() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
 
         // project check auth fail
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
@@ -437,14 +433,14 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         // project check auth success, instance not exist
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
-        when(workflowDefinitionMapper.queryByDefineName(project.getCode(), "test_def")).thenReturn(null);
+        when(workflowDefinitionDao.queryByDefineName(project.getCode(), "test_def")).thenReturn(null);
 
         ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test_def"));
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // instance exit
-        when(workflowDefinitionMapper.queryByDefineName(project.getCode(), "test"))
+        when(workflowDefinitionDao.queryByDefineName(project.getCode(), "test"))
                 .thenReturn(getWorkflowDefinition());
         when(processService.genDagData(any())).thenReturn(new DagData(getWorkflowDefinition(), null, null));
         DagData successRes = workflowDefinitionService.queryWorkflowDefinitionByName(user, projectCode, "test");
@@ -455,7 +451,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     public void testBatchCopyWorkflowDefinition() {
         Project project = getProject(projectCode);
 
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
 
@@ -476,7 +472,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_BATCH_COPY);
         Project project1 = getProject(projectCodeOther);
-        when(projectMapper.queryByCode(projectCodeOther)).thenReturn(project1);
+        when(projectDao.queryByCode(projectCodeOther)).thenReturn(project1);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project1, WORKFLOW_BATCH_COPY);
 
@@ -493,7 +489,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 Assertions.fail();
             }
         }
-        when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         when(processService.saveWorkflowDefine(user, definition, Boolean.TRUE, Boolean.TRUE)).thenReturn(2);
         Assertions.assertDoesNotThrow(() -> workflowDefinitionService.batchCopyWorkflowDefinition(
                 user, projectCodeOther, String.valueOf(processDefinitionCode), projectCode));
@@ -502,10 +498,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testBatchMoveWorkflowDefinition() {
         Project project1 = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project1);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project1);
 
         Project project2 = getProject(projectCodeOther);
-        when(projectMapper.queryByCode(projectCodeOther)).thenReturn(project2);
+        when(projectDao.queryByCode(projectCodeOther)).thenReturn(project2);
 
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project1, TASK_DEFINITION_MOVE);
@@ -526,7 +522,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 Assertions.fail();
             }
         }
-        when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         when(processService.saveWorkflowDefine(user, definition, Boolean.TRUE, Boolean.TRUE)).thenReturn(2);
         when(workflowTaskRelationMapper.queryByWorkflowDefinitionCode(processDefinitionCode))
                 .thenReturn(getProcessTaskRelation());
@@ -537,7 +533,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void deleteWorkflowDefinitionByCodeTest() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
 
         Project project = getProject(projectCode);
 
@@ -624,7 +620,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Test
     public void batchDeleteWorkflowDefinitionByCodeTest() {
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
 
         Project project = getProject(projectCode);
 
@@ -635,7 +631,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         WorkflowDefinition process = getWorkflowDefinition();
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(process);
-        when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         Throwable exception = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.batchDeleteWorkflowDefinitionByCodes(user, projectCode, twoCodes));
         String formatter = MessageFormat.format(Status.BATCH_DELETE_WORKFLOW_DEFINE_BY_CODES_ERROR.getMsg(),
@@ -647,7 +643,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         final String singleCodes = "11";
         definitionCodes = Lists.newArrayList(singleCodes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
-        when(workflowDefinitionMapper.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryByCodes(definitionCodes)).thenReturn(workflowDefinitionList);
         when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(process));
 
         // process definition online
@@ -674,7 +670,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testVerifyWorkflowDefinitionName() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
 
         // project check auth fail
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
@@ -686,12 +682,12 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         // project check auth success, process not exist
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_CREATE);
-        when(workflowDefinitionMapper.verifyByDefineName(project.getCode(), "test_pdf")).thenReturn(null);
+        when(workflowDefinitionDao.verifyByDefineName(project.getCode(), "test_pdf")).thenReturn(null);
         Assertions.assertDoesNotThrow(
                 () -> workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0));
 
         // process exist
-        when(workflowDefinitionMapper.verifyByDefineName(project.getCode(), "test_pdf"))
+        when(workflowDefinitionDao.verifyByDefineName(project.getCode(), "test_pdf"))
                 .thenReturn(getWorkflowDefinition());
         ServiceException existsEx = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.verifyWorkflowDefinitionName(user, projectCode, "test_pdf", 0));
@@ -714,11 +710,11 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testGetTaskNodeListByDefinitionCode() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, project, null);
 
         // process definition not exist
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(null);
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.empty());
         ServiceException notFoundEx = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, 46L));
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFoundEx.getCode());
@@ -727,7 +723,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         when(processService.genDagData(any()))
                 .thenReturn(new DagData(workflowDefinition, null, Collections.emptyList()));
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
         Assertions.assertNotNull(
                 workflowDefinitionService.getTaskNodeListByDefinitionCode(user, projectCode, 46L));
     }
@@ -735,14 +731,14 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testGetTaskNodeListByDefinitionCodes() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, project, null);
 
         // process definition not exist
         String defineCodes = "46";
         Set<Long> defineCodeSet = Lists.newArrayList(defineCodes.split(Constants.COMMA)).stream().map(Long::parseLong)
                 .collect(Collectors.toSet());
-        when(workflowDefinitionMapper.queryByCodes(defineCodeSet)).thenReturn(null);
+        when(workflowDefinitionDao.queryByCodes(defineCodeSet)).thenReturn(null);
         ServiceException notExistEx = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes));
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notExistEx.getCode());
@@ -751,12 +747,12 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(workflowDefinition);
 
-        when(workflowDefinitionMapper.queryByCodes(defineCodeSet)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryByCodes(defineCodeSet)).thenReturn(workflowDefinitionList);
         when(processService.genDagData(any())).thenReturn(new DagData(workflowDefinition, null, null));
         Project project1 = getProject(projectCode);
         List<Project> projects = new ArrayList<>();
         projects.add(project1);
-        when(projectMapper.queryProjectCreatedAndAuthorizedByUserId(user.getId())).thenReturn(projects);
+        when(projectDao.queryProjectCreatedAndAuthorizedByUserId(user.getId())).thenReturn(projects);
 
         Assertions.assertNotNull(
                 workflowDefinitionService.getNodeListMapByDefinitionCodes(user, projectCode, defineCodes));
@@ -765,13 +761,13 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testQueryAllWorkflowDefinitionByProjectCode() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project, WORKFLOW_DEFINITION);
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         List<WorkflowDefinition> workflowDefinitionList = new ArrayList<>();
         workflowDefinitionList.add(workflowDefinition);
-        when(workflowDefinitionMapper.queryAllDefinitionList(projectCode)).thenReturn(workflowDefinitionList);
+        when(workflowDefinitionDao.queryAllDefinitionList(projectCode)).thenReturn(workflowDefinitionList);
         Assertions.assertNotNull(
                 workflowDefinitionService.queryAllWorkflowDefinitionByProjectCode(user, projectCode));
     }
@@ -779,7 +775,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testViewTree() {
         Project project1 = getProject(projectCode);
-        when(projectMapper.queryByCode(1)).thenReturn(project1);
+        when(projectDao.queryByCode(1L)).thenReturn(project1);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project1, WORKFLOW_TREE_VIEW);
         // process definition not exist
@@ -789,7 +785,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(), notFoundEx.getCode());
 
         // task instance not existproject
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
         when(processService.genDagGraph(workflowDefinition)).thenReturn(new DAG<>());
         Assertions.assertNotNull(
                 workflowDefinitionService.viewTree(user, workflowDefinition.getProjectCode(), 46, 10));
@@ -802,10 +798,10 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testSubProcessViewTree() {
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
 
         Project project1 = getProject(1);
-        when(projectMapper.queryByCode(1)).thenReturn(project1);
+        when(projectDao.queryByCode(1L)).thenReturn(project1);
         Mockito.doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(user, project1, WORKFLOW_TREE_VIEW);
         when(processService.genDagGraph(workflowDefinition)).thenReturn(new DAG<>());
@@ -816,7 +812,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testUpdateWorkflowDefinition() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(getProject(projectCode));
+        when(projectDao.queryByCode(projectCode)).thenReturn(getProject(projectCode));
         Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(user, project);
 
         try {
@@ -831,9 +827,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testCreateWorkflowDefinitionShouldSyncVersionToResponse() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
-        when(workflowDefinitionMapper.verifyByDefineName(projectCode, name)).thenReturn(null);
+        when(workflowDefinitionDao.verifyByDefineName(projectCode, name)).thenReturn(null);
         when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
         when(processService.saveTaskDefine(eq(user), eq(projectCode), anyList(), eq(Boolean.TRUE))).thenReturn(1);
         when(processService.saveWorkflowDefine(any(User.class), any(WorkflowDefinition.class), eq(Boolean.TRUE),
@@ -854,11 +850,11 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         Project project = getProject(projectCode);
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         workflowDefinition.setName("origin-name");
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
         when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
-        when(workflowDefinitionMapper.queryByCode(processDefinitionCode)).thenReturn(workflowDefinition);
-        when(workflowDefinitionMapper.verifyByDefineName(projectCode, name)).thenReturn(null);
+        when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(workflowDefinition));
+        when(workflowDefinitionDao.verifyByDefineName(projectCode, name)).thenReturn(null);
         when(processService.saveTaskDefine(eq(user), eq(projectCode), anyList(), eq(Boolean.TRUE))).thenReturn(1);
         when(processService.saveWorkflowDefine(any(User.class), any(WorkflowDefinition.class), eq(Boolean.TRUE),
                 eq(Boolean.TRUE))).thenReturn(2);
@@ -891,7 +887,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     @Test
     public void testViewVariables() {
         Project project = getProject(projectCode);
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
 
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -57,15 +57,15 @@ import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceContextDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceMapDao;
 import org.apache.dolphinscheduler.extract.master.command.RunWorkflowCommandParam;
@@ -108,7 +108,7 @@ public class WorkflowInstanceServiceTest {
     WorkflowInstanceServiceImpl workflowInstanceService;
 
     @Mock
-    ProjectMapper projectMapper;
+    ProjectDao projectDao;
 
     @Mock
     ProjectServiceImpl projectService;
@@ -129,7 +129,7 @@ public class WorkflowInstanceServiceTest {
     WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
 
     @Mock
-    WorkflowDefinitionMapper workflowDefinitionMapper;
+    WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     WorkflowDefinitionService workflowDefinitionService;
@@ -225,11 +225,11 @@ public class WorkflowInstanceServiceTest {
         pageReturn.setRecords(workflowInstanceList);
 
         // data parameter check
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(Mockito.any(),
                 Mockito.any(Project.class),
                 Mockito.any());
-        when(workflowDefinitionMapper.selectById(Mockito.anyInt())).thenReturn(getProcessDefinition());
+        when(workflowDefinitionDao.queryById(Mockito.any())).thenReturn(getProcessDefinition());
         when(workflowInstanceMapper.queryWorkflowInstanceListPaging(Mockito.any(Page.class), Mockito.any(),
                 Mockito.any(),
                 Mockito.any(), Mockito.any(), Mockito.any(),
@@ -309,7 +309,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
         assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
@@ -337,7 +337,7 @@ public class WorkflowInstanceServiceTest {
         String endTime = "2020-08-02 00:00:00";
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
         assertThrowsServiceException(Status.PROJECT_NOT_FOUND, () -> workflowInstanceService
@@ -367,7 +367,7 @@ public class WorkflowInstanceServiceTest {
         String startTime = "2020-01-01 00:00:00";
         String endTime = "2020-08-02 00:00:00";
 
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, project,
                 WORKFLOW_INSTANCE);
 
@@ -391,7 +391,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
         assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
@@ -432,7 +432,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
         assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
@@ -484,7 +484,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
         assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
@@ -540,7 +540,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         doThrow(new ServiceException(Status.PROJECT_NOT_FOUND, projectCode))
                 .when(projectService)
                 .checkProjectAndAuthThrowException(loginUser, projectCode, INSTANCE_UPDATE);
@@ -550,7 +550,7 @@ public class WorkflowInstanceServiceTest {
 
         // process instance null
         WorkflowInstance workflowInstance = getProcessInstance();
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         doNothing()
                 .when(projectService)
                 .checkProjectAndAuthThrowException(loginUser, projectCode, INSTANCE_UPDATE);
@@ -577,7 +577,7 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setUserId(1);
         workflowDefinition.setProjectCode(projectCode);
         Tenant tenant = getTenant();
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
         when(tenantMapper.queryByTenantCode("root")).thenReturn(tenant);
         when(processService.getTenantForWorkflow(Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn(tenant.getTenantCode());
@@ -615,7 +615,7 @@ public class WorkflowInstanceServiceTest {
             Assertions.assertNotNull(processInstanceFinishRes2);
 
             // success
-            when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
+            when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
 
             when(processService.saveWorkflowDefine(loginUser, workflowDefinition, Boolean.FALSE, Boolean.FALSE))
                     .thenReturn(1);
@@ -632,7 +632,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // project auth fail
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         Mockito.doThrow(new ServiceException(Status.PROJECT_NOT_FOUND))
                 .when(projectService).checkProjectAndAuthThrowException(loginUser, project, WORKFLOW_INSTANCE);
         assertThrowsServiceException(Status.PROJECT_NOT_FOUND,
@@ -671,7 +671,7 @@ public class WorkflowInstanceServiceTest {
         Project project = getProject(projectCode);
 
         // workflow instance not exist
-        when(projectMapper.queryByCode(projectCode)).thenReturn(project);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
         assertThrows(ServiceException.class,
                 () -> workflowInstanceService.deleteWorkflowInstanceById(loginUser, 1));
 
@@ -695,7 +695,7 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setId(1);
         workflowDefinition.setUserId(1);
         workflowDefinition.setProjectCode(0L);
-        when(workflowDefinitionMapper.queryByCode(46L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
         when(processService.findWorkflowInstanceDetailById(Mockito.anyInt())).thenReturn(Optional.empty());
         assertThrows(ServiceException.class,
                 () -> workflowInstanceService.deleteWorkflowInstanceById(loginUser, 1));
@@ -763,7 +763,7 @@ public class WorkflowInstanceServiceTest {
         WorkflowDefinition workflowDefinition = new WorkflowDefinition();
         workflowDefinition.setCode(100L);
         workflowDefinition.setProjectCode(1L);
-        when(workflowDefinitionMapper.queryByCode(100L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(100L)).thenReturn(Optional.of(workflowDefinition));
 
         WorkflowInstanceVariablesDTO result = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
 
@@ -818,7 +818,7 @@ public class WorkflowInstanceServiceTest {
         WorkflowDefinition workflowDefinition = new WorkflowDefinition();
         workflowDefinition.setCode(101L);
         workflowDefinition.setProjectCode(1L);
-        when(workflowDefinitionMapper.queryByCode(101L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(101L)).thenReturn(Optional.of(workflowDefinition));
 
         WorkflowInstanceVariablesDTO result = workflowInstanceService.viewVariables(loginUser, projectCode, 2);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowTaskLineageServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowTaskLineageServiceTest.java
@@ -32,9 +32,9 @@ import org.apache.dolphinscheduler.dao.entity.WorkFlowRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkFlowRelationDetail;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskLineage;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowTaskLineageDao;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -61,13 +61,13 @@ public class WorkflowTaskLineageServiceTest {
     private WorkflowTaskLineageDao workflowTaskLineageDao;
 
     @Mock
-    private ProjectMapper projectMapper;
+    private ProjectDao projectDao;
 
     @Mock
     private TaskDefinitionMapper taskDefinitionMapper;
 
     @Mock
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     /**
      * get mock Project
@@ -88,7 +88,7 @@ public class WorkflowTaskLineageServiceTest {
     public void testQueryWorkFlowLineageByName() {
         Project project = getProject("test");
         String name = "test";
-        when(projectMapper.queryByCode(1L)).thenReturn(project);
+        when(projectDao.queryByCode(1L)).thenReturn(project);
         when(workflowTaskLineageDao.queryWorkFlowLineageByName(Mockito.anyLong(), Mockito.any()))
                 .thenReturn(getWorkFlowLineages());
         List<WorkFlowRelationDetail> workFlowLineages = workflowLineageService.queryWorkFlowLineageByName(1L, name);
@@ -116,7 +116,7 @@ public class WorkflowTaskLineageServiceTest {
         workFlowRelationDetail.setWorkFlowName("testProcessDefinitionName");
         workFlowRelationDetailList.add(workFlowRelationDetail);
 
-        when(projectMapper.queryByCode(1L)).thenReturn(project);
+        when(projectDao.queryByCode(1L)).thenReturn(project);
         when(workflowTaskLineageDao.queryByProjectCode(project.getCode())).thenReturn(workflowTaskLineages);
         when(workflowTaskLineageDao.queryWorkFlowLineageByCode(workflowTaskLineage.getWorkflowDefinitionCode()))
                 .thenReturn(workFlowRelationDetailList);
@@ -161,7 +161,7 @@ public class WorkflowTaskLineageServiceTest {
 
         when(workflowTaskLineageDao.queryWorkFlowLineageByDept(projectCode, workflowDefinitionCode, taskCode))
                 .thenReturn(dependentWorkflowList);
-        when(workflowDefinitionMapper.queryByCode(50L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(50L)).thenReturn(Optional.of(workflowDefinition));
         when(taskDefinitionMapper.queryByCode(999L)).thenReturn(null); // Task definition not found (dirty data)
 
         // Should return Optional.empty() because all records are orphaned
@@ -207,8 +207,8 @@ public class WorkflowTaskLineageServiceTest {
 
         when(workflowTaskLineageDao.queryWorkFlowLineageByDept(projectCode, workflowDefinitionCode, taskCode))
                 .thenReturn(dependentWorkflowList);
-        when(workflowDefinitionMapper.queryByCode(50L)).thenReturn(workflowDefinition1);
-        when(workflowDefinitionMapper.queryByCode(60L)).thenReturn(workflowDefinition2);
+        when(workflowDefinitionDao.queryByCode(50L)).thenReturn(Optional.of(workflowDefinition1));
+        when(workflowDefinitionDao.queryByCode(60L)).thenReturn(Optional.of(workflowDefinition2));
         when(taskDefinitionMapper.queryByCode(300L)).thenReturn(validTaskDefinition);
         when(taskDefinitionMapper.queryByCode(999L)).thenReturn(null); // Orphaned record
 
@@ -248,7 +248,7 @@ public class WorkflowTaskLineageServiceTest {
 
         when(workflowTaskLineageDao.queryWorkFlowLineageByDept(projectCode, workflowDefinitionCode, 0L))
                 .thenReturn(dependentWorkflowList);
-        when(workflowDefinitionMapper.queryByCode(50L)).thenReturn(workflowDefinition);
+        when(workflowDefinitionDao.queryByCode(50L)).thenReturn(Optional.of(workflowDefinition));
         when(taskDefinitionMapper.queryByCode(999L)).thenReturn(null); // Task definition not found
 
         // Should return Optional.empty() because all records are orphaned

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/WorkflowLineageServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/WorkflowLineageServiceImplTest.java
@@ -29,7 +29,7 @@ import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskLineage;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowTaskLineageDao;
 
 import java.util.Arrays;
@@ -54,7 +54,7 @@ class WorkflowLineageServiceImplTest {
     private WorkflowTaskLineageDao workflowTaskLineageDao;
 
     @Mock
-    private WorkflowDefinitionMapper workflowDefinitionMapper;
+    private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
     private TaskDefinitionMapper taskDefinitionMapper;
@@ -62,7 +62,7 @@ class WorkflowLineageServiceImplTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(workflowLineageService, "workflowTaskLineageDao", workflowTaskLineageDao);
-        ReflectionTestUtils.setField(workflowLineageService, "workflowDefinitionMapper", workflowDefinitionMapper);
+        ReflectionTestUtils.setField(workflowLineageService, "workflowDefinitionDao", workflowDefinitionDao);
         ReflectionTestUtils.setField(workflowLineageService, "taskDefinitionMapper", taskDefinitionMapper);
     }
 
@@ -77,7 +77,7 @@ class WorkflowLineageServiceImplTest {
                 workflowLineageService.queryDownstreamDependentWorkflowDefinitions(workflowCode);
 
         assertThat(result).isEmpty();
-        verifyNoInteractions(workflowDefinitionMapper, taskDefinitionMapper);
+        verifyNoInteractions(workflowDefinitionDao, taskDefinitionMapper);
     }
 
     @Test
@@ -108,7 +108,7 @@ class WorkflowLineageServiceImplTest {
         workflowDefinition201.setCode(201L);
         workflowDefinition201.setVersion(4);
 
-        when(workflowDefinitionMapper.queryByCodes(Arrays.asList(200L, 201L)))
+        when(workflowDefinitionDao.queryByCodes(Arrays.asList(200L, 201L)))
                 .thenReturn(Arrays.asList(workflowDefinition200, workflowDefinition201));
 
         TaskDefinition taskDefinition = new TaskDefinition();
@@ -158,7 +158,7 @@ class WorkflowLineageServiceImplTest {
         when(workflowTaskLineageDao
                 .queryWorkFlowLineageByDept(Constants.DEFAULT_PROJECT_CODE, root, Constants.DEPENDENT_ALL_TASK))
                         .thenReturn(Collections.singletonList(edge));
-        when(workflowDefinitionMapper.queryByCodes(Collections.singletonList(child)))
+        when(workflowDefinitionDao.queryByCodes(Collections.singletonList(child)))
                 .thenReturn(Collections.singletonList(WorkflowDefinition.builder().code(child).version(1).build()));
 
         List<WorkflowDefinition> result =
@@ -195,9 +195,9 @@ class WorkflowLineageServiceImplTest {
 
         WorkflowDefinition workflowB = WorkflowDefinition.builder().code(codeB).version(1).build();
         WorkflowDefinition workflowC = WorkflowDefinition.builder().code(codeC).version(1).build();
-        when(workflowDefinitionMapper.queryByCodes(Collections.singletonList(codeB)))
+        when(workflowDefinitionDao.queryByCodes(Collections.singletonList(codeB)))
                 .thenReturn(Collections.singletonList(workflowB));
-        when(workflowDefinitionMapper.queryByCodes(Collections.singletonList(codeC)))
+        when(workflowDefinitionDao.queryByCodes(Collections.singletonList(codeC)))
                 .thenReturn(Collections.singletonList(workflowC));
 
         List<WorkflowDefinition> result =
@@ -223,7 +223,7 @@ class WorkflowLineageServiceImplTest {
         WorkflowDefinition workflowB = new WorkflowDefinition();
         workflowB.setCode(codeB);
         workflowB.setReleaseState(ReleaseState.OFFLINE);
-        when(workflowDefinitionMapper.queryByCodes(Collections.singletonList(codeB)))
+        when(workflowDefinitionDao.queryByCodes(Collections.singletonList(codeB)))
                 .thenReturn(Collections.singletonList(workflowB));
 
         List<WorkflowDefinition> result =

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ProjectDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ProjectDao.java
@@ -23,11 +23,35 @@ import org.apache.dolphinscheduler.dao.entity.ProjectUser;
 import java.util.Collection;
 import java.util.List;
 
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
 public interface ProjectDao extends IDao<Project> {
 
     List<Project> queryByCodes(Collection<Long> projectCodes);
 
     Project queryByCode(Long projectCode);
 
+    Project queryDetailById(int projectId);
+
+    Project queryByName(String projectName);
+
+    IPage<Project> queryProjectListPaging(IPage<Project> page,
+                                          List<Integer> projectsIds,
+                                          String searchName);
+
+    List<Project> queryProjectCreatedByUser(int userId);
+
+    List<Project> queryAuthedProjectListByUserId(int userId);
+
+    List<Project> queryProjectCreatedAndAuthorizedByUserId(int userId);
+
     ProjectUser queryProjectWithUserByWorkflowInstanceId(int workflowInstanceId);
+
+    List<Project> queryAllProject(int userId);
+
+    List<Project> listAuthorizedProjects(int userId, List<Integer> projectsIds);
+
+    List<Project> queryAllProjectForDependent();
+
+    Project queryProjectByTaskInstanceId(int taskInstanceId);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/WorkflowDefinitionDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/WorkflowDefinitionDao.java
@@ -17,8 +17,11 @@
 
 package org.apache.dolphinscheduler.dao.repository;
 
+import org.apache.dolphinscheduler.dao.entity.DependentSimplifyDefinition;
+import org.apache.dolphinscheduler.dao.entity.ProjectWorkflowDefinitionCount;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
+import org.apache.dolphinscheduler.dao.model.WorkflowDefinitionCountDto;
 
 import java.util.Collection;
 import java.util.List;
@@ -46,4 +49,19 @@ public interface WorkflowDefinitionDao extends IDao<WorkflowDefinition> {
     void deleteByWorkflowDefinitionCode(long workflowDefinitionCode);
 
     List<WorkflowDefinition> queryByCodes(Collection<Long> workflowDefinitionCodes);
+
+    WorkflowDefinition queryByDefineName(long projectCode, String workflowDefinitionName);
+
+    WorkflowDefinition verifyByDefineName(long projectCode, String workflowDefinitionName);
+
+    List<WorkflowDefinition> queryAllDefinitionList(long projectCode);
+
+    List<DependentSimplifyDefinition> queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(long projectCode,
+                                                                                                 Collection<Long> codes);
+
+    List<WorkflowDefinitionCountDto> countDefinitionByProjectCodes(Collection<Long> projectCodes);
+
+    List<Long> queryDefinitionCodeListByProjectCodes(List<Long> projectCodes);
+
+    List<ProjectWorkflowDefinitionCount> queryProjectWorkflowDefinitionCountByProjectCodes(List<Long> projectCodes);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ProjectDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ProjectDaoImpl.java
@@ -30,6 +30,8 @@ import lombok.NonNull;
 
 import org.springframework.stereotype.Repository;
 
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
 @Repository
 public class ProjectDaoImpl extends BaseDao<Project, ProjectMapper> implements ProjectDao {
 
@@ -48,7 +50,59 @@ public class ProjectDaoImpl extends BaseDao<Project, ProjectMapper> implements P
     }
 
     @Override
+    public Project queryDetailById(int projectId) {
+        return mybatisMapper.queryDetailById(projectId);
+    }
+
+    @Override
+    public Project queryByName(String projectName) {
+        return mybatisMapper.queryByName(projectName);
+    }
+
+    @Override
+    public IPage<Project> queryProjectListPaging(IPage<Project> page,
+                                                 List<Integer> projectsIds,
+                                                 String searchName) {
+        return mybatisMapper.queryProjectListPaging(page, projectsIds, searchName);
+    }
+
+    @Override
+    public List<Project> queryProjectCreatedByUser(int userId) {
+        return mybatisMapper.queryProjectCreatedByUser(userId);
+    }
+
+    @Override
+    public List<Project> queryAuthedProjectListByUserId(int userId) {
+        return mybatisMapper.queryAuthedProjectListByUserId(userId);
+    }
+
+    @Override
+    public List<Project> queryProjectCreatedAndAuthorizedByUserId(int userId) {
+        return mybatisMapper.queryProjectCreatedAndAuthorizedByUserId(userId);
+    }
+
+    @Override
     public ProjectUser queryProjectWithUserByWorkflowInstanceId(int workflowInstanceId) {
         return mybatisMapper.queryProjectWithUserByWorkflowInstanceId(workflowInstanceId);
+    }
+
+    @Override
+    public List<Project> queryAllProject(int userId) {
+        return mybatisMapper.queryAllProject(userId);
+    }
+
+    @Override
+    public List<Project> listAuthorizedProjects(int userId, List<Integer> projectsIds) {
+        return mybatisMapper.listAuthorizedProjects(userId, projectsIds);
+    }
+
+    @Override
+    public List<Project> queryAllProjectForDependent() {
+        return mybatisMapper.queryAllProjectForDependent();
+    }
+
+    @Override
+    public Project queryProjectByTaskInstanceId(int taskInstanceId) {
+        return mybatisMapper.queryProjectByTaskInstanceId(taskInstanceId);
     }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowDefinitionDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowDefinitionDaoImpl.java
@@ -17,9 +17,12 @@
 
 package org.apache.dolphinscheduler.dao.repository.impl;
 
+import org.apache.dolphinscheduler.dao.entity.DependentSimplifyDefinition;
+import org.apache.dolphinscheduler.dao.entity.ProjectWorkflowDefinitionCount;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
+import org.apache.dolphinscheduler.dao.model.WorkflowDefinitionCountDto;
 import org.apache.dolphinscheduler.dao.repository.BaseDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
@@ -78,5 +81,41 @@ public class WorkflowDefinitionDaoImpl extends BaseDao<WorkflowDefinition, Workf
             return Collections.emptyList();
         }
         return mybatisMapper.queryByCodes(workflowDefinitionCodes);
+    }
+
+    @Override
+    public WorkflowDefinition queryByDefineName(long projectCode, String workflowDefinitionName) {
+        return mybatisMapper.queryByDefineName(projectCode, workflowDefinitionName);
+    }
+
+    @Override
+    public WorkflowDefinition verifyByDefineName(long projectCode, String workflowDefinitionName) {
+        return mybatisMapper.verifyByDefineName(projectCode, workflowDefinitionName);
+    }
+
+    @Override
+    public List<WorkflowDefinition> queryAllDefinitionList(long projectCode) {
+        return mybatisMapper.queryAllDefinitionList(projectCode);
+    }
+
+    @Override
+    public List<DependentSimplifyDefinition> queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(long projectCode,
+                                                                                                        Collection<Long> codes) {
+        return mybatisMapper.queryDefinitionListByProjectCodeAndWorkflowDefinitionCodes(projectCode, codes);
+    }
+
+    @Override
+    public List<WorkflowDefinitionCountDto> countDefinitionByProjectCodes(Collection<Long> projectCodes) {
+        return mybatisMapper.countDefinitionByProjectCodes(projectCodes);
+    }
+
+    @Override
+    public List<Long> queryDefinitionCodeListByProjectCodes(List<Long> projectCodes) {
+        return mybatisMapper.queryDefinitionCodeListByProjectCodes(projectCodes);
+    }
+
+    @Override
+    public List<ProjectWorkflowDefinitionCount> queryProjectWorkflowDefinitionCountByProjectCodes(List<Long> projectCodes) {
+        return mybatisMapper.queryProjectWorkflowDefinitionCountByProjectCodes(projectCodes);
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Tracking issue: #18249

Add the remaining query methods on ProjectDao and WorkflowDefinitionDao, and replace every direct ProjectMapper / WorkflowDefinitionMapper reference in dolphinscheduler-api with the corresponding Dao, so Mapper usage stays inside dolphinscheduler-dao.repository as documented in dolphinscheduler-dao/CLAUDE.md.

Notes:
- WorkflowDefinitionDao#queryByCode returns Optional<WorkflowDefinition> (Mapper returned a bare nullable WorkflowDefinition), so affected ServiceImpl call sites use .orElse(null) for behavior-preserving substitution. Test classes were migrated to mock the Dao instead of the Mapper; queryByCode stubs are wrapped with Optional.of / Optional.empty.
- BaseDao#deleteById and BaseDao#updateById return boolean where the Mapper returned int; affected call sites in ProjectServiceImpl and ProjectServiceTest were adapted accordingly. selectBatchIds was replaced with the equivalent IDao#queryByIds.
- ProcessServiceImpl in dolphinscheduler-service still depends on WorkflowDefinitionMapper and is out of scope for this commit; TaskDefinitionServiceImplTest keeps both a Dao and a Mapper mock to serve the two @InjectMocks targets it exercises.

No production behavior changes; the Mapper interfaces themselves are untouched.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
