### PR TITLE
[Fix-18311][Worker] Avoid false kill success on alive check warnings

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/shell/AbstractShell.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/shell/AbstractShell.java
@@ -301,6 +301,10 @@ public abstract class AbstractShell {
             this.exitCode = exitCode;
         }
 
+        public int getExitCode() {
+            return exitCode;
+        }
+
     }
 
     /**

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -24,6 +24,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.DEFAULT_
 import static org.apache.dolphinscheduler.plugin.task.api.TaskConstants.TASK_TYPE_SET_K8S;
 
 import org.apache.dolphinscheduler.common.constants.Constants;
+import org.apache.dolphinscheduler.common.shell.AbstractShell.ExitCodeException;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.common.utils.PropertyUtils;
@@ -102,6 +103,8 @@ public final class ProcessUtils {
     private static final String SIGINT = "2";
     private static final String SIGTERM = "15";
     private static final String SIGKILL = "9";
+    private static final String OPERATION_NOT_PERMITTED = "Operation not permitted";
+    private static final String PERMISSION_DENIED = "Permission denied";
 
     /**
      * Terminate the task process, support multi-level signal processing and fallback strategy
@@ -243,9 +246,16 @@ public final class ProcessUtils {
             // If the command executes successfully, the process exists
             return true;
         } catch (Exception e) {
-            // If the command fails, the process does not exist
-            return false;
+            return isAliveCheckPermissionFailure(e);
         }
+    }
+
+    private static boolean isAliveCheckPermissionFailure(Exception e) {
+        if (e instanceof ExitCodeException && ((ExitCodeException) e).getExitCode() == 0) {
+            return true;
+        }
+        return StringUtils.containsIgnoreCase(e.getMessage(), OPERATION_NOT_PERMITTED)
+                || StringUtils.containsIgnoreCase(e.getMessage(), PERMISSION_DENIED);
     }
 
     /**

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.utils;
 
+import org.apache.dolphinscheduler.common.shell.AbstractShell.ExitCodeException;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
@@ -197,6 +198,93 @@ public class ProcessUtilsTest {
         // Verify SIGTERM,SIGKILL was never called
         mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -15 12345 1234"), Mockito.never());
         mockedOSUtils.verify(() -> OSUtils.exeCmd("kill -9 12345 1234"), Mockito.never());
+    }
+
+    @Test
+    void testKillProcessTreatsPermissionDeniedAsAlive() throws Exception {
+        // Arrange
+        TaskExecutionContext taskRequest = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskRequest.getProcessId()).thenReturn(12345);
+        Mockito.when(taskRequest.getTenantCode()).thenReturn("testTenant");
+
+        String pstreeCmd;
+        String pstreeOutput;
+        if (SystemUtils.IS_OS_MAC) {
+            pstreeCmd = "pstree -sp 12345";
+            pstreeOutput = "-+= 12345 sudo -+- 1234 86.sh";
+        } else {
+            pstreeCmd = "pstree -p 12345";
+            pstreeOutput = "sudo(12345)---86.sh(1234)";
+        }
+        mockedOSUtils.when(() -> OSUtils.exeCmd(pstreeCmd)).thenReturn(pstreeOutput);
+
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -2.*")))
+                .thenReturn("kill -2 12345 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -2 12345 1234"))
+                .thenThrow(new ExitCodeException(1, "kill: (12345) - Operation not permitted"));
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -15.*")))
+                .thenReturn("kill -15 12345 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -15 12345 1234"))
+                .thenThrow(new ExitCodeException(1, "kill: (12345) - Operation not permitted"));
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -9.*")))
+                .thenReturn("kill -9 12345 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -9 12345 1234"))
+                .thenThrow(new ExitCodeException(1, "kill: (12345) - Operation not permitted"));
+
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -0.*")))
+                .thenReturn("kill -0 12345")
+                .thenReturn("kill -0 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd(Mockito.matches(".*kill -0.*")))
+                .thenThrow(new ExitCodeException(1, "kill: (12345) - Operation not permitted"))
+                .thenThrow(new ExitCodeException(1, "kill: (1234) - Operation not permitted"));
+
+        // Act
+        boolean result = ProcessUtils.kill(taskRequest);
+
+        // Assert
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    void testKillProcessTreatsZeroExitWithProfileWarningAsAlive() throws Exception {
+        // Arrange
+        TaskExecutionContext taskRequest = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskRequest.getProcessId()).thenReturn(12345);
+        Mockito.when(taskRequest.getTenantCode()).thenReturn("testTenant");
+
+        String pstreeCmd;
+        String pstreeOutput;
+        if (SystemUtils.IS_OS_MAC) {
+            pstreeCmd = "pstree -sp 12345";
+            pstreeOutput = "-+= 12345 sudo -+- 1234 86.sh";
+        } else {
+            pstreeCmd = "pstree -p 12345";
+            pstreeOutput = "sudo(12345)---86.sh(1234)";
+        }
+        mockedOSUtils.when(() -> OSUtils.exeCmd(pstreeCmd)).thenReturn(pstreeOutput);
+
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -2.*")))
+                .thenReturn("kill -2 12345 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -2 12345 1234")).thenReturn("");
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -15.*")))
+                .thenReturn("kill -15 12345 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -15 12345 1234")).thenReturn("");
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -9.*")))
+                .thenReturn("kill -9 12345 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd("kill -9 12345 1234")).thenReturn("");
+
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -0.*")))
+                .thenReturn("kill -0 12345")
+                .thenReturn("kill -0 1234");
+        mockedOSUtils.when(() -> OSUtils.exeCmd(Mockito.matches(".*kill -0.*")))
+                .thenThrow(new ExitCodeException(0, "profile: line 1: warning"))
+                .thenThrow(new ExitCodeException(0, "profile: line 1: warning"));
+
+        // Act
+        boolean result = ProcessUtils.kill(taskRequest);
+
+        // Assert
+        Assertions.assertFalse(result);
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Fix #18311.

When DolphinScheduler checks whether task child processes are still alive, `kill -0` can fail with permission-related stderr or even exit with code 0 while shell profile warnings are written to stderr. The previous logic treated every exception from the alive check as "process gone", which could make task kill verification report success while child processes were still alive.

## Changes

- Expose `ExitCodeException#getExitCode()` so callers can distinguish `kill -0` exit semantics.
- Treat `Operation not permitted` / `Permission denied` from `kill -0` as evidence that the process still exists.
- Treat `ExitCodeException` with exit code `0` from `kill -0` as alive, covering shell profile stderr warnings.
- Add regression tests for both permission-denied and zero-exit-with-stderr cases.

## Verification

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-api -am -Dtest=ProcessUtilsTest#testKillProcessTreatsPermissionDeniedAsAlive+testKillProcessTreatsZeroExitWithProfileWarningAsAlive -Dsurefire.failIfNoSpecifiedTests=false clean test
```

Result: `Tests run: 2, Failures: 0, Errors: 0`.

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-api -am -Dtest=ProcessUtilsTest -Dsurefire.failIfNoSpecifiedTests=false clean test
```

Result: `Tests run: 8, Failures: 0, Errors: 0`.

```bash
git diff --check
```

Result: passed.
