### PR TITLE
[Improvement-17563][Helm] Update mysql helm chart version

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -51,8 +51,8 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: zookeeper.enabled
 - name: mysql
-  version: 9.4.1
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 14.0.3
+  repository: https://charts.bitnami.com/bitnami
   condition: mysql.enabled
 - name: minio
   version: 11.10.26


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. AI assisted with preparing this dependency update and running local Helm validation.

## Purpose of the pull request

Closes #17563.

This pull request updates the MySQL Helm chart dependency used by the DolphinScheduler Kubernetes chart.

## Brief change log

- Update the mysql chart dependency from `9.4.1` to `14.0.3`.
- Use the current Bitnami chart repository for the mysql dependency.

## Verify this pull request

This pull request is already covered by existing Helm validation.

- `helm dependency update deploy/kubernetes/dolphinscheduler`
- `helm lint deploy/kubernetes/dolphinscheduler`
- `helm template dolphinscheduler deploy/kubernetes/dolphinscheduler`
- `helm template dolphinscheduler deploy/kubernetes/dolphinscheduler --set postgresql.enabled=false --set mysql.enabled=true --set datasource.profile=mysql`
- `git diff --check`

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

This pull request does not contain an incompatible change.
