### PR TITLE
[Fix-16617] Replace deprecated SeaTunnel CLI params -e/--dep[Fix-16617] Replace deprecated SeaTunnel CLI params for 2.3.1+ compatibilityloy-mode …

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkParameters.java
@@ -35,8 +35,8 @@ public class SeatunnelFlinkParameters extends SeatunnelParameters {
     public enum RunModeEnum {
 
         NONE("none"),
-        RUN("--deploy-mode run"),
-        RUN_APPLICATION("--deploy-mode run-application");
+        RUN("--master run"),
+        RUN_APPLICATION("--master run-application");
 
         private final String command;
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/spark/SeatunnelSparkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/spark/SeatunnelSparkTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.plugin.task.seatunnel.spark;
 
-import static org.apache.dolphinscheduler.plugin.task.seatunnel.Constants.DEPLOY_MODE_OPTIONS;
 import static org.apache.dolphinscheduler.plugin.task.seatunnel.Constants.MASTER_OPTIONS;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
@@ -51,19 +50,18 @@ public class SeatunnelSparkTask extends SeatunnelTask {
     @Override
     public List<String> buildOptions() throws Exception {
         List<String> args = super.buildOptions();
-        args.add(DEPLOY_MODE_OPTIONS);
-        args.add(seatunnelParameters.getDeployMode().getCommand());
-
-        MasterTypeEnum master = DeployModeEnum.local == seatunnelParameters.getDeployMode() ? MasterTypeEnum.LOCAL
-                : seatunnelParameters.getMaster();
-
-        args.add(MASTER_OPTIONS);
-        if (MasterTypeEnum.SPARK.equals(master) || MasterTypeEnum.MESOS.equals(master)) {
-            args.add(master.getCommand() + seatunnelParameters.getMasterUrl());
+        if (DeployModeEnum.local == seatunnelParameters.getDeployMode()) {
+            args.add(MASTER_OPTIONS);
+            args.add(MasterTypeEnum.LOCAL.getCommand());
         } else {
-            args.add(master.getCommand());
+            MasterTypeEnum master = seatunnelParameters.getMaster();
+            args.add(MASTER_OPTIONS);
+            if (MasterTypeEnum.SPARK.equals(master) || MasterTypeEnum.MESOS.equals(master)) {
+                args.add(master.getCommand() + seatunnelParameters.getMasterUrl());
+            } else {
+                args.add(master.getCommand());
+            }
         }
-
         return args;
     }
 }


### PR DESCRIPTION
Closes #16617

## What changes were made?

- Replaced deprecated `--deploy-mode` CLI parameter with `--master` in `SeatunnelSparkTask.java` for SeaTunnel 2.3.1+ compatibility
- Updated `SeatunnelFlinkParameters.java` RunModeEnum to use `--master` instead of `--deploy-mode`

## Why?

SeaTunnel 2.3.1+ deprecated `-e`/`--deploy-mode` and requires `-m`/`--master` instead. Running SeaTunnel tasks with DS 3.2.x on SeaTunnel 2.3.7 results in the error