### PR TITLE
[Fix-18340][Helm] Fix duplicate app.kubernetes.io/name label on ConfigMap

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-alert.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-alert.yaml
@@ -20,7 +20,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "dolphinscheduler.fullname" . }}-alert
   labels:
-    app.kubernetes.io/name: {{ include "dolphinscheduler.fullname" . }}-alert
     {{- include "dolphinscheduler.alert.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.alert.customizedConfig }}

--- a/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-api.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-api.yaml
@@ -20,7 +20,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "dolphinscheduler.fullname" . }}-api
   labels:
-    app.kubernetes.io/name: {{ include "dolphinscheduler.fullname" . }}-api
     {{- include "dolphinscheduler.api.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.api.customizedConfig }}

--- a/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-master.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-master.yaml
@@ -20,7 +20,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "dolphinscheduler.fullname" . }}-master
   labels:
-    app.kubernetes.io/name: {{ include "dolphinscheduler.fullname" . }}-master
     {{- include "dolphinscheduler.master.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.master.customizedConfig }}

--- a/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-worker.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/configmap-dolphinscheduler-worker.yaml
@@ -20,7 +20,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "dolphinscheduler.fullname" . }}-worker
   labels:
-    app.kubernetes.io/name: {{ include "dolphinscheduler.fullname" . }}-worker
     {{- include "dolphinscheduler.worker.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.worker.customizedConfig }}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

NO

## Purpose of the pull request

Fix duplicate labels on Helm chart ConfigMap.

## Brief change log

Remove manually added `app.kubernetes.io/name` label on ConfigMap which are already defined by function in `_helpers.tpl`.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

