### PR TITLE
[Fix-18409][Common] Fix DAG.addEdge accepting an edge that creates a cycle when paths converge

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/graph/DAG.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/graph/DAG.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -391,14 +392,14 @@ public class DAG<Node, NodeInfo, EdgeInfo> {
         }
 
         // Whether an edge can be successfully added(fromNode -> toNode),need to determine whether the DAG has cycle!
-        int verticesCount = getNodesCount();
+        Set<Node> visited = new HashSet<>();
 
         Queue<Node> queue = new LinkedList<>();
 
         queue.add(toNode);
 
         // if DAG doesn't find fromNode, it's not has cycle!
-        while (!queue.isEmpty() && (--verticesCount > 0)) {
+        while (!queue.isEmpty()) {
             Node key = queue.poll();
 
             for (Node subsequentNode : getSubsequentNodes(key)) {
@@ -406,7 +407,9 @@ public class DAG<Node, NodeInfo, EdgeInfo> {
                     return false;
                 }
 
-                queue.add(subsequentNode);
+                if (visited.add(subsequentNode)) {
+                    queue.add(subsequentNode);
+                }
             }
         }
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/graph/DAGTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/graph/DAGTest.java
@@ -239,6 +239,36 @@ public class DAGTest {
         }
     }
 
+    /**
+     * test cycle detection with converging paths
+     */
+    @Test
+    public void testCycleWithConvergingPaths() {
+        clear();
+
+        // 1->2, 1->3, 1->4
+        // 2->5, 3->5, 4->5
+        // 5->6
+        // 6->7
+
+        for (int i = 1; i <= 7; ++i) {
+            graph.addNode(i, "v(" + i + ")");
+        }
+
+        Assertions.assertTrue(graph.addEdge(1, 2));
+        Assertions.assertTrue(graph.addEdge(1, 3));
+        Assertions.assertTrue(graph.addEdge(1, 4));
+        Assertions.assertTrue(graph.addEdge(2, 5));
+        Assertions.assertTrue(graph.addEdge(3, 5));
+        Assertions.assertTrue(graph.addEdge(4, 5));
+        Assertions.assertTrue(graph.addEdge(5, 6));
+        Assertions.assertTrue(graph.addEdge(6, 7));
+
+        // 7->1 would create a cycle, so it must be rejected
+        Assertions.assertFalse(graph.addEdge(7, 1));
+        Assertions.assertFalse(graph.hasCycle());
+    }
+
     @Test
     public void testTopologicalSort() {
         makeGraph();


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES - the bug was found using AI-assisted static analysis, and the fix and regression test were AI-assisted. I verified everything myself: I confirmed the failure by running the new test against unmodified `dev` (fails), reviewed the logic, and confirmed the fix (passes) with the full `dolphinscheduler-common` suite green.

## Purpose of the pull request

Closes #18409. `DAG.isLegalAddEdge` bounds its cycle-check BFS with a node-count budget (`--verticesCount > 0`) instead of tracking visited nodes. On graphs where paths converge, a node is enqueued once per incoming edge, exhausting the budget before the BFS reaches `fromNode`, so a cycle-creating edge is wrongly judged legal and inserted. This replaces the budget with a visited-set - the correct BFS termination condition - which cannot be defeated by path convergence and also avoids redundant re-enqueueing on dense graphs.

## Brief change log

- `common/graph/DAG.java`: track visited nodes in `isLegalAddEdge` instead of a decrementing `verticesCount` budget; add `HashSet` import.
- `common/graph/DAGTest.java`: add `testCycleWithConvergingPaths`, a fan-shaped graph asserting the cycle-creating back-edge is rejected and no cycle is introduced.

## Verify this pull request

This change added tests and can be verified as follows:
- `testCycleWithConvergingPaths` fails on current `dev` (`addEdge` returns `true` for a cycle-creating edge) and passes with the fix.
- Full `dolphinscheduler-common` suite passes (139 tests, 0 failures) on JDK 8.
- Spotless format check passes.