### PR TITLE
[Improvement-18249][DAO] Route AlertGroupMapper and AccessTokenMapperaccess through repository Dao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TokenAuditOperatorImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/audit/operator/impl/TokenAuditOperatorImpl.java
@@ -23,7 +23,7 @@ import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 
 import java.util.List;
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
 public class TokenAuditOperatorImpl extends BaseAuditOperator {
 
     @Autowired
-    private AccessTokenMapper accessTokenMapper;
+    private AccessTokenDao accessTokenDao;
 
     @Autowired
     private UserDao userDao;
@@ -60,7 +60,7 @@ public class TokenAuditOperatorImpl extends BaseAuditOperator {
             return "";
         }
 
-        AccessToken obj = accessTokenMapper.selectById(objId);
+        AccessToken obj = accessTokenDao.queryById(objId);
         return obj == null ? "" : obj.getUserName();
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/ResourcePermissionCheckServiceImpl.java
@@ -32,11 +32,11 @@ import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkerGroup;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertPluginInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.EnvironmentMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
 import org.apache.dolphinscheduler.dao.repository.K8sNamespaceDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
@@ -326,10 +326,10 @@ public class ResourcePermissionCheckServiceImpl
     @Component
     public static class AlertGroupResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
-        private final AlertGroupMapper alertGroupMapper;
+        private final AlertGroupDao alertGroupDao;
 
-        public AlertGroupResourcePermissionCheck(AlertGroupMapper alertGroupMapper) {
-            this.alertGroupMapper = alertGroupMapper;
+        public AlertGroupResourcePermissionCheck(AlertGroupDao alertGroupDao) {
+            this.alertGroupDao = alertGroupDao;
         }
 
         @Override
@@ -344,7 +344,7 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
-            List<AlertGroup> alertGroupList = alertGroupMapper.queryAllGroupList();
+            List<AlertGroup> alertGroupList = alertGroupDao.queryAllGroupList();
             return alertGroupList.stream().map(AlertGroup::getId).collect(toSet());
         }
     }
@@ -413,10 +413,10 @@ public class ResourcePermissionCheckServiceImpl
     @Component
     public static class AccessTokenResourcePermissionCheck implements ResourceAcquisitionAndPermissionCheck<Integer> {
 
-        private final AccessTokenMapper accessTokenMapper;
+        private final AccessTokenDao accessTokenDao;
 
-        public AccessTokenResourcePermissionCheck(AccessTokenMapper accessTokenMapper) {
-            this.accessTokenMapper = accessTokenMapper;
+        public AccessTokenResourcePermissionCheck(AccessTokenDao accessTokenDao) {
+            this.accessTokenDao = accessTokenDao;
         }
 
         @Override
@@ -431,7 +431,7 @@ public class ResourcePermissionCheckServiceImpl
 
         @Override
         public Set<Integer> listAuthorizedResourceIds(int userId, Logger logger) {
-            return accessTokenMapper.listAuthorizedAccessToken(userId, null).stream().map(AccessToken::getId)
+            return accessTokenDao.listAuthorizedAccessToken(userId, null).stream().map(AccessToken::getId)
                     .collect(toSet());
         }
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AccessTokenServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AccessTokenServiceImpl.java
@@ -31,7 +31,7 @@ import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.EncryptionUtils;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -51,7 +51,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTokenService {
 
     @Autowired
-    private AccessTokenMapper accessTokenMapper;
+    private AccessTokenDao accessTokenDao;
 
     /**
      * query access token list
@@ -71,7 +71,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         if (loginUser.getUserType() == UserType.ADMIN_USER) {
             userId = 0;
         }
-        IPage<AccessToken> accessTokenList = accessTokenMapper.selectAccessTokenPage(page, searchVal, userId);
+        IPage<AccessToken> accessTokenList = accessTokenDao.queryAccessTokenPage(page, searchVal, userId);
         pageInfo.setTotal((int) accessTokenList.getTotal());
         pageInfo.setTotalList(accessTokenList.getRecords());
         return pageInfo;
@@ -92,7 +92,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         }
         userId = loginUser.getUserType().equals(UserType.ADMIN_USER) ? 0 : userId;
         // query access token for specified user
-        List<AccessToken> accessTokenList = this.accessTokenMapper.queryAccessTokenByUser(userId);
+        List<AccessToken> accessTokenList = this.accessTokenDao.queryAccessTokenByUser(userId);
         return accessTokenList;
     }
 
@@ -134,7 +134,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         accessToken.setCreateTime(new Date());
         accessToken.setUpdateTime(new Date());
 
-        int insert = accessTokenMapper.insert(accessToken);
+        int insert = accessTokenDao.insert(accessToken);
 
         if (insert > 0) {
             return accessToken;
@@ -168,7 +168,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
 
-        AccessToken accessToken = accessTokenMapper.selectById(id);
+        AccessToken accessToken = accessTokenDao.queryById(id);
         if (accessToken == null) {
             throw new ServiceException(Status.ACCESS_TOKEN_NOT_EXIST, id);
         }
@@ -177,7 +177,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         if (accessToken.getUserId() != loginUser.getId() && !loginUser.getUserType().equals(UserType.ADMIN_USER)) {
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
-        accessTokenMapper.deleteById(id);
+        accessTokenDao.deleteById(id);
     }
 
     /**
@@ -198,7 +198,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         }
 
         // 2. check if token is existed
-        AccessToken accessToken = accessTokenMapper.selectById(id);
+        AccessToken accessToken = accessTokenDao.queryById(id);
         if (accessToken == null) {
             log.error("Access token does not exist, accessTokenId:{}.", id);
             throw new ServiceException(Status.ACCESS_TOKEN_NOT_EXIST, id);
@@ -219,8 +219,7 @@ public class AccessTokenServiceImpl extends BaseServiceImpl implements AccessTok
         accessToken.setToken(token);
         accessToken.setUpdateTime(new Date());
 
-        int i = accessTokenMapper.updateById(accessToken);
-        if (i <= 0) {
+        if (!accessTokenDao.updateById(accessToken)) {
             throw new ServiceException(Status.ACCESS_TOKEN_NOT_EXIST, id);
         }
         return accessToken;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertGroupServiceImpl.java
@@ -30,7 +30,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -57,7 +57,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroupService {
 
     @Autowired
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     /**
      * query alert group list
@@ -68,14 +68,14 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
     @Override
     public List<AlertGroup> queryAllAlertGroup(User loginUser) {
         if (loginUser.getUserType().equals(UserType.ADMIN_USER)) {
-            return alertGroupMapper.queryAllGroupList();
+            return alertGroupDao.queryAllGroupList();
         }
         Set<Integer> ids = resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.ALERT_GROUP,
                 loginUser.getId(), log);
         if (ids.isEmpty()) {
             return Collections.emptyList();
         }
-        return alertGroupMapper.selectBatchIds(ids);
+        return alertGroupDao.queryByIds(ids);
     }
 
     /**
@@ -93,7 +93,7 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
             throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
         // check if exist
-        AlertGroup alertGroup = alertGroupMapper.selectById(id);
+        AlertGroup alertGroup = alertGroupDao.queryById(id);
         if (alertGroup == null) {
             throw new ServiceException(Status.ALERT_GROUP_NOT_EXIST, id);
         }
@@ -113,7 +113,7 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
     public PageInfo<AlertGroup> listPaging(User loginUser, String searchVal, Integer pageNo, Integer pageSize) {
         Page<AlertGroup> page = new Page<>(pageNo, pageSize);
         if (loginUser.getUserType().equals(UserType.ADMIN_USER)) {
-            IPage<AlertGroup> alertGroupIPage = alertGroupMapper.queryAlertGroupPage(page, searchVal);
+            IPage<AlertGroup> alertGroupIPage = alertGroupDao.queryAlertGroupPage(page, searchVal);
             return PageInfo.of(alertGroupIPage);
         }
 
@@ -124,7 +124,7 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
         }
 
         IPage<AlertGroup> alertGroupIPage =
-                alertGroupMapper.queryAlertGroupPageByIds(page, new ArrayList<>(ids), searchVal);
+                alertGroupDao.queryAlertGroupPageByIds(page, new ArrayList<>(ids), searchVal);
         return PageInfo.of(alertGroupIPage);
     }
 
@@ -161,7 +161,7 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
 
         // insert
         try {
-            int insert = alertGroupMapper.insert(alertGroup);
+            int insert = alertGroupDao.insert(alertGroup);
             if (insert > 0) {
                 log.info("Create alert group complete, groupName:{}", alertGroup.getGroupName());
                 return alertGroup;
@@ -193,7 +193,7 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
         if (checkDescriptionLength(desc)) {
             throw new ServiceException(Status.DESCRIPTION_TOO_LONG_ERROR);
         }
-        AlertGroup alertGroup = alertGroupMapper.selectById(id);
+        AlertGroup alertGroup = alertGroupDao.queryById(id);
 
         if (alertGroup == null) {
             throw new ServiceException(Status.ALERT_GROUP_NOT_EXIST);
@@ -209,7 +209,7 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
         alertGroup.setCreateUserId(loginUser.getId());
         alertGroup.setAlertInstanceIds(alertInstanceIds);
         try {
-            alertGroupMapper.updateById(alertGroup);
+            alertGroupDao.updateById(alertGroup);
             log.info("Update alert group complete, groupName:{}", alertGroup.getGroupName());
             return alertGroup;
         } catch (DuplicateKeyException ex) {
@@ -240,12 +240,12 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
         }
 
         // check exist
-        AlertGroup alertGroup = alertGroupMapper.selectById(id);
+        AlertGroup alertGroup = alertGroupDao.queryById(id);
         if (alertGroup == null) {
             throw new ServiceException(Status.ALERT_GROUP_NOT_EXIST);
         }
 
-        alertGroupMapper.deleteById(id);
+        alertGroupDao.deleteById(id);
         log.info("Delete alert group complete, groupId:{}", id);
     }
 
@@ -257,6 +257,6 @@ public class AlertGroupServiceImpl extends BaseServiceImpl implements AlertGroup
      */
     @Override
     public boolean existGroupName(String groupName) {
-        return alertGroupMapper.existGroupName(groupName) == Boolean.TRUE;
+        return alertGroupDao.existGroupName(groupName);
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
@@ -33,9 +33,9 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.AlertPluginInstance;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertPluginInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.PluginDefineMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 import org.apache.dolphinscheduler.extract.alert.IAlertOperator;
 import org.apache.dolphinscheduler.extract.alert.request.AlertSendResponse;
 import org.apache.dolphinscheduler.extract.alert.request.AlertTestSendRequest;
@@ -78,7 +78,7 @@ public class AlertPluginInstanceServiceImpl extends BaseServiceImpl implements A
     private PluginDefineMapper pluginDefineMapper;
 
     @Autowired
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     @Autowired
     private RegistryClient registryClient;
@@ -271,7 +271,7 @@ public class AlertPluginInstanceServiceImpl extends BaseServiceImpl implements A
     }
 
     private boolean checkHasAssociatedAlertGroup(String id) {
-        List<String> idsList = alertGroupMapper.queryInstanceIdsList();
+        List<String> idsList = alertGroupDao.queryInstanceIdsList();
         if (CollectionUtils.isEmpty(idsList)) {
             return false;
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -39,9 +39,9 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectUser;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
@@ -77,7 +77,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
 
     @Autowired
-    private AccessTokenMapper accessTokenMapper;
+    private AccessTokenDao accessTokenDao;
 
     @Autowired
     private UserDao userDao;
@@ -92,7 +92,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     private DataSourceUserDao datasourceUserDao;
 
     @Autowired
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     @Autowired
     private ProjectDao projectDao;
@@ -448,7 +448,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         // delete user
         userDao.queryTenantCodeByUserId(id);
 
-        accessTokenMapper.deleteAccessTokenByUserId(id);
+        accessTokenDao.deleteByUserId(id);
         sessionService.expireSession(id);
 
         if (!userDao.deleteById(id)) {
@@ -751,7 +751,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         } else {
             user = userDao.queryDetailsById(loginUser.getId());
 
-            List<AlertGroup> alertGroups = alertGroupMapper.queryByUserId(loginUser.getId());
+            List<AlertGroup> alertGroups = alertGroupDao.queryByUserId(loginUser.getId());
 
             StringBuilder sb = new StringBuilder();
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertGroupControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertGroupControllerTest.java
@@ -28,9 +28,10 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.entity.AlertGroup;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 
 import java.util.Date;
+import java.util.Objects;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -43,8 +44,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
-
 public class AlertGroupControllerTest extends AbstractControllerTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AlertGroupController.class);
@@ -52,21 +51,22 @@ public class AlertGroupControllerTest extends AbstractControllerTest {
     private static final String defaultTestAlertGroupName = "cxc test group name";
 
     @Autowired
-    AlertGroupMapper alertGroupMapper;
+    AlertGroupDao alertGroupDao;
 
     private int createEntity() {
         AlertGroup alertGroup = new AlertGroup();
         alertGroup.setGroupName(defaultTestAlertGroupName);
         alertGroup.setCreateTime(new Date());
         alertGroup.setUpdateTime(new Date());
-        alertGroupMapper.insert(alertGroup);
+        alertGroupDao.insert(alertGroup);
         return alertGroup.getId();
     }
 
     @AfterEach
     public void clear() {
-        alertGroupMapper.delete(
-                new QueryWrapper<AlertGroup>().lambda().eq(AlertGroup::getGroupName, defaultTestAlertGroupName));
+        alertGroupDao.queryAllGroupList().stream()
+                .filter(group -> Objects.equals(group.getGroupName(), defaultTestAlertGroupName))
+                .forEach(group -> alertGroupDao.deleteById(group.getId()));
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AccessTokenResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AccessTokenResourcePermissionCheckTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class AccessTokenResourcePermissionCheckTest {
     private ResourcePermissionCheckServiceImpl.AccessTokenResourcePermissionCheck accessTokenResourcePermissionCheck;
 
     @Mock
-    private AccessTokenMapper accessTokenMapper;
+    private AccessTokenDao accessTokenDao;
 
     @Test
     public void testPermissionCheck() {
@@ -69,7 +69,7 @@ public class AccessTokenResourcePermissionCheckTest {
         ids.add(accessToken.getId());
         List<AccessToken> accessTokens = Arrays.asList(accessToken);
 
-        Mockito.when(accessTokenMapper.listAuthorizedAccessToken(user.getId(), null)).thenReturn(accessTokens);
+        Mockito.when(accessTokenDao.listAuthorizedAccessToken(user.getId(), null)).thenReturn(accessTokens);
 
         Assertions.assertEquals(ids,
                 accessTokenResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AlertGroupResourcePermissionCheckTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/AlertGroupResourcePermissionCheckTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class AlertGroupResourcePermissionCheckTest {
     private ResourcePermissionCheckServiceImpl.AlertGroupResourcePermissionCheck alertGroupResourcePermissionCheck;
 
     @Mock
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     @Test
     public void testPermissionCheck() {
@@ -69,7 +69,7 @@ public class AlertGroupResourcePermissionCheckTest {
         ids.add(alertGroup.getId());
         List<AlertGroup> alertGroups = Arrays.asList(alertGroup);
 
-        Mockito.when(alertGroupMapper.queryAllGroupList()).thenReturn(alertGroups);
+        Mockito.when(alertGroupDao.queryAllGroupList()).thenReturn(alertGroups);
 
         Assertions.assertEquals(ids, alertGroupResourcePermissionCheck.listAuthorizedResourceIds(user.getId(), logger));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AccessTokenServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AccessTokenServiceTest.java
@@ -38,7 +38,7 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.dao.entity.AccessToken;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -69,7 +69,7 @@ public class AccessTokenServiceTest {
     private AccessTokenServiceImpl accessTokenService;
 
     @Mock
-    private AccessTokenMapper accessTokenMapper;
+    private AccessTokenDao accessTokenDao;
 
     @Mock
     private ResourcePermissionCheckService resourcePermissionCheckService;
@@ -82,12 +82,12 @@ public class AccessTokenServiceTest {
         User user = new User();
         user.setId(1);
         user.setUserType(UserType.ADMIN_USER);
-        when(accessTokenMapper.selectAccessTokenPage(any(Page.class), eq("zhangsan"), eq(0))).thenReturn(tokenPage);
+        when(accessTokenDao.queryAccessTokenPage(any(Page.class), eq("zhangsan"), eq(0))).thenReturn(tokenPage);
         PageInfo<AccessToken> pageInfo = accessTokenService.queryAccessTokenList(user, "zhangsan", 1, 10);
         assertEquals(0, (int) pageInfo.getTotal());
 
         tokenPage.setTotal(1L);
-        when(accessTokenMapper.selectAccessTokenPage(any(Page.class), eq("zhangsan"), eq(0))).thenReturn(tokenPage);
+        when(accessTokenDao.queryAccessTokenPage(any(Page.class), eq("zhangsan"), eq(0))).thenReturn(tokenPage);
         pageInfo = accessTokenService.queryAccessTokenList(user, "zhangsan", 1, 10);
         assertTrue(pageInfo.getTotal() > 0);
     }
@@ -101,7 +101,7 @@ public class AccessTokenServiceTest {
 
         user.setUserType(UserType.ADMIN_USER);
         List<AccessToken> accessTokenList = Lists.newArrayList(this.getEntity());
-        when(this.accessTokenMapper.queryAccessTokenByUser(Mockito.anyInt())).thenReturn(accessTokenList);
+        when(this.accessTokenDao.queryAccessTokenByUser(Mockito.anyInt())).thenReturn(accessTokenList);
         assertDoesNotThrow(() -> accessTokenService.queryAccessTokenByUser(user, 1));
     }
 
@@ -122,7 +122,7 @@ public class AccessTokenServiceTest {
         user.setId(1);
 
         // Given Token
-        when(accessTokenMapper.insert(any(AccessToken.class))).thenReturn(2);
+        when(accessTokenDao.insert(any(AccessToken.class))).thenReturn(2);
         assertDoesNotThrow(() -> {
             accessTokenService.createToken(user, 1, getDate(), "AccessTokenServiceTest");
         });
@@ -132,7 +132,7 @@ public class AccessTokenServiceTest {
                 () -> accessTokenService.createToken(user, 1, getDate(), null));
 
         // Throw Service Exception when insert failed
-        when(accessTokenMapper.insert(any(AccessToken.class))).thenReturn(0);
+        when(accessTokenDao.insert(any(AccessToken.class))).thenReturn(0);
         assertThrowsServiceException(Status.CREATE_ACCESS_TOKEN_ERROR,
                 () -> accessTokenService.createToken(user, 1, getDate(), "AccessTokenServiceTest"));
     }
@@ -150,7 +150,7 @@ public class AccessTokenServiceTest {
     public void testDelAccessTokenById() {
         AccessToken accessToken = getEntity();
 
-        when(accessTokenMapper.selectById(1)).thenReturn(accessToken);
+        when(accessTokenDao.queryById(1)).thenReturn(accessToken);
         User userLogin = new User();
         userLogin.setId(1);
         userLogin.setUserType(UserType.ADMIN_USER);
@@ -195,8 +195,8 @@ public class AccessTokenServiceTest {
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ACCESS_TOKEN, null, 0,
                 baseServiceLogger)).thenReturn(true);
         // Given Token
-        when(accessTokenMapper.selectById(1)).thenReturn(getEntity());
-        when(accessTokenMapper.updateById(any())).thenReturn(1);
+        when(accessTokenDao.queryById(1)).thenReturn(getEntity());
+        when(accessTokenDao.updateById(any())).thenReturn(true);
         AccessToken accessToken =
                 accessTokenService.updateToken(getLoginUser(), 1, Integer.MAX_VALUE, getDate(), "token");
         assertEquals("token", accessToken.getToken());
@@ -224,7 +224,7 @@ public class AccessTokenServiceTest {
                 () -> accessTokenService.updateToken(user, 1, Integer.MAX_VALUE, getDate(), "token"));
 
         // Throw Service Exception when update failed
-        when(accessTokenMapper.updateById(any(AccessToken.class))).thenReturn(0);
+        when(accessTokenDao.updateById(any(AccessToken.class))).thenReturn(false);
         assertThrowsServiceException(Status.ACCESS_TOKEN_NOT_EXIST,
                 () -> accessTokenService.updateToken(getLoginUser(), 1, Integer.MAX_VALUE, getDate(), "token"));
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertGroupServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertGroupServiceTest.java
@@ -37,7 +37,7 @@ import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -76,7 +76,7 @@ public class AlertGroupServiceTest {
     private AlertGroupServiceImpl alertGroupService;
 
     @Mock
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     private String groupName = "AlertGroupServiceTest";
 
@@ -87,7 +87,7 @@ public class AlertGroupServiceTest {
     public void testQueryAlertGroup() {
         User user = getLoginUser();
 
-        when(alertGroupMapper.queryAllGroupList()).thenReturn(getList());
+        when(alertGroupDao.queryAllGroupList()).thenReturn(getList());
         List<AlertGroup> alertGroups = alertGroupService.queryAllAlertGroup(user);
         Assertions.assertEquals(1, alertGroups.size());
 
@@ -126,12 +126,12 @@ public class AlertGroupServiceTest {
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ALERT_GROUP, new Object[]{999}, 1,
                 baseServiceLogger))
                         .thenReturn(true);
-        when(alertGroupMapper.selectById(999)).thenReturn(null);
+        when(alertGroupDao.queryById(999)).thenReturn(null);
 
         assertThrowsServiceException(Status.ALERT_GROUP_NOT_EXIST,
                 () -> alertGroupService.queryAlertGroupById(user, 999));
 
-        when(alertGroupMapper.selectById(999)).thenReturn(getEntity());
+        when(alertGroupDao.queryById(999)).thenReturn(getEntity());
         assertDoesNotThrow(() -> alertGroupService.queryAlertGroupById(user, 999));
     }
 
@@ -140,7 +140,7 @@ public class AlertGroupServiceTest {
         IPage<AlertGroup> page = new Page<>(1, 10);
         page.setTotal(1L);
         page.setRecords(getList());
-        when(alertGroupMapper.queryAlertGroupPage(any(Page.class), eq(groupName))).thenReturn(page);
+        when(alertGroupDao.queryAlertGroupPage(any(Page.class), eq(groupName))).thenReturn(page);
         User user = new User();
         // no operate
         user.setUserType(UserType.GENERAL_USER);
@@ -162,7 +162,7 @@ public class AlertGroupServiceTest {
         when(resourcePermissionCheckService.userOwnedResourceIdsAcquisition(AuthorizationType.ALERT_GROUP, user.getId(),
                 alertGroupServiceLogger))
                         .thenReturn(Collections.singleton(1));
-        when(alertGroupMapper.queryAlertGroupPageByIds(any(Page.class), any(List.class), eq(groupName)))
+        when(alertGroupDao.queryAlertGroupPageByIds(any(Page.class), any(List.class), eq(groupName)))
                 .thenReturn(page);
 
         alertGroupService.listPaging(user, groupName, 1, 10).getTotal();
@@ -171,7 +171,7 @@ public class AlertGroupServiceTest {
     @Test
     public void testCreateAlertgroup() {
 
-        when(alertGroupMapper.insert(any(AlertGroup.class))).thenReturn(2);
+        when(alertGroupDao.insert(any(AlertGroup.class))).thenReturn(2);
         User user = new User();
         user.setId(0);
         // no operate
@@ -192,11 +192,11 @@ public class AlertGroupServiceTest {
         AlertGroup alertGroup = alertGroupService.createAlertGroup(user, groupName, groupName, null);
         assertNotNull(alertGroup);
 
-        when(alertGroupMapper.insert(any(AlertGroup.class))).thenReturn(-1);
+        when(alertGroupDao.insert(any(AlertGroup.class))).thenReturn(-1);
         assertThrowsServiceException(Status.CREATE_ALERT_GROUP_ERROR,
                 () -> alertGroupService.createAlertGroup(user, groupName, groupName, null));
 
-        when(alertGroupMapper.insert(any(AlertGroup.class))).thenThrow(DuplicateKeyException.class);
+        when(alertGroupDao.insert(any(AlertGroup.class))).thenThrow(DuplicateKeyException.class);
         assertThrowsServiceException(Status.ALERT_GROUP_EXIST,
                 () -> alertGroupService.createAlertGroup(user, groupName, groupName, null));
     }
@@ -204,7 +204,7 @@ public class AlertGroupServiceTest {
     @Test
     public void testCreateAlertgroupDuplicate() {
 
-        when(alertGroupMapper.insert(any(AlertGroup.class))).thenThrow(new DuplicateKeyException("group name exist"));
+        when(alertGroupDao.insert(any(AlertGroup.class))).thenThrow(new DuplicateKeyException("group name exist"));
         User user = new User();
         user.setUserType(UserType.ADMIN_USER);
         user.setId(0);
@@ -241,7 +241,7 @@ public class AlertGroupServiceTest {
         // success
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ALERT_GROUP, new Object[]{2},
                 user.getId(), baseServiceLogger)).thenReturn(true);
-        when(alertGroupMapper.selectById(2)).thenReturn(getEntity());
+        when(alertGroupDao.queryById(2)).thenReturn(getEntity());
         assertDoesNotThrow(() -> alertGroupService.updateAlertGroupById(user, 2, groupName, groupName, null));
     }
 
@@ -254,8 +254,8 @@ public class AlertGroupServiceTest {
                 user.getId(), ALERT_GROUP_UPDATE, baseServiceLogger)).thenReturn(true);
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ALERT_GROUP,
                 new Object[]{2}, user.getId(), baseServiceLogger)).thenReturn(true);
-        when(alertGroupMapper.selectById(2)).thenReturn(getEntity());
-        when(alertGroupMapper.updateById(Mockito.any()))
+        when(alertGroupDao.queryById(2)).thenReturn(getEntity());
+        when(alertGroupDao.updateById(Mockito.any()))
                 .thenThrow(new DuplicateKeyException("group name exist"));
         assertThrowsServiceException(Status.ALERT_GROUP_EXIST,
                 () -> alertGroupService.updateAlertGroupById(user, 2, groupName, groupName, null));
@@ -290,7 +290,7 @@ public class AlertGroupServiceTest {
         // success
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ALERT_GROUP, new Object[]{4}, 0,
                 baseServiceLogger)).thenReturn(true);
-        when(alertGroupMapper.selectById(4)).thenReturn(getEntity());
+        when(alertGroupDao.queryById(4)).thenReturn(getEntity());
         assertDoesNotThrow(() -> alertGroupService.deleteAlertGroupById(user, 4));
     }
 
@@ -299,7 +299,7 @@ public class AlertGroupServiceTest {
         // group name not exist
         boolean result = alertGroupService.existGroupName(groupName);
         Assertions.assertFalse(result);
-        when(alertGroupMapper.existGroupName(groupName)).thenReturn(true);
+        when(alertGroupDao.existGroupName(groupName)).thenReturn(true);
 
         // group name exist
         result = alertGroupService.existGroupName(groupName);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceServiceTest.java
@@ -37,9 +37,9 @@ import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.AlertPluginInstance;
 import org.apache.dolphinscheduler.dao.entity.PluginDefine;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertPluginInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.PluginDefineMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
 
@@ -80,7 +80,7 @@ public class AlertPluginInstanceServiceTest {
     private PluginDefineMapper pluginDefineMapper;
 
     @Mock
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     @Mock
     private RegistryClient registryClient;
@@ -232,7 +232,7 @@ public class AlertPluginInstanceServiceTest {
                 () -> alertPluginInstanceService.deleteById(noPermUser, 1));
 
         List<String> ids = Arrays.asList("11,2,3", "5,96", null, "98,1");
-        when(alertGroupMapper.queryInstanceIdsList()).thenReturn(ids);
+        when(alertGroupDao.queryInstanceIdsList()).thenReturn(ids);
         when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.ALERT_PLUGIN_INSTANCE,
                 1, ALERT_PLUGIN_DELETE, baseServiceLogger)).thenReturn(true);
         when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ALERT_PLUGIN_INSTANCE,
@@ -247,7 +247,7 @@ public class AlertPluginInstanceServiceTest {
         assertThrowsServiceException(Status.DELETE_ALERT_PLUGIN_INSTANCE_ERROR_HAS_ALERT_GROUP_ASSOCIATED,
                 () -> alertPluginInstanceService.deleteById(user, 5));
 
-        when(alertGroupMapper.queryInstanceIdsList()).thenReturn(Collections.emptyList());
+        when(alertGroupDao.queryInstanceIdsList()).thenReturn(Collections.emptyList());
         Assertions.assertDoesNotThrow(() -> alertPluginInstanceService.deleteById(user, 9));
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -37,9 +37,9 @@ import org.apache.dolphinscheduler.dao.entity.AlertGroup;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
-import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
@@ -78,7 +78,7 @@ public class UsersServiceTest {
     private UserDao userDao;
 
     @Mock
-    private AccessTokenMapper accessTokenMapper;
+    private AccessTokenDao accessTokenDao;
 
     @Mock
     private TenantDao tenantDao;
@@ -87,7 +87,7 @@ public class UsersServiceTest {
     private ProjectUserDao projectUserDao;
 
     @Mock
-    private AlertGroupMapper alertGroupMapper;
+    private AlertGroupDao alertGroupDao;
 
     @Mock
     private DataSourceUserDao datasourceUserDao;
@@ -548,7 +548,7 @@ public class UsersServiceTest {
         loginUser.setUserType(null);
         loginUser.setId(1);
         when(userDao.queryDetailsById(1)).thenReturn(getGeneralUser());
-        when(alertGroupMapper.queryByUserId(1)).thenReturn(getAlertGroups());
+        when(alertGroupDao.queryByUserId(1)).thenReturn(getAlertGroups());
         User generalInfo = usersService.getUserInfo(loginUser);
         Assertions.assertEquals("userTest0001", generalInfo.getUserName());
     }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/AccessTokenDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/AccessTokenDao.java
@@ -15,29 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.audit.operator.impl;
+package org.apache.dolphinscheduler.dao.repository;
 
-import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
-import org.apache.dolphinscheduler.dao.entity.AlertGroup;
-import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
+import org.apache.dolphinscheduler.dao.entity.AccessToken;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import java.util.List;
 
-@Service
-public class AlertGroupAuditOperatorImpl extends BaseAuditOperator {
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
-    @Autowired
-    private AlertGroupDao alertGroupDao;
+public interface AccessTokenDao extends IDao<AccessToken> {
 
-    @Override
-    public String getObjectNameFromIdentity(Object identity) {
-        Long objId = toLong(identity);
-        if (objId == -1) {
-            return "";
-        }
+    IPage<AccessToken> queryAccessTokenPage(Page<AccessToken> page, String userName, int userId);
 
-        AlertGroup obj = alertGroupDao.queryById(objId);
-        return obj == null ? "" : obj.getGroupName();
-    }
+    List<AccessToken> queryAccessTokenByUser(int userId);
+
+    void deleteByUserId(int userId);
+
+    List<AccessToken> listAuthorizedAccessToken(int userId, List<Integer> accessTokensIds);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/AlertGroupDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/AlertGroupDao.java
@@ -15,29 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.api.audit.operator.impl;
+package org.apache.dolphinscheduler.dao.repository;
 
-import org.apache.dolphinscheduler.api.audit.operator.BaseAuditOperator;
 import org.apache.dolphinscheduler.dao.entity.AlertGroup;
-import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import java.util.List;
 
-@Service
-public class AlertGroupAuditOperatorImpl extends BaseAuditOperator {
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
-    @Autowired
-    private AlertGroupDao alertGroupDao;
+public interface AlertGroupDao extends IDao<AlertGroup> {
 
-    @Override
-    public String getObjectNameFromIdentity(Object identity) {
-        Long objId = toLong(identity);
-        if (objId == -1) {
-            return "";
-        }
+    IPage<AlertGroup> queryAlertGroupPage(Page<AlertGroup> page, String groupName);
 
-        AlertGroup obj = alertGroupDao.queryById(objId);
-        return obj == null ? "" : obj.getGroupName();
-    }
+    IPage<AlertGroup> queryAlertGroupPageByIds(Page<AlertGroup> page, List<Integer> ids, String searchVal);
+
+    List<AlertGroup> queryAllGroupList();
+
+    List<AlertGroup> queryByUserId(int userId);
+
+    List<String> queryInstanceIdsList();
+
+    boolean existGroupName(String groupName);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/AccessTokenDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/AccessTokenDaoImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.AccessToken;
+import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
+import org.apache.dolphinscheduler.dao.repository.AccessTokenDao;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+
+import java.util.List;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+
+@Repository
+public class AccessTokenDaoImpl extends BaseDao<AccessToken, AccessTokenMapper> implements AccessTokenDao {
+
+    public AccessTokenDaoImpl(@NonNull AccessTokenMapper accessTokenMapper) {
+        super(accessTokenMapper);
+    }
+
+    @Override
+    public IPage<AccessToken> queryAccessTokenPage(Page<AccessToken> page, String userName, int userId) {
+        return mybatisMapper.selectAccessTokenPage(page, userName, userId);
+    }
+
+    @Override
+    public List<AccessToken> queryAccessTokenByUser(int userId) {
+        return mybatisMapper.queryAccessTokenByUser(userId);
+    }
+
+    @Override
+    public void deleteByUserId(int userId) {
+        mybatisMapper.deleteAccessTokenByUserId(userId);
+    }
+
+    @Override
+    public List<AccessToken> listAuthorizedAccessToken(int userId, List<Integer> accessTokensIds) {
+        return mybatisMapper.listAuthorizedAccessToken(userId, accessTokensIds);
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/AlertGroupDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/AlertGroupDaoImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.AlertGroup;
+import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
+import org.apache.dolphinscheduler.dao.repository.AlertGroupDao;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+
+import java.util.List;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+
+@Repository
+public class AlertGroupDaoImpl extends BaseDao<AlertGroup, AlertGroupMapper> implements AlertGroupDao {
+
+    public AlertGroupDaoImpl(@NonNull AlertGroupMapper alertGroupMapper) {
+        super(alertGroupMapper);
+    }
+
+    @Override
+    public IPage<AlertGroup> queryAlertGroupPage(Page<AlertGroup> page, String groupName) {
+        return mybatisMapper.queryAlertGroupPage(page, groupName);
+    }
+
+    @Override
+    public IPage<AlertGroup> queryAlertGroupPageByIds(Page<AlertGroup> page, List<Integer> ids, String searchVal) {
+        return mybatisMapper.queryAlertGroupPageByIds(page, ids, searchVal);
+    }
+
+    @Override
+    public List<AlertGroup> queryAllGroupList() {
+        return mybatisMapper.queryAllGroupList();
+    }
+
+    @Override
+    public List<AlertGroup> queryByUserId(int userId) {
+        return mybatisMapper.queryByUserId(userId);
+    }
+
+    @Override
+    public List<String> queryInstanceIdsList() {
+        return mybatisMapper.queryInstanceIdsList();
+    }
+
+    @Override
+    public boolean existGroupName(String groupName) {
+        return Boolean.TRUE.equals(mybatisMapper.existGroupName(groupName));
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, gpt 5.5

## Purpose of the pull request

Introduce AlertGroupDao and AccessTokenDao so the api layer depends only on the repository abstraction. The two mappers are bundled because UsersServiceImpl and ResourcePermissionCheckServiceImpl share both.

AlertGroupDao preserves the mapper's custom ORDER BY update_time DESC in queryAllGroupList (cannot be replaced with IDao.queryAll). existGroupName returns primitive boolean via Boolean.TRUE.equals so callers drop the == Boolean.TRUE dance.

AccessTokenDao renames mapper.selectAccessTokenPage to queryAccessTokenPage and mapper.deleteAccessTokenByUserId to deleteByUserId. updateById in AccessTokenServiceImpl switches from int to boolean so the guard becomes !success instead of i <= 0.

AlertGroupControllerTest.clear() replaces the BaseMapper.delete(QueryWrapper) idiom with a queryAllGroupList stream + deleteById loop so the controller test can stop reaching into MyBatis-Plus internals.

Tracking issue: #18249

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
