### PR TITLE
[Improvement-18249][DAO] Route DataSourceMapper and DataSourceUserMapper access through repository Dao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -35,10 +35,10 @@ import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
 import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertPluginInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentMapper;
 import org.apache.dolphinscheduler.dao.mapper.QueueMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
 import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
@@ -384,10 +384,10 @@ public class ResourcePermissionCheckServiceImpl
     @Component
     public static class DataSourceResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
-        private final DataSourceMapper dataSourceMapper;
+        private final DataSourceDao dataSourceDao;
 
-        public DataSourceResourcePermissionCheck(DataSourceMapper dataSourceMapper) {
-            this.dataSourceMapper = dataSourceMapper;
+        public DataSourceResourcePermissionCheck(DataSourceDao dataSourceDao) {
+            this.dataSourceDao = dataSourceDao;
         }
 
         @Override
@@ -402,7 +402,7 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
-            return dataSourceMapper.listAuthorizedDataSource(userId, null).stream().map(DataSource::getId)
+            return dataSourceDao.listAuthorizedDataSource(userId, null).stream().map(DataSource::getId)
                     .collect(toSet());
         }
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -50,9 +50,9 @@ import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
@@ -132,7 +132,7 @@ public class PythonGateway {
     private ScheduleDao scheduleDao;
 
     @Autowired
-    private DataSourceMapper dataSourceMapper;
+    private DataSourceDao dataSourceDao;
 
     @Autowired
     private ApiConfig apiConfig;
@@ -484,7 +484,7 @@ public class PythonGateway {
      */
     public DataSource getDatasource(String datasourceName, String type) {
 
-        List<DataSource> dataSourceList = dataSourceMapper.queryDataSourceByName(datasourceName);
+        List<DataSource> dataSourceList = dataSourceDao.queryDataSourceByName(datasourceName);
         if (dataSourceList == null || dataSourceList.isEmpty()) {
             String msg = String.format("Can not find any datasource by name %s", datasourceName);
             log.error(msg);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -31,8 +31,8 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
+import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.BaseDataSourceParamDTO;
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.DataSourceProcessor;
 import org.apache.dolphinscheduler.plugin.datasource.api.utils.DataSourceUtils;
@@ -72,10 +72,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class DataSourceServiceImpl extends BaseServiceImpl implements DataSourceService {
 
     @Autowired
-    private DataSourceMapper dataSourceMapper;
+    private DataSourceDao dataSourceDao;
 
     @Autowired
-    private DataSourceUserMapper datasourceUserMapper;
+    private DataSourceUserDao datasourceUserDao;
 
     private static final String TABLE = "TABLE";
     private static final String VIEW = "VIEW";
@@ -112,7 +112,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
         dataSource.setCreateTime(now);
         dataSource.setUpdateTime(now);
         try {
-            dataSourceMapper.insert(dataSource);
+            dataSourceDao.insert(dataSource);
             return dataSource;
         } catch (DuplicateKeyException ex) {
             throw new ServiceException(Status.DATASOURCE_EXIST);
@@ -123,7 +123,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     public DataSource updateDataSource(User loginUser, BaseDataSourceParamDTO dataSourceParam) {
         DataSourceUtils.checkDatasourceParam(dataSourceParam);
         // determine whether the data source exists
-        DataSource dataSource = dataSourceMapper.selectById(dataSourceParam.getId());
+        DataSource dataSource = dataSourceDao.queryById(dataSourceParam.getId());
         if (dataSource == null) {
             throw new ServiceException(Status.RESOURCE_NOT_EXIST);
         }
@@ -160,7 +160,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
         dataSource.setConnectionParams(JSONUtils.toJsonString(connectionParam));
         dataSource.setUpdateTime(now);
         try {
-            dataSourceMapper.updateById(dataSource);
+            dataSourceDao.updateById(dataSource);
             return dataSource;
         } catch (DuplicateKeyException ex) {
             throw new ServiceException(Status.DATASOURCE_EXIST);
@@ -168,13 +168,13 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     }
 
     private boolean checkName(String name) {
-        List<DataSource> queryDataSource = dataSourceMapper.queryDataSourceByName(name.trim());
+        List<DataSource> queryDataSource = dataSourceDao.queryDataSourceByName(name.trim());
         return queryDataSource != null && !queryDataSource.isEmpty();
     }
 
     @Override
     public BaseDataSourceParamDTO queryDataSource(int id, User loginUser) {
-        DataSource dataSource = dataSourceMapper.selectById(id);
+        DataSource dataSource = dataSourceDao.queryById(id);
         if (dataSource == null) {
             log.error("Datasource does not exist, id:{}.", id);
             throw new ServiceException(Status.RESOURCE_NOT_EXIST);
@@ -203,14 +203,14 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
         Page<DataSource> dataSourcePage = new Page<>(pageNo, pageSize);
         PageInfo<DataSource> pageInfo = new PageInfo<>(pageNo, pageSize);
         if (loginUser.getUserType().equals(UserType.ADMIN_USER)) {
-            dataSourceList = dataSourceMapper.selectPaging(dataSourcePage, 0, searchVal);
+            dataSourceList = dataSourceDao.queryDataSourcePaging(dataSourcePage, 0, searchVal);
         } else {
             Set<Integer> ids = resourcePermissionCheckService
                     .userOwnedResourceIdsAcquisition(AuthorizationType.DATASOURCE, loginUser.getId(), log);
             if (ids.isEmpty()) {
                 return pageInfo;
             }
-            dataSourceList = dataSourceMapper.selectPagingByIds(dataSourcePage, new ArrayList<>(ids), searchVal);
+            dataSourceList = dataSourceDao.queryDataSourcePagingByIds(dataSourcePage, new ArrayList<>(ids), searchVal);
         }
 
         List<DataSource> dataSources = dataSourceList != null ? dataSourceList.getRecords() : new ArrayList<>();
@@ -246,14 +246,14 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
         List<DataSource> datasourceList;
         if (loginUser.getUserType().equals(UserType.ADMIN_USER)) {
-            datasourceList = dataSourceMapper.queryDataSourceByType(0, type);
+            datasourceList = dataSourceDao.queryDataSourceByType(0, type);
         } else {
             Set<Integer> ids = resourcePermissionCheckService
                     .userOwnedResourceIdsAcquisition(AuthorizationType.DATASOURCE, loginUser.getId(), log);
             if (ids.isEmpty()) {
                 return Collections.emptyList();
             }
-            datasourceList = dataSourceMapper.selectBatchIds(ids).stream()
+            datasourceList = dataSourceDao.queryByIds(ids).stream()
                     .filter(dataSource -> dataSource.getType().getCode() == type).collect(Collectors.toList());
         }
 
@@ -262,7 +262,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
     @Override
     public void verifyDataSourceName(String name) {
-        List<DataSource> dataSourceList = dataSourceMapper.queryDataSourceByName(name);
+        List<DataSource> dataSourceList = dataSourceDao.queryDataSourceByName(name);
         if (dataSourceList != null && !dataSourceList.isEmpty()) {
             throw new ServiceException(Status.DATASOURCE_EXIST);
         }
@@ -280,7 +280,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
     @Override
     public void connectionTest(User loginUser, int id) {
-        DataSource dataSource = dataSourceMapper.selectById(id);
+        DataSource dataSource = dataSourceDao.queryById(id);
 
         if (dataSource == null) {
             throw new ServiceException(Status.RESOURCE_NOT_EXIST);
@@ -299,7 +299,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     @Transactional
     public void delete(User loginUser, int datasourceId) {
         // query datasource by id
-        DataSource dataSource = dataSourceMapper.selectById(datasourceId);
+        DataSource dataSource = dataSourceDao.queryById(datasourceId);
 
         if (dataSource == null) {
             throw new ServiceException(Status.RESOURCE_NOT_EXIST);
@@ -310,8 +310,8 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
-        dataSourceMapper.deleteById(datasourceId);
-        datasourceUserMapper.deleteByDatasourceId(datasourceId);
+        dataSourceDao.deleteById(datasourceId);
+        datasourceUserDao.deleteByDatasourceId(datasourceId);
     }
 
     @Override
@@ -319,17 +319,17 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
         List<DataSource> datasourceList;
         if (canOperatorPermissions(loginUser, null, AuthorizationType.DATASOURCE, null)) {
             // admin gets all data sources except userId
-            datasourceList = dataSourceMapper.queryDatasourceExceptUserId(userId);
+            datasourceList = dataSourceDao.queryDatasourceExceptUserId(userId);
         } else {
             // non-admins users get their own data sources
-            datasourceList = dataSourceMapper.selectByMap(Collections.singletonMap("user_id", loginUser.getId()));
+            datasourceList = dataSourceDao.queryByUserId(loginUser.getId());
         }
         List<DataSource> resultList = new ArrayList<>();
         Set<DataSource> datasourceSet;
         if (datasourceList != null && !datasourceList.isEmpty()) {
             datasourceSet = new HashSet<>(datasourceList);
 
-            List<DataSource> authedDataSourceList = dataSourceMapper.queryAuthedDatasource(userId);
+            List<DataSource> authedDataSourceList = dataSourceDao.queryAuthedDatasource(userId);
 
             Set<DataSource> authedDataSourceSet;
             if (authedDataSourceList != null && !authedDataSourceList.isEmpty()) {
@@ -343,13 +343,13 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
 
     @Override
     public List<DataSource> authedDatasource(User loginUser, Integer userId) {
-        List<DataSource> authedDatasourceList = dataSourceMapper.queryAuthedDatasource(userId);
+        List<DataSource> authedDatasourceList = dataSourceDao.queryAuthedDatasource(userId);
         return authedDatasourceList;
     }
 
     @Override
     public List<ParamsOptions> getTables(User loginUser, Integer datasourceId, String database) {
-        DataSource dataSource = dataSourceMapper.selectById(datasourceId);
+        DataSource dataSource = dataSourceDao.queryById(datasourceId);
 
         if (dataSource == null) {
             throw new ServiceException(Status.QUERY_DATASOURCE_ERROR);
@@ -419,7 +419,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     @Override
     public List<ParamsOptions> getTableColumns(User loginUser, Integer datasourceId, String database,
                                                String tableName) {
-        DataSource dataSource = dataSourceMapper.selectById(datasourceId);
+        DataSource dataSource = dataSourceDao.queryById(datasourceId);
 
         if (dataSource == null) {
             throw new ServiceException(Status.QUERY_DATASOURCE_ERROR);
@@ -476,7 +476,7 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     @Override
     public List<ParamsOptions> getDatabases(User loginUser, Integer datasourceId) {
 
-        DataSource dataSource = dataSourceMapper.selectById(datasourceId);
+        DataSource dataSource = dataSourceDao.queryById(datasourceId);
 
         if (dataSource == null) {
             throw new ServiceException(Status.QUERY_DATASOURCE_ERROR);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -41,9 +41,9 @@ import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
@@ -89,7 +89,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     private ProjectUserMapper projectUserMapper;
 
     @Autowired
-    private DataSourceUserMapper datasourceUserMapper;
+    private DataSourceUserDao datasourceUserDao;
 
     @Autowired
     private AlertGroupMapper alertGroupMapper;
@@ -716,7 +716,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             throw new ServiceException(Status.USER_NOT_EXIST, userId);
         }
 
-        datasourceUserMapper.deleteByUserId(userId);
+        datasourceUserDao.deleteByUserId(userId);
 
         if (StringUtils.isEmpty(datasourceIds)) {
             return;
@@ -733,7 +733,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             datasourceUser.setPerm(Constants.AUTHORIZE_WRITABLE_PERM);
             datasourceUser.setCreateTime(now);
             datasourceUser.setUpdateTime(now);
-            datasourceUserMapper.insert(datasourceUser);
+            datasourceUserDao.insert(datasourceUser);
         }
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/DataSourceResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/DataSourceResourcePermissionCheckTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class DataSourceResourcePermissionCheckTest {
     private ResourcePermissionCheckServiceImpl.DataSourceResourcePermissionCheck dataSourceResourcePermissionCheck;
 
     @Mock
-    private DataSourceMapper dataSourceMapper;
+    private DataSourceDao dataSourceDao;
 
     @Test
     public void testPermissionCheck() {
@@ -69,7 +69,7 @@ public class DataSourceResourcePermissionCheckTest {
         ids.add(dataSource.getId());
         List<DataSource> dataSources = Arrays.asList(dataSource);
 
-        Mockito.when(dataSourceMapper.listAuthorizedDataSource(user.getId(), null)).thenReturn(dataSources);
+        Mockito.when(dataSourceDao.listAuthorizedDataSource(user.getId(), null)).thenReturn(dataSources);
 
         Assertions.assertEquals(ids, dataSourceResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
@@ -33,8 +33,8 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
+import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.plugin.datasource.api.constants.DataSourceConstants;
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.BaseDataSourceParamDTO;
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.DataSourceProcessor;
@@ -88,10 +88,10 @@ public class DataSourceServiceTest {
     private DataSourceServiceImpl dataSourceService;
 
     @Mock
-    private DataSourceMapper dataSourceMapper;
+    private DataSourceDao dataSourceDao;
 
     @Mock
-    private DataSourceUserMapper datasourceUserMapper;
+    private DataSourceUserDao datasourceUserDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -137,7 +137,7 @@ public class DataSourceServiceTest {
         DataSource dataSource = new DataSource();
         dataSource.setName(dataSourceName);
         dataSourceList.add(dataSource);
-        when(dataSourceMapper.queryDataSourceByName(dataSourceName.trim())).thenReturn(dataSourceList);
+        when(dataSourceDao.queryDataSourceByName(dataSourceName.trim())).thenReturn(dataSourceList);
         passResourcePermissionCheckService();
 
         // DATASOURCE_EXIST
@@ -148,7 +148,7 @@ public class DataSourceServiceTest {
                 MockedStatic<DataSourceClientProvider> mockedStaticDataSourceClientProvider =
                         Mockito.mockStatic(DataSourceClientProvider.class)) {
 
-            when(dataSourceMapper.queryDataSourceByName(dataSourceName.trim())).thenReturn(null);
+            when(dataSourceDao.queryDataSourceByName(dataSourceName.trim())).thenReturn(null);
 
             // DESCRIPTION TOO LONG
             postgreSqlDatasourceParam.setNote(randomStringWithLengthN(512));
@@ -160,7 +160,7 @@ public class DataSourceServiceTest {
             assertDoesNotThrow(() -> dataSourceService.createDataSource(loginUser, postgreSqlDatasourceParam));
 
             // Duplicated Key Exception
-            when(dataSourceMapper.insert(Mockito.any(DataSource.class))).thenThrow(DuplicateKeyException.class);
+            when(dataSourceDao.insert(Mockito.any(DataSource.class))).thenThrow(DuplicateKeyException.class);
             assertThrowsServiceException(Status.DATASOURCE_EXIST,
                     () -> dataSourceService.createDataSource(loginUser, postgreSqlDatasourceParam));
         }
@@ -187,14 +187,14 @@ public class DataSourceServiceTest {
         postgreSqlDatasourceParam.setName(dataSourceUpdateName);
 
         // RESOURCE_NOT_EXIST
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(null);
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(null);
         assertThrowsServiceException(Status.RESOURCE_NOT_EXIST,
                 () -> dataSourceService.updateDataSource(loginUser, postgreSqlDatasourceParam));
 
         // USER_NO_OPERATION_PERM
         DataSource dataSource = new DataSource();
         dataSource.setUserId(0);
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(dataSource);
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(dataSource);
         assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
                 () -> dataSourceService.updateDataSource(loginUser, postgreSqlDatasourceParam));
 
@@ -208,8 +208,8 @@ public class DataSourceServiceTest {
         anotherDataSource.setName(dataSourceUpdateName);
         List<DataSource> dataSourceList = new ArrayList<>();
         dataSourceList.add(anotherDataSource);
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(dataSource);
-        when(dataSourceMapper.queryDataSourceByName(postgreSqlDatasourceParam.getName()))
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(dataSource);
+        when(dataSourceDao.queryDataSourceByName(postgreSqlDatasourceParam.getName()))
                 .thenReturn(dataSourceList);
         passResourcePermissionCheckService();
         assertThrowsServiceException(Status.DATASOURCE_EXIST,
@@ -219,7 +219,7 @@ public class DataSourceServiceTest {
                 MockedStatic<DataSourceClientProvider> mockedStaticDataSourceClientProvider =
                         Mockito.mockStatic(DataSourceClientProvider.class)) {
             // DATASOURCE_CONNECT_FAILED
-            when(dataSourceMapper.queryDataSourceByName(postgreSqlDatasourceParam.getName())).thenReturn(null);
+            when(dataSourceDao.queryDataSourceByName(postgreSqlDatasourceParam.getName())).thenReturn(null);
 
             // DESCRIPTION TOO LONG
             postgreSqlDatasourceParam.setNote(randomStringWithLengthN(512));
@@ -231,7 +231,7 @@ public class DataSourceServiceTest {
             assertDoesNotThrow(() -> dataSourceService.updateDataSource(loginUser, postgreSqlDatasourceParam));
 
             // Duplicated Key Exception
-            when(dataSourceMapper.updateById(Mockito.any(DataSource.class))).thenThrow(DuplicateKeyException.class);
+            when(dataSourceDao.updateById(Mockito.any(DataSource.class))).thenThrow(DuplicateKeyException.class);
             assertThrowsServiceException(Status.DATASOURCE_EXIST,
                     () -> dataSourceService.updateDataSource(loginUser, postgreSqlDatasourceParam));
         }
@@ -252,7 +252,7 @@ public class DataSourceServiceTest {
 
         // test query datasource as general user with no datasource authed
         when(dataSourceList.getRecords()).thenReturn(getSingleDataSourceList());
-        when(dataSourceMapper.selectPagingByIds(Mockito.any(), Mockito.any(), Mockito.any()))
+        when(dataSourceDao.queryDataSourcePagingByIds(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(dataSourceList);
         assertDoesNotThrow(() -> dataSourceService.queryDataSourceListPaging(generalUser, searchVal, pageNo, pageSize));
 
@@ -267,7 +267,7 @@ public class DataSourceServiceTest {
     public void testConnectionTest() {
         User loginUser = getAdminUser();
         int dataSourceId = -1;
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(null);
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(null);
         assertThrowsServiceException(Status.RESOURCE_NOT_EXIST,
                 () -> dataSourceService.connectionTest(loginUser, dataSourceId));
 
@@ -275,7 +275,7 @@ public class DataSourceServiceTest {
                 MockedStatic<DataSourceUtils> ignored =
                         Mockito.mockStatic(DataSourceUtils.class)) {
             DataSource dataSource = getOracleDataSource(999);
-            when(dataSourceMapper.selectById(dataSource.getId())).thenReturn(dataSource);
+            when(dataSourceDao.queryById(dataSource.getId())).thenReturn(dataSource);
             DataSourceProcessor dataSourceProcessor = Mockito.mock(DataSourceProcessor.class);
 
             when(DataSourceUtils.getDatasourceProcessor(Mockito.any())).thenReturn(dataSourceProcessor);
@@ -295,14 +295,14 @@ public class DataSourceServiceTest {
         User loginUser = getAdminUser();
         int dataSourceId = 1;
         // resource not exist
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(null);
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(null);
         assertThrowsServiceException(Status.RESOURCE_NOT_EXIST,
                 () -> dataSourceService.delete(loginUser, dataSourceId));
 
         // user no operation perm
         DataSource dataSource = new DataSource();
         dataSource.setUserId(0);
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(dataSource);
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(dataSource);
         assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
                 () -> dataSourceService.delete(loginUser, dataSourceId));
 
@@ -312,9 +312,9 @@ public class DataSourceServiceTest {
         loginUser.setId(1);
         dataSource.setId(22);
         passResourcePermissionCheckService();
-        when(dataSourceMapper.selectById(dataSourceId)).thenReturn(dataSource);
+        when(dataSourceDao.queryById(dataSourceId)).thenReturn(dataSource);
         assertDoesNotThrow(() -> dataSourceService.delete(loginUser, dataSourceId));
-        Mockito.verify(datasourceUserMapper).deleteByDatasourceId(dataSourceId);
+        Mockito.verify(datasourceUserDao).deleteByDatasourceId(dataSourceId);
 
     }
 
@@ -329,8 +329,8 @@ public class DataSourceServiceTest {
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.DATASOURCE, null, 0,
                 baseServiceLogger)).thenReturn(true);
         // test admin user
-        when(dataSourceMapper.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
-        when(dataSourceMapper.queryDatasourceExceptUserId(userId)).thenReturn(getDataSourceList());
+        when(dataSourceDao.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
+        when(dataSourceDao.queryDatasourceExceptUserId(userId)).thenReturn(getDataSourceList());
         List<DataSource> dataSources = dataSourceService.unAuthDatasource(loginUser, userId);
         logger.info(dataSources.toString());
         Assertions.assertTrue(CollectionUtils.isNotEmpty(dataSources));
@@ -338,7 +338,7 @@ public class DataSourceServiceTest {
         // test non-admin user
         loginUser.setId(2);
         loginUser.setUserType(UserType.GENERAL_USER);
-        when(dataSourceMapper.selectByMap(Collections.singletonMap("user_id", loginUser.getId())))
+        when(dataSourceDao.queryByUserId(loginUser.getId()))
                 .thenReturn(getDataSourceList());
         dataSources = dataSourceService.unAuthDatasource(loginUser, userId);
         logger.info(dataSources.toString());
@@ -353,7 +353,7 @@ public class DataSourceServiceTest {
         int userId = 3;
 
         // test admin user
-        when(dataSourceMapper.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
+        when(dataSourceDao.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
         List<DataSource> dataSources = dataSourceService.authedDatasource(loginUser, userId);
         logger.info(dataSources.toString());
         Assertions.assertTrue(CollectionUtils.isNotEmpty(dataSources));
@@ -384,7 +384,7 @@ public class DataSourceServiceTest {
         DataSource dataSource = new DataSource();
         dataSource.setId(1);
         dataSource.setType(DbType.MYSQL);
-        when(dataSourceMapper.selectBatchIds(Collections.singleton(1)))
+        when(dataSourceDao.queryByIds(Collections.singleton(1)))
                 .thenReturn(Collections.singletonList(dataSource));
 
         List<DataSource> list =
@@ -397,7 +397,7 @@ public class DataSourceServiceTest {
         User loginUser = new User();
         loginUser.setUserType(UserType.GENERAL_USER);
         String dataSourceName = "dataSource1";
-        when(dataSourceMapper.queryDataSourceByName(dataSourceName)).thenReturn(getDataSourceList());
+        when(dataSourceDao.queryDataSourceByName(dataSourceName)).thenReturn(getDataSourceList());
         assertThrowsServiceException(Status.DATASOURCE_EXIST,
                 () -> dataSourceService.verifyDataSourceName(dataSourceName));
     }
@@ -405,7 +405,7 @@ public class DataSourceServiceTest {
     @Test
     public void testQueryDataSource() {
         // datasource not exists
-        when(dataSourceMapper.selectById(999)).thenReturn(null);
+        when(dataSourceDao.queryById(999)).thenReturn(null);
         User loginUser = new User();
         loginUser.setUserType(UserType.GENERAL_USER);
         loginUser.setId(2);
@@ -414,7 +414,7 @@ public class DataSourceServiceTest {
                 () -> dataSourceService.queryDataSource(999, loginUser));
 
         DataSource dataSource = getOracleDataSource(1);
-        when(dataSourceMapper.selectById(dataSource.getId())).thenReturn(dataSource);
+        when(dataSourceDao.queryById(dataSource.getId())).thenReturn(dataSource);
         when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.DATASOURCE,
                 loginUser.getId(), DATASOURCE, baseServiceLogger)).thenReturn(true);
 
@@ -611,7 +611,7 @@ public class DataSourceServiceTest {
         DataSource dataSource = getOracleDataSource();
         int datasourceId = 1;
         dataSource.setId(datasourceId);
-        when(dataSourceMapper.selectById(datasourceId)).thenReturn(null);
+        when(dataSourceDao.queryById(datasourceId)).thenReturn(null);
 
         try {
             dataSourceService.getDatabases(loginUser, datasourceId);
@@ -619,7 +619,7 @@ public class DataSourceServiceTest {
             Assertions.assertTrue(e.getMessage().contains(Status.QUERY_DATASOURCE_ERROR.getMsg()));
         }
 
-        when(dataSourceMapper.selectById(datasourceId)).thenReturn(dataSource);
+        when(dataSourceDao.queryById(datasourceId)).thenReturn(dataSource);
         MySQLConnectionParam connectionParam = new MySQLConnectionParam();
         Connection connection = Mockito.mock(Connection.class);
         MockedStatic<DataSourceUtils> dataSourceUtils = Mockito.mockStatic(DataSourceUtils.class);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -39,9 +39,9 @@ import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
-import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
+import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
@@ -90,7 +90,7 @@ public class UsersServiceTest {
     private AlertGroupMapper alertGroupMapper;
 
     @Mock
-    private DataSourceUserMapper datasourceUserMapper;
+    private DataSourceUserDao datasourceUserDao;
 
     @Mock
     private K8sNamespaceUserMapper k8sNamespaceUserMapper;
@@ -519,7 +519,6 @@ public class UsersServiceTest {
 
         // test admin user
         when(userDao.queryById(userId)).thenReturn(getUser());
-        when(datasourceUserMapper.deleteByUserId(Mockito.anyInt())).thenReturn(1);
         assertDoesNotThrow(() -> usersService.grantDataSource(loginUser, userId, datasourceIds));
 
         // test non-admin user

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/DataSourceDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/DataSourceDao.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository;
+
+import org.apache.dolphinscheduler.dao.entity.DataSource;
+
+import java.util.List;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+
+public interface DataSourceDao extends IDao<DataSource> {
+
+    List<DataSource> queryDataSourceByType(int userId, Integer type);
+
+    IPage<DataSource> queryDataSourcePaging(IPage<DataSource> page, int userId, String name);
+
+    List<DataSource> queryDataSourceByName(String name);
+
+    List<DataSource> queryAuthedDatasource(int userId);
+
+    List<DataSource> queryDatasourceExceptUserId(int userId);
+
+    <T> List<DataSource> listAuthorizedDataSource(int userId, T[] dataSourceIds);
+
+    IPage<DataSource> queryDataSourcePagingByIds(Page<DataSource> dataSourcePage,
+                                                 List<Integer> dataSourceIds,
+                                                 String name);
+
+    List<DataSource> queryByUserId(int userId);
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/DataSourceUserDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/DataSourceUserDao.java
@@ -15,29 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.audit.operator.impl;
+package org.apache.dolphinscheduler.dao.repository;
 
-import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
-import org.apache.dolphinscheduler.dao.entity.DataSource;
-import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
+import org.apache.dolphinscheduler.dao.entity.DatasourceUser;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+public interface DataSourceUserDao extends IDao<DatasourceUser> {
 
-@Service
-public class DatasourceAuditOperatorImpl extends BaseAuditOperator {
+    void deleteByUserId(int userId);
 
-    @Autowired
-    private DataSourceDao dataSourceDao;
-
-    @Override
-    public String getObjectNameFromIdentity(Object identity) {
-        Long objId = toLong(identity);
-        if (objId == -1) {
-            return "";
-        }
-
-        DataSource obj = dataSourceDao.queryById(objId);
-        return obj == null ? "" : obj.getName();
-    }
+    void deleteByDatasourceId(int datasourceId);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/DataSourceDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/DataSourceDaoImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.DataSource;
+import org.apache.dolphinscheduler.dao.mapper.DataSourceMapper;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
+
+import java.util.Collections;
+import java.util.List;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+
+@Repository
+public class DataSourceDaoImpl extends BaseDao<DataSource, DataSourceMapper> implements DataSourceDao {
+
+    public DataSourceDaoImpl(@NonNull DataSourceMapper dataSourceMapper) {
+        super(dataSourceMapper);
+    }
+
+    @Override
+    public List<DataSource> queryDataSourceByType(int userId, Integer type) {
+        return mybatisMapper.queryDataSourceByType(userId, type);
+    }
+
+    @Override
+    public IPage<DataSource> queryDataSourcePaging(IPage<DataSource> page, int userId, String name) {
+        return mybatisMapper.selectPaging(page, userId, name);
+    }
+
+    @Override
+    public List<DataSource> queryDataSourceByName(String name) {
+        return mybatisMapper.queryDataSourceByName(name);
+    }
+
+    @Override
+    public List<DataSource> queryAuthedDatasource(int userId) {
+        return mybatisMapper.queryAuthedDatasource(userId);
+    }
+
+    @Override
+    public List<DataSource> queryDatasourceExceptUserId(int userId) {
+        return mybatisMapper.queryDatasourceExceptUserId(userId);
+    }
+
+    @Override
+    public <T> List<DataSource> listAuthorizedDataSource(int userId, T[] dataSourceIds) {
+        return mybatisMapper.listAuthorizedDataSource(userId, dataSourceIds);
+    }
+
+    @Override
+    public IPage<DataSource> queryDataSourcePagingByIds(Page<DataSource> dataSourcePage,
+                                                        List<Integer> dataSourceIds,
+                                                        String name) {
+        return mybatisMapper.selectPagingByIds(dataSourcePage, dataSourceIds, name);
+    }
+
+    @Override
+    public List<DataSource> queryByUserId(int userId) {
+        return mybatisMapper.selectByMap(Collections.singletonMap("user_id", userId));
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/DataSourceUserDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/DataSourceUserDaoImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.DatasourceUser;
+import org.apache.dolphinscheduler.dao.mapper.DataSourceUserMapper;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DataSourceUserDaoImpl extends BaseDao<DatasourceUser, DataSourceUserMapper> implements DataSourceUserDao {
+
+    public DataSourceUserDaoImpl(@NonNull DataSourceUserMapper dataSourceUserMapper) {
+        super(dataSourceUserMapper);
+    }
+
+    @Override
+    public void deleteByUserId(int userId) {
+        mybatisMapper.deleteByUserId(userId);
+    }
+
+    @Override
+    public void deleteByDatasourceId(int datasourceId) {
+        mybatisMapper.deleteByDatasourceId(datasourceId);
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, gpt 5.5

## Purpose of the pull request

Introduce DataSourceDao and DataSourceUserDao so the api layer depends only on the repository abstraction. The two mappers are bundled because DataSourceServiceImpl and UsersServiceImpl share both.

DataSourceDao renames mapper.selectPaging / selectPagingByIds to queryDataSourcePaging / queryDataSourcePagingByIds and folds the selectByMap("user_id", X) idiom from DataSourceServiceImpl into queryByUserId(int) so the QueryWrapper-style call no longer leaks into the api layer.

DataSourceUserDao exposes deleteByUserId / deleteByDatasourceId as void (the mapper-returned row count was never consulted at the call sites).

Tracking issue: #18249

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
