### PR TITLE
[Fix-18311][TaskPlugin] Fix task process kill status check

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/shell/AbstractShell.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/shell/AbstractShell.java
@@ -301,6 +301,10 @@ public abstract class AbstractShell {
             this.exitCode = exitCode;
         }
 
+        public int getExitCode() {
+            return exitCode;
+        }
+
     }
 
     /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/shell/AbstractShellTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/shell/AbstractShellTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.common.shell;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AbstractShellTest {
+
+    @Test
+    void testExitCodeExceptionShouldExposeExitCode() {
+        AbstractShell.ExitCodeException exception =
+                new AbstractShell.ExitCodeException(127, "command not found");
+
+        Assertions.assertEquals(127, exception.getExitCode());
+        Assertions.assertEquals("command not found", exception.getMessage());
+    }
+}

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -24,6 +24,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.DEFAULT_
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SET_K8S;
 
 import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.shell.AbstractShell.ExitCodeException;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
@@ -242,6 +243,11 @@ public final class ProcessUtils {
             OSUtils.exeCmd(checkCmd);
             // If the command executes successfully, the process exists
             return true;
+        } catch (ExitCodeException e) {
+            // `kill -0` may exit with code 0 but still raise an ExitCodeException because the tenant
+            // login shell wrote to stderr (e.g. "HISTSIZE: readonly variable" warnings from /etc/profile.d).
+            // Exit code 0 means the signal check succeeded, so the process is actually alive.
+            return e.getExitCode() == 0;
         } catch (Exception e) {
             // If the command fails, the process does not exist
             return false;

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.utils;
 
+import org.apache.dolphinscheduler.common.shell.AbstractShell.ExitCodeException;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
@@ -49,6 +50,7 @@ public class ProcessUtilsTest {
             mockedOSUtils.close();
         }
     }
+
     @Test
     public void testGetPidList() throws Exception {
         // first
@@ -197,6 +199,44 @@ public class ProcessUtilsTest {
         // Verify SIGTERM,SIGKILL was never called
         mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -15 12345 1234"), Mockito.never());
         mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -9 12345 1234"), Mockito.never());
+    }
+
+    @Test
+    void testKillProcessShouldKillPermittedChildrenWhenSudoParentCheckIsDenied() throws Exception {
+        TaskExecutionContext taskRequest = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskRequest.getProcessId()).thenReturn(12345);
+        Mockito.when(taskRequest.getTenantCode()).thenReturn("testTenant");
+
+        String pstreeCmd;
+        String pstreeOutput;
+        if (SystemUtils.IS_OS_MAC) {
+            pstreeCmd = "pstree -sp 12345";
+            pstreeOutput = "-+= 12345 sudo -+- 1234 86.sh --- 5678 python3";
+        } else {
+            pstreeCmd = "pstree -p 12345";
+            pstreeOutput = "sudo(12345)---86.sh(1234)---python3(5678)";
+        }
+        mockedOSUtils.when(() -> OSUtils.exeCmd(pstreeCmd)).thenReturn(pstreeOutput);
+
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -0 12345"))
+                .thenThrow(new ExitCodeException(1, "Operation not permitted"));
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -0 1234"))
+                .thenThrow(new ExitCodeException(0, "HISTSIZE: readonly variable"))
+                .thenThrow(new ExitCodeException(1, "No such process"));
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -0 5678"))
+                .thenThrow(new ExitCodeException(0, "HISTSIZE: readonly variable"))
+                .thenThrow(new ExitCodeException(1, "No such process"));
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -2 1234 5678")).thenReturn("");
+
+        boolean result = ProcessUtils.kill(taskRequest);
+
+        Assertions.assertTrue(result);
+        mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -2 1234 5678"), Mockito.times(1));
+        mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -2 12345 1234 5678"), Mockito.never());
+        mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -15 1234 5678"), Mockito.never());
+        mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -9 1234 5678"), Mockito.never());
     }
 
     @Test


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. Codex/ChatGPT assisted with debugging, code changes, tests, issue drafting, and PR draft preparation. I reviewed the changes and verified them locally.

## Purpose of the pull request

Fix task kill status checking when `kill -0` returns `Operation not permitted` for an unkillable sudo parent process or when tenant login shell emits stderr with exit code 0.

Closes #18311.

## Brief change log

- Add exit code accessor to `ExitCodeException`.
- Distinguish alive, not-alive, and no-permission process states in `ProcessUtils`.
- Continue killing permitted child processes instead of reporting success when only the sudo parent check is denied.
- Add unit coverage for `ExitCodeException` and the sudo-parent-denied plus killable-child process scenario.

## Verify this pull request

This change added tests and can be verified as follows:

- `./mvnw -pl dolphinscheduler-common -Dspotless.check.skip=true -Djacoco.skip=true -Dtest=AbstractShellTest test`
- `./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-api -am -Dspotless.check.skip=true -Djacoco.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ProcessUtilsTest test`
- `./mvnw -pl dolphinscheduler-common,dolphinscheduler-task-plugin/dolphinscheduler-task-api -DskipTests -Djacoco.skip=true spotless:check`

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`.
