### PR TITLE
[Improvement-18249][DAO] Route UserMapper access through UserDao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TokenAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TokenAuditOperatorImpl.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import java.util.List;
 import java.util.Map;
@@ -39,13 +39,13 @@ public class TokenAuditOperatorImpl extends BaseAuditOperator {
     private AccessTokenMapper accessTokenMapper;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Override
     public void modifyAuditOperationType(AuditType auditType, Map<String, Object> paramsMap,
                                          List<AuditLog> auditLogList) {
         if (paramsMap.get(AuditLogConstants.USER_ID) != null) {
-            User user = userMapper.selectById(paramsMap.get(AuditLogConstants.USER_ID).toString());
+            User user = userDao.queryById(paramsMap.get(AuditLogConstants.USER_ID).toString());
             auditLogList.forEach(auditLog -> {
                 auditLog.setModelName(user.getUserName());
                 auditLog.setModelId(Long.valueOf(user.getId()));

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/UserAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/UserAuditOperatorImpl.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.api.audit.operator.impl;
 
 import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 public class UserAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Override
     public String getObjectNameFromIdentity(Object identity) {
@@ -37,7 +37,7 @@ public class UserAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        User obj = userMapper.selectById(objId);
+        User obj = userDao.queryById(objId);
         return obj == null ? "" : obj.getUserName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptor.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptor.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.Flag;
 import org.apache.dolphinscheduler.common.thread.ThreadLocalContext;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -47,7 +47,7 @@ import org.springframework.web.servlet.ModelAndView;
 public class LoginHandlerInterceptor implements HandlerInterceptor {
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Autowired
     private Authenticator authenticator;
@@ -76,7 +76,7 @@ public class LoginHandlerInterceptor implements HandlerInterceptor {
                 return false;
             }
         } else {
-            user = userMapper.queryUserByToken(token, new Date());
+            user = userDao.queryUserByToken(token, new Date());
             if (user == null) {
                 response.setStatus(HttpStatus.SC_UNAUTHORIZED);
                 log.info("user token has expired");

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -37,8 +37,8 @@ import org.apache.dolphinscheduler.dao.entity.ProjectWorkflowDefinitionCount;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -85,7 +85,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     /**
      * create project
@@ -260,7 +260,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             putMsg(result, Status.SUCCESS);
             return result;
         }
-        List<User> userList = userMapper.selectByIds(projectList.stream()
+        List<User> userList = userDao.queryByIds(projectList.stream()
                 .map(Project::getUserId).distinct().collect(Collectors.toList()));
         Map<Integer, String> userMap = userList.stream().collect(Collectors.toMap(User::getId, User::getUserName));
         List<Long> projectCodes = projectList.stream().map(Project::getCode).distinct().collect(Collectors.toList());
@@ -394,7 +394,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             putMsg(result, Status.PROJECT_ALREADY_EXISTS, projectName);
             return result;
         }
-        User user = userMapper.selectById(loginUser.getId());
+        User user = userDao.queryById(loginUser.getId());
         if (user == null) {
             log.error("user {} not exists", loginUser.getId());
             putMsg(result, Status.USER_NOT_EXIST, loginUser.getId());
@@ -546,7 +546,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
         this.checkProjectAndAuthThrowException(loginUser, project, PROJECT);
 
         // 2. query authorized user list
-        List<User> users = this.userMapper.queryAuthedUserListByProjectId(project.getId());
+        List<User> users = this.userDao.queryAuthedUserListByProjectId(project.getId());
         result.setData(users);
         this.putMsg(result, Status.SUCCESS);
         return result;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/QueueServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/QueueServiceImpl.java
@@ -32,8 +32,8 @@ import org.apache.dolphinscheduler.dao.entity.Queue;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +60,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
     private QueueMapper queueMapper;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Autowired
     private TenantDao tenantDao;
@@ -197,7 +197,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
         if (checkIfQueueIsInUsing(existsQueue.getQueueName(), updateQueue.getQueueName())) {
             // update user related old queue
             Integer relatedUserNums =
-                    userMapper.updateUserQueue(existsQueue.getQueueName(), updateQueue.getQueueName());
+                    userDao.updateUserQueue(existsQueue.getQueueName(), updateQueue.getQueueName());
             log.info("Old queue have related {} users, exec update user success.", relatedUserNums);
         }
 
@@ -232,7 +232,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL_TENANTS, tenantList.size());
         }
 
-        List<User> userList = userMapper.queryUserListByQueue(queue.getQueueName());
+        List<User> userList = userDao.queryUserListByQueue(queue.getQueueName());
         if (CollectionUtils.isNotEmpty(userList)) {
             log.warn("Delete queue failed, because there are {} users using it.", userList.size());
             throw new ServiceException(Status.DELETE_QUEUE_BY_ID_FAIL_USERS, userList.size());
@@ -290,7 +290,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
      * @return true if need to update user
      */
     private boolean checkIfQueueIsInUsing(String oldQueue, String newQueue) {
-        return !oldQueue.equals(newQueue) && userMapper.existUser(oldQueue) == Boolean.TRUE;
+        return !oldQueue.equals(newQueue) && userDao.existUser(oldQueue) == Boolean.TRUE;
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -70,8 +70,8 @@ import org.apache.dolphinscheduler.api.vo.resources.FetchFileContentResponse;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageEntity;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
 import org.apache.dolphinscheduler.spi.enums.ResourceType;
@@ -101,7 +101,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     private TenantDao tenantDao;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Autowired
     private StorageOperator storageOperator;
@@ -392,7 +392,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     @Override
     public String queryResourceBaseDir(User loginUser, ResourceType type) {
 
-        User user = userMapper.selectById(loginUser.getId());
+        User user = userDao.queryById(loginUser.getId());
         if (user == null) {
             throw new ServiceException(Status.USER_NOT_EXIST);
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -36,10 +36,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -73,7 +73,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
     private ScheduleDao scheduleDao;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Autowired
     private QueueService queueService;
@@ -235,7 +235,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL_DEFINES, schedules.size());
         }
 
-        List<User> userList = userMapper.queryUserListByTenant(tenant.getId());
+        List<User> userList = userDao.queryUserListByTenant(tenant.getId());
         if (CollectionUtils.isNotEmpty(userList)) {
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL_USERS, userList.size());
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -44,9 +44,9 @@ import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -80,7 +80,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     private AccessTokenMapper accessTokenMapper;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Autowired
     private TenantDao tenantDao;
@@ -174,7 +174,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         user.setQueue(queue);
 
         // save user
-        userMapper.insert(user);
+        userDao.insert(user);
         return user;
     }
 
@@ -198,7 +198,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         user.setState(Flag.YES.getCode());
 
         // save user
-        userMapper.insert(user);
+        userDao.insert(user);
         return user;
     }
 
@@ -210,7 +210,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
      */
     @Override
     public User getUserByUserName(String userName) {
-        return userMapper.queryByUserNameAccurately(userName);
+        return userDao.queryByUserNameAccurately(userName);
     }
 
     /**
@@ -221,7 +221,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
      */
     @Override
     public User queryUser(int id) {
-        return userMapper.selectById(id);
+        return userDao.queryById(id);
     }
 
     @Override
@@ -229,7 +229,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         if (CollectionUtils.isEmpty(ids)) {
             return new ArrayList<>();
         }
-        return userMapper.selectByIds(ids);
+        return userDao.queryByIds(ids);
     }
 
     /**
@@ -240,7 +240,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
      */
     @Override
     public User queryUser(String name) {
-        return userMapper.queryByUserNameAccurately(name);
+        return userDao.queryByUserNameAccurately(name);
     }
 
     /**
@@ -253,7 +253,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     @Override
     public User queryUser(String name, String password) {
         String md5 = EncryptionUtils.getMd5(password);
-        return userMapper.queryUserByNamePassword(name, md5);
+        return userDao.queryUserByNamePassword(name, md5);
     }
 
     /**
@@ -300,7 +300,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
 
         Page<User> page = new Page<>(pageNo, pageSize);
 
-        IPage<User> scheduleList = userMapper.queryUserPaging(page, searchVal);
+        IPage<User> scheduleList = userDao.queryUserPaging(page, searchVal);
 
         PageInfo<User> pageInfo = new PageInfo<>(pageNo, pageSize);
         pageInfo.setTotal((int) scheduleList.getTotal());
@@ -319,9 +319,9 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
         // Ensure the update time is set
         user.setUpdateTime(new Date());
-        int updatedRows = userMapper.updateById(user);
+        boolean updated = userDao.updateById(user);
 
-        if (updatedRows == 0) {
+        if (!updated) {
             throw new ServiceException(Status.UPDATE_USER_ERROR);
         }
         return user;
@@ -343,7 +343,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         if (!canOperator(loginUser, userId)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        User user = userMapper.selectById(userId);
+        User user = userDao.queryById(userId);
         if (user == null) {
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
         }
@@ -365,7 +365,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             }
 
             // todo: use the db unique index
-            User tempUser = userMapper.queryByUserNameAccurately(userName);
+            User tempUser = userDao.queryByUserNameAccurately(userName);
             if (tempUser != null && !userId.equals(tempUser.getId())) {
                 throw new ServiceException(Status.USER_NAME_EXIST);
             }
@@ -408,7 +408,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         user.setUpdateTime(new Date());
         user.setTenantId(tenantId);
         // updateWorkflowInstance user
-        if (userMapper.updateById(user) <= 0) {
+        if (!userDao.updateById(user)) {
             throw new ServiceException(Status.UPDATE_USER_ERROR);
         }
         return user;
@@ -432,7 +432,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM, id);
         }
         // check exist
-        User tempUser = userMapper.selectById(id);
+        User tempUser = userDao.queryById(id);
         if (tempUser == null) {
             log.error("User does not exist, userId:{}.", id);
             throw new ServiceException(Status.USER_NOT_EXIST, id);
@@ -446,12 +446,12 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             throw new ServiceException(Status.TRANSFORM_PROJECT_OWNERSHIP, projectNames);
         }
         // delete user
-        userMapper.queryTenantCodeByUserId(id);
+        userDao.queryTenantCodeByUserId(id);
 
         accessTokenMapper.deleteAccessTokenByUserId(id);
         sessionService.expireSession(id);
 
-        if (userMapper.deleteById(id) <= 0) {
+        if (!userDao.deleteById(id)) {
             log.error("User delete error, userId:{}.", id);
             throw new ServiceException(Status.DELETE_USER_BY_ID_ERROR);
         }
@@ -475,7 +475,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // 2. check if user is existed
-        User user = this.userMapper.selectById(userId);
+        User user = this.userDao.queryById(userId);
         if (user == null) {
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
         }
@@ -506,7 +506,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // check exist
-        User tempUser = userMapper.selectById(userId);
+        User tempUser = userDao.queryById(userId);
         if (tempUser == null) {
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
         }
@@ -542,7 +542,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     @Transactional
     public void grantProject(User loginUser, int userId, String projectIds) {
         // check exist
-        User tempUser = userMapper.selectById(userId);
+        User tempUser = userDao.queryById(userId);
         if (tempUser == null) {
             log.error("User does not exist, userId:{}.", userId);
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
@@ -583,7 +583,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     @Override
     public void grantProjectByCode(final User loginUser, final int userId, final long projectCode) {
         // 1. check if user is existed
-        User tempUser = this.userMapper.selectById(userId);
+        User tempUser = this.userDao.queryById(userId);
         if (tempUser == null) {
             log.error("User does not exist, userId:{}.", userId);
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
@@ -635,7 +635,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // 2. check if user is existed
-        User user = this.userMapper.selectById(userId);
+        User user = this.userDao.queryById(userId);
         if (user == null) {
             log.error("User does not exist, userId:{}.", userId);
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
@@ -671,7 +671,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // check exist
-        User tempUser = userMapper.selectById(userId);
+        User tempUser = userDao.queryById(userId);
         if (tempUser == null) {
             log.error("User does not exist, userId:{}.", userId);
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
@@ -711,7 +711,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             log.warn("Only admin can grant datasource.");
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        User user = userMapper.selectById(userId);
+        User user = userDao.queryById(userId);
         if (user == null) {
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
         }
@@ -749,7 +749,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         if (loginUser.getUserType() == UserType.ADMIN_USER) {
             user = loginUser;
         } else {
-            user = userMapper.queryDetailsById(loginUser.getId());
+            user = userDao.queryDetailsById(loginUser.getId());
 
             List<AlertGroup> alertGroups = alertGroupMapper.queryByUserId(loginUser.getId());
 
@@ -792,7 +792,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             log.warn("Only admin can query all general users.");
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        return userMapper.queryAllGeneralUser();
+        return userDao.queryAllGeneralUser();
     }
 
     /**
@@ -807,7 +807,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         if (!canOperatorPermissions(loginUser, null, AuthorizationType.ACCESS_TOKEN, USER_MANAGER)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        return userMapper.queryEnabledUsers();
+        return userDao.queryEnabledUsers();
     }
 
     /**
@@ -820,7 +820,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     public Result<Object> verifyUserName(String userName) {
 
         Result<Object> result = new Result<>();
-        User user = userMapper.queryByUserNameAccurately(userName);
+        User user = userDao.queryByUserNameAccurately(userName);
         if (user != null) {
             putMsg(result, Status.USER_NAME_EXIST);
         } else {
@@ -845,13 +845,13 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
-        List<User> userList = userMapper.selectList(null);
+        List<User> userList = userDao.queryAll();
         List<User> resultUsers = new ArrayList<>();
         Set<User> userSet;
         if (userList != null && !userList.isEmpty()) {
             userSet = new HashSet<>(userList);
 
-            List<User> authedUserList = userMapper.queryUserListByAlertGroupId(alertgroupId);
+            List<User> authedUserList = userDao.queryUserListByAlertGroupId(alertgroupId);
 
             if (authedUserList != null && !authedUserList.isEmpty()) {
                 Set<User> authedUserSet = new HashSet<>(authedUserList);
@@ -876,7 +876,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             log.warn("Only admin can authorize user.");
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        return userMapper.queryUserListByAlertGroupId(alertGroupId);
+        return userDao.queryUserListByAlertGroupId(alertGroupId);
     }
 
     /**
@@ -952,7 +952,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             throw new ServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR, userName);
         }
 
-        User user = userMapper.queryByUserNameAccurately(userName);
+        User user = userDao.queryByUserNameAccurately(userName);
 
         if (user == null) {
             throw new ServiceException(Status.USER_NOT_EXIST, userName);
@@ -964,9 +964,9 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
 
         user.setState(Flag.YES.ordinal());
         user.setUpdateTime(new Date());
-        userMapper.updateById(user);
+        userDao.updateById(user);
 
-        return userMapper.queryByUserNameAccurately(userName);
+        return userDao.queryByUserNameAccurately(userName);
     }
 
     /**
@@ -1034,7 +1034,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
                                       String tenantCode,
                                       String queue,
                                       int state) {
-        User user = userMapper.queryByUserNameAccurately(userName);
+        User user = userDao.queryByUserNameAccurately(userName);
         if (Objects.isNull(user)) {
             Tenant tenant = tenantDao.queryByCode(tenantCode).orElse(null);
             user = createUser(userName, userPassword, email, tenant.getId(), phone, queue, state);
@@ -1042,7 +1042,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         updateUser(user, user.getId(), userName, userPassword, email, user.getTenantId(), phone, queue, state, null);
-        user = userMapper.queryDetailsById(user.getId());
+        user = userDao.queryDetailsById(user.getId());
         return user;
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -79,7 +79,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
@@ -88,6 +87,7 @@ import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
 import org.apache.dolphinscheduler.plugin.task.api.model.ConditionDependentItem;
@@ -153,7 +153,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     private ProjectService projectService;
 
     @Autowired
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Autowired
     private WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
@@ -508,7 +508,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                 schedulerService.queryScheduleByWorkflowDefinitionCodes(workflowDefinitionCodes)
                         .stream()
                         .collect(Collectors.toMap(Schedule::getWorkflowDefinitionCode, Function.identity()));
-        List<UserWithWorkflowDefinitionCode> userWithCodes = userMapper.queryUserWithWorkflowDefinitionCode(
+        List<UserWithWorkflowDefinitionCode> userWithCodes = userDao.queryUserWithWorkflowDefinitionCode(
                 workflowDefinitionCodes);
         for (WorkflowDefinition pd : workflowDefinitions) {
             userWithCodes.stream()

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptorTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/interceptor/LoginHandlerInterceptorTest.java
@@ -26,7 +26,7 @@ import org.apache.dolphinscheduler.api.security.Authenticator;
 import org.apache.dolphinscheduler.common.enums.ProfileType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import java.util.Date;
 
@@ -60,8 +60,8 @@ public class LoginHandlerInterceptorTest {
     LoginHandlerInterceptor interceptor;
     @MockBean(name = "authenticator")
     private Authenticator authenticator;
-    @MockBean(name = "userMapper")
-    private UserMapper userMapper;
+    @MockBean(name = "userDao")
+    private UserDao userDao;
 
     @Test
     public void testPreHandle() {
@@ -82,7 +82,7 @@ public class LoginHandlerInterceptorTest {
         // test token
         String token = "123456";
         when(request.getHeader("token")).thenReturn(token);
-        when(userMapper.queryUserByToken(eq(token), any(Date.class))).thenReturn(mockUser);
+        when(userDao.queryUserByToken(eq(token), any(Date.class))).thenReturn(mockUser);
         Assertions.assertTrue(interceptor.preHandle(request, response, null));
 
         // test disable user

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -37,8 +37,8 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -90,7 +90,7 @@ public class ProjectServiceTest {
     private WorkflowDefinitionDao workflowDefinitionDao;
 
     @Mock
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -276,12 +276,12 @@ public class ProjectServiceTest {
         Assertions.assertEquals(Status.PROJECT_ALREADY_EXISTS.getCode(), result.getCode().intValue());
 
         // USER_NOT_EXIST
-        Mockito.when(userMapper.selectById(Mockito.any())).thenReturn(null);
+        Mockito.when(userDao.queryById(Mockito.any())).thenReturn(null);
         result = projectService.update(loginUser, 2L, "test", "desc");
         Assertions.assertEquals(Status.USER_NOT_EXIST.getCode(), result.getCode().intValue());
 
         // success
-        Mockito.when(userMapper.selectById(Mockito.any())).thenReturn(new User());
+        Mockito.when(userDao.queryById(Mockito.any())).thenReturn(new User());
         project.setUserId(1);
         Mockito.when(projectDao.updateById(Mockito.any(Project.class))).thenReturn(true);
         result = projectService.update(loginUser, 2L, "test", "desc");
@@ -334,7 +334,7 @@ public class ProjectServiceTest {
                 .thenReturn(true);
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.PROJECTS, new Object[]{1},
                 0, baseServiceLogger)).thenReturn(true);
-        Mockito.when(this.userMapper.queryAuthedUserListByProjectId(1)).thenReturn(this.getUserList());
+        Mockito.when(this.userDao.queryAuthedUserListByProjectId(1)).thenReturn(this.getUserList());
         Result result = this.projectService.queryAuthorizedUser(loginUser, 3682329499136L);
         logger.info("SUCCESS 1: {}", result.toString());
         List<User> users = (List<User>) result.getData();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/QueueServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/QueueServiceTest.java
@@ -35,7 +35,7 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Queue;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -76,7 +76,7 @@ public class QueueServiceTest {
     private QueueMapper queueMapper;
 
     @Mock
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -181,7 +181,7 @@ public class QueueServiceTest {
         Assertions.assertEquals(formatter, exception.getMessage());
 
         // success
-        when(userMapper.existUser(Mockito.anyString())).thenReturn(false);
+        when(userDao.existUser(Mockito.anyString())).thenReturn(false);
         assertDoesNotThrow(() -> queueService.updateQueue(getLoginUser(), 1, NOT_EXISTS, NOT_EXISTS));
         Queue queue = queueService.updateQueue(getLoginUser(), 1, NOT_EXISTS, NOT_EXISTS);
         Assertions.assertNull(queue.getCreateTime());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
@@ -38,10 +38,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -90,7 +90,7 @@ public class TenantServiceTest {
     private WorkflowInstanceMapper workflowInstanceMapper;
 
     @Mock
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -192,7 +192,7 @@ public class TenantServiceTest {
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES))
                         .thenReturn(getInstanceList());
         when(scheduleDao.queryScheduleListByTenant(tenantCode)).thenReturn(getScheduleList());
-        when(userMapper.queryUserListByTenant(3)).thenReturn(getUserList());
+        when(userDao.queryUserListByTenant(3)).thenReturn(getUserList());
 
         // TENANT_NOT_EXIST
         assertThrowsServiceException(Status.TENANT_NOT_EXIST, () -> tenantService.deleteTenantById(getLoginUser(), 12));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -42,9 +42,9 @@ import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +75,7 @@ public class UsersServiceTest {
     private UsersServiceImpl usersService;
 
     @Mock
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     @Mock
     private AccessTokenMapper accessTokenMapper;
@@ -181,7 +181,7 @@ public class UsersServiceTest {
     public void testQueryUser() {
         String userName = "userTest0001";
         String userPassword = "userTest0001";
-        when(userMapper.queryUserByNamePassword(userName, EncryptionUtils.getMd5(userPassword)))
+        when(userDao.queryUserByNamePassword(userName, EncryptionUtils.getMd5(userPassword)))
                 .thenReturn(getGeneralUser());
         User queryUser = usersService.queryUser(userName, userPassword);
         Assertions.assertNotNull(queryUser);
@@ -195,7 +195,7 @@ public class UsersServiceTest {
         ids.add(1);
         List<User> userList = new ArrayList<>();
         userList.add(new User());
-        when(userMapper.selectByIds(ids)).thenReturn(userList);
+        when(userDao.queryByIds(ids)).thenReturn(userList);
         List<User> userList1 = usersService.queryUser(ids);
         Assertions.assertFalse(userList1.isEmpty());
     }
@@ -237,7 +237,7 @@ public class UsersServiceTest {
         // success
         Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ACCESS_TOKEN, null, 0,
                 serviceLogger)).thenReturn(true);
-        when(userMapper.queryEnabledUsers()).thenReturn(getUserList());
+        when(userDao.queryEnabledUsers()).thenReturn(getUserList());
         List<User> users = usersService.queryUserList(user);
         Assertions.assertFalse(users.isEmpty());
     }
@@ -247,7 +247,7 @@ public class UsersServiceTest {
         User user = new User();
         IPage<User> page = new Page<>(1, 10);
         page.setRecords(getUserList());
-        when(userMapper.queryUserPaging(any(Page.class), eq("userTest"))).thenReturn(page);
+        when(userDao.queryUserPaging(any(Page.class), eq("userTest"))).thenReturn(page);
 
         // no operate
         Result result = usersService.queryUserList(user, "userTest", 1, 10);
@@ -280,8 +280,8 @@ public class UsersServiceTest {
                         "Asia/Shanghai"));
 
         // success
-        when(userMapper.selectById(any())).thenReturn(getUser());
-        when(userMapper.updateById(any())).thenReturn(1);
+        when(userDao.queryById(any())).thenReturn(getUser());
+        when(userDao.updateById(any())).thenReturn(true);
         assertDoesNotThrow(() -> usersService.updateUser(getLoginUser(),
                 1,
                 userName,
@@ -294,8 +294,8 @@ public class UsersServiceTest {
                 "Asia/Shanghai"));
 
         // non-admin should not modify tenantId and queue
-        when(userMapper.selectById(2)).thenReturn(getNonAdminUser());
-        User user = userMapper.selectById(2);
+        when(userDao.queryById(2)).thenReturn(getNonAdminUser());
+        User user = userDao.queryById(2);
         assertThrowsServiceException(Status.USER_NO_OPERATION_PERM, () -> usersService.updateUser(user,
                 2,
                 userName,
@@ -320,13 +320,13 @@ public class UsersServiceTest {
         // update failure (0 rows affected) -> UPDATE_USER_ERROR
         User failingUser = new User();
         failingUser.setId(1);
-        Mockito.when(userMapper.updateById(Mockito.any())).thenReturn(0);
+        Mockito.when(userDao.updateById(Mockito.any())).thenReturn(false);
         assertThrowsServiceException(Status.UPDATE_USER_ERROR, () -> usersService.updateUser(failingUser));
 
         // success path (1 row affected)
         User successUser = new User();
         successUser.setId(2);
-        Mockito.when(userMapper.updateById(Mockito.any())).thenReturn(1);
+        Mockito.when(userDao.updateById(Mockito.any())).thenReturn(true);
         User updated = usersService.updateUser(successUser);
         Assertions.assertNotNull(updated);
         Assertions.assertEquals(2, updated.getId());
@@ -336,9 +336,9 @@ public class UsersServiceTest {
     @Test
     public void testDeleteUserById() {
         User loginUser = new User();
-        when(userMapper.queryTenantCodeByUserId(1)).thenReturn(getUser());
-        when(userMapper.selectById(1)).thenReturn(getUser());
-        when(userMapper.deleteById(1)).thenReturn(1);
+        when(userDao.queryTenantCodeByUserId(1)).thenReturn(getUser());
+        when(userDao.queryById(1)).thenReturn(getUser());
+        when(userDao.deleteById(1)).thenReturn(true);
         // no operate
         assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
                 () -> usersService.deleteUserById(loginUser, 3));
@@ -367,18 +367,18 @@ public class UsersServiceTest {
         // user not exist
         loginUser.setId(1);
         loginUser.setUserType(UserType.ADMIN_USER);
-        when(userMapper.selectById(userId)).thenReturn(null);
+        when(userDao.queryById(userId)).thenReturn(null);
         assertThrowsServiceException(Status.USER_NOT_EXIST,
                 () -> usersService.grantProject(loginUser, userId, projectIds));
 
         // SUCCESS
-        when(userMapper.selectById(userId)).thenReturn(getUser());
+        when(userDao.queryById(userId)).thenReturn(getUser());
         assertDoesNotThrow(() -> usersService.grantProject(loginUser, userId, projectIds));
 
         // ERROR: NO_CURRENT_OPERATING_PERMISSION
         loginUser.setId(3);
         loginUser.setUserType(UserType.GENERAL_USER);
-        when(userMapper.selectById(3)).thenReturn(loginUser);
+        when(userDao.queryById(3)).thenReturn(loginUser);
         assertThrowsServiceException(Status.NO_CURRENT_OPERATING_PERMISSION,
                 () -> usersService.grantProject(loginUser, userId, projectIds));
     }
@@ -392,18 +392,18 @@ public class UsersServiceTest {
         // user not exist
         loginUser.setId(1);
         loginUser.setUserType(UserType.ADMIN_USER);
-        when(userMapper.selectById(userId)).thenReturn(null);
+        when(userDao.queryById(userId)).thenReturn(null);
         assertThrowsServiceException(Status.USER_NOT_EXIST,
                 () -> usersService.grantProjectWithReadPerm(loginUser, userId, projectIds));
 
         // SUCCESS
-        when(userMapper.selectById(userId)).thenReturn(getUser());
+        when(userDao.queryById(userId)).thenReturn(getUser());
         assertDoesNotThrow(() -> usersService.grantProjectWithReadPerm(loginUser, userId, projectIds));
 
         // ERROR: NO_CURRENT_OPERATING_PERMISSION
         loginUser.setId(3);
         loginUser.setUserType(UserType.GENERAL_USER);
-        when(userMapper.selectById(3)).thenReturn(loginUser);
+        when(userDao.queryById(3)).thenReturn(loginUser);
         assertThrowsServiceException(Status.NO_CURRENT_OPERATING_PERMISSION,
                 () -> usersService.grantProjectWithReadPerm(loginUser, userId, projectIds));
     }
@@ -414,8 +414,8 @@ public class UsersServiceTest {
         final long projectCode = 1L;
         final int projectCreator = 1;
         final int authorizer = 100;
-        Mockito.when(this.userMapper.selectById(authorizer)).thenReturn(this.getUser());
-        Mockito.when(this.userMapper.selectById(projectCreator)).thenReturn(this.getUser());
+        Mockito.when(this.userDao.queryById(authorizer)).thenReturn(this.getUser());
+        Mockito.when(this.userDao.queryById(projectCreator)).thenReturn(this.getUser());
         Mockito.when(this.projectDao.queryByCode(projectCode)).thenReturn(this.getProject());
 
         // ERROR: USER_NOT_EXIST
@@ -446,7 +446,7 @@ public class UsersServiceTest {
 
     @Test
     public void testRevokeProject() {
-        Mockito.when(this.userMapper.selectById(1)).thenReturn(this.getUser());
+        Mockito.when(this.userDao.queryById(1)).thenReturn(this.getUser());
 
         final long projectCode = 3682329499136L;
 
@@ -470,7 +470,7 @@ public class UsersServiceTest {
 
     @Test
     public void testRevokeProjectById() {
-        Mockito.when(this.userMapper.selectById(1)).thenReturn(this.getUser());
+        Mockito.when(this.userDao.queryById(1)).thenReturn(this.getUser());
 
         String projectId = "100000";
 
@@ -492,7 +492,7 @@ public class UsersServiceTest {
     @Test
     public void testGrantNamespaces() {
         String namespaceIds = "100000,120000";
-        when(userMapper.selectById(1)).thenReturn(getUser());
+        when(userDao.queryById(1)).thenReturn(getUser());
         User loginUser = new User();
 
         // user not exist
@@ -513,12 +513,12 @@ public class UsersServiceTest {
         // user not exist
         loginUser.setId(1);
         loginUser.setUserType(UserType.ADMIN_USER);
-        when(userMapper.selectById(userId)).thenReturn(null);
+        when(userDao.queryById(userId)).thenReturn(null);
         assertThrowsServiceException(Status.USER_NOT_EXIST,
                 () -> usersService.grantDataSource(loginUser, userId, datasourceIds));
 
         // test admin user
-        when(userMapper.selectById(userId)).thenReturn(getUser());
+        when(userDao.queryById(userId)).thenReturn(getUser());
         when(datasourceUserMapper.deleteByUserId(Mockito.anyInt())).thenReturn(1);
         assertDoesNotThrow(() -> usersService.grantDataSource(loginUser, userId, datasourceIds));
 
@@ -548,7 +548,7 @@ public class UsersServiceTest {
         // get general user
         loginUser.setUserType(null);
         loginUser.setId(1);
-        when(userMapper.queryDetailsById(1)).thenReturn(getGeneralUser());
+        when(userDao.queryDetailsById(1)).thenReturn(getGeneralUser());
         when(alertGroupMapper.queryByUserId(1)).thenReturn(getAlertGroups());
         User generalInfo = usersService.getUserInfo(loginUser);
         Assertions.assertEquals("userTest0001", generalInfo.getUserName());
@@ -562,7 +562,7 @@ public class UsersServiceTest {
                 () -> usersService.queryAllGeneralUsers(loginUser));
         // success
         loginUser.setUserType(UserType.ADMIN_USER);
-        when(userMapper.queryAllGeneralUser()).thenReturn(getUserList());
+        when(userDao.queryAllGeneralUser()).thenReturn(getUserList());
         List<User> users = usersService.queryAllGeneralUsers(loginUser);
         Assertions.assertFalse(users.isEmpty());
     }
@@ -573,7 +573,7 @@ public class UsersServiceTest {
         Result result = usersService.verifyUserName("admin89899");
         Assertions.assertEquals(Status.SUCCESS.getMsg(), result.getMsg());
         // exist user
-        when(userMapper.queryByUserNameAccurately("userTest0001")).thenReturn(getUser());
+        when(userDao.queryByUserNameAccurately("userTest0001")).thenReturn(getUser());
         result = usersService.verifyUserName("userTest0001");
         Assertions.assertEquals(Status.USER_NAME_EXIST.getMsg(), result.getMsg());
     }
@@ -581,8 +581,8 @@ public class UsersServiceTest {
     @Test
     public void testUnauthorizedUser() {
         User loginUser = new User();
-        when(userMapper.selectList(null)).thenReturn(getUserList());
-        when(userMapper.queryUserListByAlertGroupId(2)).thenReturn(getUserList());
+        when(userDao.queryAll()).thenReturn(getUserList());
+        when(userDao.queryUserListByAlertGroupId(2)).thenReturn(getUserList());
         // no operate
         assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
                 () -> usersService.unauthorizedUser(loginUser, 2));
@@ -595,7 +595,7 @@ public class UsersServiceTest {
     @Test
     public void testAuthorizedUser() {
         User loginUser = new User();
-        when(userMapper.queryUserListByAlertGroupId(2)).thenReturn(getUserList());
+        when(userDao.queryUserListByAlertGroupId(2)).thenReturn(getUserList());
         // no operate
         assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
                 () -> usersService.authorizedUser(loginUser, 2));
@@ -675,12 +675,12 @@ public class UsersServiceTest {
         // user state error
         userName = "userTest0001";
         final String existingName = userName;
-        when(userMapper.queryByUserNameAccurately(existingName)).thenReturn(getUser());
+        when(userDao.queryByUserNameAccurately(existingName)).thenReturn(getUser());
         assertThrowsServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR,
                 () -> usersService.activateUser(user, existingName));
 
         // success
-        when(userMapper.queryByUserNameAccurately(existingName)).thenReturn(getDisabledUser());
+        when(userDao.queryByUserNameAccurately(existingName)).thenReturn(getDisabledUser());
         User activated = usersService.activateUser(user, existingName);
         Assertions.assertNotNull(activated);
     }
@@ -701,8 +701,8 @@ public class UsersServiceTest {
 
         // batch activate user names
         user.setUserType(UserType.ADMIN_USER);
-        when(userMapper.queryByUserNameAccurately("userTest0001")).thenReturn(getUser());
-        when(userMapper.queryByUserNameAccurately("userTest0002")).thenReturn(getDisabledUser());
+        when(userDao.queryByUserNameAccurately("userTest0001")).thenReturn(getUser());
+        when(userDao.queryByUserNameAccurately("userTest0002")).thenReturn(getDisabledUser());
         Map<String, Object> result = usersService.batchActivateUser(user, userNames);
         Map<String, Object> successData = (Map<String, Object>) result.get("success");
         int totalSuccess = (Integer) successData.get("sum");
@@ -725,17 +725,17 @@ public class UsersServiceTest {
         int stat = 1;
 
         // User exists
-        when(userMapper.existUser(userName)).thenReturn(true);
-        when(userMapper.selectById(getUser().getId())).thenReturn(getUser());
-        when(userMapper.queryDetailsById(getUser().getId())).thenReturn(getUser());
-        when(userMapper.queryByUserNameAccurately(userName)).thenReturn(getUser());
-        when(userMapper.updateById(any())).thenReturn(1);
+        when(userDao.existUser(userName)).thenReturn(true);
+        when(userDao.queryById(getUser().getId())).thenReturn(getUser());
+        when(userDao.queryDetailsById(getUser().getId())).thenReturn(getUser());
+        when(userDao.queryByUserNameAccurately(userName)).thenReturn(getUser());
+        when(userDao.updateById(any())).thenReturn(true);
         when(tenantDao.queryByCode(tenantCode)).thenReturn(Optional.of(getTenant()));
         user = usersService.createUserIfNotExists(userName, userPassword, email, phone, tenantCode, queueName, stat);
         Assertions.assertEquals(getUser(), user);
 
         // User not exists
-        Mockito.when(userMapper.existUser(userName)).thenReturn(false);
+        Mockito.when(userDao.existUser(userName)).thenReturn(false);
         Mockito.when(tenantDao.queryByCode(tenantCode)).thenReturn(Optional.of(getTenant()));
         user = usersService.createUserIfNotExists(userName, userPassword, email, phone, tenantCode, queueName, stat);
         Assertions.assertNotNull(user);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -62,7 +62,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowTaskRelationMapper;
@@ -71,6 +70,7 @@ import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TaskDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
+import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionLogDao;
 import org.apache.dolphinscheduler.dao.utils.WorkerGroupUtils;
@@ -198,7 +198,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     private GlobalParamsValidator globalParamsValidator;
 
     @Mock
-    private UserMapper userMapper;
+    private UserDao userDao;
 
     protected User user;
     protected Exception exception;
@@ -357,7 +357,7 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 eq(projectCode))).thenReturn(pageListingResult);
         String user1 = "user1";
         String user2 = "user2";
-        when(userMapper.queryUserWithWorkflowDefinitionCode(processDefinitionCodes))
+        when(userDao.queryUserWithWorkflowDefinitionCode(processDefinitionCodes))
                 .thenReturn(Arrays.asList(
                         UserWithWorkflowDefinitionCode.builder()
                                 .workflowDefinitionCode(processDefinitionCode1)

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/UserDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/UserDao.java
@@ -18,6 +18,43 @@
 package org.apache.dolphinscheduler.dao.repository;
 
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.UserWithWorkflowDefinitionCode;
+
+import java.util.Date;
+import java.util.List;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 public interface UserDao extends IDao<User> {
+
+    List<User> queryAllGeneralUser();
+
+    User queryByUserNameAccurately(String userName);
+
+    User queryUserByNamePassword(String userName, String password);
+
+    IPage<User> queryUserPaging(Page<User> page, String userName);
+
+    User queryDetailsById(int userId);
+
+    List<User> queryUserListByAlertGroupId(int alertGroupId);
+
+    List<User> queryUserListByTenant(int tenantId);
+
+    User queryTenantCodeByUserId(int userId);
+
+    User queryUserByToken(String token, Date now);
+
+    List<User> queryUserListByQueue(String queueName);
+
+    Boolean existUser(String queue);
+
+    Integer updateUserQueue(String oldQueue, String newQueue);
+
+    List<User> queryAuthedUserListByProjectId(int projectId);
+
+    List<User> queryEnabledUsers();
+
+    List<UserWithWorkflowDefinitionCode> queryUserWithWorkflowDefinitionCode(List<Long> workflowDefinitionCodes);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/UserDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/UserDaoImpl.java
@@ -18,13 +18,20 @@
 package org.apache.dolphinscheduler.dao.repository.impl;
 
 import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.UserWithWorkflowDefinitionCode;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.BaseDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 
+import java.util.Date;
+import java.util.List;
+
 import lombok.NonNull;
 
 import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 @Repository
 public class UserDaoImpl extends BaseDao<User, UserMapper> implements UserDao {
@@ -33,4 +40,78 @@ public class UserDaoImpl extends BaseDao<User, UserMapper> implements UserDao {
         super(userMapper);
     }
 
+    @Override
+    public List<User> queryAllGeneralUser() {
+        return mybatisMapper.queryAllGeneralUser();
+    }
+
+    @Override
+    public User queryByUserNameAccurately(String userName) {
+        return mybatisMapper.queryByUserNameAccurately(userName);
+    }
+
+    @Override
+    public User queryUserByNamePassword(String userName, String password) {
+        return mybatisMapper.queryUserByNamePassword(userName, password);
+    }
+
+    @Override
+    public IPage<User> queryUserPaging(Page<User> page, String userName) {
+        return mybatisMapper.queryUserPaging(page, userName);
+    }
+
+    @Override
+    public User queryDetailsById(int userId) {
+        return mybatisMapper.queryDetailsById(userId);
+    }
+
+    @Override
+    public List<User> queryUserListByAlertGroupId(int alertGroupId) {
+        return mybatisMapper.queryUserListByAlertGroupId(alertGroupId);
+    }
+
+    @Override
+    public List<User> queryUserListByTenant(int tenantId) {
+        return mybatisMapper.queryUserListByTenant(tenantId);
+    }
+
+    @Override
+    public User queryTenantCodeByUserId(int userId) {
+        return mybatisMapper.queryTenantCodeByUserId(userId);
+    }
+
+    @Override
+    public User queryUserByToken(String token, Date now) {
+        return mybatisMapper.queryUserByToken(token, now);
+    }
+
+    @Override
+    public List<User> queryUserListByQueue(String queueName) {
+        return mybatisMapper.queryUserListByQueue(queueName);
+    }
+
+    @Override
+    public Boolean existUser(String queue) {
+        return mybatisMapper.existUser(queue);
+    }
+
+    @Override
+    public Integer updateUserQueue(String oldQueue, String newQueue) {
+        return mybatisMapper.updateUserQueue(oldQueue, newQueue);
+    }
+
+    @Override
+    public List<User> queryAuthedUserListByProjectId(int projectId) {
+        return mybatisMapper.queryAuthedUserListByProjectId(projectId);
+    }
+
+    @Override
+    public List<User> queryEnabledUsers() {
+        return mybatisMapper.queryEnabledUsers();
+    }
+
+    @Override
+    public List<UserWithWorkflowDefinitionCode> queryUserWithWorkflowDefinitionCode(List<Long> workflowDefinitionCodes) {
+        return mybatisMapper.queryUserWithWorkflowDefinitionCode(workflowDefinitionCodes);
+    }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Tracking issue: #18249

Expose every UserMapper method the api layer needs on UserDao (queryAllGeneralUser, queryByUserNameAccurately, queryUserByNamePassword, queryUserPaging, queryDetailsById, queryUserListByAlertGroupId, queryUserListByTenant, queryTenantCodeByUserId, queryUserByToken, queryUserListByQueue, existUser, updateUserQueue,
queryAuthedUserListByProjectId, queryEnabledUsers, queryUserWithWorkflowDefinitionCode) and replace every direct UserMapper reference in dolphinscheduler-api with the Dao, so Mapper usage stays inside dolphinscheduler-dao.repository as documented in dolphinscheduler-dao/CLAUDE.md.

Notes:
- BaseDao#updateById and BaseDao#deleteById return boolean (Mapper returned int); affected call sites in UsersServiceImpl (updateUser, deleteUserById, updateUserByUserName) were refactored to use the boolean directly. Test mocks switched thenReturn(1/0) to thenReturn(true/false).
- selectById / selectByIds / selectList(null) were replaced with their IDao equivalents queryById / queryByIds / queryAll.
- LoginHandlerInterceptorTest's @MockBean(name = "userMapper") was updated to @MockBean(name = "userDao") so Spring resolves the renamed field.

UserMapper-look-alikes (ProjectUserMapper, DataSourceUserMapper, K8sNamespaceUserMapper) are out of scope for this commit and were deliberately left untouched.

No production behavior changes; the Mapper interface itself is untouched.

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
