### PR TITLE
[Fix-18370] [API&UI] Allow environments without bound worker groups to be visible and selectable

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/fields/use-environment-name.ts
@@ -57,7 +57,7 @@ export function useEnvironmentName(
 
   const filterByWorkerGroup = (option: IEnvironmentNameOption) => {
     if (!model.workerGroup) return false
-    if (!option?.workerGroups?.length) return false
+    if (!option?.workerGroups?.length) return true
     return option.workerGroups.indexOf(model.workerGroup) !== -1
   }
 

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -428,9 +428,10 @@ export default defineComponent({
             path='environmentCode'
           >
             <NSelect
-              options={this.environmentList.filter((item: any) =>
-                item.workerGroups?.includes(this.startForm.workerGroup)
-              )}
+              options={this.environmentList.filter((item: any) => {
+                if (!item?.workerGroups?.length) return true
+                return item.workerGroups.includes(this.startForm.workerGroup)
+              })}
               v-model:value={this.startForm.environmentCode}
               clearable
               filterable

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
@@ -97,9 +97,10 @@ export default defineComponent({
     const projectCode = Number(router.currentRoute.value.params.projectCode)
 
     const environmentOptions = computed(() =>
-      variables.environmentList.filter((item: any) =>
-        item.workerGroups?.includes(timingState.timingForm.workerGroup)
-      )
+      variables.environmentList.filter((item: any) => {
+        if (!item?.workerGroups?.length) return true
+        return item.workerGroups.includes(timingState.timingForm.workerGroup)
+      })
     )
 
     const projectPreferences = ref({} as any)


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

NO

## Purpose of the pull request

close #18370 

## Brief change log

allow environments without bound worker groups to be visible and selectable.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
