### PR TITLE
[Fix-18389] DataX task should read JSON from resource file when custom template uses resource file

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
@@ -31,6 +31,7 @@ import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.log.SensitiveDataConverter;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.model.TaskResponse;
+import org.apache.dolphinscheduler.plugin.task.api.resource.ResourceContext;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
 import org.apache.dolphinscheduler.plugin.task.api.shell.IShellInterceptorBuilder;
 import org.apache.dolphinscheduler.plugin.task.api.shell.ShellInterceptorBuilderFactory;
@@ -185,7 +186,15 @@ public class DataxTask extends AbstractTask {
         }
 
         if (dataXParameters.getCustomConfig() == Flag.YES.ordinal()) {
-            json = dataXParameters.getJson().replaceAll("\\r\\n", System.lineSeparator());
+            if (CollectionUtils.isNotEmpty(dataXParameters.getResourceList())) {
+                String resourceFileName = dataXParameters.getResourceList().get(0).getResourceName();
+                ResourceContext resourceContext = taskRequest.getResourceContext();
+                json = FileUtils.readFileToString(
+                        new File(resourceContext.getResourceItem(resourceFileName).getResourceAbsolutePathInLocal()),
+                        StandardCharsets.UTF_8);
+            } else {
+                json = dataXParameters.getJson().replaceAll("\\r\\n", System.lineSeparator());
+            }
         } else {
             ObjectNode job = JSONUtils.createObjectNode();
             job.putArray("content").addAll(buildDataxJobContentJson());


### PR DESCRIPTION
## Bug Description

When using DataX with custom template and resource file, the json field in task params is empty "{}" and the actual JSON content from the resource file is never read by the task. This causes DataX to fail with plugin initialization error.

Issue: #18389

## Root Cause

In DataxTask.buildDataxJsonFile(), when customConfig == YES, the method directly uses dataXParameters.getJson() which is "{}" (empty object). It never reads the actual JSON content from the downloaded resource file.

## Fix

When customConfig == YES and esourceList is not empty, read the JSON content from the downloaded resource file using ResourceContext, matching the pattern used by SeatunnelTask.

## Changes

- DataxTask.java: Added import for ResourceContext
- DataxTask.java: Modified uildDataxJsonFile() to read resource file content when resource files are provided alongside custom template mode

## Verification

1. Resource file is downloaded successfully to execution directory
2. Task now reads the resource file content and uses it as the DataX job JSON
3. Falls back to original behavior (using json field) when no resource files are specified