### PR TITLE
[Improvement-17563][Helm] Update mysql helm chart version

### DIFF
--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -76,7 +76,7 @@ include_mail = false
 include_verbatim = false
 
 # Enable the checking of fragments in links.
-include_fragments = "none"
+include_fragments = false
 
 # User agent to send with each request.
 user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -76,7 +76,7 @@ include_mail = false
 include_verbatim = false
 
 # Enable the checking of fragments in links.
-include_fragments = false
+include_fragments = "none"
 
 # User agent to send with each request.
 user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"

--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -52,7 +52,7 @@ dependencies:
   condition: zookeeper.enabled
 - name: mysql
   version: 9.10.6
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: mysql.enabled
 - name: minio
   version: 11.10.26

--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -51,8 +51,8 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: zookeeper.enabled
 - name: mysql
-  version: 9.4.1
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 9.23.0
+  repository: https://charts.bitnami.com/bitnami
   condition: mysql.enabled
 - name: minio
   version: 11.10.26

--- a/deploy/kubernetes/dolphinscheduler/Chart.yaml
+++ b/deploy/kubernetes/dolphinscheduler/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: zookeeper.enabled
 - name: mysql
-  version: 9.23.0
+  version: 9.10.6
   repository: https://charts.bitnami.com/bitnami
   condition: mysql.enabled
 - name: minio

--- a/deploy/kubernetes/dolphinscheduler/README.md
+++ b/deploy/kubernetes/dolphinscheduler/README.md
@@ -270,7 +270,7 @@ Please refer to the [Quick Start in Kubernetes](../../../docs/docs/en/guide/inst
 | mysql.enabled | bool | `false` | If not exists external MySQL, by default, the DolphinScheduler will use a internal MySQL |
 | mysql.image.registry | string | `"docker.io"` |  |
 | mysql.image.repository | string | `"bitnamilegacy/mysql"` |  |
-| mysql.image.tag | string | `"8.0.31-debian-11-r0"` |  |
+| mysql.image.tag | string | `"8.0.36-debian-12-r8"` |  |
 | mysql.primary.persistence.enabled | bool | `false` | Set mysql.primary.persistence.enabled to true to mount a new volume for internal MySQL |
 | mysql.primary.persistence.size | string | `"20Gi"` | `PersistentVolumeClaim` size |
 | mysql.primary.persistence.storageClass | string | `"-"` | MySQL data persistent volume storage class. If set to "-", storageClassName: "", which disables dynamic provisioning |

--- a/deploy/kubernetes/dolphinscheduler/README.md
+++ b/deploy/kubernetes/dolphinscheduler/README.md
@@ -270,7 +270,7 @@ Please refer to the [Quick Start in Kubernetes](../../../docs/docs/en/guide/inst
 | mysql.enabled | bool | `false` | If not exists external MySQL, by default, the DolphinScheduler will use a internal MySQL |
 | mysql.image.registry | string | `"docker.io"` |  |
 | mysql.image.repository | string | `"bitnamilegacy/mysql"` |  |
-| mysql.image.tag | string | `"8.0.36-debian-12-r8"` |  |
+| mysql.image.tag | string | `"8.0.33-debian-11-r30"` |  |
 | mysql.primary.persistence.enabled | bool | `false` | Set mysql.primary.persistence.enabled to true to mount a new volume for internal MySQL |
 | mysql.primary.persistence.size | string | `"20Gi"` | `PersistentVolumeClaim` size |
 | mysql.primary.persistence.storageClass | string | `"-"` | MySQL data persistent volume storage class. If set to "-", storageClassName: "", which disables dynamic provisioning |

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -111,7 +111,7 @@ mysql:
   image:
     registry: docker.io
     repository: bitnamilegacy/mysql
-    tag: 8.0.31-debian-11-r0
+    tag: 8.0.36-debian-12-r8
 
 minio:
   # -- Deploy minio and configure it as the default storage for DolphinScheduler, note this is for demo only, not for production.

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -111,7 +111,7 @@ mysql:
   image:
     registry: docker.io
     repository: bitnamilegacy/mysql
-    tag: 8.0.36-debian-12-r8
+    tag: 8.0.33-debian-11-r30
 
 minio:
   # -- Deploy minio and configure it as the default storage for DolphinScheduler, note this is for demo only, not for production.


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes. Assisted by AI for code navigation, Helm chart validation, CI log investigation, and PR preparation.

## Purpose of the pull request

Close #17563.

Update the bundled MySQL Helm chart dependency used by the DolphinScheduler Kubernetes chart while keeping the MySQL server version within the supported range.

## Brief change log

- Update the Bitnami MySQL Helm chart dependency from `9.4.1` to `9.10.6` (`appVersion: 8.0.33`).
- Switch the MySQL chart dependency repository back to the current Bitnami chart repository.
- Align the configured MySQL image tag to `8.0.33-debian-11-r30` while keeping the existing `bitnamilegacy/mysql` repository pattern used by the chart.
- Update the Helm chart README value table for the MySQL image tag.
- Fix the lychee v0.24.0 config format for `include_fragments` to keep the dead-link CI job compatible with the latest snap package.

## Verify this pull request

This change was verified locally as follows:

- `helm dependency build .`
- `helm lint .`
- `helm lint . --set postgresql.enabled=false --set mysql.enabled=true`
- `helm template ds .`
- `helm template ds . --set postgresql.enabled=false --set mysql.enabled=true`
- `lychee 0.24.0 -c .github/workflows/lychee.toml -v /tmp/ds-lychee-empty.md`
- `./mvnw spotless:check -DskipTests`
