### PR TITLE
[Improvement-18249][DAO] Route TaskInstanceMapper access through TaskInstanceDao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TaskInstancesAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TaskInstancesAuditOperatorImpl.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.api.audit.operator.impl;
 
 import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 public class TaskInstancesAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private TaskInstanceMapper taskInstanceMapper;
+    private TaskInstanceDao taskInstanceDao;
 
     @Override
     protected String getObjectNameFromIdentity(Object identity) {
@@ -37,7 +37,7 @@ public class TaskInstancesAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        TaskInstance obj = taskInstanceMapper.selectById(objId);
+        TaskInstance obj = taskInstanceDao.queryById(objId);
         return obj == null ? "" : obj.getName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
@@ -36,12 +36,12 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
 import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.model.TaskInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.model.WorkflowDefinitionCountDto;
 import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -88,7 +88,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
     private ErrorCommandMapper errorCommandMapper;
 
     @Autowired
-    private TaskInstanceMapper taskInstanceMapper;
+    private TaskInstanceDao taskInstanceDao;
 
     @Override
     public TaskInstanceCountVO getTaskInstanceStateCountByProject(User loginUser,
@@ -99,7 +99,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         Date start = startDate == null ? null : transformDate(startDate);
         Date end = endDate == null ? null : transformDate(endDate);
         List<TaskInstanceStatusCountDto> taskInstanceStatusCounts =
-                taskInstanceMapper.countTaskInstanceStateByProjectCodes(start, end, Lists.newArrayList(projectCode));
+                taskInstanceDao.countTaskInstanceStateByProjectCodes(start, end, Lists.newArrayList(projectCode));
         return TaskInstanceCountVO.of(taskInstanceStatusCounts);
     }
 
@@ -114,7 +114,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         Date start = startDate == null ? null : transformDate(startDate);
         Date end = endDate == null ? null : transformDate(endDate);
         List<TaskInstanceStatusCountDto> taskInstanceStatusCounts =
-                taskInstanceMapper.countTaskInstanceStateByProjectCodes(start, end, projectCodes);
+                taskInstanceDao.countTaskInstanceStateByProjectCodes(start, end, projectCodes);
         return TaskInstanceCountVO.of(taskInstanceStatusCounts);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskInstanceServiceImpl.java
@@ -34,7 +34,6 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
@@ -77,9 +76,6 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
 
     @Autowired
     ProcessService processService;
-
-    @Autowired
-    TaskInstanceMapper taskInstanceMapper;
 
     @Autowired
     TaskInstanceDao taskInstanceDao;
@@ -141,7 +137,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
         IPage<TaskInstance> taskInstanceIPage;
         if (taskExecuteType == TaskExecuteType.STREAM) {
             // stream task without workflow instance
-            taskInstanceIPage = taskInstanceMapper.queryStreamTaskInstanceListPaging(
+            taskInstanceIPage = taskInstanceDao.queryStreamTaskInstanceListPaging(
                     page,
                     projectCode,
                     workflowDefinitionName,
@@ -155,7 +151,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
                     start,
                     end);
         } else {
-            taskInstanceIPage = taskInstanceMapper.queryTaskInstanceListPaging(
+            taskInstanceIPage = taskInstanceDao.queryTaskInstanceListPaging(
                     page,
                     projectCode,
                     workflowInstanceId,
@@ -226,8 +222,8 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
         // change the state of the task instance
         task.setState(TaskExecutionStatus.FORCED_SUCCESS);
         task.setEndTime(new Date());
-        int changedNum = taskInstanceMapper.updateById(task);
-        if (changedNum <= 0) {
+        boolean changed = taskInstanceDao.updateById(task);
+        if (!changed) {
             throw new ServiceException(Status.FORCE_TASK_SUCCESS_ERROR);
         }
         processService.forceWorkflowInstanceSuccessByTaskInstanceId(task);
@@ -242,7 +238,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, FORCED_SUCCESS);
 
-        TaskInstance taskInstance = taskInstanceMapper.selectById(taskInstanceId);
+        TaskInstance taskInstance = taskInstanceDao.queryById(taskInstanceId);
         if (taskInstance == null) {
             log.error("Task definition can not be found, projectCode:{}, taskInstanceId:{}.", projectCode,
                     taskInstanceId);
@@ -266,7 +262,7 @@ public class TaskInstanceServiceImpl extends BaseServiceImpl implements TaskInst
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, project, FORCED_SUCCESS);
 
-        TaskInstance taskInstance = taskInstanceMapper.selectById(taskInstanceId);
+        TaskInstance taskInstance = taskInstanceDao.queryById(taskInstanceId);
         if (taskInstance == null) {
             log.error("Task definition can not be found, projectCode:{}, taskInstanceId:{}.", projectCode,
                     taskInstanceId);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -80,7 +80,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
@@ -88,6 +87,7 @@ import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
+import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
 import org.apache.dolphinscheduler.plugin.task.api.model.ConditionDependentItem;
@@ -169,7 +169,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     private WorkflowInstanceService workflowInstanceService;
 
     @Autowired
-    private TaskInstanceMapper taskInstanceMapper;
+    private TaskInstanceDao taskInstanceDao;
 
     @Autowired
     private ScheduleMapper scheduleMapper;
@@ -1168,7 +1168,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                 for (int i = limit - 1; i >= 0; i--) {
                     WorkflowInstance workflowInstance = workflowInstanceList.get(i);
                     TaskInstance taskInstance =
-                            taskInstanceMapper.queryByInstanceIdAndCode(workflowInstance.getId(), nodeCode);
+                            taskInstanceDao.queryByWorkflowInstanceIdAndTaskCode(workflowInstance.getId(), nodeCode);
                     if (taskInstance == null) {
                         treeViewDto.getInstances().add(new Instance(-1, "not running", 0, "null"));
                     } else {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -67,7 +67,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
 import org.apache.dolphinscheduler.dao.mapper.RelationSubWorkflowMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
@@ -149,9 +148,6 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Autowired
     WorkflowDefinitionService workflowDefinitionService;
-
-    @Autowired
-    TaskInstanceMapper taskInstanceMapper;
 
     @Autowired
     WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
@@ -680,7 +676,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         // Fetch valid task instances for the workflow
         List<TaskInstance> taskInstanceList =
-                taskInstanceMapper.findValidTaskListByWorkflowInstanceId(workflowInstance.getId(), Flag.YES);
+                taskInstanceDao.queryValidTaskListByWorkflowInstanceId(workflowInstance.getId());
 
         for (TaskInstance taskInstance : taskInstanceList) {
             TaskDefinitionLog taskDefinitionLog = taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(
@@ -734,7 +730,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
         List<Task> taskList = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(nodeList)) {
-            List<TaskInstance> taskInstances = taskInstanceMapper.queryByWorkflowInstanceIdsAndTaskCodes(
+            List<TaskInstance> taskInstances = taskInstanceDao.queryByWorkflowInstanceIdsAndTaskCodes(
                     Collections.singletonList(workflowInstanceId), nodeList);
             for (Long node : nodeList) {
                 TaskInstance taskInstance = null;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
@@ -46,9 +46,9 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
 import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 
@@ -104,7 +104,7 @@ public class DataAnalysisServiceTest {
     ErrorCommandMapper errorCommandMapper;
 
     @Mock
-    TaskInstanceMapper taskInstanceMapper;
+    TaskInstanceDao taskInstanceDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -192,7 +192,7 @@ public class DataAnalysisServiceTest {
         user.setUserType(UserType.GENERAL_USER);
         when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.PROJECTS, 1,
                 serviceLogger)).thenReturn(projectIds());
-        when(taskInstanceMapper.countTaskInstanceStateByProjectCodes(any(), any(), any()))
+        when(taskInstanceDao.countTaskInstanceStateByProjectCodes(any(), any(), any()))
                 .thenReturn(Collections.emptyList());
         assertDoesNotThrow(() -> dataAnalysisServiceImpl.getTaskInstanceStateCountByProject(user, 1L, null, null));
 
@@ -206,7 +206,7 @@ public class DataAnalysisServiceTest {
 
         // when instanceStateCounter return null, then return nothing
         user.setUserType(UserType.GENERAL_USER);
-        when(taskInstanceMapper.countTaskInstanceStateByProjectCodes(any(), any(), any()))
+        when(taskInstanceDao.countTaskInstanceStateByProjectCodes(any(), any(), any()))
                 .thenReturn(Collections.emptyList());
         TaskInstanceCountVO taskInstanceStateCountByProject =
                 dataAnalysisServiceImpl.getTaskInstanceStateCountByProject(user, 1L, null, null);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskInstanceServiceTest.java
@@ -40,7 +40,6 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
@@ -82,9 +81,6 @@ public class TaskInstanceServiceTest {
 
     @Mock
     ProcessService processService;
-
-    @Mock
-    TaskInstanceMapper taskInstanceMapper;
 
     @Mock
     UsersService usersService;
@@ -156,7 +152,7 @@ public class TaskInstanceServiceTest {
         doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, projectCode, TASK_INSTANCE);
         when(usersService.queryUser(loginUser.getId())).thenReturn(loginUser);
         when(usersService.getUserIdByName(loginUser.getUserName())).thenReturn(loginUser.getId());
-        when(taskInstanceMapper.queryTaskInstanceListPaging(
+        when(taskInstanceDao.queryTaskInstanceListPaging(
                 Mockito.any(),
                 Mockito.any(),
                 Mockito.any(),
@@ -194,7 +190,7 @@ public class TaskInstanceServiceTest {
         Assertions.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
 
         // executor name empty
-        when(taskInstanceMapper.queryTaskInstanceListPaging(
+        when(taskInstanceDao.queryTaskInstanceListPaging(
                 Mockito.any(Page.class), eq(project.getCode()), eq(1),
                 eq(""), eq(""), eq(""), eq(null),
                 eq(""), Mockito.any(), eq("192.168.xx.xx"), eq(TaskExecuteType.BATCH), eq(start), eq(end)))
@@ -215,7 +211,7 @@ public class TaskInstanceServiceTest {
         Assertions.assertEquals(Status.SUCCESS.getCode(), (int) executorNullRes.getCode());
 
         // start/end date null
-        when(taskInstanceMapper.queryTaskInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()), eq(1),
+        when(taskInstanceDao.queryTaskInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()), eq(1),
                 eq(""), eq(""), eq(""), eq(null),
                 eq(""), Mockito.any(), eq("192.168.xx.xx"), eq(TaskExecuteType.BATCH), any(), any()))
                         .thenReturn(pageReturn);
@@ -224,7 +220,7 @@ public class TaskInstanceServiceTest {
         Assertions.assertEquals(Status.SUCCESS.getCode(), (int) executorNullDateRes.getCode());
 
         // start date error format
-        when(taskInstanceMapper.queryTaskInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()), eq(1),
+        when(taskInstanceDao.queryTaskInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()), eq(1),
                 eq(""), eq(""), eq(""), eq(null),
                 eq(""), Mockito.any(), eq("192.168.xx.xx"), eq(TaskExecuteType.BATCH), any(), any()))
                         .thenReturn(pageReturn);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -63,7 +63,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
@@ -71,6 +70,7 @@ import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
 import org.apache.dolphinscheduler.dao.model.PageListingResult;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
+import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.utils.WorkerGroupUtils;
@@ -174,7 +174,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     private WorkflowInstanceService workflowInstanceService;
 
     @Mock
-    private TaskInstanceMapper taskInstanceMapper;
+    private TaskInstanceDao taskInstanceDao;
 
     @Mock
     private TaskDefinitionLogDao taskDefinitionLogDao;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -58,7 +58,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
@@ -148,9 +147,6 @@ public class WorkflowInstanceServiceTest {
 
     @Mock
     private TaskInstanceContextDao taskInstanceContextDao;
-
-    @Mock
-    TaskInstanceMapper taskInstanceMapper;
 
     @Mock
     CuringParamsService curingGlobalParamsService;

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TaskInstanceDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TaskInstanceDao.java
@@ -17,12 +17,18 @@
 
 package org.apache.dolphinscheduler.dao.repository;
 
+import org.apache.dolphinscheduler.common.enums.TaskExecuteType;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
+import org.apache.dolphinscheduler.dao.model.TaskInstanceStatusCountDto;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 
+import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
 public interface TaskInstanceDao extends IDao<TaskInstance> {
 
@@ -101,4 +107,38 @@ public interface TaskInstanceDao extends IDao<TaskInstance> {
 
     void updateTaskInstanceState(Integer taskInstanceId, TaskExecutionStatus originState,
                                  TaskExecutionStatus targetState);
+
+    List<TaskInstanceStatusCountDto> countTaskInstanceStateByProjectCodes(Date startTime,
+                                                                          Date endTime,
+                                                                          Collection<Long> projectCodes);
+
+    List<TaskInstance> queryByWorkflowInstanceIdsAndTaskCodes(List<Integer> workflowInstanceIds,
+                                                              List<Long> taskCodes);
+
+    IPage<TaskInstance> queryTaskInstanceListPaging(IPage<TaskInstance> page,
+                                                    Long projectCode,
+                                                    Integer workflowInstanceId,
+                                                    String workflowInstanceName,
+                                                    String searchVal,
+                                                    String taskName,
+                                                    Long taskCode,
+                                                    String executorName,
+                                                    int[] statusArray,
+                                                    String host,
+                                                    TaskExecuteType taskExecuteType,
+                                                    Date startTime,
+                                                    Date endTime);
+
+    IPage<TaskInstance> queryStreamTaskInstanceListPaging(IPage<TaskInstance> page,
+                                                          Long projectCode,
+                                                          String workflowDefinitionName,
+                                                          String searchVal,
+                                                          String taskName,
+                                                          Long taskCode,
+                                                          String executorName,
+                                                          int[] statusArray,
+                                                          String host,
+                                                          TaskExecuteType taskExecuteType,
+                                                          Date startTime,
+                                                          Date endTime);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TaskInstanceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TaskInstanceDaoImpl.java
@@ -19,17 +19,20 @@ package org.apache.dolphinscheduler.dao.repository.impl;
 
 import org.apache.dolphinscheduler.common.enums.FailureStrategy;
 import org.apache.dolphinscheduler.common.enums.Flag;
+import org.apache.dolphinscheduler.common.enums.TaskExecuteType;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.model.TaskInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.repository.BaseDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -39,6 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
 /**
  * Task Instance DAO implementation
@@ -178,5 +183,53 @@ public class TaskInstanceDaoImpl extends BaseDao<TaskInstance, TaskInstanceMappe
                                         TaskExecutionStatus originState,
                                         TaskExecutionStatus targetState) {
         mybatisMapper.updateTaskInstanceState(taskInstanceId, originState.getCode(), targetState.getCode());
+    }
+
+    @Override
+    public List<TaskInstanceStatusCountDto> countTaskInstanceStateByProjectCodes(Date startTime,
+                                                                                 Date endTime,
+                                                                                 Collection<Long> projectCodes) {
+        return mybatisMapper.countTaskInstanceStateByProjectCodes(startTime, endTime, projectCodes);
+    }
+
+    @Override
+    public List<TaskInstance> queryByWorkflowInstanceIdsAndTaskCodes(List<Integer> workflowInstanceIds,
+                                                                     List<Long> taskCodes) {
+        return mybatisMapper.queryByWorkflowInstanceIdsAndTaskCodes(workflowInstanceIds, taskCodes);
+    }
+
+    @Override
+    public IPage<TaskInstance> queryTaskInstanceListPaging(IPage<TaskInstance> page,
+                                                           Long projectCode,
+                                                           Integer workflowInstanceId,
+                                                           String workflowInstanceName,
+                                                           String searchVal,
+                                                           String taskName,
+                                                           Long taskCode,
+                                                           String executorName,
+                                                           int[] statusArray,
+                                                           String host,
+                                                           TaskExecuteType taskExecuteType,
+                                                           Date startTime,
+                                                           Date endTime) {
+        return mybatisMapper.queryTaskInstanceListPaging(page, projectCode, workflowInstanceId, workflowInstanceName,
+                searchVal, taskName, taskCode, executorName, statusArray, host, taskExecuteType, startTime, endTime);
+    }
+
+    @Override
+    public IPage<TaskInstance> queryStreamTaskInstanceListPaging(IPage<TaskInstance> page,
+                                                                 Long projectCode,
+                                                                 String workflowDefinitionName,
+                                                                 String searchVal,
+                                                                 String taskName,
+                                                                 Long taskCode,
+                                                                 String executorName,
+                                                                 int[] statusArray,
+                                                                 String host,
+                                                                 TaskExecuteType taskExecuteType,
+                                                                 Date startTime,
+                                                                 Date endTime) {
+        return mybatisMapper.queryStreamTaskInstanceListPaging(page, projectCode, workflowDefinitionName, searchVal,
+                taskName, taskCode, executorName, statusArray, host, taskExecuteType, startTime, endTime);
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Tracking issue: #18249

Expose the methods the api layer needs on TaskInstanceDao (countTaskInstanceStateByProjectCodes, queryByWorkflowInstanceIdsAndTaskCodes, queryTaskInstanceListPaging, queryStreamTaskInstanceListPaging) and replace every direct TaskInstanceMapper reference in dolphinscheduler-api with the Dao, so Mapper usage stays inside dolphinscheduler-dao.repository as documented in dolphinscheduler-dao/CLAUDE.md.

Notes:
- selectById was replaced with the IDao#queryById equivalent. The Mapper's queryByInstanceIdAndCode is exposed on the Dao as the more descriptive queryByWorkflowInstanceIdAndTaskCode (already present); api callers were updated to the new name.
- The Mapper's findValidTaskListByWorkflowInstanceId(id, Flag) is collapsed on the Dao to queryValidTaskListByWorkflowInstanceId(id), which already hard-codes Flag.YES. All current api callers passed Flag.YES so they drop the argument.
- BaseDao#updateById returns boolean where the Mapper returned int; the affected call site in TaskInstanceServiceImpl#forceTaskSuccess (int changedNum = ...; if (changedNum <= 0) {...}) was refactored to boolean changed = ...; if (!changed) {...}.

No production behavior changes; the Mapper interface itself is untouched.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
