### PR TITLE
[Fix-18292][Registry] Carry deleted node value in JDBC registry REMOVE event

### DIFF
--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryDataChangeListenerAdapter.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryDataChangeListenerAdapter.java
@@ -46,13 +46,14 @@ public class JdbcRegistryDataChangeListenerAdapter implements JdbcRegistryDataCh
     }
 
     @Override
-    public void onJdbcRegistryDataDeleted(String eventPath) {
+    public void onJdbcRegistryDataDeleted(String eventPath, String value) {
         if (!isPathMatch(watchedPath, eventPath, listener.getSubscribeScope())) {
             return;
         }
         final Event event = Event.builder()
                 .watchedPath(watchedPath)
                 .eventPath(eventPath)
+                .eventData(value)
                 .type(Event.Type.REMOVE)
                 .build();
         listener.notify(event);

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryDataChangeListener.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryDataChangeListener.java
@@ -21,7 +21,7 @@ public interface JdbcRegistryDataChangeListener {
 
     void onJdbcRegistryDataChanged(String key, String value);
 
-    void onJdbcRegistryDataDeleted(String key);
+    void onJdbcRegistryDataDeleted(String key, String value);
 
     void onJdbcRegistryDataAdded(String key, String value);
 

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryServer.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/main/java/org/apache/dolphinscheduler/plugin/registry/jdbc/server/JdbcRegistryServer.java
@@ -196,7 +196,8 @@ public class JdbcRegistryServer implements IJdbcRegistryServer {
 
                     @Override
                     public void onRegistryRowDeleted(JdbcRegistryDataDTO data) {
-                        jdbcRegistryDataChangeListener.onJdbcRegistryDataDeleted(data.getDataKey());
+                        jdbcRegistryDataChangeListener.onJdbcRegistryDataDeleted(data.getDataKey(),
+                                data.getDataValue());
                     }
                 });
     }

--- a/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/test/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryDataChangeListenerAdapterTest.java
+++ b/dolphinscheduler-registry/dolphinscheduler-registry-plugins/dolphinscheduler-registry-jdbc/src/test/java/org/apache/dolphinscheduler/plugin/registry/jdbc/JdbcRegistryDataChangeListenerAdapterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.registry.jdbc;
+
+import org.apache.dolphinscheduler.registry.api.Event;
+import org.apache.dolphinscheduler.registry.api.SubscribeListener;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.truth.Truth;
+
+class JdbcRegistryDataChangeListenerAdapterTest {
+
+    private static final String WATCHED_PATH = "/nodes/master";
+
+    /**
+     * The REMOVE event must carry the deleted node value as eventData, otherwise downstream listeners
+     * (e.g. AbstractClusterSubscribeListener / AbstractHAServer) cannot parse the removed server and will
+     * silently drop the event, leaving stale registry data in memory.
+     */
+    @Test
+    void onJdbcRegistryDataDeleted_shouldInjectDeletedValueAsEventData() {
+        final String eventPath = "/nodes/master/127.0.0.1:5678";
+        final String deletedValue = "{\"address\":\"127.0.0.1:5678\"}";
+        final AtomicReference<Event> notified = new AtomicReference<>();
+
+        final JdbcRegistryDataChangeListenerAdapter adapter = new JdbcRegistryDataChangeListenerAdapter(
+                WATCHED_PATH, capturingListener(notified, SubscribeListener.SubscribeScope.CHILDREN_ONLY));
+
+        adapter.onJdbcRegistryDataDeleted(eventPath, deletedValue);
+
+        final Event event = notified.get();
+        Truth.assertThat(event).isNotNull();
+        Truth.assertThat(event.getType()).isEqualTo(Event.Type.REMOVE);
+        Truth.assertThat(event.getWatchedPath()).isEqualTo(WATCHED_PATH);
+        Truth.assertThat(event.getEventPath()).isEqualTo(eventPath);
+        Truth.assertThat(event.getEventData()).isEqualTo(deletedValue);
+    }
+
+    private SubscribeListener capturingListener(final AtomicReference<Event> holder,
+                                                final SubscribeListener.SubscribeScope scope) {
+        return new SubscribeListener() {
+
+            @Override
+            public void notify(final Event event) {
+                holder.set(event);
+            }
+
+            @Override
+            public SubscribeScope getSubscribeScope() {
+                return scope;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The root-cause investigation, the fix, and the unit test were produced with AI assistance (Claude Code) and reviewed by me before submitting.

## Purpose of the pull request

This pull request fixes #18292.

When ephemeral nodes expire and are purged from the JDBC registry, the resulting `REMOVE` event was built **without** `eventData`. Downstream subscribers rely on it:

- `AbstractClusterSubscribeListener#notify` calls `parseServerFromHeartbeat(event.getEventData())`; on `null` it logs `"Unknown cluster change event"` and returns **before** `onServerRemove(...)`.
- `AbstractHAServer` compares `serverIdentify.equals(event.getEventData())`.

So the removal is effectively missed: Master instances keep stale registry data in memory (e.g. `MasterSlotManager` referencing slots that no longer exist), and commands assigned to those slots are never fetched.

The ZooKeeper and Etcd registries already populate `eventData` on `REMOVE` events — the JDBC registry was the only one dropping it. The deleted value is available (the `DELETE` change-event persists the full row and round-trips it through JSON); it simply was not threaded through to the event.

## Brief change log

- `JdbcRegistryDataChangeListener#onJdbcRegistryDataDeleted` now takes `(String key, String value)`, symmetric with `onJdbcRegistryDataChanged` / `onJdbcRegistryDataAdded`.
- `JdbcRegistryServer#onRegistryRowDeleted` passes `data.getDataValue()`.
- `JdbcRegistryDataChangeListenerAdapter#onJdbcRegistryDataDeleted` injects the value into the `REMOVE` `Event` via `.eventData(value)`.

## Verify this pull request

This change added tests and can be verified as follows:

- Added `JdbcRegistryDataChangeListenerAdapterTest`, asserting the `REMOVE` event carries the deleted node value as `eventData`.
- Verified red-green: removing the `.eventData(value)` line makes the test fail (`getEventData() expected <value> but was null`); with the fix it passes. `spotless:check` is clean.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

This change does not contain an incompatible change (the modified interface is internal to the JDBC registry plugin), so no update to `docs/docs/en/guide/upgrade/incompatible.md` is required.
