### PR TITLE
Fix #18311: isProcessAlive incorrectly reports process as dead when kill -0 returns stderr

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import org.apache.dolphinscheduler.common.shell.AbstractShell.ExitCodeException;
 
 @Slf4j
 public final class ProcessUtils {
@@ -242,8 +243,17 @@ public final class ProcessUtils {
             OSUtils.exeCmd(checkCmd);
             // If the command executes successfully, the process exists
             return true;
+        } catch (ExitCodeException e) {
+            // kill -0 may return exit code 0 (process exists) even when stderr contains
+            // messages like "Operation not permitted". Only non-zero exit code means process is dead.
+            if (e.getExitCode() == 0) {
+                log.debug("kill -0 returned exit code 0 with non-empty stderr for pid {}, process is alive", pid);
+                return true;
+            }
+            log.debug("kill -0 returned exit code {} for pid {}, process is not alive", e.getExitCode(), pid);
+            return false;
         } catch (Exception e) {
-            // If the command fails, the process does not exist
+            // If the command fails for other reasons, assume process does not exist
             return false;
         }
     }


### PR DESCRIPTION
## Description

Fixes #18311.

When `kill -0 <pid>` returns exit code 0 but with non-empty stderr (e.g., "Operation not permitted"), `AbstractShell.runCommand()` throws `ExitCodeException` because it treats any non-empty stderr as an error. This causes `isProcessAlive()` to catch the exception and return `false`, incorrectly reporting the process as dead.

## Root Cause

In `AbstractShell.runCommand()`:
```java
if (exitCode != 0 || errMsg.length() > 0) {
    throw new ExitCodeException(exitCode, errMsg.toString());
}
```

This throws `ExitCodeException` even when `exitCode == 0` but stderr has output. `kill -0` on many systems will write "Operation not permitted" to stderr when called without full permissions, while still returning exit code 0 (process exists).

## Fix

Catch `ExitCodeException` explicitly in `isProcessAlive()` and check the exit code:
- Exit code 0: process is alive (return `true`)
- Non-zero exit code: process is dead (return `false`)
- Other exceptions: process is dead (return `false`)

## Changes

- Modified 1 file: `ProcessUtils.java`
- Added import for `AbstractShell.ExitCodeException`
- Updated `isProcessAlive()` to handle `ExitCodeException` with exit code check

Closes #18311