### PR TITLE
[Improvement-18249][DAO] Route ClusterMapper and K8sNamespaceMapper access through repository Dao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/K8SNamespaceAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/K8SNamespaceAuditOperatorImpl.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.api.audit.operator.impl;
 
 import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 public class K8SNamespaceAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private K8sNamespaceMapper k8sNamespaceMapper;
+    private K8sNamespaceDao k8sNamespaceDao;
 
     @Override
     public String getObjectNameFromIdentity(Object identity) {
@@ -37,7 +37,7 @@ public class K8SNamespaceAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        K8sNamespace obj = k8sNamespaceMapper.selectById(objId);
+        K8sNamespace obj = k8sNamespaceDao.queryById(objId);
         return obj == null ? "" : obj.getNamespace();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/k8s/K8sManager.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/k8s/K8sManager.java
@@ -18,7 +18,7 @@
 package org.apache.dolphinscheduler.api.k8s;
 
 import org.apache.dolphinscheduler.dao.entity.Cluster;
-import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
 import org.apache.dolphinscheduler.service.utils.ClusterConfUtils;
 
 import java.util.Hashtable;
@@ -46,7 +46,7 @@ public class K8sManager {
     private static Map<Long, KubernetesClient> clientMap = new Hashtable<>();
 
     @Autowired
-    private ClusterMapper clusterMapper;
+    private ClusterDao clusterDao;
 
     /**
      * get k8s client for api use
@@ -88,7 +88,7 @@ public class K8sManager {
         if (clusterCode == null) {
             return;
         }
-        Cluster cluster = clusterMapper.queryByClusterCode(clusterCode);
+        Cluster cluster = clusterDao.queryByClusterCode(clusterCode);
         if (cluster == null) {
             return;
         }
@@ -99,7 +99,7 @@ public class K8sManager {
     }
 
     private void createK8sClientInner(Long clusterCode) {
-        Cluster cluster = clusterMapper.queryByClusterCode(clusterCode);
+        Cluster cluster = clusterDao.queryByClusterCode(clusterCode);
         if (cluster == null) {
             return;
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -37,10 +37,10 @@ import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertPluginInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentMapper;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
@@ -207,10 +207,10 @@ public class ResourcePermissionCheckServiceImpl
     @Component
     public static class K8sNamespaceResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
-        private final K8sNamespaceMapper k8sNamespaceMapper;
+        private final K8sNamespaceDao k8sNamespaceDao;
 
-        public K8sNamespaceResourcePermissionCheck(K8sNamespaceMapper k8sNamespaceMapper) {
-            this.k8sNamespaceMapper = k8sNamespaceMapper;
+        public K8sNamespaceResourcePermissionCheck(K8sNamespaceDao k8sNamespaceDao) {
+            this.k8sNamespaceDao = k8sNamespaceDao;
         }
 
         @Override
@@ -225,7 +225,7 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
-            List<K8sNamespace> k8sNamespaces = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
+            List<K8sNamespace> k8sNamespaces = k8sNamespaceDao.queryAuthedNamespaceListByUserId(userId);
             return k8sNamespaces.stream().map(K8sNamespace::getId).collect(Collectors.toSet());
         }
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceImpl.java
@@ -27,10 +27,9 @@ import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
-import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 import org.apache.dolphinscheduler.service.utils.ClusterConfUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -48,7 +47,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
@@ -60,13 +58,13 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class ClusterServiceImpl extends BaseServiceImpl implements ClusterService {
 
     @Autowired
-    private ClusterMapper clusterMapper;
+    private ClusterDao clusterDao;
 
     @Autowired
     private K8sManager k8sManager;
 
     @Autowired
-    private K8sNamespaceMapper k8sNamespaceMapper;
+    private K8sNamespaceDao k8sNamespaceDao;
 
     /**
      * create cluster
@@ -85,7 +83,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
 
         checkParams(name, config);
 
-        Cluster clusterExistByName = clusterMapper.queryByClusterName(name);
+        Cluster clusterExistByName = clusterDao.queryByClusterName(name);
         if (clusterExistByName != null) {
             throw new ServiceException(Status.CLUSTER_NAME_EXISTS, name);
         }
@@ -99,7 +97,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
         cluster.setUpdateTime(new Date());
         cluster.setCode(CodeGenerateUtils.genCode());
 
-        if (clusterMapper.insert(cluster) > 0) {
+        if (clusterDao.insert(cluster) > 0) {
             return cluster.getCode();
         }
         throw new ServiceException(Status.CREATE_CLUSTER_ERROR);
@@ -118,7 +116,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
 
         Page<Cluster> page = new Page<>(pageNo, pageSize);
 
-        IPage<Cluster> clusterIPage = clusterMapper.queryClusterListPaging(page, searchVal);
+        IPage<Cluster> clusterIPage = clusterDao.queryClusterListPaging(page, searchVal);
 
         PageInfo<ClusterDto> pageInfo = new PageInfo<>(pageNo, pageSize);
         pageInfo.setTotal((int) clusterIPage.getTotal());
@@ -142,7 +140,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
      */
     @Override
     public List<ClusterDto> queryAllClusterList() {
-        List<Cluster> clusterList = clusterMapper.queryAllClusterList();
+        List<Cluster> clusterList = clusterDao.queryAllClusterList();
         if (CollectionUtils.isEmpty(clusterList)) {
             return Collections.emptyList();
         }
@@ -164,7 +162,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
     @Override
     public ClusterDto queryClusterByCode(Long code) {
 
-        Cluster cluster = clusterMapper.queryByClusterCode(code);
+        Cluster cluster = clusterDao.queryByClusterCode(code);
 
         if (cluster == null) {
             throw new ServiceException(Status.QUERY_CLUSTER_BY_CODE_ERROR, code);
@@ -182,7 +180,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
     @Override
     public ClusterDto queryClusterByName(String name) {
 
-        Cluster cluster = clusterMapper.queryByClusterName(name);
+        Cluster cluster = clusterDao.queryByClusterName(name);
         if (cluster == null) {
             throw new ServiceException(Status.QUERY_CLUSTER_BY_NAME_ERROR, name);
         }
@@ -203,15 +201,13 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
-        Long relatedNamespaceNumber = k8sNamespaceMapper
-                .selectCount(new QueryWrapper<K8sNamespace>().lambda().eq(K8sNamespace::getClusterCode, code));
+        long relatedNamespaceNumber = k8sNamespaceDao.countByClusterCode(code);
 
         if (relatedNamespaceNumber > 0) {
             throw new ServiceException(Status.DELETE_CLUSTER_RELATED_NAMESPACE_EXISTS);
         }
 
-        int delete = clusterMapper.deleteByCode(code);
-        if (delete > 0) {
+        if (clusterDao.deleteByCode(code)) {
             return;
         }
         throw new ServiceException(Status.DELETE_CLUSTER_ERROR);
@@ -242,12 +238,12 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
 
         checkParams(name, config);
 
-        Cluster clusterExistByName = clusterMapper.queryByClusterName(name);
+        Cluster clusterExistByName = clusterDao.queryByClusterName(name);
         if (clusterExistByName != null && !clusterExistByName.getCode().equals(code)) {
             throw new ServiceException(Status.CLUSTER_NAME_EXISTS, name);
         }
 
-        Cluster clusterExist = clusterMapper.queryByClusterCode(code);
+        Cluster clusterExist = clusterDao.queryByClusterCode(code);
         if (clusterExist == null) {
             throw new ServiceException(Status.CLUSTER_NOT_EXISTS, name);
         }
@@ -267,7 +263,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
         clusterExist.setName(name);
         clusterExist.setDescription(desc);
         clusterExist.setUpdateTime(DateUtils.getCurrentDate());
-        clusterMapper.updateById(clusterExist);
+        clusterDao.updateById(clusterExist);
         return clusterExist;
     }
 
@@ -284,7 +280,7 @@ public class ClusterServiceImpl extends BaseServiceImpl implements ClusterServic
             throw new ServiceException(Status.CLUSTER_NAME_IS_NULL);
         }
 
-        Cluster cluster = clusterMapper.queryByClusterName(clusterName);
+        Cluster cluster = clusterDao.queryByClusterName(clusterName);
         if (cluster != null) {
             throw new ServiceException(Status.CLUSTER_NAME_EXISTS);
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/K8SNamespaceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/K8SNamespaceServiceImpl.java
@@ -28,8 +28,8 @@ import org.apache.dolphinscheduler.common.utils.CodeGenerateUtils;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
 import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -59,13 +59,13 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNamespaceService {
 
     @Autowired
-    private K8sNamespaceMapper k8sNamespaceMapper;
+    private K8sNamespaceDao k8sNamespaceDao;
 
     @Autowired
     private K8sClientService k8sClientService;
 
     @Autowired
-    private ClusterMapper clusterMapper;
+    private ClusterDao clusterDao;
 
     /**
      * query namespace list paging
@@ -87,7 +87,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
 
         Page<K8sNamespace> page = new Page<>(pageNo, pageSize);
 
-        IPage<K8sNamespace> k8sNamespaceList = k8sNamespaceMapper.queryK8sNamespacePaging(page, searchVal);
+        IPage<K8sNamespace> k8sNamespaceList = k8sNamespaceDao.queryK8sNamespacePaging(page, searchVal);
 
         Integer count = (int) k8sNamespaceList.getTotal();
         PageInfo<K8sNamespace> pageInfo = new PageInfo<>(pageNo, pageSize);
@@ -127,7 +127,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
             throw new ServiceException(Status.K8S_NAMESPACE_EXIST, namespace, clusterCode);
         }
 
-        Cluster cluster = clusterMapper.queryByClusterCode(clusterCode);
+        Cluster cluster = clusterDao.queryByClusterCode(clusterCode);
         if (cluster == null) {
             log.error("Cluster does not exist, clusterCode:{}", clusterCode);
             throw new ServiceException(Status.CLUSTER_NOT_EXISTS, namespace, clusterCode);
@@ -155,7 +155,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
             }
         }
 
-        k8sNamespaceMapper.insert(k8sNamespaceObj);
+        k8sNamespaceDao.insert(k8sNamespaceObj);
         log.info("K8s namespace create complete, namespace:{}.", k8sNamespaceObj.getNamespace());
         return k8sNamespaceObj;
     }
@@ -204,13 +204,13 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
-        K8sNamespace k8sNamespaceObj = k8sNamespaceMapper.selectById(id);
+        K8sNamespace k8sNamespaceObj = k8sNamespaceDao.queryById(id);
         if (k8sNamespaceObj == null) {
             log.error("K8s namespace does not exist, namespaceId:{}.", id);
             throw new ServiceException(Status.K8S_NAMESPACE_NOT_EXIST, id);
         }
 
-        k8sNamespaceMapper.deleteById(id);
+        k8sNamespaceDao.deleteById(id);
         log.info("K8s namespace delete complete, namespace:{}.", k8sNamespaceObj.getNamespace());
     }
 
@@ -221,7 +221,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
      * @return true if the k8s and namespace not exists, otherwise return false
      */
     private boolean checkNamespaceExistInDb(String namespace, Long clusterCode) {
-        return k8sNamespaceMapper.existNamespace(namespace, clusterCode) == Boolean.TRUE;
+        return k8sNamespaceDao.existNamespace(namespace, clusterCode);
     }
 
     /**
@@ -237,12 +237,12 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
         // query all namespace list, this auth does not like project
-        List<K8sNamespace> namespaceList = k8sNamespaceMapper.selectList(null);
+        List<K8sNamespace> namespaceList = k8sNamespaceDao.queryAll();
         if (namespaceList == null || namespaceList.isEmpty()) {
             return Collections.emptyList();
         }
         Set<K8sNamespace> namespaceSet = new HashSet<>(namespaceList);
-        List<K8sNamespace> authedProjectList = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
+        List<K8sNamespace> authedProjectList = k8sNamespaceDao.queryAuthedNamespaceListByUserId(userId);
         return getUnauthorizedNamespaces(namespaceSet, authedProjectList);
     }
 
@@ -258,7 +258,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
         if (loginUser.getId() != userId && isNotAdmin(loginUser)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        return k8sNamespaceMapper.queryAuthedNamespaceListByUserId(userId);
+        return k8sNamespaceDao.queryAuthedNamespaceListByUserId(userId);
     }
 
     /**
@@ -271,9 +271,9 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
     public List<K8sNamespace> queryNamespaceAvailable(User loginUser) {
         List<K8sNamespace> k8sNamespaces;
         if (isAdmin(loginUser)) {
-            k8sNamespaces = k8sNamespaceMapper.selectList(null);
+            k8sNamespaces = k8sNamespaceDao.queryAll();
         } else {
-            k8sNamespaces = k8sNamespaceMapper.queryAuthedNamespaceListByUserId(loginUser.getId());
+            k8sNamespaces = k8sNamespaceDao.queryAuthedNamespaceListByUserId(loginUser.getId());
         }
         setClusterName(k8sNamespaces);
         return k8sNamespaces;
@@ -285,7 +285,7 @@ public class K8SNamespaceServiceImpl extends BaseServiceImpl implements K8sNames
      */
     private void setClusterName(List<K8sNamespace> k8sNamespaces) {
         if (CollectionUtils.isNotEmpty(k8sNamespaces)) {
-            List<Cluster> clusters = clusterMapper.queryAllClusterList();
+            List<Cluster> clusters = clusterDao.queryAllClusterList();
             if (CollectionUtils.isNotEmpty(clusters)) {
                 Map<Long, String> codeNameMap = clusters.stream()
                         .collect(Collectors.toMap(Cluster::getCode, Cluster::getName, (a, b) -> a));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/k8s/K8sManagerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/k8s/K8sManagerTest.java
@@ -18,7 +18,7 @@
 package org.apache.dolphinscheduler.api.k8s;
 
 import org.apache.dolphinscheduler.dao.entity.Cluster;
-import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +45,7 @@ public class K8sManagerTest {
     private K8sManager k8sManager;
 
     @Mock
-    private ClusterMapper clusterMapper;
+    private ClusterDao clusterDao;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -57,7 +57,7 @@ public class K8sManagerTest {
 
     @Test
     public void getK8sClient() {
-        Mockito.when(clusterMapper.selectList(Mockito.any())).thenReturn(getClusterList());
+        Mockito.when(clusterDao.queryAll()).thenReturn(getClusterList());
 
         KubernetesClient result = k8sManager.getK8sClient(1L);
         Assertions.assertNull(result);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/K8sNamespaceResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/K8sNamespaceResourcePermissionCheckTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class K8sNamespaceResourcePermissionCheckTest {
     private ResourcePermissionCheckServiceImpl.K8sNamespaceResourcePermissionCheck k8sNamespaceResourcePermissionCheck;
 
     @Mock
-    private K8sNamespaceMapper k8sNamespaceMapper;
+    private K8sNamespaceDao k8sNamespaceDao;
 
     @Test
     public void testPermissionCheck() {
@@ -69,7 +69,7 @@ public class K8sNamespaceResourcePermissionCheckTest {
         ids.add(k8sNamespace.getId());
         List<K8sNamespace> k8sNamespaces = Arrays.asList(k8sNamespace);
 
-        Mockito.when(k8sNamespaceMapper.queryAuthedNamespaceListByUserId(user.getId())).thenReturn(k8sNamespaces);
+        Mockito.when(k8sNamespaceDao.queryAuthedNamespaceListByUserId(user.getId())).thenReturn(k8sNamespaces);
 
         Assertions.assertEquals(ids,
                 k8sNamespaceResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/K8SNamespaceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/K8SNamespaceServiceTest.java
@@ -28,8 +28,8 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
 import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -62,10 +62,10 @@ public class K8SNamespaceServiceTest {
     private K8SNamespaceServiceImpl k8sNamespaceService;
 
     @Mock
-    private K8sNamespaceMapper k8sNamespaceMapper;
+    private K8sNamespaceDao k8sNamespaceDao;
 
     @Mock
-    private ClusterMapper clusterMapper;
+    private ClusterDao clusterDao;
 
     @Mock
     private K8sClientService k8sClientService;
@@ -78,7 +78,7 @@ public class K8SNamespaceServiceTest {
         IPage<K8sNamespace> page = new Page<>(1, 10);
         page.setTotal(1L);
         page.setRecords(getNamespaceList());
-        Mockito.when(k8sNamespaceMapper.queryK8sNamespacePaging(Mockito.any(Page.class), Mockito.eq(namespace)))
+        Mockito.when(k8sNamespaceDao.queryK8sNamespacePaging(Mockito.any(Page.class), Mockito.eq(namespace)))
                 .thenReturn(page);
         Result result = k8sNamespaceService.queryListPaging(getLoginUser(), namespace, 1, 10);
         logger.info(result.toString());
@@ -95,7 +95,7 @@ public class K8SNamespaceServiceTest {
         assertThrowsServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR,
                 () -> k8sNamespaceService.registerK8sNamespace(getLoginUser(), namespace, null));
         // correct
-        Mockito.when(clusterMapper.queryByClusterCode(Mockito.anyLong())).thenReturn(getCluster());
+        Mockito.when(clusterDao.queryByClusterCode(Mockito.anyLong())).thenReturn(getCluster());
         K8sNamespace created = k8sNamespaceService.registerK8sNamespace(getLoginUser(), namespace, clusterCode);
         Assertions.assertNotNull(created);
         Assertions.assertEquals(namespace, created.getNamespace());
@@ -105,7 +105,7 @@ public class K8SNamespaceServiceTest {
     @Test
     public void verifyNamespaceK8s() {
 
-        Mockito.when(k8sNamespaceMapper.existNamespace(namespace, clusterCode)).thenReturn(true);
+        Mockito.when(k8sNamespaceDao.existNamespace(namespace, clusterCode)).thenReturn(true);
 
         // namespace null
         Result result = k8sNamespaceService.verifyNamespaceK8s(null, clusterCode);
@@ -130,15 +130,15 @@ public class K8SNamespaceServiceTest {
 
     @Test
     public void deleteNamespaceById() {
-        Mockito.when(k8sNamespaceMapper.deleteById(Mockito.<Serializable>any())).thenReturn(1);
-        Mockito.when(k8sNamespaceMapper.selectById(1)).thenReturn(getNamespace());
+        Mockito.when(k8sNamespaceDao.deleteById(Mockito.<Serializable>any())).thenReturn(true);
+        Mockito.when(k8sNamespaceDao.queryById(1)).thenReturn(getNamespace());
 
         Assertions.assertDoesNotThrow(() -> k8sNamespaceService.deleteNamespaceById(getLoginUser(), 1));
     }
 
     @Test
     public void testQueryAuthorizedNamespace() {
-        Mockito.when(k8sNamespaceMapper.queryAuthedNamespaceListByUserId(2)).thenReturn(getNamespaceList());
+        Mockito.when(k8sNamespaceDao.queryAuthedNamespaceListByUserId(2)).thenReturn(getNamespaceList());
 
         User loginUser = getLoginUser();
 
@@ -156,8 +156,8 @@ public class K8SNamespaceServiceTest {
 
     @Test
     public void testQueryUnAuthorizedNamespace() {
-        Mockito.when(k8sNamespaceMapper.queryAuthedNamespaceListByUserId(2)).thenReturn(new ArrayList<>());
-        Mockito.when(k8sNamespaceMapper.selectList(Mockito.any())).thenReturn(getNamespaceList());
+        Mockito.when(k8sNamespaceDao.queryAuthedNamespaceListByUserId(2)).thenReturn(new ArrayList<>());
+        Mockito.when(k8sNamespaceDao.queryAll()).thenReturn(getNamespaceList());
 
         // test admin user
         User loginUser = new User();
@@ -185,8 +185,8 @@ public class K8SNamespaceServiceTest {
         cluster.setName("test");
         clusters.add(cluster);
 
-        Mockito.when(k8sNamespaceMapper.selectList(Mockito.any())).thenReturn(k8sNamespaces);
-        Mockito.when(clusterMapper.queryAllClusterList()).thenReturn(clusters);
+        Mockito.when(k8sNamespaceDao.queryAll()).thenReturn(k8sNamespaces);
+        Mockito.when(clusterDao.queryAllClusterList()).thenReturn(clusters);
         List<K8sNamespace> result = k8sNamespaceService.queryNamespaceAvailable(getLoginUser());
         Assertions.assertEquals(result.get(0).getClusterName(), cluster.getName());
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/ClusterServiceTest.java
@@ -29,8 +29,8 @@ import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
-import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -62,13 +62,13 @@ public class ClusterServiceTest {
     private ClusterServiceImpl clusterService;
 
     @Mock
-    private ClusterMapper clusterMapper;
+    private ClusterDao clusterDao;
 
     @Mock
     private K8sManager k8sManager;
 
     @Mock
-    private K8sNamespaceMapper k8sNamespaceMapper;
+    private K8sNamespaceDao k8sNamespaceDao;
 
     public static final String testUserName = "clusterServerTest";
 
@@ -98,11 +98,11 @@ public class ClusterServiceTest {
         assertThrowsServiceException(Status.CLUSTER_NAME_IS_NULL,
                 () -> clusterService.createCluster(loginUser, "", getConfig(), getDesc()));
 
-        when(clusterMapper.queryByClusterName(clusterName)).thenReturn(getCluster());
+        when(clusterDao.queryByClusterName(clusterName)).thenReturn(getCluster());
         assertThrowsServiceException(Status.CLUSTER_NAME_EXISTS,
                 () -> clusterService.createCluster(loginUser, clusterName, getConfig(), getDesc()));
 
-        when(clusterMapper.insert(Mockito.any(Cluster.class))).thenReturn(1);
+        when(clusterDao.insert(Mockito.any(Cluster.class))).thenReturn(1);
         Assertions.assertDoesNotThrow(
                 () -> clusterService.createCluster(loginUser, "testName", "testConfig", "testDesc"));
     }
@@ -128,12 +128,12 @@ public class ClusterServiceTest {
         assertThrowsServiceException(Status.CLUSTER_NOT_EXISTS,
                 () -> clusterService.updateClusterByCode(adminUser, 2L, clusterName, getConfig(), getDesc()));
 
-        when(clusterMapper.queryByClusterName(clusterName)).thenReturn(getCluster());
+        when(clusterDao.queryByClusterName(clusterName)).thenReturn(getCluster());
         assertThrowsServiceException(Status.CLUSTER_NAME_EXISTS,
                 () -> clusterService.updateClusterByCode(adminUser, 2L, clusterName, getConfig(), getDesc()));
 
-        when(clusterMapper.updateById(Mockito.any(Cluster.class))).thenReturn(1);
-        when(clusterMapper.queryByClusterCode(1L)).thenReturn(getCluster());
+        when(clusterDao.updateById(Mockito.any(Cluster.class))).thenReturn(true);
+        when(clusterDao.queryByClusterCode(1L)).thenReturn(getCluster());
         Cluster cluster = clusterService.updateClusterByCode(adminUser, 1L, "testName", getConfig(), "test");
         assertNotNull(cluster);
         assertNotNull(cluster.getUpdateTime());
@@ -141,7 +141,7 @@ public class ClusterServiceTest {
 
     @Test
     public void testQueryAllClusterList() {
-        when(clusterMapper.queryAllClusterList()).thenReturn(Lists.newArrayList(getCluster()));
+        when(clusterDao.queryAllClusterList()).thenReturn(Lists.newArrayList(getCluster()));
         List<ClusterDto> clusterDtos = clusterService.queryAllClusterList();
         Assertions.assertEquals(clusterDtos.size(), 1);
     }
@@ -151,7 +151,7 @@ public class ClusterServiceTest {
         IPage<Cluster> page = new Page<>(1, 10);
         page.setRecords(getList());
         page.setTotal(1L);
-        when(clusterMapper.queryClusterListPaging(Mockito.any(Page.class), Mockito.eq(clusterName))).thenReturn(page);
+        when(clusterDao.queryClusterListPaging(Mockito.any(Page.class), Mockito.eq(clusterName))).thenReturn(page);
 
         PageInfo<ClusterDto> clusterDtoPageInfo = clusterService.queryClusterListPaging(1, 10, clusterName);
         Assertions.assertTrue(CollectionUtils.isNotEmpty(clusterDtoPageInfo.getTotalList()));
@@ -159,21 +159,21 @@ public class ClusterServiceTest {
 
     @Test
     public void testQueryClusterByName() {
-        when(clusterMapper.queryByClusterName(clusterName)).thenReturn(null);
+        when(clusterDao.queryByClusterName(clusterName)).thenReturn(null);
         assertThrowsServiceException(Status.QUERY_CLUSTER_BY_NAME_ERROR,
                 () -> clusterService.queryClusterByName(clusterName));
 
-        when(clusterMapper.queryByClusterName(clusterName)).thenReturn(getCluster());
+        when(clusterDao.queryByClusterName(clusterName)).thenReturn(getCluster());
         ClusterDto clusterDto = clusterService.queryClusterByName(clusterName);
         assertNotNull(clusterDto);
     }
 
     @Test
     public void testQueryClusterByCode() {
-        when(clusterMapper.queryByClusterCode(1L)).thenReturn(null);
+        when(clusterDao.queryByClusterCode(1L)).thenReturn(null);
         assertThrowsServiceException(Status.QUERY_CLUSTER_BY_CODE_ERROR, () -> clusterService.queryClusterByCode(1L));
 
-        when(clusterMapper.queryByClusterCode(1L)).thenReturn(getCluster());
+        when(clusterDao.queryByClusterCode(1L)).thenReturn(getCluster());
         ClusterDto clusterDto = clusterService.queryClusterByCode(1L);
         assertNotNull(clusterDto);
     }
@@ -186,10 +186,10 @@ public class ClusterServiceTest {
         });
 
         final User adminUser = getAdminUser();
-        when(clusterMapper.deleteByCode(1L)).thenReturn(1);
+        when(clusterDao.deleteByCode(1L)).thenReturn(true);
         assertDoesNotThrow(() -> clusterService.deleteClusterByCode(adminUser, 1L));
 
-        when(k8sNamespaceMapper.selectCount(Mockito.any())).thenReturn(1L);
+        when(k8sNamespaceDao.countByClusterCode(Mockito.anyLong())).thenReturn(1L);
         assertThrowsServiceException(Status.DELETE_CLUSTER_RELATED_NAMESPACE_EXISTS,
                 () -> clusterService.deleteClusterByCode(adminUser, 1L));
     }
@@ -198,7 +198,7 @@ public class ClusterServiceTest {
     public void testVerifyCluster() {
         assertThrowsServiceException(Status.CLUSTER_NAME_IS_NULL, () -> clusterService.verifyCluster(""));
 
-        when(clusterMapper.queryByClusterName(clusterName)).thenReturn(getCluster());
+        when(clusterDao.queryByClusterName(clusterName)).thenReturn(getCluster());
         assertThrowsServiceException(Status.CLUSTER_NAME_EXISTS, () -> clusterService.verifyCluster(clusterName));
     }
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ClusterDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ClusterDao.java
@@ -15,29 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.audit.operator.impl;
+package org.apache.dolphinscheduler.dao.repository;
 
-import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.Cluster;
-import org.apache.dolphinscheduler.dao.repository.ClusterDao;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import java.util.List;
 
-@Service
-public class ClusterAuditOperatorImpl extends BaseAuditOperator {
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
-    @Autowired
-    private ClusterDao clusterDao;
+public interface ClusterDao extends IDao<Cluster> {
 
-    @Override
-    public String getObjectNameFromIdentity(Object identity) {
-        Long objId = toLong(identity);
-        if (objId == -1) {
-            return "";
-        }
+    Cluster queryByClusterName(String name);
 
-        Cluster obj = clusterDao.queryByClusterCode(objId);
-        return obj == null ? "" : obj.getName();
-    }
+    Cluster queryByClusterCode(Long clusterCode);
+
+    List<Cluster> queryAllClusterList();
+
+    IPage<Cluster> queryClusterListPaging(IPage<Cluster> page, String searchName);
+
+    boolean deleteByCode(Long code);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/K8sNamespaceDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/K8sNamespaceDao.java
@@ -15,29 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.audit.operator.impl;
+package org.apache.dolphinscheduler.dao.repository;
 
-import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
-import org.apache.dolphinscheduler.dao.entity.Cluster;
-import org.apache.dolphinscheduler.dao.repository.ClusterDao;
+import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import java.util.List;
 
-@Service
-public class ClusterAuditOperatorImpl extends BaseAuditOperator {
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
-    @Autowired
-    private ClusterDao clusterDao;
+public interface K8sNamespaceDao extends IDao<K8sNamespace> {
 
-    @Override
-    public String getObjectNameFromIdentity(Object identity) {
-        Long objId = toLong(identity);
-        if (objId == -1) {
-            return "";
-        }
+    IPage<K8sNamespace> queryK8sNamespacePaging(IPage<K8sNamespace> page, String searchVal);
 
-        Cluster obj = clusterDao.queryByClusterCode(objId);
-        return obj == null ? "" : obj.getName();
-    }
+    boolean existNamespace(String namespace, Long clusterCode);
+
+    List<K8sNamespace> queryNamespaceExceptUserId(int userId);
+
+    List<K8sNamespace> queryAuthedNamespaceListByUserId(Integer userId);
+
+    K8sNamespace queryByNamespaceCode(Long namespaceCode);
+
+    long countByClusterCode(Long clusterCode);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ClusterDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ClusterDaoImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.Cluster;
+import org.apache.dolphinscheduler.dao.mapper.ClusterMapper;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+import org.apache.dolphinscheduler.dao.repository.ClusterDao;
+
+import java.util.List;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
+@Repository
+public class ClusterDaoImpl extends BaseDao<Cluster, ClusterMapper> implements ClusterDao {
+
+    public ClusterDaoImpl(@NonNull ClusterMapper clusterMapper) {
+        super(clusterMapper);
+    }
+
+    @Override
+    public Cluster queryByClusterName(String name) {
+        return mybatisMapper.queryByClusterName(name);
+    }
+
+    @Override
+    public Cluster queryByClusterCode(Long clusterCode) {
+        return mybatisMapper.queryByClusterCode(clusterCode);
+    }
+
+    @Override
+    public List<Cluster> queryAllClusterList() {
+        return mybatisMapper.queryAllClusterList();
+    }
+
+    @Override
+    public IPage<Cluster> queryClusterListPaging(IPage<Cluster> page, String searchName) {
+        return mybatisMapper.queryClusterListPaging(page, searchName);
+    }
+
+    @Override
+    public boolean deleteByCode(Long code) {
+        return mybatisMapper.deleteByCode(code) > 0;
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/K8sNamespaceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/K8sNamespaceDaoImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.K8sNamespace;
+import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceMapper;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
+
+import java.util.List;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
+@Repository
+public class K8sNamespaceDaoImpl extends BaseDao<K8sNamespace, K8sNamespaceMapper> implements K8sNamespaceDao {
+
+    public K8sNamespaceDaoImpl(@NonNull K8sNamespaceMapper k8sNamespaceMapper) {
+        super(k8sNamespaceMapper);
+    }
+
+    @Override
+    public IPage<K8sNamespace> queryK8sNamespacePaging(IPage<K8sNamespace> page, String searchVal) {
+        return mybatisMapper.queryK8sNamespacePaging(page, searchVal);
+    }
+
+    @Override
+    public boolean existNamespace(String namespace, Long clusterCode) {
+        return Boolean.TRUE.equals(mybatisMapper.existNamespace(namespace, clusterCode));
+    }
+
+    @Override
+    public List<K8sNamespace> queryNamespaceExceptUserId(int userId) {
+        return mybatisMapper.queryNamespaceExceptUserId(userId);
+    }
+
+    @Override
+    public List<K8sNamespace> queryAuthedNamespaceListByUserId(Integer userId) {
+        return mybatisMapper.queryAuthedNamespaceListByUserId(userId);
+    }
+
+    @Override
+    public K8sNamespace queryByNamespaceCode(Long namespaceCode) {
+        return mybatisMapper.queryByNamespaceCode(namespaceCode);
+    }
+
+    @Override
+    public long countByClusterCode(Long clusterCode) {
+        return mybatisMapper.selectCount(
+                new QueryWrapper<K8sNamespace>().lambda().eq(K8sNamespace::getClusterCode, clusterCode));
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, gpt-5.5

## Purpose of the pull request

Introduce ClusterDao and K8sNamespaceDao to encapsulate the two K8s-related mappers so the api layer depends only on the repository abstraction. The two mappers are bundled together because they share call sites in ClusterServiceImpl and K8SNamespaceServiceImpl.

ClusterDao mirrors the mapper API and packages deleteByCode as boolean (returning row count > 0) to match the IDao convention.

K8sNamespaceDao mirrors the mapper API; existNamespace returns primitive boolean via Boolean.TRUE.equals, and countByClusterCode encapsulates the LambdaQueryWrapper that previously leaked into ClusterServiceImpl.

Tracking issue: #18249

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
