### PR TITLE
[Fix-18389] DataX task reads custom JSON from resource file when json field is empty

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
@@ -186,6 +186,23 @@ public class DataxTask extends AbstractTask {
 
         if (dataXParameters.getCustomConfig() == Flag.YES.ordinal()) {
             json = dataXParameters.getJson().replaceAll("\\r\\n", System.lineSeparator());
+            if (StringUtils.isBlank(json) || "{}".equals(json.trim())) {
+                List<ResourceInfo> resourceFilesList = dataXParameters.getResourceFilesList();
+                if (CollectionUtils.isNotEmpty(resourceFilesList)) {
+                    for (ResourceInfo resourceInfo : resourceFilesList) {
+                        String resourceName = resourceInfo.getResourceName();
+                        if (resourceName != null && resourceName.endsWith(".json")) {
+                            File resourceFile = new File(taskRequest.getExecutePath(),
+                                    new File(resourceName).getName());
+                            if (resourceFile.exists()) {
+                                log.info("Loading DataX custom JSON from resource file: {}", resourceFile.getAbsolutePath());
+                                json = FileUtils.readFileToString(resourceFile, StandardCharsets.UTF_8);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
         } else {
             ObjectNode job = JSONUtils.createObjectNode();
             job.putArray("content").addAll(buildDataxJobContentJson());


### PR DESCRIPTION
﻿## Description

Fix DataX task failure when using custom JSON template with resource files.

### Problem
When users select "Custom template" (customConfig=1) and upload a JSON resource file in the DataX task definition, the json field is set to {} (empty object) instead of reading the resource file content. This causes DataX execution to fail because the generated JSON has missing reader/writer plugin configurations.

### Root Cause
In DataxTask.buildDataxJsonFile(), when customConfig == Flag.YES, the method only uses dataXParameters.getJson() without checking if a resource file was provided. The resource file is already downloaded to the execution path by the framework, but the task code never reads it.

### Fix
When customConfig == YES and the json field is empty or "{}", check the esourceList for JSON resource files. If found, read the first matching JSON resource file from the execution directory and use its content as the DataX job JSON.

Closes #18389
