### PR TITLE
[Improvement-17563][Helm] Update mysql helm chart version

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -51,8 +51,8 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: zookeeper.enabled
 - name: mysql
-  version: 9.4.1
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 14.0.3
+  repository: https://charts.bitnami.com/bitnami
   condition: mysql.enabled
 - name: minio
   version: 11.10.26


### PR DESCRIPTION
## Purpose\n\nUpdate the MySQL Helm chart dependency to the latest Bitnami chart version for #17563.\n\n## Changes\n\n- Update the mysql chart dependency from 9.4.1 to 14.0.3\n- Use the current Bitnami chart repository for the mysql dependency\n\n## Verification\n\n- helm dependency update deploy/kubernetes/dolphinscheduler\n- helm lint deploy/kubernetes/dolphinscheduler\n- helm template dolphinscheduler deploy/kubernetes/dolphinscheduler\n- helm template dolphinscheduler deploy/kubernetes/dolphinscheduler --set postgresql.enabled=false --set mysql.enabled=true --set datasource.profile=mysql\n- git diff --check