### PR TITLE
[Improvement-17933][api] Restrict audit logs to current user for non-admin users

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AuditLogController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AuditLogController.java
@@ -93,6 +93,7 @@ public class AuditLogController extends BaseController {
                                                               @RequestParam(value = "modelName", required = false) String modelName) {
         checkPageParams(pageNo, pageSize);
         PageInfo<AuditDto> auditDtoPageInfo = auditService.queryLogListPaging(
+                loginUser,
                 modelTypes,
                 operationTypes,
                 startDate,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AuditService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AuditService.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.api.service;
 import org.apache.dolphinscheduler.api.dto.AuditDto;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
+import org.apache.dolphinscheduler.dao.entity.User;
 
 /**
  * audit information service
@@ -36,6 +37,7 @@ public interface AuditService {
     /**
      * query audit log list
      *
+     * @param loginUser           login user
      * @param modelTypes          model types
      * @param modelName           model name
      * @param operationTypes      operation types
@@ -46,7 +48,8 @@ public interface AuditService {
      * @param pageSize            page size
      * @return                    audit log string
      */
-    PageInfo<AuditDto> queryLogListPaging(String modelTypes,
+    PageInfo<AuditDto> queryLogListPaging(User loginUser,
+                                          String modelTypes,
                                           String operationTypes, String startTime,
                                           String endTime, String userName, String modelName,
                                           Integer pageNo, Integer pageSize);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AuditServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AuditServiceImpl.java
@@ -22,7 +22,9 @@ import org.apache.dolphinscheduler.api.service.AuditService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.common.enums.AuditModelType;
 import org.apache.dolphinscheduler.common.enums.AuditOperationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
+import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AuditLogMapper;
 
 import java.util.ArrayList;
@@ -59,6 +61,7 @@ public class AuditServiceImpl extends BaseServiceImpl implements AuditService {
     /**
      * query audit log paging
      *
+     * @param loginUser           login user
      * @param modelTypes          object types
      * @param operationTypes      operation types
      * @param startDate           start time
@@ -70,7 +73,8 @@ public class AuditServiceImpl extends BaseServiceImpl implements AuditService {
      * @return audit log string data
      */
     @Override
-    public PageInfo<AuditDto> queryLogListPaging(String modelTypes,
+    public PageInfo<AuditDto> queryLogListPaging(User loginUser,
+                                                 String modelTypes,
                                                  String operationTypes,
                                                  String startDate,
                                                  String endDate,
@@ -83,10 +87,11 @@ public class AuditServiceImpl extends BaseServiceImpl implements AuditService {
 
         Date start = checkAndParseDateParameters(startDate);
         Date end = checkAndParseDateParameters(endDate);
+        Integer userId = loginUser.getUserType() == UserType.ADMIN_USER ? null : loginUser.getId();
 
         IPage<AuditLog> logIPage =
                 auditLogMapper.queryAuditLog(new Page<>(pageNo, pageSize), objectTypeCodeList, operationTypeCodeList,
-                        userName, modelName, start, end);
+                        userId, userName, modelName, start, end);
         List<AuditDto> auditDtos =
                 logIPage.getRecords().stream().map(this::transformAuditLog).collect(Collectors.toList());
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AuditServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AuditServiceTest.java
@@ -18,13 +18,16 @@
 package org.apache.dolphinscheduler.api.service;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.service.impl.AuditServiceImpl;
 import org.apache.dolphinscheduler.common.enums.AuditModelType;
 import org.apache.dolphinscheduler.common.enums.AuditOperationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.dao.entity.AuditLog;
+import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.mapper.AuditLogMapper;
 
 import java.util.ArrayList;
@@ -59,11 +62,13 @@ public class AuditServiceTest {
         IPage<AuditLog> page = new Page<>(1, 10);
         page.setRecords(getLists());
         page.setTotal(1L);
-        when(auditLogMapper.queryAuditLog(Mockito.any(Page.class), Mockito.any(), Mockito.any(), Mockito.eq(""),
+        when(auditLogMapper.queryAuditLog(Mockito.any(Page.class), Mockito.any(), Mockito.any(), Mockito.isNull(),
+                Mockito.eq(""),
                 Mockito.eq(""),
                 eq(start), eq(end))).thenReturn(page);
         Assertions.assertDoesNotThrow(() -> {
             auditService.queryLogListPaging(
+                    getUser(1, "admin", UserType.ADMIN_USER),
                     "",
                     "",
                     "2020-11-01 00:00:00",
@@ -73,6 +78,29 @@ public class AuditServiceTest {
                     1,
                     10);
         });
+    }
+
+    @Test
+    public void testQueryLogListPagingRestrictsGeneralUserToOwnAuditLogs() {
+        IPage<AuditLog> page = new Page<>(1, 10);
+        page.setRecords(getLists());
+        page.setTotal(1L);
+        when(auditLogMapper.queryAuditLog(Mockito.any(Page.class), Mockito.any(), Mockito.any(), Mockito.eq(10),
+                Mockito.eq("otherUser"), Mockito.eq(""), Mockito.isNull(), Mockito.isNull())).thenReturn(page);
+
+        auditService.queryLogListPaging(
+                getUser(10, "generalUser", UserType.GENERAL_USER),
+                "",
+                "",
+                null,
+                null,
+                "otherUser",
+                "",
+                1,
+                10);
+
+        verify(auditLogMapper).queryAuditLog(Mockito.any(Page.class), Mockito.any(), Mockito.any(), Mockito.eq(10),
+                Mockito.eq("otherUser"), Mockito.eq(""), Mockito.isNull(), Mockito.isNull());
     }
 
     private List<AuditLog> getLists() {
@@ -87,5 +115,13 @@ public class AuditServiceTest {
         auditLog.setOperationType(AuditOperationType.CREATE.getName());
         auditLog.setModelType(AuditModelType.PROJECT.getName());
         return auditLog;
+    }
+
+    private User getUser(Integer id, String userName, UserType userType) {
+        User user = new User();
+        user.setId(id);
+        user.setUserName(userName);
+        user.setUserType(userType);
+        return user;
     }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AuditLogMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/AuditLogMapper.java
@@ -35,6 +35,7 @@ public interface AuditLogMapper extends BaseMapper<AuditLog> {
     IPage<AuditLog> queryAuditLog(IPage<AuditLog> page,
                                   @Param("modelTypeList") List<String> modelTypeList,
                                   @Param("operationTypeList") List<String> operationTypeList,
+                                  @Param("userId") Integer userId,
                                   @Param("userName") String userName,
                                   @Param("modelName") String modelName,
                                   @Param("startDate") Date startDate,

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AuditLogMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AuditLogMapper.xml
@@ -50,6 +50,9 @@
                 #{operation_type}
             </foreach>
         </if>
+        <if test="userId != null">
+            and log.user_id = #{userId}
+        </if>
         <if test="userName != null and userName != ''">
             and u.user_name like concat ('%', #{userName}, '%')
         </if>

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AuditLogMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/AuditLogMapperTest.java
@@ -80,7 +80,15 @@ public class AuditLogMapperTest extends BaseDaoTest {
         List<String> operationTypeList = Lists.newArrayList(AuditOperationType.CREATE.getName());
 
         IPage<AuditLog> logIPage =
-                logMapper.queryAuditLog(page, objectTypeList, operationTypeList, "", "", null, null);
+                logMapper.queryAuditLog(page, objectTypeList, operationTypeList, null, "", "", null, null);
         Assertions.assertNotEquals(0, logIPage.getTotal());
+
+        IPage<AuditLog> userLogPage =
+                logMapper.queryAuditLog(new Page<>(1, 3), objectTypeList, operationTypeList, 1, "", "", null, null);
+        Assertions.assertNotEquals(0, userLogPage.getTotal());
+
+        IPage<AuditLog> otherUserLogPage =
+                logMapper.queryAuditLog(new Page<>(1, 3), objectTypeList, operationTypeList, 2, "", "", null, null);
+        Assertions.assertEquals(0, otherUserLogPage.getTotal());
     }
 }


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The patch and tests were assisted by AI and reviewed locally.

## Purpose of the pull request

Fix #17933. Restrict global audit log queries so non-admin users can only view their own audit logs, while administrators keep the full audit view.

## Brief change log

- Pass login user context from `AuditLogController` to `AuditService`.
- Add an optional `userId` filter to `AuditLogMapper.queryAuditLog`.
- Apply `userId` filtering for non-admin users and keep admin queries global.
- Add/adjust unit tests for service behavior and mapper userId filtering.

## Verify this pull request

This change added tests and can be verified as follows:

- `./mvnw verify -B -pl "dolphinscheduler-dao,dolphinscheduler-api" -Dmaven.test.skip=false -Dspotless.skip=true -DskipUT=false -Danalyze.skip=true -Djacoco.skip=true -Dsurefire.printSummary=true -Dsurefire.useFile=false -Dsurefire.reportFormat=plain -Dsurefire.redirectTestOutputToFile=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest='AuditServiceTest'`
- `./mvnw verify -B -pl "dolphinscheduler-dao" -Dmaven.test.skip=false -Dspotless.skip=true -DskipUT=false -Danalyze.skip=true -Djacoco.skip=true -Dsurefire.printSummary=true -Dsurefire.useFile=false -Dsurefire.reportFormat=plain -Dsurefire.redirectTestOutputToFile=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest='AuditLogMapperTest'`
- `./mvnw spotless:check -B -pl "dolphinscheduler-dao,dolphinscheduler-api"`

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)
