### PR TITLE
[Improvement-18372][API&UI]Consistent workerGroup switching logic: The coordinated behavior across task creation, scheduled execution, and runtime is now fully consistent.

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -250,7 +250,24 @@ export default defineComponent({
     }
 
     const updateWorkerGroup = () => {
-      startState.startForm.environmentCode = null
+      const environmentOptions = variables.environmentList.filter(
+        (item: any) => {
+          if (!item?.workerGroups?.length) return true
+          return item.workerGroups.includes(startState.startForm.workerGroup)
+        }
+      )
+      if (startState.startForm.environmentCode) {
+        const elementExists =
+          environmentOptions.find(
+            (item: any) => item.value === startState.startForm.environmentCode
+          ) !== undefined
+        if (!elementExists) {
+          startState.startForm.environmentCode = null
+        }
+      } else {
+        startState.startForm.environmentCode =
+          (environmentOptions[0]?.value as string | null) ?? null
+      }
     }
 
     const addStartParams = () => {
@@ -428,9 +445,10 @@ export default defineComponent({
             path='environmentCode'
           >
             <NSelect
-              options={this.environmentList.filter((item: any) =>
-                item.workerGroups?.includes(this.startForm.workerGroup)
-              )}
+              options={this.environmentList.filter((item: any) => {
+                if (!item?.workerGroups?.length) return true
+                return item.workerGroups.includes(this.startForm.workerGroup)
+              })}
               v-model:value={this.startForm.environmentCode}
               clearable
               filterable

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -445,10 +445,9 @@ export default defineComponent({
             path='environmentCode'
           >
             <NSelect
-              options={this.environmentList.filter((item: any) => {
-                if (!item?.workerGroups?.length) return true
-                return item.workerGroups.includes(this.startForm.workerGroup)
-              })}
+              options={this.environmentList.filter((item: any) =>
+                item.workerGroups?.includes(this.startForm.workerGroup)
+              )}
               v-model:value={this.startForm.environmentCode}
               clearable
               filterable

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
@@ -181,7 +181,20 @@ export default defineComponent({
     }
 
     const updateWorkerGroup = () => {
-      timingState.timingForm.environmentCode = null
+      if (timingState.timingForm.environmentCode) {
+        const elementExists =
+          environmentOptions.value.find(
+            (item: any) => item.value === timingState.timingForm.environmentCode
+          ) !== undefined
+        if (!elementExists) {
+          timingState.timingForm.environmentCode = null
+        }
+      } else {
+        timingState.timingForm.environmentCode =
+          environmentOptions.value.length === 0
+            ? null
+            : environmentOptions.value[0].value
+      }
     }
 
     const handlePreview = () => {


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

Yes

## Purpose of the pull request

close #18372 

## Brief change log

**timing-modal.tsx**: Updated environment handling logic
   - Allow environments without bound workerGroup to be visible
   - Changed workerGroup switch behavior: only clear environment if not available in new workerGroup
   - Auto-select first available environment when none is selected

 **start-modal.tsx**: Updated environment handling logic
   - Allow environments without bound workerGroup to be visible
   - Changed workerGroup switch behavior: only clear environment if not available in new workerGroup
   - Auto-select first available environment when none is selected

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
