### PR TITLE
[Improvement-18249][DAO] Route TenantMapper access through TenantDao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TenantAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TenantAuditOperatorImpl.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.api.audit.operator.impl;
 
 import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 public class TenantAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     @Override
     public String getObjectNameFromIdentity(Object identity) {
@@ -37,7 +37,7 @@ public class TenantAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        Tenant obj = tenantMapper.selectById(objId);
+        Tenant obj = tenantDao.queryById(objId);
         return obj == null ? "" : obj.getTenantCode();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -39,9 +39,9 @@ import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentMapper;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkerGroupDao;
 
@@ -355,10 +355,10 @@ public class ResourcePermissionCheckServiceImpl
     @Component
     public static class TenantResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
-        private final TenantMapper tenantMapper;
+        private final TenantDao tenantDao;
 
-        public TenantResourcePermissionCheck(TenantMapper tenantMapper) {
-            this.tenantMapper = tenantMapper;
+        public TenantResourcePermissionCheck(TenantDao tenantDao) {
+            this.tenantDao = tenantDao;
         }
 
         @Override
@@ -373,7 +373,7 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
-            List<Tenant> tenantList = tenantMapper.queryAll();
+            List<Tenant> tenantList = tenantDao.queryAll();
             return tenantList.stream().map(Tenant::getId).collect(Collectors.toSet());
         }
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/QueueServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/QueueServiceImpl.java
@@ -32,8 +32,8 @@ import org.apache.dolphinscheduler.dao.entity.Queue;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,7 +63,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
     private UserMapper userMapper;
 
     @Autowired
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     /**
      * Check the queue new object valid or not
@@ -226,7 +226,7 @@ public class QueueServiceImpl extends BaseServiceImpl implements QueueService {
             throw new ServiceException(Status.QUEUE_NOT_EXIST);
         }
 
-        List<Tenant> tenantList = tenantMapper.queryTenantListByQueueId(queue.getId());
+        List<Tenant> tenantList = tenantDao.queryTenantListByQueueId(queue.getId());
         if (CollectionUtils.isNotEmpty(tenantList)) {
             log.warn("Delete queue failed, because there are {} tenants using it.", tenantList.size());
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL_TENANTS, tenantList.size());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TenantServiceImpl.java
@@ -36,10 +36,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -64,7 +64,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class TenantServiceImpl extends BaseServiceImpl implements TenantService {
 
     @Autowired
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     @Autowired
     private WorkflowInstanceMapper workflowInstanceMapper;
@@ -143,7 +143,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
         }
         Tenant tenant = new Tenant(tenantCode, desc, queueId);
         createTenantValid(tenant);
-        tenantMapper.insert(tenant);
+        tenantDao.insert(tenant);
 
         return tenant;
     }
@@ -166,7 +166,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             return new PageInfo<>(pageNo, pageSize);
         }
         Page<Tenant> page = new Page<>(pageNo, pageSize);
-        IPage<Tenant> tenantPage = tenantMapper.queryTenantPaging(page, new ArrayList<>(ids), searchVal);
+        IPage<Tenant> tenantPage = tenantDao.queryTenantPaging(page, new ArrayList<>(ids), searchVal);
         return PageInfo.of(tenantPage);
     }
 
@@ -195,12 +195,11 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
         }
         Tenant updateTenant = new Tenant(id, tenantCode, desc, queueId);
-        Tenant existsTenant = tenantMapper.queryById(id);
+        Tenant existsTenant = tenantDao.queryDetailById(id);
         updateTenantValid(existsTenant, updateTenant);
 
         updateTenant.setCreateTime(existsTenant.getCreateTime());
-        int update = tenantMapper.updateById(updateTenant);
-        if (update <= 0) {
+        if (!tenantDao.updateById(updateTenant)) {
             throw new ServiceException(Status.UPDATE_TENANT_ERROR);
         }
     }
@@ -221,7 +220,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
-        Tenant tenant = tenantMapper.queryById(id);
+        Tenant tenant = tenantDao.queryDetailById(id);
         if (Objects.isNull(tenant)) {
             throw new ServiceException(Status.TENANT_NOT_EXIST);
         }
@@ -241,8 +240,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_FAIL_USERS, userList.size());
         }
 
-        int delete = tenantMapper.deleteById(id);
-        if (delete <= 0) {
+        if (!tenantDao.deleteById(id)) {
             throw new ServiceException(Status.DELETE_TENANT_BY_ID_ERROR);
         }
 
@@ -269,7 +267,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
         }
-        return tenantMapper.selectBatchIds(ids);
+        return tenantDao.queryByIds(ids);
     }
 
     /**
@@ -292,8 +290,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
      * @return ture if the tenant code exists, otherwise return false
      */
     private boolean checkTenantExists(String tenantCode) {
-        Boolean existTenant = tenantMapper.existTenant(tenantCode);
-        return Boolean.TRUE.equals(existTenant);
+        return tenantDao.existTenant(tenantCode);
     }
 
     /**
@@ -304,7 +301,7 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
      */
     @Override
     public Tenant queryByTenantCode(String tenantCode) {
-        return tenantMapper.queryByTenantCode(tenantCode);
+        return tenantDao.queryByCode(tenantCode).orElse(null);
     }
 
     /**
@@ -320,12 +317,12 @@ public class TenantServiceImpl extends BaseServiceImpl implements TenantService 
     @Override
     public Tenant createTenantIfNotExists(String tenantCode, String desc, String queue, String queueName) {
         if (checkTenantExists(tenantCode)) {
-            return tenantMapper.queryByTenantCode(tenantCode);
+            return tenantDao.queryByCode(tenantCode).orElse(null);
         }
         Queue queueObj = queueService.createQueueIfNotExists(queue, queueName);
         Tenant tenant = new Tenant(tenantCode, desc, queueObj.getId());
         createTenantValid(tenant);
-        tenantMapper.insert(tenant);
+        tenantDao.insert(tenant);
         return tenant;
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -44,9 +44,9 @@ import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -83,7 +83,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     private UserMapper userMapper;
 
     @Autowired
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     @Autowired
     private ProjectUserMapper projectUserMapper;
@@ -764,7 +764,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             }
         }
 
-        Tenant tenant = tenantMapper.selectById(user.getTenantId());
+        Tenant tenant = tenantDao.queryById(user.getTenantId());
         if (tenant != null) {
             user.setTenantCode(tenant.getTenantCode());
         }
@@ -884,7 +884,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
      * @return true if tenant exists, otherwise return false
      */
     private boolean checkTenantExists(int tenantId) {
-        return tenantMapper.queryById(tenantId) != null;
+        return tenantDao.queryDetailById(tenantId) != null;
     }
 
     /**
@@ -1036,7 +1036,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
                                       int state) {
         User user = userMapper.queryByUserNameAccurately(userName);
         if (Objects.isNull(user)) {
-            Tenant tenant = tenantMapper.queryByTenantCode(tenantCode);
+            Tenant tenant = tenantDao.queryByCode(tenantCode).orElse(null);
             user = createUser(userName, userPassword, email, tenant.getId(), phone, queue, state);
             return user;
         }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TenantResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TenantResourcePermissionCheckTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class TenantResourcePermissionCheckTest {
     private ResourcePermissionCheckServiceImpl.TenantResourcePermissionCheck tenantResourcePermissionCheck;
 
     @Mock
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     @Test
     public void testPermissionCheck() {
@@ -69,7 +69,7 @@ public class TenantResourcePermissionCheckTest {
         ids.add(tenant.getId());
         List<Tenant> tenants = Arrays.asList(tenant);
 
-        Mockito.when(tenantMapper.queryAll()).thenReturn(tenants);
+        Mockito.when(tenantDao.queryAll()).thenReturn(tenants);
 
         Assertions.assertEquals(ids, tenantResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TenantServiceTest.java
@@ -38,10 +38,10 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
@@ -80,7 +81,7 @@ public class TenantServiceTest {
     private QueueService queueService;
 
     @Mock
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     @Mock
     private ScheduleDao scheduleDao;
@@ -103,7 +104,7 @@ public class TenantServiceTest {
     public void testCreateTenant() {
 
         User loginUser = getLoginUser();
-        when(tenantMapper.existTenant(tenantCode)).thenReturn(true);
+        when(tenantDao.existTenant(tenantCode)).thenReturn(true);
         when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TENANT, loginUser.getId(),
                 TENANT_CREATE, baseServiceLogger)).thenReturn(true);
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.TENANT, null, 0,
@@ -133,7 +134,7 @@ public class TenantServiceTest {
 
     @Test
     public void testCreateTenantError() {
-        when(tenantMapper.existTenant(tenantCode)).thenReturn(true);
+        when(tenantDao.existTenant(tenantCode)).thenReturn(true);
 
         // tenantCode exist
         assertThrowsServiceException(Status.OS_TENANT_CODE_EXIST,
@@ -153,7 +154,7 @@ public class TenantServiceTest {
         ids.add(1);
         when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.TENANT,
                 getLoginUser().getId(), tenantServiceImplLogger)).thenReturn(ids);
-        when(tenantMapper.queryTenantPaging(any(Page.class), Mockito.anyList(), Mockito.eq(tenantDesc)))
+        when(tenantDao.queryTenantPaging(any(Page.class), Mockito.anyList(), Mockito.eq(tenantDesc)))
                 .thenReturn(page);
         PageInfo<Tenant> pageInfo = tenantService.queryTenantList(getLoginUser(), tenantDesc, 1, 10);
         Assertions.assertTrue(CollectionUtils.isNotEmpty(pageInfo.getTotalList()));
@@ -162,12 +163,12 @@ public class TenantServiceTest {
 
     @Test
     public void testUpdateTenant() {
-        when(tenantMapper.queryById(1)).thenReturn(getTenant());
+        when(tenantDao.queryDetailById(1)).thenReturn(getTenant());
         when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.TENANT, getLoginUser().getId(),
                 TENANT_UPDATE, baseServiceLogger)).thenReturn(true);
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.TENANT, null, 0,
                 baseServiceLogger)).thenReturn(true);
-        when(tenantMapper.updateById(any())).thenReturn(1);
+        when(tenantDao.updateById(any())).thenReturn(true);
 
         // update not exists tenant
         assertThrowsServiceException(Status.TENANT_NOT_EXIST,
@@ -186,7 +187,7 @@ public class TenantServiceTest {
                 getLoginUser().getId(), TENANT_DELETE, baseServiceLogger)).thenReturn(true);
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.TENANT, null, 0,
                 baseServiceLogger)).thenReturn(true);
-        when(tenantMapper.queryById(1)).thenReturn(getTenant());
+        when(tenantDao.queryDetailById(1)).thenReturn(getTenant());
         when(workflowInstanceMapper.queryByTenantCodeAndStatus(tenantCode,
                 WorkflowExecutionStatus.NOT_TERMINAL_STATES))
                         .thenReturn(getInstanceList());
@@ -202,25 +203,25 @@ public class TenantServiceTest {
 
         // DELETE_TENANT_BY_ID_FAIL_DEFINES
         when(workflowInstanceMapper.queryByTenantCodeAndStatus(any(), any())).thenReturn(Collections.emptyList());
-        when(tenantMapper.queryById(2)).thenReturn(getTenant(2));
+        when(tenantDao.queryDetailById(2)).thenReturn(getTenant(2));
         assertThrowsServiceException(Status.DELETE_TENANT_BY_ID_FAIL_DEFINES,
                 () -> tenantService.deleteTenantById(getLoginUser(), 2));
 
         // DELETE_TENANT_BY_ID_FAIL_USERS
-        when(tenantMapper.queryById(3)).thenReturn(getTenant(3));
+        when(tenantDao.queryDetailById(3)).thenReturn(getTenant(3));
         when(scheduleDao.queryScheduleListByTenant(tenantCode)).thenReturn(Collections.emptyList());
         assertThrowsServiceException(Status.DELETE_TENANT_BY_ID_FAIL_USERS,
                 () -> tenantService.deleteTenantById(getLoginUser(), 3));
 
         // success
-        when(tenantMapper.queryById(4)).thenReturn(getTenant(4));
-        when(tenantMapper.deleteById(4)).thenReturn(1);
+        when(tenantDao.queryDetailById(4)).thenReturn(getTenant(4));
+        when(tenantDao.deleteById(4)).thenReturn(true);
         assertDoesNotThrow(() -> tenantService.deleteTenantById(getLoginUser(), 4));
     }
 
     @Test
     public void testVerifyTenantCode() {
-        when(tenantMapper.existTenant(tenantCode)).thenReturn(true);
+        when(tenantDao.existTenant(tenantCode)).thenReturn(true);
         // tenantCode exist
         assertThrowsServiceException(Status.OS_TENANT_CODE_EXIST,
                 () -> tenantService.verifyTenantCode(getTenant().getTenantCode()));
@@ -233,13 +234,13 @@ public class TenantServiceTest {
         Tenant tenant;
 
         // Tenant exists
-        when(tenantMapper.existTenant(tenantCode)).thenReturn(true);
-        when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(getTenant());
+        when(tenantDao.existTenant(tenantCode)).thenReturn(true);
+        when(tenantDao.queryByCode(tenantCode)).thenReturn(Optional.of(getTenant()));
         tenant = tenantService.createTenantIfNotExists(tenantCode, tenantDesc, queue, queueName);
         Assertions.assertEquals(getTenant(), tenant);
 
         // Tenant not exists
-        when(tenantMapper.existTenant(tenantCode)).thenReturn(false);
+        when(tenantDao.existTenant(tenantCode)).thenReturn(false);
         when(queueService.createQueueIfNotExists(queue, queueName)).thenReturn(getQueue());
         tenant = tenantService.createTenantIfNotExists(tenantCode, tenantDesc, queue, queueName);
         Assertions.assertEquals(tenantCode, tenant.getTenantCode());

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -42,13 +42,14 @@ import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.UserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -80,7 +81,7 @@ public class UsersServiceTest {
     private AccessTokenMapper accessTokenMapper;
 
     @Mock
-    private TenantMapper tenantMapper;
+    private TenantDao tenantDao;
 
     @Mock
     private ProjectUserMapper projectUserMapper;
@@ -170,7 +171,7 @@ public class UsersServiceTest {
                         state));
 
         // success
-        Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
+        Mockito.when(tenantDao.queryDetailById(1)).thenReturn(getTenant());
         User created =
                 usersService.createUser(loginUser, userNameOk, passwordOk, emailOk, 1, phoneOk, queueName, state);
         Assertions.assertNotNull(created);
@@ -729,13 +730,13 @@ public class UsersServiceTest {
         when(userMapper.queryDetailsById(getUser().getId())).thenReturn(getUser());
         when(userMapper.queryByUserNameAccurately(userName)).thenReturn(getUser());
         when(userMapper.updateById(any())).thenReturn(1);
-        when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(getTenant());
+        when(tenantDao.queryByCode(tenantCode)).thenReturn(Optional.of(getTenant()));
         user = usersService.createUserIfNotExists(userName, userPassword, email, phone, tenantCode, queueName, stat);
         Assertions.assertEquals(getUser(), user);
 
         // User not exists
         Mockito.when(userMapper.existUser(userName)).thenReturn(false);
-        Mockito.when(tenantMapper.queryByTenantCode(tenantCode)).thenReturn(getTenant());
+        Mockito.when(tenantDao.queryByCode(tenantCode)).thenReturn(Optional.of(getTenant()));
         user = usersService.createUserIfNotExists(userName, userPassword, email, phone, tenantCode, queueName, stat);
         Assertions.assertNotNull(user);
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -58,12 +58,12 @@ import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowInstance;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowInstanceMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceContextDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
+import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceMapDao;
@@ -140,7 +140,7 @@ public class WorkflowInstanceServiceTest {
     UsersService usersService;
 
     @Mock
-    TenantMapper tenantMapper;
+    TenantDao tenantDao;
 
     @Mock
     TaskDefinitionMapper taskDefinitionMapper;
@@ -574,7 +574,7 @@ public class WorkflowInstanceServiceTest {
         workflowDefinition.setProjectCode(projectCode);
         Tenant tenant = getTenant();
         when(workflowDefinitionDao.queryByCode(46L)).thenReturn(Optional.of(workflowDefinition));
-        when(tenantMapper.queryByTenantCode("root")).thenReturn(tenant);
+        when(tenantDao.queryByCode("root")).thenReturn(Optional.of(tenant));
         when(processService.getTenantForWorkflow(Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn(tenant.getTenantCode());
         when(workflowInstanceDao.updateById(workflowInstance)).thenReturn(true);

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TenantDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TenantDao.java
@@ -19,10 +19,20 @@ package org.apache.dolphinscheduler.dao.repository;
 
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 
+import java.util.List;
 import java.util.Optional;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
 public interface TenantDao extends IDao<Tenant> {
 
     Optional<Tenant> queryByCode(String tenantCode);
 
+    Tenant queryDetailById(int tenantId);
+
+    List<Tenant> queryTenantListByQueueId(Integer queueId);
+
+    IPage<Tenant> queryTenantPaging(IPage<Tenant> page, List<Integer> ids, String searchVal);
+
+    boolean existTenant(String tenantCode);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TenantDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TenantDaoImpl.java
@@ -22,11 +22,14 @@ import org.apache.dolphinscheduler.dao.mapper.TenantMapper;
 import org.apache.dolphinscheduler.dao.repository.BaseDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 
+import java.util.List;
 import java.util.Optional;
 
 import lombok.NonNull;
 
 import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
 
 @Repository
 public class TenantDaoImpl extends BaseDao<Tenant, TenantMapper> implements TenantDao {
@@ -38,5 +41,25 @@ public class TenantDaoImpl extends BaseDao<Tenant, TenantMapper> implements Tena
     @Override
     public Optional<Tenant> queryByCode(String tenantCode) {
         return Optional.ofNullable(mybatisMapper.queryByTenantCode(tenantCode));
+    }
+
+    @Override
+    public Tenant queryDetailById(int tenantId) {
+        return mybatisMapper.queryById(tenantId);
+    }
+
+    @Override
+    public List<Tenant> queryTenantListByQueueId(Integer queueId) {
+        return mybatisMapper.queryTenantListByQueueId(queueId);
+    }
+
+    @Override
+    public IPage<Tenant> queryTenantPaging(IPage<Tenant> page, List<Integer> ids, String searchVal) {
+        return mybatisMapper.queryTenantPaging(page, ids, searchVal);
+    }
+
+    @Override
+    public boolean existTenant(String tenantCode) {
+        return Boolean.TRUE.equals(mybatisMapper.existTenant(tenantCode));
     }
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, gpt5.5

## Purpose of the pull request

Encapsulate TenantMapper behind TenantDao so the api layer depends only on the repository abstraction.

Add methods to TenantDao: queryDetailById (preserves the mapper's custom JOIN against t_ds_queue that returns queue_name / queue), queryTenantListByQueueId, queryTenantPaging, and existTenant (boolean instead of nullable Boolean via Boolean.TRUE.equals).

Switch updateById / deleteById call sites in TenantServiceImpl from int to boolean using the IDao convention: <=0 becomes !success in the guard. The selectBatchIds call becomes queryByIds, and existTenant downstream checks drop the Boolean.TRUE.equals dance since the Dao returns primitive.

Tracking issue: #18249

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
