### PR TITLE
[Helm] Update PostgreSQL chart to 18.6.7 and MinIO chart to 17.0.21

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -43,7 +43,7 @@ appVersion: 3.1.0
 
 dependencies:
 - name: postgresql
-  version: 12.1.5
+  version: 18.6.7
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: zookeeper

--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -55,6 +55,6 @@ dependencies:
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: mysql.enabled
 - name: minio
-  version: 11.10.26
+  version: 17.0.21
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: minio.enabled


### PR DESCRIPTION
Update Helm chart dependencies:
- PostgreSQL: 12.1.5 -> 18.6.7
- MinIO: 11.10.26 -> 17.0.21