### PR TITLE
Fix DST timezone issue causing incorrect day offset with $[yyyyMMdd-1] parameter (#18015)

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtils.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -648,7 +648,13 @@ public class TimePlaceholderUtils {
 
             if (Character.isDigit(expression.charAt(index + 1))) {
                 String addMinuteExpr = expression.substring(index + 1);
-                Date targetDate = addMinutes(date, calcMinutes(addMinuteExpr));
+                int addMinuteValue = calcMinutes(addMinuteExpr);
+                Date targetDate;
+                if (addMinuteValue % (60 * 24) == 0) {
+                    targetDate = addDays(date, addMinuteValue / (60 * 24));
+                } else {
+                    targetDate = addMinutes(date, addMinuteValue);
+                }
                 String dateFormat = expression.substring(0, index);
 
                 return new AbstractMap.SimpleImmutableEntry<>(targetDate, dateFormat);
@@ -658,7 +664,13 @@ public class TimePlaceholderUtils {
 
             if (Character.isDigit(expression.charAt(index + 1))) {
                 String addMinuteExpr = expression.substring(index + 1);
-                Date targetDate = addMinutes(date, 0 - calcMinutes(addMinuteExpr));
+                int addMinuteValue = calcMinutes(addMinuteExpr);
+                Date targetDate;
+                if (addMinuteValue % (60 * 24) == 0) {
+                    targetDate = addDays(date, -(addMinuteValue / (60 * 24)));
+                } else {
+                    targetDate = addMinutes(date, -addMinuteValue);
+                }
                 String dateFormat = expression.substring(0, index);
 
                 return new AbstractMap.SimpleImmutableEntry<>(targetDate, dateFormat);


### PR DESCRIPTION
## What is the purpose of the pull request

Fix the DST (Daylight Saving Time) timezone issue where system parameter expressions like \$[yyyyMMdd-1] produce incorrect results when the system timezone is set to a region with DST transitions (e.g., America/Los_Angeles).

## Brief change log

- Modified \calcMinutes(String expression, Date date)\ in \TimePlaceholderUtils.java\ to use day-based arithmetic (\ddDays\) instead of minute-based arithmetic (\ddMinutes\) when the minute value is a multiple of 24 hours (1440 minutes). This ensures correct day offset calculation across DST boundaries where a day may have 23 or 25 hours.

## Verifying this change

The issue occurs specifically when:
1. System timezone is set to a DST-observing timezone (e.g., America/Los_Angeles)
2. Using date parameter expressions like \$[yyyyMMdd-1]
3. The date falls on or near a DST transition day (e.g., March 9, 2026 for LA)

Before fix: \Calendar.add(MINUTE, -1440)\ on March 9 00:10 LA time returns March 7 23:10 (two-day offset)
After fix: \Calendar.add(DAY_OF_MONTH, -1)\ on March 9 00:10 LA time returns March 8 00:10 (correct one-day offset)

## Verify this pull request

This pull request is already covered by existing tests.

Closes #18015