### PR TITLE
[Improvement-18364][Master] Limit switch condition evaluation

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/SwitchTaskUtils.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/SwitchTaskUtils.java
@@ -17,12 +17,14 @@
 
 package org.apache.dolphinscheduler.server.master.utils;
 
+import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;
 
 import org.apache.commons.collections4.MapUtils;
 
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,6 +39,10 @@ import delight.nashornsandbox.NashornSandboxes;
 
 @Slf4j
 public class SwitchTaskUtils {
+
+    private static final long MAX_EVALUATION_CPU_TIME_MILLIS = 1_000L;
+    private static final long MAX_EVALUATION_MEMORY_BYTES = 64L * 1024L * 1024L;
+    private static final int MAX_PREPARED_STATEMENTS = 128;
 
     private static final NashornSandbox sandbox;
     private static final String rgex = "['\"]*\\$\\{(.*?)\\}['\"]*";
@@ -67,6 +73,12 @@ public class SwitchTaskUtils {
 
     static {
         sandbox = NashornSandboxes.create();
+        sandbox.setExecutor(Executors.newCachedThreadPool(
+                ThreadUtils.newDaemonThreadFactory("switch-condition-evaluator-%d")));
+        sandbox.setMaxCPUTime(MAX_EVALUATION_CPU_TIME_MILLIS);
+        sandbox.setMaxMemory(MAX_EVALUATION_MEMORY_BYTES);
+        sandbox.setMaxPreparedStatements(MAX_PREPARED_STATEMENTS);
+        sandbox.allowNoBraces(false);
         try {
             sandbox.eval(NASHORN_POLYFILL_ARRAY_PROTOTYPE_INCLUDES);
         } catch (ScriptException e) {
@@ -75,8 +87,10 @@ public class SwitchTaskUtils {
     }
 
     public static boolean evaluate(String expression) throws ScriptException {
-        Object result = sandbox.eval(expression);
-        return Boolean.TRUE.equals(result);
+        synchronized (sandbox) {
+            Object result = sandbox.eval(expression);
+            return Boolean.TRUE.equals(result);
+        }
     }
 
     public static String generateContentWithTaskParams(String condition, Map<String, Property> globalParams,

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/utils/SwitchTaskUtilsTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/utils/SwitchTaskUtilsTest.java
@@ -21,6 +21,7 @@ import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
 import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +29,8 @@ import javax.script.ScriptException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 public class SwitchTaskUtilsTest {
 
@@ -81,6 +84,26 @@ public class SwitchTaskUtilsTest {
         SwitchTaskUtils.evaluate(SwitchTaskUtils.NASHORN_POLYFILL_ARRAY_PROTOTYPE_INCLUDES);
         result = SwitchTaskUtils.evaluate(content);
         Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testInfiniteLoopTimesOut() {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            Assertions.assertThrowsExactly(ScriptCPUAbuseException.class, () -> {
+                SwitchTaskUtils.evaluate("while (true) { }");
+            });
+        });
+    }
+
+    @Test
+    public void testExpensiveExpressionTimesOut() {
+        String content = "var total = 0; for (var i = 0; i < 2147483647; i++) { total += i; } total > 0";
+
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            Assertions.assertThrowsExactly(ScriptCPUAbuseException.class, () -> {
+                SwitchTaskUtils.evaluate(content);
+            });
+        });
     }
 
 }


### PR DESCRIPTION
## Purpose

Switch conditions are evaluated through the shared Nashorn sandbox. The sandbox already supports CPU and memory guards, but the current utility does not configure them, so a malformed condition can keep evaluation busy indefinitely.

## Changes

- Configure the Switch condition sandbox with CPU and memory limits.
- Run sandbox evaluation through a daemon executor required by the Nashorn sandbox monitor.
- Serialize access to the shared sandbox instance.
- Add regression coverage for infinite and very expensive condition expressions.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home ./mvnw -q -pl dolphinscheduler-master -am -Dtest=SwitchTaskUtilsTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dspotless.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dmaven.javadoc.skip=true -Drat.skip=true -Dlicense.skip=true test`
- `git diff --check -- dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/utils/SwitchTaskUtils.java dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/utils/SwitchTaskUtilsTest.java`