### PR TITLE
[ISSUE-17563] Update MySQL Helm Chart version from 9.4.1 to 9.23.0

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: zookeeper.enabled
 - name: mysql
-  version: 9.4.1
+  version: 9.23.0
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: mysql.enabled
 - name: minio


### PR DESCRIPTION
## What is the purpose of the change
Update the MySQL Helm Chart dependency version in DolphinScheduler Kubernetes deployment from 9.4.1 to 9.23.0.

## Brief changelog
- Changed mysql dependency version from 9.4.1 to 9.23.0 in deploy/kubernetes/dolphinscheduler/Chart.yaml

## Verify this pull request
This change updates a single dependency version number in the Helm Chart configuration file.

Closes #17563