### PR TITLE
[Improvement-18249][DAO] Route ProjectUserMapper access through ProjectUserDao

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/python/PythonGateway.java
@@ -50,10 +50,10 @@ import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionMapper;
 import org.apache.dolphinscheduler.dao.repository.DataSourceDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
 import org.apache.dolphinscheduler.dao.repository.ScheduleDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageEntity;
@@ -138,7 +138,7 @@ public class PythonGateway {
     private ApiConfig apiConfig;
 
     @Autowired
-    private ProjectUserMapper projectUserMapper;
+    private ProjectUserDao projectUserDao;
 
     // TODO replace this user to build in admin user if we make sure build in one could not be change
     private final User dummyAdminUser = new User() {
@@ -391,7 +391,7 @@ public class PythonGateway {
         projectUser.setPerm(Constants.AUTHORIZE_WRITABLE_PERM);
         projectUser.setCreateTime(now);
         projectUser.setUpdateTime(now);
-        return projectUserMapper.insert(projectUser);
+        return projectUserDao.insert(projectUser);
     }
 
     /*
@@ -406,7 +406,7 @@ public class PythonGateway {
         if (project == null) {
             projectService.createProject(user, name, desc);
         } else if (project.getUserId() != user.getId()) {
-            ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), user.getId());
+            ProjectUser projectUser = projectUserDao.queryProjectRelation(project.getId(), user.getId());
             if (projectUser == null) {
                 grantProjectToUser(project, user);
             }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -36,8 +36,8 @@ import org.apache.dolphinscheduler.dao.entity.ProjectUser;
 import org.apache.dolphinscheduler.dao.entity.ProjectWorkflowDefinitionCount;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
@@ -79,7 +79,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
     private ProjectDao projectDao;
 
     @Autowired
-    private ProjectUserMapper projectUserMapper;
+    private ProjectUserDao projectUserDao;
 
     @Autowired
     private WorkflowDefinitionDao workflowDefinitionDao;
@@ -219,7 +219,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return;
         }
         // case 3: check user permission level
-        ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), loginUser.getId());
+        ProjectUser projectUser = projectUserDao.queryProjectRelation(project.getId(), loginUser.getId());
         if (projectUser == null || projectUser.getPerm() != Constants.DEFAULT_ADMIN_PERMISSION) {
             throw new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM, loginUser.getUserName(), project.getCode());
         }
@@ -312,7 +312,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
 
         for (Project project : projectList) {
             if (userProjectIds.contains(project.getId())) {
-                ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), userId);
+                ProjectUser projectUser = projectUserDao.queryProjectRelation(project.getId(), userId);
                 if (projectUser == null) {
                     // in this case, the user is the project owner, maybe it's better to set it to ALL_PERMISSION.
                     project.setPerm(Constants.DEFAULT_ADMIN_PERMISSION);
@@ -610,7 +610,7 @@ public class ProjectServiceImpl extends BaseServiceImpl implements ProjectServic
             return Constants.ALL_PERMISSIONS;
         }
 
-        ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), user.getId());
+        ProjectUser projectUser = projectUserDao.queryProjectRelation(project.getId(), user.getId());
 
         if (projectUser == null) {
             return 0;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskGroupServiceImpl.java
@@ -32,9 +32,9 @@ import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectUser;
 import org.apache.dolphinscheduler.dao.entity.TaskGroup;
 import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.mapper.TaskGroupMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -65,7 +65,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
     private ProjectDao projectDao;
 
     @Autowired
-    private ProjectUserMapper projectUserMapper;
+    private ProjectUserDao projectUserDao;
 
     @Autowired
     private TaskGroupQueueService taskGroupQueueService;
@@ -285,7 +285,7 @@ public class TaskGroupServiceImpl extends BaseServiceImpl implements TaskGroupSe
         if (project.getUserId().equals(loginUser.getId())) {
             return;
         }
-        ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), loginUser.getId());
+        ProjectUser projectUser = projectUserDao.queryProjectRelation(project.getId(), loginUser.getId());
         if (projectUser == null) {
             log.warn("User {} does not have operation permission for project {}", loginUser.getUserName(),
                     project.getCode());

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/UsersServiceImpl.java
@@ -42,9 +42,9 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 
@@ -86,7 +86,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
     private TenantDao tenantDao;
 
     @Autowired
-    private ProjectUserMapper projectUserMapper;
+    private ProjectUserDao projectUserDao;
 
     @Autowired
     private DataSourceUserDao datasourceUserDao;
@@ -485,7 +485,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             Project project = this.projectDao.queryDetailById(Integer.parseInt(projectId));
             if (project != null) {
                 // 4. delete the relationship between project and user
-                this.projectUserMapper.deleteProjectRelation(project.getId(), user.getId());
+                this.projectUserDao.deleteProjectRelation(project.getId(), user.getId());
             }
         });
     }
@@ -515,9 +515,9 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             return;
         }
         Arrays.stream(projectIds.split(Constants.COMMA)).distinct().forEach(projectId -> {
-            ProjectUser projectUserOld = projectUserMapper.queryProjectRelation(Integer.parseInt(projectId), userId);
+            ProjectUser projectUserOld = projectUserDao.queryProjectRelation(Integer.parseInt(projectId), userId);
             if (projectUserOld != null) {
-                projectUserMapper.deleteProjectRelation(Integer.parseInt(projectId), userId);
+                projectUserDao.deleteProjectRelation(Integer.parseInt(projectId), userId);
             }
             Date now = new Date();
             ProjectUser projectUser = new ProjectUser();
@@ -526,7 +526,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             projectUser.setPerm(Constants.READ_PERMISSION);
             projectUser.setCreateTime(now);
             projectUser.setUpdateTime(now);
-            projectUserMapper.insert(projectUser);
+            projectUserDao.insert(projectUser);
         });
     }
 
@@ -557,9 +557,9 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             return;
         }
         Arrays.stream(projectIds.split(",")).distinct().forEach(projectId -> {
-            ProjectUser projectUserOld = projectUserMapper.queryProjectRelation(Integer.parseInt(projectId), userId);
+            ProjectUser projectUserOld = projectUserDao.queryProjectRelation(Integer.parseInt(projectId), userId);
             if (projectUserOld != null) {
-                projectUserMapper.deleteProjectRelation(Integer.parseInt(projectId), userId);
+                projectUserDao.deleteProjectRelation(Integer.parseInt(projectId), userId);
             }
             Date now = new Date();
             ProjectUser projectUser = new ProjectUser();
@@ -568,7 +568,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             projectUser.setPerm(Constants.AUTHORIZE_WRITABLE_PERM);
             projectUser.setCreateTime(now);
             projectUser.setUpdateTime(now);
-            projectUserMapper.insert(projectUser);
+            projectUserDao.insert(projectUser);
         });
     }
 
@@ -604,7 +604,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // 4. maintain the relationship between project and user if not exists
-        ProjectUser projectUser = projectUserMapper.queryProjectRelation(project.getId(), userId);
+        ProjectUser projectUser = projectUserDao.queryProjectRelation(project.getId(), userId);
         if (projectUser == null) {
             Date today = new Date();
             projectUser = new ProjectUser();
@@ -613,7 +613,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
             projectUser.setPerm(Constants.AUTHORIZE_WRITABLE_PERM);
             projectUser.setCreateTime(today);
             projectUser.setUpdateTime(today);
-            this.projectUserMapper.insert(projectUser);
+            this.projectUserDao.insert(projectUser);
         }
         log.info("User is granted permission for projects, userId:{}, projectCode:{}.", userId, projectCode);
     }
@@ -649,7 +649,7 @@ public class UsersServiceImpl extends BaseServiceImpl implements UsersService {
         }
 
         // 4. delete th relationship between project and user
-        this.projectUserMapper.deleteProjectRelation(project.getId(), user.getId());
+        this.projectUserDao.deleteProjectRelation(project.getId(), user.getId());
         log.info("User is revoked permission for projects, userId:{}, projectCode:{}.", userId, projectCode);
     }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -36,8 +36,8 @@ import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
-import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
 
@@ -81,7 +81,7 @@ public class ProjectServiceTest {
     private ProjectDao projectDao;
 
     @Mock
-    private ProjectUserMapper projectUserMapper;
+    private ProjectUserDao projectUserDao;
 
     @Mock
     private TaskGroupService taskGroupService;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/UsersServiceTest.java
@@ -40,9 +40,9 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper;
 import org.apache.dolphinscheduler.dao.mapper.AlertGroupMapper;
 import org.apache.dolphinscheduler.dao.mapper.K8sNamespaceUserMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 import org.apache.dolphinscheduler.dao.repository.DataSourceUserDao;
 import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.dao.repository.UserDao;
 
@@ -84,7 +84,7 @@ public class UsersServiceTest {
     private TenantDao tenantDao;
 
     @Mock
-    private ProjectUserMapper projectUserMapper;
+    private ProjectUserDao projectUserDao;
 
     @Mock
     private AlertGroupMapper alertGroupMapper;

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ProjectUserDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/ProjectUserDao.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository;
+
+import org.apache.dolphinscheduler.dao.entity.ProjectUser;
+
+public interface ProjectUserDao extends IDao<ProjectUser> {
+
+    ProjectUser queryProjectRelation(int projectId, int userId);
+
+    void deleteProjectRelation(int projectId, int userId);
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ProjectUserDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/ProjectUserDaoImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.repository.impl;
+
+import org.apache.dolphinscheduler.dao.entity.ProjectUser;
+import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
+import org.apache.dolphinscheduler.dao.repository.BaseDao;
+import org.apache.dolphinscheduler.dao.repository.ProjectUserDao;
+
+import lombok.NonNull;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProjectUserDaoImpl extends BaseDao<ProjectUser, ProjectUserMapper> implements ProjectUserDao {
+
+    public ProjectUserDaoImpl(@NonNull ProjectUserMapper projectUserMapper) {
+        super(projectUserMapper);
+    }
+
+    @Override
+    public ProjectUser queryProjectRelation(int projectId, int userId) {
+        return mybatisMapper.queryProjectRelation(projectId, userId);
+    }
+
+    @Override
+    public void deleteProjectRelation(int projectId, int userId) {
+        mybatisMapper.deleteProjectRelation(projectId, userId);
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES, gpt 5.5

## Purpose of the pull request

Introduce ProjectUserDao so the api layer depends only on the repository abstraction. The Dao exposes queryProjectRelation as a straight delegate and packages deleteProjectRelation as void since the row-count return was never consulted at the api call sites.

Tracking issue: #18249

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
