### PR TITLE
[Fix-18269][Master] Move LogicFakeTask to test scope

### DIFF
--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTask.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTask.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.executor.plugin.fake;
+package org.apache.dolphinscheduler.server.master.integration.fake;
 
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
-import org.apache.dolphinscheduler.plugin.task.api.parameters.LogicFakeTaskParameters;
 import org.apache.dolphinscheduler.plugin.task.api.parser.TaskOutputParameterParser;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.AbstractLogicTask;

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskChannel.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskChannel.java
@@ -15,30 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.plugin.task.api.parameters;
+package org.apache.dolphinscheduler.server.master.integration.fake;
 
-import org.apache.commons.lang3.StringUtils;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
+import org.apache.dolphinscheduler.plugin.task.api.task.AbstractLogicTaskChannel;
 
 import com.google.common.annotations.VisibleForTesting;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 @VisibleForTesting
-public class LogicFakeTaskParameters extends AbstractParameters {
-
-    private String shellScript;
+public class LogicFakeTaskChannel extends AbstractLogicTaskChannel {
 
     @Override
-    public boolean checkParameters() {
-        if (StringUtils.isEmpty(shellScript)) {
-            throw new IllegalArgumentException("shellScript is null or empty");
-        }
-        return true;
+    public AbstractParameters parseParameters(String taskParams) {
+        return JSONUtils.parseObject(taskParams, LogicFakeTaskParameters.class);
     }
-
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskChannelFactory.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskChannelFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.plugin.task.api.task;
+package org.apache.dolphinscheduler.server.master.integration.fake;
 
 import org.apache.dolphinscheduler.plugin.task.api.TaskChannel;
 import org.apache.dolphinscheduler.plugin.task.api.TaskChannelFactory;

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskParameters.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskParameters.java
@@ -15,19 +15,32 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.plugin.task.api.task;
+package org.apache.dolphinscheduler.server.master.integration.fake;
 
-import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
-import org.apache.dolphinscheduler.plugin.task.api.parameters.LogicFakeTaskParameters;
+
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import com.google.common.annotations.VisibleForTesting;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @VisibleForTesting
-public class LogicFakeTaskChannel extends AbstractLogicTaskChannel {
+public class LogicFakeTaskParameters extends AbstractParameters {
+
+    private String shellScript;
 
     @Override
-    public AbstractParameters parseParameters(String taskParams) {
-        return JSONUtils.parseObject(taskParams, LogicFakeTaskParameters.class);
+    public boolean checkParameters() {
+        if (StringUtils.isEmpty(shellScript)) {
+            throw new IllegalArgumentException("shellScript is null or empty");
+        }
+        return true;
     }
+
 }

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskParametersTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskParametersTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.plugin.task.api.parameters;
+package org.apache.dolphinscheduler.server.master.integration.fake;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskPluginFactory.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/integration/fake/LogicFakeTaskPluginFactory.java
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.server.master.engine.executor.plugin.fake;
+package org.apache.dolphinscheduler.server.master.integration.fake;
 
-import org.apache.dolphinscheduler.plugin.task.api.task.LogicFakeTaskChannelFactory;
-import org.apache.dolphinscheduler.server.master.engine.IWorkflowRepository;
 import org.apache.dolphinscheduler.server.master.engine.executor.plugin.ILogicTaskPluginFactory;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
 
@@ -29,12 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 @Component
 @VisibleForTesting
 public class LogicFakeTaskPluginFactory implements ILogicTaskPluginFactory<LogicFakeTask> {
-
-    private final IWorkflowRepository workflowRepository;
-
-    public LogicFakeTaskPluginFactory(final IWorkflowRepository workflowRepository) {
-        this.workflowRepository = workflowRepository;
-    }
 
     @Override
     public LogicFakeTask createLogicTask(final ITaskExecutor taskExecutor) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/TaskPluginManagerTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/TaskPluginManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.dolphinscheduler.plugin.task.api.task.DependentLogicTaskChanne
 import org.apache.dolphinscheduler.plugin.task.api.task.SubWorkflowLogicTaskChannelFactory;
 import org.apache.dolphinscheduler.plugin.task.api.task.SwitchLogicTaskChannelFactory;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -37,6 +38,15 @@ class TaskPluginManagerTest {
             SwitchLogicTaskChannelFactory.NAME})
     void testGetTaskChannel_logicTaskChannel(String type) {
         assertThat(TaskPluginManager.getTaskChannel(type)).isNotNull();
+    }
+
+    @Test
+    void shouldNotLoadLogicFakeTaskChannel() {
+        IllegalArgumentException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> TaskPluginManager.getTaskChannel("LogicFakeTask"));
+
+        assertThat(exception).hasMessageThat().contains("Cannot find TaskChannel");
     }
 
 }


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES. The code change, verification, and PR description were assisted by OpenAI Codex.

## Purpose of the pull request

Close #18269.

`LogicFakeTask` is intended only for master integration tests, but it was compiled from production source sets and registered as a production task type. This pull request moves the fake task implementation and related plugin code to test scope so it is no longer packaged into production binaries.

## Brief change log

- Move `LogicFakeTask`, `LogicFakeTaskPluginFactory`, `LogicFakeTaskChannel`, `LogicFakeTaskChannelFactory`, and `LogicFakeTaskParameters` into `dolphinscheduler-master` test sources.
- Register the fake task channel from test scope with `@AutoService(TaskChannelFactory.class)`.
- Add a regression test to verify production `TaskPluginManager` cannot load `LogicFakeTask`.

## Verify this pull request

This change added tests and can be verified as follows:

- `./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-api -Dtest=TaskPluginManagerTest -Djacoco.skip=true test`
- `./mvnw -pl dolphinscheduler-master -Dtest=WorkflowStartBasicTestCase#testStartWorkflow_with_oneSuccessTask -Djacoco.skip=true clean test`

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

This pull request does not contain incompatible changes.