### PR TITLE
[Improvement-18249][DAO] Route WorkflowInstanceMapper access through WorkflowInstanceDao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/WorkflowInstanceAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/WorkflowInstanceAuditOperatorImpl.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.common.enums.AuditOperationType;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Service;
 public class WorkflowInstanceAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @Override
     public void modifyAuditOperationType(AuditType auditType, Map<String, Object> paramsMap,
@@ -64,7 +64,7 @@ public class WorkflowInstanceAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        WorkflowInstance obj = workflowInstanceMapper.queryDetailById(objId);
+        WorkflowInstance obj = workflowInstanceDao.queryDetailById(objId);
         return obj == null ? "" : obj.getName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataAnalysisServiceImpl.java
@@ -36,13 +36,13 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
 import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.model.TaskInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.model.WorkflowDefinitionCountDto;
 import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -76,7 +76,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
     private ProjectService projectService;
 
     @Autowired
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @Autowired
     private WorkflowDefinitionDao workflowDefinitionDao;
@@ -126,7 +126,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, PROJECT_OVERVIEW);
         Date start = startDate == null ? null : transformDate(startDate);
         Date end = endDate == null ? null : transformDate(endDate);
-        List<WorkflowInstanceStatusCountDto> workflowInstanceStatusCountDtos = workflowInstanceMapper
+        List<WorkflowInstanceStatusCountDto> workflowInstanceStatusCountDtos = workflowInstanceDao
                 .countWorkflowInstanceStateByProjectCodes(start, end, Lists.newArrayList(projectCode));
         return WorkflowInstanceCountVO.of(workflowInstanceStatusCountDtos);
     }
@@ -143,7 +143,7 @@ public class DataAnalysisServiceImpl extends BaseServiceImpl implements DataAnal
         Date end = endDate == null ? null : transformDate(endDate);
 
         List<WorkflowInstanceStatusCountDto> workflowInstanceStatusCountDtos =
-                workflowInstanceMapper.countWorkflowInstanceStateByProjectCodes(start, end, projectCodes);
+                workflowInstanceDao.countWorkflowInstanceStateByProjectCodes(start, end, projectCodes);
         return WorkflowInstanceCountVO.of(workflowInstanceStatusCountDtos);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -36,10 +36,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -67,7 +67,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
     private TenantDao tenantDao;
 
     @Autowired
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @Autowired
     private ScheduleDao scheduleDao;
@@ -244,11 +244,11 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_ERROR);
         }
 
-        workflowInstanceMapper.updateWorkflowInstanceByTenantCode(tenant.getTenantCode(), Constants.DEFAULT);
+        workflowInstanceDao.updateWorkflowInstanceByTenantCode(tenant.getTenantCode(), Constants.DEFAULT);
     }
 
     private List<WorkflowInstance> getWorkflowInstancesByTenant(Tenant tenant) {
-        return workflowInstanceMapper.queryByTenantCodeAndStatus(
+        return workflowInstanceDao.queryByTenantCodeAndStatus(
                 tenant.getTenantCode(),
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES);
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkerGroupServiceImpl.java
@@ -43,10 +43,10 @@ import org.apache.dolphinscheduler.dao.entity.WorkerGroupPageDetail;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.extract.base.client.Clients;
 import org.apache.dolphinscheduler.extract.master.IMasterContainerService;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
@@ -81,7 +81,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
     private WorkerGroupDao workerGroupDao;
 
     @Autowired
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @Autowired
     private RegistryClient registryClient;
@@ -322,7 +322,7 @@ public class WorkerGroupServiceImpl extends BaseServiceImpl implements WorkerGro
             log.error("Worker group does not exist, workerGroupId:{}.", id);
             throw new ServiceException(Status.DELETE_WORKER_GROUP_NOT_EXIST);
         }
-        List<WorkflowInstance> workflowInstances = workflowInstanceMapper.queryByWorkerGroupNameAndStatus(
+        List<WorkflowInstance> workflowInstances = workflowInstanceDao.queryByWorkerGroupNameAndStatus(
                 workerGroup.getName(),
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES);
         if (CollectionUtils.isNotEmpty(workflowInstances)) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -68,7 +68,6 @@ import org.apache.dolphinscheduler.dao.mapper.RelationSubWorkflowMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceContextDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
@@ -135,9 +134,6 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     private TaskInstanceService taskInstanceService;
 
     @Autowired
-    WorkflowInstanceMapper workflowInstanceMapper;
-
-    @Autowired
     WorkflowInstanceDao workflowInstanceDao;
 
     @Autowired
@@ -198,7 +194,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
             throw new ServiceException(Status.START_TIME_BIGGER_THAN_END_TIME_ERROR, startTime, endTime);
         }
 
-        return workflowInstanceMapper.queryTopNWorkflowInstance(size, start, end, WorkflowExecutionStatus.SUCCESS,
+        return workflowInstanceDao.queryTopNWorkflowInstance(size, start, end, WorkflowExecutionStatus.SUCCESS,
                 projectCode);
     }
 
@@ -254,7 +250,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         Page<WorkflowInstance> page = new Page<>(pageNo, pageSize);
         PageInfo<WorkflowInstance> pageInfo = new PageInfo<>(pageNo, pageSize);
 
-        IPage<WorkflowInstance> workflowInstanceList = workflowInstanceMapper.queryWorkflowInstanceListPaging(
+        IPage<WorkflowInstance> workflowInstanceList = workflowInstanceDao.queryWorkflowInstanceListPaging(
                 page,
                 projectCode,
                 workflowDefinitionCode,
@@ -600,7 +596,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
 
-        WorkflowInstance workflowInstance = workflowInstanceMapper.queryDetailById(workflowInstanceId);
+        WorkflowInstance workflowInstance = workflowInstanceDao.queryDetailById(workflowInstanceId);
 
         if (workflowInstance == null) {
             log.error("workflow instance does not exist, projectCode:{}, workflowInstanceId:{}.", projectCode,
@@ -705,7 +701,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
     public GanttDto viewGantt(User loginUser, long projectCode, Integer workflowInstanceId) throws Exception {
         // check user access for project
         projectService.checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
-        WorkflowInstance workflowInstance = workflowInstanceMapper.queryDetailById(workflowInstanceId);
+        WorkflowInstance workflowInstance = workflowInstanceDao.queryDetailById(workflowInstanceId);
 
         if (workflowInstance == null) {
             log.error("workflow instance does not exist, projectCode:{}, workflowInstanceId:{}.", projectCode,
@@ -763,7 +759,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Override
     public List<WorkflowInstance> queryByWorkflowDefinitionCodeAndStatus(Long workflowDefinitionCode, int[] states) {
-        return workflowInstanceMapper.queryByWorkflowDefinitionCodeAndStatus(workflowDefinitionCode, states);
+        return workflowInstanceDao.queryByWorkflowDefinitionCodeAndStatus(workflowDefinitionCode, states);
     }
 
     @Override
@@ -775,7 +771,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Override
     public List<WorkflowInstance> queryByWorkflowDefinitionCode(Long workflowDefinitionCode, int size) {
-        return workflowInstanceMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode, size);
+        return workflowInstanceDao.queryByWorkflowDefinitionCode(workflowDefinitionCode, size);
     }
 
     @Override
@@ -788,14 +784,14 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
         if (triggerCode == null) {
             return Collections.emptyList();
         }
-        return workflowInstanceMapper.queryByTriggerCode(triggerCode);
+        return workflowInstanceDao.queryByTriggerCode(triggerCode);
     }
 
     @Override
     public void deleteWorkflowInstanceByWorkflowDefinitionCode(long workflowDefinitionCode) {
         while (true) {
             List<WorkflowInstance> workflowInstances =
-                    workflowInstanceMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode, 100);
+                    workflowInstanceDao.queryByWorkflowDefinitionCode(workflowDefinitionCode, 100);
             if (CollectionUtils.isEmpty(workflowInstances)) {
                 break;
             }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/WorkerGroupControllerTest.java
@@ -27,8 +27,8 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
 
@@ -53,8 +53,8 @@ public class WorkerGroupControllerTest extends AbstractControllerTest {
     @MockBean(name = "workerGroupDao")
     private WorkerGroupDao workerGroupDao;
 
-    @MockBean(name = "processInstanceMapper")
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    @MockBean
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @MockBean(name = "registryClient")
     private RegistryClient registryClient;
@@ -131,11 +131,11 @@ public class WorkerGroupControllerTest extends AbstractControllerTest {
         workerGroup.setId(12);
         workerGroup.setName("测试");
         Mockito.when(workerGroupDao.queryById(12)).thenReturn(workerGroup);
-        Mockito.when(workflowInstanceMapper.queryByWorkerGroupNameAndStatus("测试",
+        Mockito.when(workflowInstanceDao.queryByWorkerGroupNameAndStatus("测试",
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES))
                 .thenReturn(null);
         Mockito.when(workerGroupDao.deleteById(12)).thenReturn(true);
-        Mockito.when(workflowInstanceMapper.updateWorkflowInstanceByWorkerGroupName("测试", "")).thenReturn(1);
+        Mockito.when(workflowInstanceDao.updateWorkflowInstanceByWorkerGroupName("测试", "")).thenReturn(1);
 
         MvcResult mvcResult = mockMvc.perform(delete("/worker-groups/{id}", "12")
                 .header("sessionId", sessionId))

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataAnalysisServiceTest.java
@@ -46,10 +46,10 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.CommandMapper;
 import org.apache.dolphinscheduler.dao.mapper.ErrorCommandMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
 
 import java.text.MessageFormat;
@@ -92,7 +92,7 @@ public class DataAnalysisServiceTest {
     ProjectService projectService;
 
     @Mock
-    WorkflowInstanceMapper workflowInstanceMapper;
+    WorkflowInstanceDao workflowInstanceDao;
 
     @Mock
     WorkflowDefinitionDao workflowDefinitionDao;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
@@ -38,10 +38,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -87,7 +87,7 @@ public class TenantServiceTest {
     private ScheduleDao scheduleDao;
 
     @Mock
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @Mock
     private UserDao userDao;
@@ -188,7 +188,7 @@ public class TenantServiceTest {
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.TENANT, null, 0,
                 baseServiceLogger)).thenReturn(true);
         when(tenantDao.queryDetailById(1)).thenReturn(getTenant());
-        when(workflowInstanceMapper.queryByTenantCodeAndStatus(tenantCode,
+        when(workflowInstanceDao.queryByTenantCodeAndStatus(tenantCode,
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES))
                         .thenReturn(getInstanceList());
         when(scheduleDao.queryScheduleListByTenant(tenantCode)).thenReturn(getScheduleList());
@@ -202,7 +202,7 @@ public class TenantServiceTest {
                 () -> tenantService.deleteTenantById(getLoginUser(), 1));
 
         // DELETE_TENANT_BY_ID_FAIL_DEFINES
-        when(workflowInstanceMapper.queryByTenantCodeAndStatus(any(), any())).thenReturn(Collections.emptyList());
+        when(workflowInstanceDao.queryByTenantCodeAndStatus(any(), any())).thenReturn(Collections.emptyList());
         when(tenantDao.queryDetailById(2)).thenReturn(getTenant(2));
         assertThrowsServiceException(Status.DELETE_TENANT_BY_ID_FAIL_DEFINES,
                 () -> tenantService.deleteTenantById(getLoginUser(), 2));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkerGroupServiceTest.java
@@ -37,9 +37,9 @@ import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentWorkerGroupRelationMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
 
@@ -78,7 +78,7 @@ public class WorkerGroupServiceTest {
     private WorkerGroupDao workerGroupDao;
 
     @Mock
-    private WorkflowInstanceMapper workflowInstanceMapper;
+    private WorkflowInstanceDao workflowInstanceDao;
 
     @Mock
     private RegistryClient registryClient;
@@ -233,7 +233,7 @@ public class WorkerGroupServiceTest {
         workflowInstance.setId(1);
         List<WorkflowInstance> workflowInstances = new ArrayList<WorkflowInstance>();
         workflowInstances.add(workflowInstance);
-        when(workflowInstanceMapper.queryByWorkerGroupNameAndStatus(workerGroup.getName(),
+        when(workflowInstanceDao.queryByWorkerGroupNameAndStatus(workerGroup.getName(),
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES))
                         .thenReturn(workflowInstances);
 
@@ -250,7 +250,7 @@ public class WorkerGroupServiceTest {
                 baseServiceLogger)).thenReturn(true);
         WorkerGroup workerGroup = getWorkerGroup(1);
         when(workerGroupDao.queryById(1)).thenReturn(workerGroup);
-        when(workflowInstanceMapper.queryByWorkerGroupNameAndStatus(workerGroup.getName(),
+        when(workflowInstanceDao.queryByWorkerGroupNameAndStatus(workerGroup.getName(),
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES)).thenReturn(null);
 
         when(taskDefinitionMapper.selectList(Mockito.any())).thenReturn(null);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -59,7 +59,6 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
-import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceContextDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
@@ -120,9 +119,6 @@ public class WorkflowInstanceServiceTest {
 
     @Mock
     WorkflowInstanceDao workflowInstanceDao;
-
-    @Mock
-    WorkflowInstanceMapper workflowInstanceMapper;
 
     @Mock
     WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
@@ -226,7 +222,7 @@ public class WorkflowInstanceServiceTest {
                 Mockito.any(Project.class),
                 Mockito.any());
         when(workflowDefinitionDao.queryById(Mockito.any())).thenReturn(getProcessDefinition());
-        when(workflowInstanceMapper.queryWorkflowInstanceListPaging(Mockito.any(Page.class), Mockito.any(),
+        when(workflowInstanceDao.queryWorkflowInstanceListPaging(Mockito.any(Page.class), Mockito.any(),
                 Mockito.any(),
                 Mockito.any(), Mockito.any(), Mockito.any(),
                 eq("192.168.xx.xx"), Mockito.any(), Mockito.any())).thenReturn(pageReturn);
@@ -248,7 +244,7 @@ public class WorkflowInstanceServiceTest {
         doNothing().when(projectService).checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
         when(usersService.queryUser(loginUser.getId())).thenReturn(loginUser);
         when(usersService.getUserIdByName(loginUser.getUserName())).thenReturn(loginUser.getId());
-        when(workflowInstanceMapper.queryWorkflowInstanceListPaging(
+        when(workflowInstanceDao.queryWorkflowInstanceListPaging(
                 Mockito.any(Page.class),
                 eq(project.getCode()),
                 eq(1L),
@@ -268,7 +264,7 @@ public class WorkflowInstanceServiceTest {
         Assertions.assertEquals(Status.SUCCESS.getCode(), (int) successRes.getCode());
 
         // data parameter empty
-        when(workflowInstanceMapper.queryWorkflowInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()),
+        when(workflowInstanceDao.queryWorkflowInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()),
                 eq(1L), eq(""), eq(""), Mockito.any(),
                 eq("192.168.xx.xx"), eq(null), eq(null))).thenReturn(pageReturn);
         successRes = workflowInstanceService.queryWorkflowInstanceList(loginUser, projectCode, 1, "",
@@ -287,7 +283,7 @@ public class WorkflowInstanceServiceTest {
         Assertions.assertEquals(Status.SUCCESS.getCode(), (int) executorExistRes.getCode());
 
         // executor name empty
-        when(workflowInstanceMapper.queryWorkflowInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()),
+        when(workflowInstanceDao.queryWorkflowInstanceListPaging(Mockito.any(Page.class), eq(project.getCode()),
                 eq(1L), eq(""), eq("admin"), Mockito.any(),
                 eq("192.168.xx.xx"), eq(start), eq(end))).thenReturn(pageReturn);
         Result executorEmptyRes =
@@ -318,7 +314,7 @@ public class WorkflowInstanceServiceTest {
                 workflowInstanceService.queryByTriggerCode(loginUser, projectCode, null);
         Assertions.assertTrue(nullTriggerRes.isEmpty());
 
-        when(workflowInstanceMapper.queryByTriggerCode(999L)).thenReturn(new ArrayList<>());
+        when(workflowInstanceDao.queryByTriggerCode(999L)).thenReturn(new ArrayList<>());
         List<WorkflowInstance> emptyRes = workflowInstanceService.queryByTriggerCode(loginUser, projectCode, 999L);
         Assertions.assertTrue(emptyRes.isEmpty());
     }
@@ -345,7 +341,7 @@ public class WorkflowInstanceServiceTest {
         assertThrowsServiceException(Status.NEGTIVE_SIZE_NUMBER_ERROR, () -> workflowInstanceService
                 .queryTopNLongestRunningWorkflowInstance(loginUser, projectCode, -1, startTime, endTime));
 
-        when(workflowInstanceMapper.queryTopNWorkflowInstance(Mockito.eq(size), Mockito.any(), Mockito.any(),
+        when(workflowInstanceDao.queryTopNWorkflowInstance(Mockito.eq(size), Mockito.any(), Mockito.any(),
                 Mockito.eq(WorkflowExecutionStatus.SUCCESS), Mockito.eq(projectCode)))
                         .thenReturn(new ArrayList<>());
         List<WorkflowInstance> successRes = workflowInstanceService.queryTopNLongestRunningWorkflowInstance(loginUser,
@@ -717,11 +713,11 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setCommandType(CommandType.SCHEDULER);
         workflowInstance.setScheduleTime(new Date());
         workflowInstance.setGlobalParams("");
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(workflowInstance);
         WorkflowInstanceVariablesDTO successRes = workflowInstanceService.viewVariables(loginUser, projectCode, 1);
         Assertions.assertNotNull(successRes);
 
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(null);
         assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
                 () -> workflowInstanceService.viewVariables(loginUser, projectCode, 1));
 
@@ -754,7 +750,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setGlobalParams(globalParamsJson);
         workflowInstance.setWorkflowDefinitionCode(100L);
 
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(workflowInstance);
 
         WorkflowDefinition workflowDefinition = new WorkflowDefinition();
         workflowDefinition.setCode(100L);
@@ -789,7 +785,7 @@ public class WorkflowInstanceServiceTest {
         doNothing().when(projectService)
                 .checkProjectAndAuthThrowException(loginUser, projectCode, WORKFLOW_INSTANCE);
 
-        when(workflowInstanceMapper.queryDetailById(999)).thenReturn(null);
+        when(workflowInstanceDao.queryDetailById(999)).thenReturn(null);
 
         assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
                 () -> workflowInstanceService.viewVariables(loginUser, projectCode, 999));
@@ -809,7 +805,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setGlobalParams("");
         workflowInstance.setWorkflowDefinitionCode(101L);
 
-        when(workflowInstanceMapper.queryDetailById(2)).thenReturn(workflowInstance);
+        when(workflowInstanceDao.queryDetailById(2)).thenReturn(workflowInstance);
 
         WorkflowDefinition workflowDefinition = new WorkflowDefinition();
         workflowDefinition.setCode(101L);
@@ -833,11 +829,11 @@ public class WorkflowInstanceServiceTest {
         TaskInstance taskInstance = getTaskInstance();
         taskInstance.setState(TaskExecutionStatus.RUNNING_EXECUTION);
         taskInstance.setStartTime(new Date());
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(workflowInstance);
         when(workflowDefinitionLogMapper.queryByDefinitionCodeAndVersion(
                 workflowInstance.getWorkflowDefinitionCode(),
                 workflowInstance.getWorkflowDefinitionVersion())).thenReturn(new WorkflowDefinitionLog());
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(workflowInstance);
         DAG<Long, TaskNode, TaskNodeRelation> graph = new DAG<>();
         for (long i = 1; i <= 7; ++i) {
             graph.addNode(i, new TaskNode());
@@ -848,7 +844,7 @@ public class WorkflowInstanceServiceTest {
 
         Assertions.assertNotNull(workflowInstanceService.viewGantt(loginUser, projectCode, 1));
 
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(null);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(null);
         assertThrowsServiceException(Status.WORKFLOW_INSTANCE_NOT_EXIST,
                 () -> workflowInstanceService.viewGantt(loginUser, projectCode, 1));
 
@@ -882,7 +878,7 @@ public class WorkflowInstanceServiceTest {
         workflowInstance.setScheduleTime(new Date());
         workflowInstance.setCommandParam(JSONUtils.toJsonString(runWorkflowCommandParam));
 
-        when(workflowInstanceMapper.queryDetailById(1)).thenReturn(workflowInstance);
+        when(workflowInstanceDao.queryDetailById(1)).thenReturn(workflowInstance);
         Assertions.assertNotNull(workflowInstanceService.viewVariables(loginUser, projectCode, 1));
 
         final RunWorkflowCommandParam commandParamWithEmptyTimeZone = RunWorkflowCommandParam.builder()

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/WorkflowInstanceDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/WorkflowInstanceDao.java
@@ -19,9 +19,15 @@ package org.apache.dolphinscheduler.dao.repository;
 
 import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
+import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
 import org.apache.dolphinscheduler.plugin.task.api.model.DateInterval;
 
+import java.util.Collection;
+import java.util.Date;
 import java.util.List;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 public interface WorkflowInstanceDao extends IDao<WorkflowInstance> {
 
@@ -92,4 +98,40 @@ public interface WorkflowInstanceDao extends IDao<WorkflowInstance> {
      * Query the workflow instances under the master that need to be failover.
      */
     List<WorkflowInstance> queryNeedFailoverWorkflowInstances(String masterAddress);
+
+    WorkflowInstance queryDetailById(int id);
+
+    List<WorkflowInstanceStatusCountDto> countWorkflowInstanceStateByProjectCodes(Date startTime,
+                                                                                  Date endTime,
+                                                                                  Collection<Long> projectCodes);
+
+    int updateWorkflowInstanceByTenantCode(String originTenantCode, String destTenantCode);
+
+    int updateWorkflowInstanceByWorkerGroupName(String originWorkerGroupName, String destWorkerGroupName);
+
+    List<WorkflowInstance> queryByTenantCodeAndStatus(String tenantCode, int[] states);
+
+    List<WorkflowInstance> queryByWorkerGroupNameAndStatus(String workerGroupName, int[] states);
+
+    List<WorkflowInstance> queryTopNWorkflowInstance(int size,
+                                                     Date startTime,
+                                                     Date endTime,
+                                                     WorkflowExecutionStatus status,
+                                                     long projectCode);
+
+    IPage<WorkflowInstance> queryWorkflowInstanceListPaging(Page<WorkflowInstance> page,
+                                                            Long projectCode,
+                                                            Long workflowDefinitionCode,
+                                                            String searchVal,
+                                                            String executorName,
+                                                            int[] statusArray,
+                                                            String host,
+                                                            Date startTime,
+                                                            Date endTime);
+
+    List<WorkflowInstance> queryByWorkflowDefinitionCodeAndStatus(Long workflowDefinitionCode, int[] states);
+
+    List<WorkflowInstance> queryByWorkflowDefinitionCode(Long workflowDefinitionCode, int size);
+
+    List<WorkflowInstance> queryByTriggerCode(Long triggerCode);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/WorkflowInstanceDaoImpl.java
@@ -22,10 +22,13 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstanceRelation;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceRelationMapper;
+import org.apache.dolphinscheduler.dao.model.WorkflowInstanceStatusCountDto;
 import org.apache.dolphinscheduler.dao.repository.BaseDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.plugin.task.api.model.DateInterval;
 
+import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 
 import lombok.NonNull;
@@ -33,6 +36,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
 @Slf4j
 @Repository
@@ -174,5 +180,75 @@ public class WorkflowInstanceDaoImpl extends BaseDao<WorkflowInstance, WorkflowI
     public List<WorkflowInstance> queryNeedFailoverWorkflowInstances(String masterAddress) {
         return mybatisMapper.queryByHostAndStatus(masterAddress,
                 WorkflowExecutionStatus.NEED_FAILOVER_STATES);
+    }
+
+    @Override
+    public WorkflowInstance queryDetailById(int id) {
+        return mybatisMapper.queryDetailById(id);
+    }
+
+    @Override
+    public List<WorkflowInstanceStatusCountDto> countWorkflowInstanceStateByProjectCodes(Date startTime,
+                                                                                         Date endTime,
+                                                                                         Collection<Long> projectCodes) {
+        return mybatisMapper.countWorkflowInstanceStateByProjectCodes(startTime, endTime, projectCodes);
+    }
+
+    @Override
+    public int updateWorkflowInstanceByTenantCode(String originTenantCode, String destTenantCode) {
+        return mybatisMapper.updateWorkflowInstanceByTenantCode(originTenantCode, destTenantCode);
+    }
+
+    @Override
+    public int updateWorkflowInstanceByWorkerGroupName(String originWorkerGroupName, String destWorkerGroupName) {
+        return mybatisMapper.updateWorkflowInstanceByWorkerGroupName(originWorkerGroupName, destWorkerGroupName);
+    }
+
+    @Override
+    public List<WorkflowInstance> queryByTenantCodeAndStatus(String tenantCode, int[] states) {
+        return mybatisMapper.queryByTenantCodeAndStatus(tenantCode, states);
+    }
+
+    @Override
+    public List<WorkflowInstance> queryByWorkerGroupNameAndStatus(String workerGroupName, int[] states) {
+        return mybatisMapper.queryByWorkerGroupNameAndStatus(workerGroupName, states);
+    }
+
+    @Override
+    public List<WorkflowInstance> queryTopNWorkflowInstance(int size,
+                                                            Date startTime,
+                                                            Date endTime,
+                                                            WorkflowExecutionStatus status,
+                                                            long projectCode) {
+        return mybatisMapper.queryTopNWorkflowInstance(size, startTime, endTime, status, projectCode);
+    }
+
+    @Override
+    public IPage<WorkflowInstance> queryWorkflowInstanceListPaging(Page<WorkflowInstance> page,
+                                                                   Long projectCode,
+                                                                   Long workflowDefinitionCode,
+                                                                   String searchVal,
+                                                                   String executorName,
+                                                                   int[] statusArray,
+                                                                   String host,
+                                                                   Date startTime,
+                                                                   Date endTime) {
+        return mybatisMapper.queryWorkflowInstanceListPaging(page, projectCode, workflowDefinitionCode, searchVal,
+                executorName, statusArray, host, startTime, endTime);
+    }
+
+    @Override
+    public List<WorkflowInstance> queryByWorkflowDefinitionCodeAndStatus(Long workflowDefinitionCode, int[] states) {
+        return mybatisMapper.queryByWorkflowDefinitionCodeAndStatus(workflowDefinitionCode, states);
+    }
+
+    @Override
+    public List<WorkflowInstance> queryByWorkflowDefinitionCode(Long workflowDefinitionCode, int size) {
+        return mybatisMapper.queryByWorkflowDefinitionCode(workflowDefinitionCode, size);
+    }
+
+    @Override
+    public List<WorkflowInstance> queryByTriggerCode(Long triggerCode) {
+        return mybatisMapper.queryByTriggerCode(triggerCode);
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, ops 4.7

## Purpose of the pull request

Encapsulate WorkflowInstanceMapper behind WorkflowInstanceDao so the api layer depends only on the repository abstraction.

Add 11 methods to WorkflowInstanceDao: queryDetailById, countWorkflowInstanceStateByProjectCodes, updateWorkflowInstanceByTenantCode, updateWorkflowInstanceByWorkerGroupName, queryByTenantCodeAndStatus, queryByWorkerGroupNameAndStatus, queryTopNWorkflowInstance, queryWorkflowInstanceListPaging, queryByWorkflowDefinitionCodeAndStatus, queryByWorkflowDefinitionCode, queryByTriggerCode.

All delegate straight to the mapper preserving existing signatures and return types.

Tracking issue: #18249

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
