### PR TITLE
[Improvement-18249][DAO] Route ScheduleMapper access through ScheduleDao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/ScheduleAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/ScheduleAuditOperatorImpl.java
@@ -25,7 +25,7 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import java.util.List;
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Service;
 public class ScheduleAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private WorkflowDefinitionDao workflowDefinitionDao;
@@ -49,7 +49,7 @@ public class ScheduleAuditOperatorImpl extends BaseAuditOperator {
             return;
         }
         int id = (int) paramsMap.get(paramNameArr[0]);
-        Schedule schedule = scheduleMapper.selectById(id);
+        Schedule schedule = scheduleDao.queryById(id);
         if (schedule != null) {
             paramsMap.put(AuditLogConstants.CODE, schedule.getWorkflowDefinitionCode());
             paramNameArr[0] = AuditLogConstants.CODE;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -52,9 +52,9 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageEntity;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
@@ -129,7 +129,7 @@ public class PythonGateway {
     private SchedulerService schedulerService;
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private DataSourceMapper dataSourceMapper;
@@ -326,7 +326,7 @@ public class PythonGateway {
                                         String workerGroup,
                                         String warningType,
                                         int warningGroupId) {
-        Schedule scheduleObj = scheduleMapper.queryByWorkflowDefinitionCode(workflowCode);
+        Schedule scheduleObj = scheduleDao.queryByWorkflowDefinitionCode(workflowCode);
         // create or update schedule
         int scheduleId;
         if (scheduleObj == null) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectWorkerGroupRelationServiceImpl.java
@@ -26,9 +26,9 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectWorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectWorkerGroupDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 
@@ -66,7 +66,7 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
     private TaskDefinitionDao taskDefinitionDao;
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private ProjectService projectService;
@@ -218,7 +218,7 @@ public class ProjectWorkerGroupRelationServiceImpl extends BaseServiceImpl
         });
 
         // query all worker groups that timings depend on
-        scheduleMapper.querySchedulerListByProjectName(project.getName())
+        scheduleDao.querySchedulerListByProjectName(project.getName())
                 .stream()
                 .filter(schedule -> StringUtils.isNotEmpty(schedule.getWorkerGroup()))
                 .forEach(schedule -> usedWorkerGroups.add(schedule.getWorkerGroup()));

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SchedulerServiceImpl.java
@@ -42,8 +42,8 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.scheduler.api.SchedulerApi;
 import org.apache.dolphinscheduler.service.cron.CronUtils;
@@ -83,7 +83,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
     private ExecutorService executorService;
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private ProjectDao projectDao;
@@ -137,7 +137,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
                 workflowDefinition.getVersion());
 
         Schedule scheduleExists =
-                scheduleMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
+                scheduleDao.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         if (scheduleExists != null) {
             log.error("Schedule already exist, scheduleId:{}, workflowDefinitionCode:{}", scheduleExists.getId(),
                     workflowDefinitionCode);
@@ -184,7 +184,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         scheduleObj.setWorkflowInstancePriority(workflowInstancePriority);
         scheduleObj.setWorkerGroup(workerGroup);
         scheduleObj.setEnvironmentCode(environmentCode);
-        scheduleMapper.insert(scheduleObj);
+        scheduleDao.insert(scheduleObj);
 
         /**
          * updateWorkflowInstance receivers and cc by workflow definition id
@@ -194,7 +194,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
 
         log.info("Schedule create complete, projectCode:{}, workflowDefinitionCode:{}, scheduleId:{}.",
                 projectCode, workflowDefinitionCode, scheduleObj.getId());
-        return scheduleMapper.selectById(scheduleObj.getId());
+        return scheduleDao.queryById(scheduleObj.getId());
     }
 
     protected void projectPermCheckByWorkflowCode(User loginUser, long workflowDefinitionCode) {
@@ -242,7 +242,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         // check schedule exists
-        Schedule schedule = scheduleMapper.selectById(id);
+        Schedule schedule = scheduleDao.queryById(id);
 
         if (schedule == null) {
             log.error("Schedule does not exist, scheduleId:{}.", id);
@@ -296,7 +296,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         Page<Schedule> page = new Page<>(pageNo, pageSize);
 
         IPage<Schedule> schedulePage =
-                scheduleMapper.queryByProjectAndWorkflowDefinitionCodePaging(page, projectCode, workflowDefinitionCode,
+                scheduleDao.queryByProjectAndWorkflowDefinitionCodePaging(page, projectCode, workflowDefinitionCode,
                         searchVal);
 
         List<ScheduleVO> scheduleList = new ArrayList<>();
@@ -316,7 +316,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         if (CollectionUtils.isEmpty(workflowDefinitionCodes)) {
             return Collections.emptyList();
         }
-        return scheduleMapper.querySchedulesByWorkflowDefinitionCodes(workflowDefinitionCodes);
+        return scheduleDao.querySchedulesByWorkflowDefinitionCodes(workflowDefinitionCodes);
     }
 
     /**
@@ -333,7 +333,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         // check project auth
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
-        List<Schedule> schedules = scheduleMapper.querySchedulerListByProjectName(project.getName());
+        List<Schedule> schedules = scheduleDao.querySchedulerListByProjectName(project.getName());
         List<ScheduleVO> scheduleList = new ArrayList<>();
         for (Schedule schedule : schedules) {
             scheduleList.add(new ScheduleVO(schedule));
@@ -349,7 +349,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
      */
     @Override
     public void deleteSchedulesById(User loginUser, Integer scheduleId) {
-        Schedule schedule = scheduleMapper.selectById(scheduleId);
+        Schedule schedule = scheduleDao.queryById(scheduleId);
         if (schedule == null) {
             throw new ServiceException(Status.SCHEDULE_NOT_EXISTS, scheduleId);
         }
@@ -363,8 +363,8 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         }
 
         this.projectPermCheckByWorkflowCode(loginUser, schedule.getWorkflowDefinitionCode());
-        int delete = scheduleMapper.deleteById(scheduleId);
-        if (delete <= 0) {
+        boolean delete = scheduleDao.deleteById(scheduleId);
+        if (!delete) {
             throw new ServiceException(Status.DELETE_SCHEDULE_BY_ID_ERROR);
         }
     }
@@ -432,7 +432,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         projectService.checkProjectAndAuthThrowException(loginUser, project, null);
 
         // check schedule exists
-        Schedule schedule = scheduleMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
+        Schedule schedule = scheduleDao.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         if (schedule == null) {
             log.error("Schedule of workflow definition does not exist, workflowDefinitionCode:{}.",
                     workflowDefinitionCode);
@@ -454,14 +454,14 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
     @Override
     public void onlineScheduler(User loginUser, Long projectCode, Integer schedulerId) {
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_ONLINE_OFFLINE);
-        Schedule schedule = scheduleMapper.selectById(schedulerId);
+        Schedule schedule = scheduleDao.queryById(schedulerId);
         doOnlineScheduler(schedule);
     }
 
     @Transactional
     @Override
     public void onlineSchedulerByWorkflowCode(Long workflowDefinitionCode) {
-        Schedule schedule = scheduleMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
+        Schedule schedule = scheduleDao.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         doOnlineScheduler(schedule);
     }
 
@@ -481,7 +481,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
 
         schedule.setReleaseState(ReleaseState.ONLINE);
         schedule.setUpdateTime(new Date());
-        scheduleMapper.updateById(schedule);
+        scheduleDao.updateById(schedule);
 
         Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
         schedulerApi.insertOrUpdateScheduleTask(project.getId(), schedule);
@@ -491,14 +491,14 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
     @Override
     public void offlineScheduler(User loginUser, Long projectCode, Integer schedulerId) {
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_ONLINE_OFFLINE);
-        Schedule schedule = scheduleMapper.selectById(schedulerId);
+        Schedule schedule = scheduleDao.queryById(schedulerId);
         doOfflineScheduler(schedule);
     }
 
     @Transactional
     @Override
     public void offlineSchedulerByWorkflowCode(Long workflowDefinitionCode) {
-        Schedule schedule = scheduleMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
+        Schedule schedule = scheduleDao.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         doOfflineScheduler(schedule);
     }
 
@@ -512,7 +512,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         }
         schedule.setUpdateTime(new Date());
         schedule.setReleaseState(ReleaseState.OFFLINE);
-        scheduleMapper.updateById(schedule);
+        scheduleDao.updateById(schedule);
         WorkflowDefinition workflowDefinition =
                 workflowDefinitionDao.queryByCode(schedule.getWorkflowDefinitionCode()).orElse(null);
         Project project = projectDao.queryByCode(workflowDefinition.getProjectCode());
@@ -574,7 +574,7 @@ public class SchedulerServiceImpl extends BaseServiceImpl implements SchedulerSe
         schedule.setEnvironmentCode(environmentCode);
         schedule.setUpdateTime(now);
         schedule.setWorkflowInstancePriority(workflowInstancePriority);
-        scheduleMapper.updateById(schedule);
+        scheduleDao.updateById(schedule);
 
         workflowDefinition.setWarningGroupId(warningGroupId);
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -36,10 +36,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -70,7 +70,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
     private WorkflowInstanceMapper workflowInstanceMapper;
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private UserMapper userMapper;
@@ -231,7 +231,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL, workflowInstances.size());
         }
 
-        List<Schedule> schedules = scheduleMapper.queryScheduleListByTenant(tenant.getTenantCode());
+        List<Schedule> schedules = scheduleDao.queryScheduleListByTenant(tenant.getTenantCode());
         if (CollectionUtils.isNotEmpty(schedules)) {
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL_DEFINES, schedules.size());
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -42,9 +42,9 @@ import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroupPageDetail;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.extract.base.client.Clients;
@@ -90,7 +90,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
     private EnvironmentWorkerGroupRelationMapper environmentWorkerGroupRelationMapper;
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private TaskDefinitionMapper taskDefinitionMapper;
@@ -169,8 +169,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
         }
 
         // check if the worker group has any dependent schedulers
-        List<Schedule> schedules = scheduleMapper
-                .selectList(new QueryWrapper<Schedule>().lambda().eq(Schedule::getWorkerGroup, workerGroup.getName()));
+        List<Schedule> schedules = scheduleDao.queryScheduleByWorkerGroup(workerGroup.getName());
 
         if (CollectionUtils.isNotEmpty(schedules)) {
             List<String> workflowDefinitionNames = schedules.stream().limit(3)
@@ -356,7 +355,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
     @Override
     public Map<Long, String> queryWorkerGroupByWorkflowDefinitionCodes(List<Long> workflowDefinitionCodeList) {
         List<Schedule> workflowDefinitionScheduleList =
-                scheduleMapper.querySchedulesByWorkflowDefinitionCodes(workflowDefinitionCodeList);
+                scheduleDao.querySchedulesByWorkflowDefinitionCodes(workflowDefinitionCodeList);
         return workflowDefinitionScheduleList.stream().collect(Collectors.toMap(Schedule::getWorkflowDefinitionCode,
                 Schedule::getWorkerGroup));
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -77,7 +77,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskLineage;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
@@ -87,6 +86,7 @@ import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
@@ -172,7 +172,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     private TaskInstanceMapper taskInstanceMapper;
 
     @Autowired
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Autowired
     private ProcessService processService;
@@ -873,11 +873,11 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         workflowDefinitionUsedInOtherTaskValid(workflowDefinition);
 
         // get the timing according to the workflow definition
-        Schedule scheduleObj = scheduleMapper.queryByWorkflowDefinitionCode(code);
+        Schedule scheduleObj = scheduleDao.queryByWorkflowDefinitionCode(code);
         if (scheduleObj != null) {
             if (scheduleObj.getReleaseState() == ReleaseState.OFFLINE) {
-                int delete = scheduleMapper.deleteById(scheduleObj.getId());
-                if (delete == 0) {
+                boolean delete = scheduleDao.deleteById(scheduleObj.getId());
+                if (!delete) {
                     throw new ServiceException(Status.DELETE_SCHEDULE_BY_ID_ERROR);
                 }
             }
@@ -1381,7 +1381,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     workflowDefinition.setLocations(JSONUtils.toJsonString(jsonNodes));
                 }
                 // copy timing configuration
-                Schedule scheduleObj = scheduleMapper.queryByWorkflowDefinitionCode(oldWorkflowDefinitionCode);
+                Schedule scheduleObj = scheduleDao.queryByWorkflowDefinitionCode(oldWorkflowDefinitionCode);
                 if (scheduleObj != null) {
                     scheduleObj.setId(null);
                     scheduleObj.setUserId(loginUser.getId());
@@ -1389,7 +1389,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     scheduleObj.setReleaseState(ReleaseState.OFFLINE);
                     scheduleObj.setCreateTime(date);
                     scheduleObj.setUpdateTime(date);
-                    int insertResult = scheduleMapper.insert(scheduleObj);
+                    int insertResult = scheduleDao.insert(scheduleObj);
                     if (insertResult != 1) {
                         log.error("Schedule create error, workflowDefinitionCode:{}.", workflowDefinition.getCode());
                         throw new ServiceException(Status.CREATE_SCHEDULE_ERROR);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectWorkerGroupRelationServiceTest.java
@@ -30,9 +30,9 @@ import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroupPageDetail;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectWorkerGroupDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 
@@ -79,7 +79,7 @@ public class ProjectWorkerGroupRelationServiceTest {
     private TaskDefinitionDao taskDefinitionDao;
 
     @Mock
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     protected final static long projectCode = 1L;
 
@@ -204,7 +204,7 @@ public class ProjectWorkerGroupRelationServiceTest {
         Mockito.when(taskDefinitionDao.queryAllTaskDefinitionWorkerGroups(Mockito.anyLong()))
                 .thenReturn(new ArrayList<>());
 
-        Mockito.when(scheduleMapper.querySchedulerListByProjectName(Mockito.any()))
+        Mockito.when(scheduleDao.querySchedulerListByProjectName(Mockito.any()))
                 .thenReturn(Lists.newArrayList());
 
         List<ProjectWorkerGroup> projectWorkerGroups =

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/SchedulerServiceTest.java
@@ -25,8 +25,8 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import java.util.Optional;
@@ -50,7 +50,7 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
     private SchedulerServiceImpl schedulerService;
 
     @Mock
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Mock
     private ProjectDao projectDao;
@@ -91,7 +91,7 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
 
         // error schedule already online
         schedule.setReleaseState(ReleaseState.ONLINE);
-        Mockito.when(scheduleMapper.selectById(scheduleId)).thenReturn(schedule);
+        Mockito.when(scheduleDao.queryById(scheduleId)).thenReturn(schedule);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.deleteSchedulesById(user, scheduleId));
         Assertions.assertEquals(Status.SCHEDULE_STATE_ONLINE.getCode(), ((ServiceException) exception).getCode());
@@ -100,14 +100,14 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
         // error user not own schedule
         int notOwnUserId = 2;
         schedule.setUserId(notOwnUserId);
-        Mockito.when(scheduleMapper.selectById(scheduleId)).thenReturn(schedule);
+        Mockito.when(scheduleDao.queryById(scheduleId)).thenReturn(schedule);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.deleteSchedulesById(user, scheduleId));
         Assertions.assertEquals(Status.USER_NO_OPERATION_PERM.getMsg(), exception.getMessage());
         schedule.setUserId(userId);
 
         // error process definition not exists
-        Mockito.when(scheduleMapper.selectById(scheduleId)).thenReturn(schedule);
+        Mockito.when(scheduleDao.queryById(scheduleId)).thenReturn(schedule);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.deleteSchedulesById(user, scheduleId));
         Assertions.assertEquals(Status.WORKFLOW_DEFINITION_NOT_EXIST.getCode(),
@@ -126,13 +126,13 @@ public class SchedulerServiceTest extends BaseServiceTestTool {
 
         // error delete mapper
         Mockito.doNothing().when(projectService).checkProjectAndAuthThrowException(user, this.getProject(), null);
-        Mockito.when(scheduleMapper.deleteById(scheduleId)).thenReturn(0);
+        Mockito.when(scheduleDao.deleteById(scheduleId)).thenReturn(false);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> schedulerService.deleteSchedulesById(user, scheduleId));
         Assertions.assertEquals(Status.DELETE_SCHEDULE_BY_ID_ERROR.getCode(), ((ServiceException) exception).getCode());
 
         // success
-        Mockito.when(scheduleMapper.deleteById(scheduleId)).thenReturn(1);
+        Mockito.when(scheduleDao.deleteById(scheduleId)).thenReturn(true);
         Assertions.assertDoesNotThrow(() -> schedulerService.deleteSchedulesById(user, scheduleId));
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
@@ -38,10 +38,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -83,7 +83,7 @@ public class TenantServiceTest {
     private TenantMapper tenantMapper;
 
     @Mock
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Mock
     private WorkflowInstanceMapper workflowInstanceMapper;
@@ -190,7 +190,7 @@ public class TenantServiceTest {
         when(workflowInstanceMapper.queryByTenantCodeAndStatus(tenantCode,
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES))
                         .thenReturn(getInstanceList());
-        when(scheduleMapper.queryScheduleListByTenant(tenantCode)).thenReturn(getScheduleList());
+        when(scheduleDao.queryScheduleListByTenant(tenantCode)).thenReturn(getScheduleList());
         when(userMapper.queryUserListByTenant(3)).thenReturn(getUserList());
 
         // TENANT_NOT_EXIST
@@ -208,7 +208,7 @@ public class TenantServiceTest {
 
         // DELETE_TENANT_BY_ID_FAIL_USERS
         when(tenantMapper.queryById(3)).thenReturn(getTenant(3));
-        when(scheduleMapper.queryScheduleListByTenant(tenantCode)).thenReturn(Collections.emptyList());
+        when(scheduleDao.queryScheduleListByTenant(tenantCode)).thenReturn(Collections.emptyList());
         assertThrowsServiceException(Status.DELETE_TENANT_BY_ID_FAIL_USERS,
                 () -> tenantService.deleteTenantById(getLoginUser(), 3));
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -36,9 +36,9 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
@@ -93,7 +93,7 @@ public class WorkerGroupServiceTest {
     private TaskDefinitionMapper taskDefinitionMapper;
 
     @Mock
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     private final String GROUP_NAME = "testWorkerGroup";
 
@@ -255,7 +255,7 @@ public class WorkerGroupServiceTest {
 
         when(taskDefinitionMapper.selectList(Mockito.any())).thenReturn(null);
 
-        when(scheduleMapper.selectList(Mockito.any())).thenReturn(null);
+        when(scheduleDao.queryScheduleByWorkerGroup(Mockito.any())).thenReturn(null);
 
         assertDoesNotThrow(() -> workerGroupService.deleteWorkerGroupById(loginUser, 1));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -60,7 +60,6 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.UserWithWorkflowDefinitionCode;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
@@ -70,6 +69,7 @@ import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
@@ -162,7 +162,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     private ProjectServiceImpl projectService;
 
     @Mock
-    private ScheduleMapper scheduleMapper;
+    private ScheduleDao scheduleDao;
 
     @Mock
     private SchedulerService schedulerService;
@@ -579,8 +579,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         // scheduler list elements > 1
         workflowDefinition.setReleaseState(ReleaseState.OFFLINE);
         when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
-        when(scheduleMapper.queryByWorkflowDefinitionCode(46L)).thenReturn(getSchedule());
-        when(scheduleMapper.deleteById(46)).thenReturn(1);
+        when(scheduleDao.queryByWorkflowDefinitionCode(46L)).thenReturn(getSchedule());
+        when(scheduleDao.deleteById(46)).thenReturn(true);
         when(workflowLineageService.taskDependentMsg(project.getCode(), workflowDefinition.getCode(), 0))
                 .thenReturn(Optional.empty());
         when(workflowLineageService.deleteWorkflowLineage(anyList())).thenReturn(1);
@@ -589,7 +589,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
         // scheduler online
         Schedule schedule = getSchedule();
         schedule.setReleaseState(ReleaseState.ONLINE);
-        when(scheduleMapper.queryByWorkflowDefinitionCode(46L)).thenReturn(schedule);
+        when(scheduleDao.queryByWorkflowDefinitionCode(46L)).thenReturn(schedule);
         exception = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.deleteWorkflowDefinitionByCode(user, 46L));
         Assertions.assertEquals(Status.SCHEDULE_STATE_ONLINE.getCode(), ((ServiceException) exception).getCode());
@@ -604,8 +604,8 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         // delete success
         schedule.setReleaseState(ReleaseState.OFFLINE);
-        when(scheduleMapper.queryByWorkflowDefinitionCode(46L)).thenReturn(getSchedule());
-        when(scheduleMapper.deleteById(schedule.getId())).thenReturn(1);
+        when(scheduleDao.queryByWorkflowDefinitionCode(46L)).thenReturn(getSchedule());
+        when(scheduleDao.deleteById(schedule.getId())).thenReturn(true);
         when(workflowLineageService.taskDependentMsg(project.getCode(), workflowDefinition.getCode(), 0))
                 .thenReturn(Optional.empty());
         when(workflowLineageService.deleteWorkflowLineage(anyList())).thenReturn(1);

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ScheduleDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ScheduleDao.java
@@ -19,6 +19,24 @@ package org.apache.dolphinscheduler.dao.repository;
 
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 
+import java.util.List;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
 public interface ScheduleDao extends IDao<Schedule> {
 
+    Schedule queryByWorkflowDefinitionCode(long workflowDefinitionCode);
+
+    List<Schedule> querySchedulerListByProjectName(String projectName);
+
+    IPage<Schedule> queryByProjectAndWorkflowDefinitionCodePaging(IPage<Schedule> page,
+                                                                  long projectCode,
+                                                                  long workflowDefinitionCode,
+                                                                  String searchVal);
+
+    List<Schedule> querySchedulesByWorkflowDefinitionCodes(List<Long> workflowDefinitionCodes);
+
+    List<Schedule> queryScheduleListByTenant(String tenantCode);
+
+    List<Schedule> queryScheduleByWorkerGroup(String workerGroupName);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ScheduleDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ScheduleDaoImpl.java
@@ -22,9 +22,14 @@ import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.repository.BaseDao;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 
+import java.util.List;
+
 import lombok.NonNull;
 
 import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
 @Repository
 public class ScheduleDaoImpl extends BaseDao<Schedule, ScheduleMapper> implements ScheduleDao {
@@ -33,4 +38,38 @@ public class ScheduleDaoImpl extends BaseDao<Schedule, ScheduleMapper> implement
         super(scheduleMapper);
     }
 
+    @Override
+    public Schedule queryByWorkflowDefinitionCode(long workflowDefinitionCode) {
+        return mybatisMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode);
+    }
+
+    @Override
+    public List<Schedule> querySchedulerListByProjectName(String projectName) {
+        return mybatisMapper.querySchedulerListByProjectName(projectName);
+    }
+
+    @Override
+    public IPage<Schedule> queryByProjectAndWorkflowDefinitionCodePaging(IPage<Schedule> page,
+                                                                         long projectCode,
+                                                                         long workflowDefinitionCode,
+                                                                         String searchVal) {
+        return mybatisMapper.queryByProjectAndWorkflowDefinitionCodePaging(page, projectCode, workflowDefinitionCode,
+                searchVal);
+    }
+
+    @Override
+    public List<Schedule> querySchedulesByWorkflowDefinitionCodes(List<Long> workflowDefinitionCodes) {
+        return mybatisMapper.querySchedulesByWorkflowDefinitionCodes(workflowDefinitionCodes);
+    }
+
+    @Override
+    public List<Schedule> queryScheduleListByTenant(String tenantCode) {
+        return mybatisMapper.queryScheduleListByTenant(tenantCode);
+    }
+
+    @Override
+    public List<Schedule> queryScheduleByWorkerGroup(String workerGroupName) {
+        return mybatisMapper.selectList(
+                new QueryWrapper<Schedule>().lambda().eq(Schedule::getWorkerGroup, workerGroupName));
+    }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Tracking issue: #18249

Expose the methods the api layer needs on ScheduleDao (queryByWorkflowDefinitionCode, querySchedulerListByProjectName, queryByProjectAndWorkflowDefinitionCodePaging, querySchedulesByWorkflowDefinitionCodes, queryScheduleListByTenant, queryScheduleByWorkerGroup) and replace every direct ScheduleMapper reference in dolphinscheduler-api with the Dao, so Mapper usage stays inside dolphinscheduler-dao.repository as documented in dolphinscheduler-dao/CLAUDE.md.

Notes:
- BaseDao#deleteById and BaseDao#updateById return boolean (Mapper returned int). Affected call sites in SchedulerServiceImpl and WorkflowDefinitionServiceImpl were adapted (boolean delete = scheduleDao.deleteById(id); if (!delete)). Test mocks switched from thenReturn(1/0) to thenReturn(true/false).
- selectById was replaced with the IDao#queryById equivalent.
- WorkerGroupServiceImpl previously inlined a BaseMapper.selectList(QueryWrapper) to find schedules referencing a worker group; the QueryWrapper is now encapsulated as ScheduleDao#queryScheduleByWorkerGroup so the api layer no longer constructs a raw QueryWrapper for this lookup.

No production behavior changes; the Mapper interface itself is untouched.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
