### PR TITLE
[Improvement] Add AGENTS.md + SECURITY.md to make the security model discoverable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Agent Guide for dolphinscheduler
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+DolphinScheduler's security model defines user roles, trust boundaries, and known non-findings.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/dolphinscheduler` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/security-model.md.


### PR DESCRIPTION
**This is a proposal for the DolphinScheduler PMC to review — please
correct, reject, or discuss as needed.** The maintainer is the
decision-maker; nothing here is a requirement.

This adds the conventional `AGENTS.md → SECURITY.md` discoverability
chain so an automated security scanner can mechanically locate the
project's **existing** security model. It does **not** add or change any
model content — your security model at
`docs/docs/en/contribute/join/security-model.md` is untouched; this just
makes it reachable via the standard chain.

- `SECURITY.md` (new) — routes vulnerability reports to the ASF security
  process and points at the existing security model.
- `AGENTS.md` (new) — a Security section routing agents along
  `AGENTS.md → SECURITY.md →` your security model.

Context: the ASF Security team is preparing the project for an automated
agentic security scan being piloted by the team. Such scans refuse to run
unless the model is discoverable by that conventional path —
discoverability is the one hard gate. No project source is touched.

Questions / pushback welcome — happy to adjust file placement or wording
to match the project's house style.
