### PR TITLE
[Fix-18217][DataX] Escape single quotes in custom parameters

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
@@ -377,11 +377,16 @@ public class DataxTask extends AbstractTask {
         }
         StringBuilder customParameters = new StringBuilder("-p \"");
         for (Map.Entry<String, Property> entry : paramsMap.entrySet()) {
-            customParameters.append(String.format(CUSTOM_PARAM, entry.getKey(), entry.getValue().getValue()));
+            customParameters.append(
+                    String.format(CUSTOM_PARAM, entry.getKey(), escapeSingleQuotes(entry.getValue().getValue())));
         }
         customParameters.replace(4, 5, "");
         customParameters.append("\"");
         return customParameters;
+    }
+
+    private static String escapeSingleQuotes(String value) {
+        return value == null ? null : value.replace("'", "'\\''");
     }
 
     public String loadJvmEnv(DataxParameters dataXParameters) {

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/test/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/test/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTaskTest.java
@@ -166,6 +166,21 @@ public class DataxTaskTest {
     }
 
     @Test
+    public void testBuildCommandEscapesSingleQuotesInCustomParameters() {
+        Map<String, Property> paramsMap = new HashMap<>();
+        Property property = new Property();
+        property.setProp("ds_incr_condition");
+        property.setDirect(Direct.IN);
+        property.setType(DataType.VARCHAR);
+        property.setValue("AND create_data > '2026-05-06 10:59:09'");
+        paramsMap.put("ds_incr_condition", property);
+
+        Assertions.assertEquals(
+                "${PYTHON_LAUNCHER} ${DATAX_LAUNCHER} --jvm=\"-Xms1G -Xmx1G\" -p \"-Dds_incr_condition='AND create_data > '\\''2026-05-06 10:59:09'\\'''\" /tmp/execution/app-id_job.json",
+                dataxTask.buildCommand("/tmp/execution/app-id_job.json", paramsMap));
+    }
+
+    @Test
     public void testHandleInterruptedException() throws Exception {
         String parameters = JSONUtils.toJsonString(createDataxParameters());
         TaskExecutionContext taskExecutionContext = buildTestTaskExecutionContext();


### PR DESCRIPTION
## Purpose

Close #18217.

DataX custom parameters are rendered as `-Dkey='value'` inside the generated `-p` argument. When the value itself contains single quotes, for example a SQL condition with a timestamp literal, the generated shell command can be parsed incorrectly.

## Brief change log

- Escape single quotes in DataX custom parameter values before building the command.
- Add a regression test for a `ds_incr_condition` value containing quoted timestamp text.

## Verify this pull request

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-datax -am -Dtest=DataxTaskTest -Dsurefire.failIfNoSpecifiedTests=false clean test`
- `git diff --check`
