### PR TITLE
[Doc-18425] Improve built-in parameter usage and combination documentation

### DIFF
--- a/docs/configs/docsdev.js
+++ b/docs/configs/docsdev.js
@@ -231,6 +231,10 @@ export default {
                                 link: '/en-us/docs/dev/user_doc/guide/parameter/built-in.html',
                             },
                             {
+                                title: 'Parameter Combination',
+                                link: '/en-us/docs/dev/user_doc/guide/parameter/parameter-combination.html',
+                            },
+                            {
                                 title: 'Global Parameter',
                                 link: '/en-us/docs/dev/user_doc/guide/parameter/global.html',
                             },
@@ -957,6 +961,10 @@ export default {
                             {
                                 title: '内置参数',
                                 link: '/zh-cn/docs/dev/user_doc/guide/parameter/built-in.html',
+                            },
+                            {
+                                title: '参数组合使用',
+                                link: '/zh-cn/docs/dev/user_doc/guide/parameter/parameter-combination.html',
                             },
                             {
                                 title: '全局参数',

--- a/docs/docs/en/guide/parameter/built-in.md
+++ b/docs/docs/en/guide/parameter/built-in.md
@@ -1,5 +1,10 @@
 # Built-in Parameter
 
+DolphinScheduler provides two kinds of built-in parameters that the system fills in automatically at run time, so you do not have to declare them yourself:
+
+- **Basic built-in parameters** — a fixed set of `system.*` variables (task id, workflow name, business date, …), referenced with the `${variable}` syntax.
+- **Derived (time) built-in parameters** — date/time expressions referenced with the `$[...]` syntax, which can be freely composed and shifted (e.g. `$[yyyy-MM-dd-1]`).
+
 ## Basic Built-in Parameter
 
 |            Variable             |          Declaration Method          |                                           Meaning                                           |
@@ -17,36 +22,133 @@
 | system.project.name             | `${system.project.name}`             | The name of the project to which current task belongs                                       |
 | system.project.code             | `${system.project.code}`             | The code of the project to which current task belongs                                       |
 
-## Extended Built-in Parameter
+### About the business date (`system.biz.date` / `system.biz.curdate`)
 
-- Support custom variables in the code, declaration way: `${variable name}`. Refers to "System Parameter".
+`system.biz.curdate` is the **schedule time** of the instance, and `system.biz.date` is **one day before** it. This "minus one day" convention exists because a workflow scheduled to run in the early morning usually processes the *previous* day's data.
 
-- Benchmark variable defines as `$[...]` format, time format `$[yyyyMMddHHmmss]` can be decomposed and combined arbitrarily, such as: `$[yyyyMMdd]`, `$[HHmmss]`, `$[yyyy-MM-dd]`, etc.
+The value of the schedule time depends on how the workflow is triggered:
 
-- Or define by the following two ways:
+- **Scheduled (timing) run**: the schedule time is the time configured by the timer (not the actual firing time).
+- **Complement (backfill) run**: the schedule time is each business date in the backfill range, so `system.biz.date` shifts one day per generated instance.
+- **Manual run without a schedule time**: the system uses the current time (`now`) minus one day as the business date.
 
-  1. Use add_month(yyyyMMdd, offset) function to add or minus number of months.
-     The first parameter of this function is [yyyyMMdd], represents the time format and the second parameter is offset, represents the number of months the user wants to add or minus.
-     - Next N years：`$[add_months(yyyyMMdd,12*N)]`
-     - N years before：`$[add_months(yyyyMMdd,-12*N)]`
-     - Next N months：`$[add_months(yyyyMMdd,N)]`
-     - N months before：`$[add_months(yyyyMMdd,-N)]`
-  2. Add or minus numbers directly after the time format.
-     - Next N weeks：`$[yyyyMMdd+7*N]`
-     - First N weeks：`$[yyyyMMdd-7*N]`
-     - Next N days：`$[yyyyMMdd+N]`
-     - N days before：`$[yyyyMMdd-N]`
-     - Next N hours：`$[HHmmss+N/24]`
-     - First N hours：`$[HHmmss-N/24]`
-     - Next N minutes：`$[HHmmss+N/24/60]`
-     - First N minutes：`$[HHmmss-N/24/60]`
-  3. Business Attribute Method
-     - Today:`$[this_day(yyyy-MM-dd)]`, Such as 2022-08-26 => 2022-08-26
-     - Yesterday:`$[last_day(yyyy-MM-dd)]`, Such as 2022-08-26 => 2022-08-25
-     - Week N of the year,start the week on Monday: `$[year_week(yyyy-MM-dd)]`,Such as 2022-08-26 => 2022-34
-     - Week N of the year，start the week on N:`$[year_week(yyyy-MM-dd,N)]` Such as when N=5, 2022-08-26 => 2022-35
-     - Before(-)/After(+) The first day of Month(The unit of N is month): `$[month_first_day(yyyy-MM-dd,-N)]`,Such as when N=1, 2022-08-26 => 2022-07-01
-     - Before(-)/After(+) The last day of Month(The unit of N is month): `$[month_last_day(yyyy-MM-dd,-N)]`,Such as when N=1, 2022-08-28 => 2022-07-31
-     - Before(-)/After(+) The first day of Week(The unit of N is week): `$[week_first_day(yyyy-MM-dd,-N)]`,Such as when N=1, 2022-08-26 => 2022-08-15
-     - Before(-)/After(+) The last day of Week(The unit of N is week): `$[week_last_day(yyyy-MM-dd,-N)]`, Such as when N=1, 2022-08-26 => 2022-08-21
+### Example: printing every basic parameter
 
+Create a Shell task and paste the script below. When it runs, every placeholder is replaced with the concrete value of that instance:
+
+```shell
+echo "biz.date        = ${system.biz.date}"
+echo "biz.curdate     = ${system.biz.curdate}"
+echo "datetime        = ${system.datetime}"
+echo "execute.path    = ${system.task.execute.path}"
+echo "task.instance   = ${system.task.instance.id}"
+echo "task.def.name   = ${system.task.definition.name}"
+echo "task.def.code   = ${system.task.definition.code}"
+echo "wf.instance.id  = ${system.workflow.instance.id}"
+echo "wf.def.name     = ${system.workflow.definition.name}"
+echo "wf.def.code     = ${system.workflow.definition.code}"
+echo "project.name    = ${system.project.name}"
+echo "project.code    = ${system.project.code}"
+```
+
+A workflow instance scheduled for `2022-08-26 00:00:00` would print, for example:
+
+```text
+biz.date        = 20220825
+biz.curdate     = 20220826
+datetime        = 20220826000000
+execute.path    = /tmp/dolphinscheduler/exec/process/<...>/<taskInstanceId>
+task.instance   = 3096
+...
+```
+
+## Derived (Time) Built-in Parameter
+
+Besides the fixed `system.*` variables, DolphinScheduler supports a compact date/time template language written as `$[...]`. It lets you derive any date relative to the instance's **benchmark time**.
+
+### The benchmark time
+
+Every `$[...]` expression is evaluated against a single **benchmark time**, which is the instance's business/schedule time — the same value exposed as `${system.datetime}`. It is **not** the wall-clock time at which the task actually runs.
+
+That means:
+
+- For a **scheduled** run, `$[yyyyMMdd]` resolves to the scheduled date, so re-running or a delayed start does not change the result.
+- For a **complement (backfill)** run, the benchmark time is each backfilled business date in turn, so `$[yyyyMMdd]` walks through the range.
+- Only when no schedule time is available does the benchmark fall back to the current time.
+
+This is what makes `$[...]` safe to use in idempotent, backfillable pipelines: the derived dates track the data date, not the run date.
+
+### Format templates
+
+`$[...]` accepts Java-style date patterns supported by DolphinScheduler's date formatter, and you can decompose and combine the pieces freely:
+
+- `$[yyyyMMdd]`, `$[HHmmss]`, `$[yyyy-MM-dd]`, `$[yyyy-MM-dd HH:mm:ss]`, `$[yyyyMMddHHmmss]`, etc.
+
+### Date arithmetic
+
+You can add or subtract directly after the format. The unit is expressed through the arithmetic itself:
+
+|       Goal       |           Expression            |
+|------------------|---------------------------------|
+| Next N years     | `$[add_months(yyyyMMdd,12*N)]`  |
+| N years before   | `$[add_months(yyyyMMdd,-12*N)]` |
+| Next N months    | `$[add_months(yyyyMMdd,N)]`     |
+| N months before  | `$[add_months(yyyyMMdd,-N)]`    |
+| Next N weeks     | `$[yyyyMMdd+7*N]`               |
+| N weeks before   | `$[yyyyMMdd-7*N]`               |
+| Next N days      | `$[yyyyMMdd+N]`                 |
+| N days before    | `$[yyyyMMdd-N]`                 |
+| Next N hours     | `$[HHmmss+N/24]`                |
+| N hours before   | `$[HHmmss-N/24]`                |
+| Next N minutes   | `$[HHmmss+N/24/60]`             |
+| N minutes before | `$[HHmmss-N/24/60]`             |
+
+> `N` denotes an integer or arithmetic expression; replace it with a concrete value, for example `$[yyyyMMdd-7*2]` for two weeks before. The `add_months` function takes the date format as its first argument and the month offset as its second, so it is the safe way to shift by months or years (which do not have a fixed number of days). Direct `+/-` arithmetic works on a day/hour/minute basis, which is why hours are expressed as `N/24` and minutes as `N/24/60` of a day.
+
+### Business attribute functions
+
+These functions return calendar-aware dates. Each takes a date format as the first argument; those that accept an offset take it (in the unit noted) as the second argument. Examples assume a benchmark date of `2022-08-26`.
+
+|              Function               |                          Meaning                          |            Example → Result             |
+|-------------------------------------|-----------------------------------------------------------|-----------------------------------------|
+| `$[this_day(yyyy-MM-dd)]`           | Today (the benchmark date)                                | `2022-08-26` → `2022-08-26`             |
+| `$[last_day(yyyy-MM-dd)]`           | Yesterday                                                 | `2022-08-26` → `2022-08-25`             |
+| `$[year_week(yyyy-MM-dd)]`          | Week number of the year, week starts on Monday            | `2022-08-26` → `2022-34`                |
+| `$[year_week(yyyy-MM-dd,N)]`        | Week number, week starts on day N                         | when `N=5`, `2022-08-26` → `2022-35`    |
+| `$[month_first_day(yyyy-MM-dd,-N)]` | First day of the month, shifted by N months (unit: month) | when `N=1`, `2022-08-26` → `2022-07-01` |
+| `$[month_last_day(yyyy-MM-dd,-N)]`  | Last day of the month, shifted by N months (unit: month)  | when `N=1`, `2022-08-28` → `2022-07-31` |
+| `$[week_first_day(yyyy-MM-dd,-N)]`  | Monday of the week, shifted by N weeks (unit: week)       | when `N=1`, `2022-08-26` → `2022-08-15` |
+| `$[week_last_day(yyyy-MM-dd,-N)]`   | Sunday of the week, shifted by N weeks (unit: week)       | when `N=1`, `2022-08-26` → `2022-08-21` |
+
+> For `year_week`, the offset `N` selects the first day of the week (1 = Monday, 2 = Tuesday, …, 7 = Sunday) rather than shifting the date. Because DolphinScheduler requires at least 4 days for the first week of the year, the same date may fall in a different week number depending on which day the week starts on.
+
+### Period boundaries with a day offset
+
+There is a second family of boundary functions — `month_begin` / `month_end` / `week_begin` / `week_end`. They differ from the `*_first_day` / `*_last_day` functions above in two ways: the **second argument is required**, and it is a **day** offset applied *after* the boundary is computed (not a month/week offset). Examples assume a benchmark date of `2022-08-26` (a Friday; that week runs Monday `2022-08-22` to Sunday `2022-08-28`).
+
+|           Function           |                   Meaning                    |            Example → Result             |
+|------------------------------|----------------------------------------------|-----------------------------------------|
+| `$[month_begin(yyyyMMdd,N)]` | First day of the month, then plus N **days** | `N=0` → `20220801`; `N=3` → `20220804`  |
+| `$[month_end(yyyyMMdd,N)]`   | Last day of the month, then plus N **days**  | `N=0` → `20220831`; `N=-1` → `20220830` |
+| `$[week_begin(yyyyMMdd,N)]`  | Monday of the week, then plus N **days**     | `N=0` → `20220822`; `N=1` → `20220823`  |
+| `$[week_end(yyyyMMdd,N)]`    | Sunday of the week, then plus N **days**     | `N=0` → `20220828`; `N=-2` → `20220826` |
+
+> Rule of thumb: use `month_first_day` / `week_first_day` (offset in months/weeks) to jump *whole periods*; use `month_begin` / `week_begin` (offset in days) to land on a boundary and then nudge by a few days. Omitting the second argument of the `*_begin` / `*_end` functions raises an "expression not valid" error, whereas the `*_first_day` / `*_last_day` functions treat the offset as optional.
+
+### `timestamp()` — Unix epoch seconds
+
+`$[timestamp(...)]` converts a supported date-format, arithmetic, or boundary expression into a **Unix timestamp in seconds**. The inner expression must format its result as a full `yyyyMMddHHmmss` value; `year_week(...)` cannot be used because it returns a year/week value rather than a complete date and time.
+
+|             Expression              |                       Meaning                        |
+|-------------------------------------|------------------------------------------------------|
+| `$[timestamp(yyyyMMddHHmmss)]`      | The benchmark time as epoch seconds                  |
+| `$[timestamp(yyyyMMddHHmmss-1/24)]` | One hour before the benchmark time, as epoch seconds |
+| `$[timestamp(yyyyMMddHHmmss-1)]`    | One day before the benchmark time, as epoch seconds  |
+
+For a benchmark time of `2022-08-26 00:00:00`, `$[timestamp(yyyyMMddHHmmss)]` returns `1661443200` when the JVM default time zone is UTC+08:00. The value changes with the runtime time zone.
+
+## Custom Variable Reference
+
+You can also reference the value of any custom parameter (local, global, project-level, or passed from an upstream task) with the same `${variableName}` syntax. See [Local Parameter](local.md), [Global Parameter](global.md) and [Parameter Context](context.md) for how those values are defined and passed.
+
+For how the `${...}` and `$[...]` forms interact — and how to combine built-in parameters with your own — see [Parameter Combination](parameter-combination.md).

--- a/docs/docs/en/guide/parameter/parameter-combination.md
+++ b/docs/docs/en/guide/parameter/parameter-combination.md
@@ -1,0 +1,124 @@
+# Parameter Combination
+
+DolphinScheduler exposes several kinds of parameters — [built-in](built-in.md), [global](global.md), [local](local.md), [project-level](project-parameter.md), and values [passed from upstream tasks](context.md). This page explains how the two placeholder *forms* are resolved and how to combine them safely in real scripts.
+
+## Two placeholder forms
+
+|   Form    |                                               Purpose                                               |           Resolved by            |
+|-----------|-----------------------------------------------------------------------------------------------------|----------------------------------|
+| `${name}` | Substitute the value of a named parameter (built-in `system.*`, custom, global, local, or upstream) | Name lookup in the parameter map |
+| `$[expr]` | Evaluate a date/time expression against the instance benchmark time                                 | Time-expression engine           |
+
+The two forms are not interchangeable: `${...}` looks a name up in a map, while `$[...]` runs the date engine described in [Built-in Parameter](built-in.md#derived-time-built-in-parameter).
+
+## Resolution order (important)
+
+When a value contains both forms, DolphinScheduler always resolves them in a fixed order:
+
+1. **First** every `${name}` found in the parameter map is replaced with its value.
+2. **Then** every `$[expr]` is evaluated against the benchmark time.
+
+This ordering has one practical consequence worth remembering: a `${...}` reference is substituted *before* the date engine runs, so a custom parameter can itself expand into a `$[...]` expression and still be evaluated. The reverse does not hold — the output of a `$[...]` expression is never re-scanned for `${...}` names.
+
+## Combining built-in parameters in a Shell task
+
+The most common pattern is deriving several related dates from the same benchmark time. Because all `$[...]` expressions share the instance benchmark time, the dates stay consistent even across a complement (backfill) run:
+
+```shell
+# All three derive from the same benchmark time
+run_date=$[yyyy-MM-dd]
+prev_date=$[yyyy-MM-dd-1]
+month_start=$[month_first_day(yyyy-MM-dd,0)]
+
+echo "processing ${system.workflow.definition.name} for ${run_date}"
+echo "previous day : ${prev_date}"
+echo "month start   : ${month_start}"
+
+# Build an output path from a mix of forms
+out_dir="/data/warehouse/${system.project.name}/dt=$[yyyyMMdd]"
+echo "writing to ${out_dir}"
+```
+
+Here `run_date`, `prev_date`, `month_start`, and `out_dir` are Shell variables. Unless parameters with the same names are defined in DolphinScheduler, the scheduler leaves those `${...}` references unchanged and the Shell expands them when the script runs.
+
+For the instance scheduled on `2022-08-26`, this resolves to:
+
+```text
+processing daily_etl for 2022-08-26
+previous day : 2022-08-25
+month start   : 2022-08-01
+writing to /data/warehouse/finance/dt=20220826
+```
+
+## Combining with a custom parameter
+
+Define a local or global parameter whose value is itself a time expression, then reference it by name. Because `${...}` is resolved first, the substituted `$[...]` is still evaluated afterwards.
+
+Define a local parameter (Direction `IN`):
+
+- `partition_date` = `$[yyyyMMdd]`
+
+Then in the Shell script:
+
+```shell
+echo "partition = ${partition_date}"
+```
+
+`${partition_date}` is first replaced by the literal `$[yyyyMMdd]`, which the date engine then turns into `20220826`.
+
+## Combining in a SQL task
+
+The same rules apply to SQL. Built-in and derived parameters are commonly used to scope a query to the business date:
+
+```sql
+-- ${system.biz.date} is the benchmark date minus one day (yyyyMMdd)
+-- The $[...] range below covers that same previous calendar day
+INSERT INTO dws_user_active_di
+SELECT
+    '${system.biz.date}'           AS stat_date,
+    count(DISTINCT user_id)        AS active_users
+FROM   dwd_user_event
+WHERE  dt = '${system.biz.date}'
+  AND  event_time >= '$[yyyy-MM-dd HH:mm:ss-1]'
+  AND  event_time <  '$[yyyy-MM-dd HH:mm:ss]';
+```
+
+For the instance scheduled on `2022-08-26` this becomes:
+
+```sql
+INSERT INTO dws_user_active_di
+SELECT
+    '20220825'                     AS stat_date,
+    count(DISTINCT user_id)        AS active_users
+FROM   dwd_user_event
+WHERE  dt = '20220825'
+  AND  event_time >= '2022-08-25 00:00:00'
+  AND  event_time <  '2022-08-26 00:00:00';
+```
+
+> Quote date values in SQL. `$[...]` and `${...}` expand to bare text, so `dt = '${system.biz.date}'` needs the surrounding quotes to produce a valid string literal.
+
+## Passing a derived date to a downstream task
+
+You can compute a date in one task, export it with `setValue`, and consume it downstream by name. Combine this with `$[...]` to make the exported value track the business date.
+
+Upstream Shell task (add an `OUT` custom parameter `stat_date`):
+
+```shell
+echo '#{setValue(stat_date=$[yyyyMMdd])}'
+```
+
+Downstream task references it as an ordinary `${stat_date}`. See [Parameter Context](context.md) for the full `setValue` mechanism and [Parameter Priority](priority.md) for how conflicting names are resolved.
+
+## Things that do not work
+
+- **Producing an invalid time expression after substitution** — variables can compose a time expression; for example, with `offset=-1`, `$[yyyyMMdd${offset}]` first becomes `$[yyyyMMdd-1]` and is then evaluated. The final `$[...]` content must still match the date engine's own format/function grammar.
+- **Feeding a date result back into a name** — the output of `$[...]` is never re-scanned for `${...}`, because time evaluation is the last step.
+- **Expecting `$[...]` to use the wall-clock run time** — it always uses the instance benchmark time. If you genuinely need the real execution time, use a shell command such as `date` inside the task.
+
+## See also
+
+- [Built-in Parameter](built-in.md) — the full list of `system.*` variables and `$[...]` functions.
+- [Parameter Priority](priority.md) — which value wins when the same name comes from several sources.
+- [Parameter Context](context.md) — passing parameters between tasks with `setValue`.
+

--- a/docs/docs/zh/guide/parameter/built-in.md
+++ b/docs/docs/zh/guide/parameter/built-in.md
@@ -1,5 +1,10 @@
 # 内置参数
 
+DolphinScheduler 提供两类内置参数，系统会在运行时自动填充，无需用户自行声明：
+
+- **基础内置参数** —— 一组固定的 `system.*` 变量（任务 ID、工作流名称、业务日期等），使用 `${变量名}` 语法引用。
+- **衍生（时间）内置参数** —— 使用 `$[...]` 语法引用的日期/时间表达式，可以任意组合与偏移（例如 `$[yyyy-MM-dd-1]`）。
+
 ## 基础内置参数
 
 |               变量名               |                 声明方式                 |                含义                |
@@ -17,42 +22,133 @@
 | system.project.name             | `${system.project.name}`             | 当前任务所在项目的名称                      |
 | system.project.code             | `${system.project.code}`             | 当前任务所在项目的code                    |
 
-## 衍生内置参数
+### 关于业务日期（`system.biz.date` / `system.biz.curdate`）
 
-- 支持代码中自定义变量名，声明方式：${变量名}。可以是引用 "系统参数"
+`system.biz.curdate` 是实例的**调度时间**，`system.biz.date` 则是它的**前一天**。之所以要“减一天”，是因为在凌晨调度运行的工作流通常处理的是*前一天*的数据。
 
-- 我们定义这种基准变量为 \$[...] 格式的，\$[yyyyMMddHHmmss] 是可以任意分解组合的，比如：\$[yyyyMMdd], \$[HHmmss], \$[yyyy-MM-dd] 等
+调度时间的取值取决于工作流的触发方式：
 
-- 也可以通过以下两种方式：
+- **定时调度运行**：调度时间为定时器配置的时间（而非实际触发时刻）。
+- **补数据（回填）运行**：调度时间为回填区间内的每一个业务日期，因此每生成一个实例，`system.biz.date` 就顺移一天。
+- **手动运行且无调度时间**：系统使用当前时间（`now`）减一天作为业务日期。
 
-  1.使用add_months()函数，该函数用于加减月份，
-  第一个入口参数为[yyyyMMdd]，表示返回时间的格式
-  第二个入口参数为月份偏移量，表示加减多少个月
-  * 后 N 年：$[add_months(yyyyMMdd,12*N)]
-  * 前 N 年：$[add_months(yyyyMMdd,-12*N)]
-  * 后 N 月：$[add_months(yyyyMMdd,N)]
-  * 前 N 月：$[add_months(yyyyMMdd,-N)]
-  *******************************************
-  2.直接加减数字
-  在自定义格式后直接“+/-”数字
-  * 后 N 周：$[yyyyMMdd+7*N]
-  * 前 N 周：$[yyyyMMdd-7*N]
-  * 后 N 天：$[yyyyMMdd+N]
-  * 前 N 天：$[yyyyMMdd-N]
-  * 后 N 小时：$[HHmmss+N/24]
-  * 前 N 小时：$[HHmmss-N/24]
-  * 后 N 分钟：$[HHmmss+N/24/60]
-  * 前 N 分钟：$[HHmmss-N/24/60]
-  *******************************************
-  3.业务属性方式
-  在自定义格式后直接“+/-”数字
-  支持日志格式：所有日期表达式，例如：yyyy-MM-dd/yyyyMMddHHmmss
-  * 当天：$[this_day(yyyy-MM-dd)]，如：2022-08-26 => 2022-08-26
-  * 昨天：$[last_day(yyyy-MM-dd)]，如：2022-08-26 => 2022-08-25
-  * 年的第N周，以周一为起点：$[year_week(yyyy-MM-dd)]，如：2022-08-26 => 2022-34
-  * 年的第N周，以周N为起点：$[year_week(yyyy-MM-dd,N)]，如：N=5时 2022-08-26 => 2022-35
-  * 前(-)/后(+) N 月第一天：$[month_first_day(yyyy-MM-dd,-N)]，如：N=1时 2022-08-26 => 2022-07-01
-  * 前(-)/后(+) N 月最后一天：$[month_last_day(yyyy-MM-dd,-N)]，如：N=1时 2022-08-28 => 2022-07-31
-  * 前(-)/后(+) N 周的周一：$[week_first_day(yyyy-MM-dd,-N)]，如：N=1 2022-08-26 => 2022-08-15
-  * 前(-)/后(+) N 周的周日：$[week_last_day(yyyy-MM-dd,-N)]，如：N=1 2022-08-26 => 2022-08-21
+### 示例：打印全部基础参数
 
+新建一个 Shell 任务并粘贴下面的脚本。运行时，每个占位符都会被替换为该实例的具体取值：
+
+```shell
+echo "biz.date        = ${system.biz.date}"
+echo "biz.curdate     = ${system.biz.curdate}"
+echo "datetime        = ${system.datetime}"
+echo "execute.path    = ${system.task.execute.path}"
+echo "task.instance   = ${system.task.instance.id}"
+echo "task.def.name   = ${system.task.definition.name}"
+echo "task.def.code   = ${system.task.definition.code}"
+echo "wf.instance.id  = ${system.workflow.instance.id}"
+echo "wf.def.name     = ${system.workflow.definition.name}"
+echo "wf.def.code     = ${system.workflow.definition.code}"
+echo "project.name    = ${system.project.name}"
+echo "project.code    = ${system.project.code}"
+```
+
+一个调度时间为 `2022-08-26 00:00:00` 的工作流实例，输出示例如下：
+
+```text
+biz.date        = 20220825
+biz.curdate     = 20220826
+datetime        = 20220826000000
+execute.path    = /tmp/dolphinscheduler/exec/process/<...>/<taskInstanceId>
+task.instance   = 3096
+...
+```
+
+## 衍生（时间）内置参数
+
+除了固定的 `system.*` 变量，DolphinScheduler 还支持一套写作 `$[...]` 的紧凑日期/时间模板语言，可以基于实例的**基准时间**推导出任意日期。
+
+### 基准时间
+
+每个 `$[...]` 表达式都基于同一个**基准时间**求值，该基准时间是实例的业务/调度时间 —— 与 `${system.datetime}` 暴露的值相同。它**不是**任务实际运行的墙上时间。
+
+这意味着：
+
+- 对于**定时调度**运行，`$[yyyyMMdd]` 解析为调度日期，因此重跑或延迟启动都不会改变结果。
+- 对于**补数据（回填）**运行，基准时间依次是每一个被回填的业务日期，因此 `$[yyyyMMdd]` 会遍历整个区间。
+- 只有在没有调度时间可用时，基准时间才回退为当前时间。
+
+正是这一点让 `$[...]` 可以安全地用于幂等、可回填的数据管道：推导出的日期跟随数据日期，而非运行日期。
+
+### 格式模板
+
+`$[...]` 接受 DolphinScheduler 日期格式化器支持的 Java 风格日期模式，各部分可以自由拆分组合：
+
+- `$[yyyyMMdd]`、`$[HHmmss]`、`$[yyyy-MM-dd]`、`$[yyyy-MM-dd HH:mm:ss]`、`$[yyyyMMddHHmmss]` 等。
+
+### 日期运算
+
+可以在格式后直接加减，单位通过运算本身来表达：
+
+|   目标   |               表达式               |
+|--------|---------------------------------|
+| 后 N 年  | `$[add_months(yyyyMMdd,12*N)]`  |
+| 前 N 年  | `$[add_months(yyyyMMdd,-12*N)]` |
+| 后 N 月  | `$[add_months(yyyyMMdd,N)]`     |
+| 前 N 月  | `$[add_months(yyyyMMdd,-N)]`    |
+| 后 N 周  | `$[yyyyMMdd+7*N]`               |
+| 前 N 周  | `$[yyyyMMdd-7*N]`               |
+| 后 N 天  | `$[yyyyMMdd+N]`                 |
+| 前 N 天  | `$[yyyyMMdd-N]`                 |
+| 后 N 小时 | `$[HHmmss+N/24]`                |
+| 前 N 小时 | `$[HHmmss-N/24]`                |
+| 后 N 分钟 | `$[HHmmss+N/24/60]`             |
+| 前 N 分钟 | `$[HHmmss-N/24/60]`             |
+
+> `N` 表示整数或算术表达式，实际使用时要替换为具体值，例如前两周写作 `$[yyyyMMdd-7*2]`。`add_months` 函数的第一个参数是日期格式，第二个参数是月份偏移量，因此它是按月或按年偏移（这两者没有固定天数）的安全方式。直接 `+/-` 运算以天/小时/分钟为基础，这也是为什么小时表示为一天的 `N/24`、分钟表示为一天的 `N/24/60`。
+
+### 业务属性函数
+
+这些函数返回具有日历语义的日期。每个函数的第一个参数是日期格式；接受偏移量的函数，其第二个参数是偏移量（单位见备注）。以下示例均假设基准日期为 `2022-08-26`。
+
+|                 函数                  |          含义           |                示例 → 结果                |
+|-------------------------------------|-----------------------|---------------------------------------|
+| `$[this_day(yyyy-MM-dd)]`           | 当天（基准日期）              | `2022-08-26` → `2022-08-26`           |
+| `$[last_day(yyyy-MM-dd)]`           | 昨天                    | `2022-08-26` → `2022-08-25`           |
+| `$[year_week(yyyy-MM-dd)]`          | 年的第几周，以周一为一周起点        | `2022-08-26` → `2022-34`              |
+| `$[year_week(yyyy-MM-dd,N)]`        | 年的第几周，以周 N 为一周起点      | 当 `N=5` 时，`2022-08-26` → `2022-35`    |
+| `$[month_first_day(yyyy-MM-dd,-N)]` | 偏移 N 月后所在月的第一天（单位：月）  | 当 `N=1` 时，`2022-08-26` → `2022-07-01` |
+| `$[month_last_day(yyyy-MM-dd,-N)]`  | 偏移 N 月后所在月的最后一天（单位：月） | 当 `N=1` 时，`2022-08-28` → `2022-07-31` |
+| `$[week_first_day(yyyy-MM-dd,-N)]`  | 偏移 N 周后所在周的周一（单位：周）   | 当 `N=1` 时，`2022-08-26` → `2022-08-15` |
+| `$[week_last_day(yyyy-MM-dd,-N)]`   | 偏移 N 周后所在周的周日（单位：周）   | 当 `N=1` 时，`2022-08-26` → `2022-08-21` |
+
+> 对于 `year_week`，偏移量 `N` 用于选择一周的起始日（1 = 周一，2 = 周二，……，7 = 周日），而不是偏移日期。由于 DolphinScheduler 要求一年的第一周至少包含 4 天，同一日期在不同的一周起始日下可能落入不同的周序号。
+
+### 以天为偏移单位的周期边界函数
+
+还有第二组边界函数——`month_begin` / `month_end` / `week_begin` / `week_end`。它们与上面的 `*_first_day` / `*_last_day` 系列有两点不同：**第二个参数必填**，且它是在计算出边界之后再施加的**天**偏移（而不是月/周偏移）。以下示例假设基准日期为 `2022-08-26`（周五；该周为周一 `2022-08-22` 到周日 `2022-08-28`）。
+
+|              函数              |         含义          |                示例 → 结果                 |
+|------------------------------|---------------------|----------------------------------------|
+| `$[month_begin(yyyyMMdd,N)]` | 所在月的第一天，再加 N **天**  | `N=0` → `20220801`；`N=3` → `20220804`  |
+| `$[month_end(yyyyMMdd,N)]`   | 所在月的最后一天，再加 N **天** | `N=0` → `20220831`；`N=-1` → `20220830` |
+| `$[week_begin(yyyyMMdd,N)]`  | 所在周的周一，再加 N **天**   | `N=0` → `20220822`；`N=1` → `20220823`  |
+| `$[week_end(yyyyMMdd,N)]`    | 所在周的周日，再加 N **天**   | `N=0` → `20220828`；`N=-2` → `20220826` |
+
+> 经验法则：用 `month_first_day` / `week_first_day`（偏移单位为月/周）来跨越*整个周期*；用 `month_begin` / `week_begin`（偏移单位为天）先落到某个边界、再微调几天。`*_begin` / `*_end` 函数如果省略第二个参数会抛出 “expression not valid” 错误，而 `*_first_day` / `*_last_day` 函数的偏移量是可选的。
+
+### `timestamp()` —— Unix 时间戳（秒）
+
+`$[timestamp(...)]` 可以把受支持的日期格式、日期运算或周期边界表达式转换为**以秒为单位的 Unix 时间戳**。内层表达式必须以完整的 `yyyyMMddHHmmss` 格式输出；`year_week(...)` 只返回年和周序号，因此不能用于 `timestamp(...)`。
+
+|                 表达式                 |          含义          |
+|-------------------------------------|----------------------|
+| `$[timestamp(yyyyMMddHHmmss)]`      | 基准时间对应的 Unix 秒级时间戳   |
+| `$[timestamp(yyyyMMddHHmmss-1/24)]` | 基准时间前一小时的 Unix 秒级时间戳 |
+| `$[timestamp(yyyyMMddHHmmss-1)]`    | 基准时间前一天的 Unix 秒级时间戳  |
+
+当基准时间为 `2022-08-26 00:00:00` 且 JVM 默认时区为 UTC+08:00 时，`$[timestamp(yyyyMMddHHmmss)]` 返回 `1661443200`；运行时区不同，结果也会不同。
+
+## 引用自定义变量
+
+你同样可以用 `${变量名}` 语法引用任意自定义参数的值（本地参数、全局参数、项目级参数，或上游任务传递而来的参数）。这些值如何定义与传递，参见[本地参数](local.md)、[全局参数](global.md)与[参数传递](context.md)。
+
+关于 `${...}` 与 `$[...]` 两种写法如何相互作用，以及如何将内置参数与自定义参数组合使用，参见[参数组合使用](parameter-combination.md)。

--- a/docs/docs/zh/guide/parameter/parameter-combination.md
+++ b/docs/docs/zh/guide/parameter/parameter-combination.md
@@ -1,0 +1,124 @@
+# 参数组合使用
+
+DolphinScheduler 提供了多种参数：[内置参数](built-in.md)、[全局参数](global.md)、[本地参数](local.md)、[项目级别参数](project-parameter.md)，以及[上游任务传递](context.md)的值。本文说明两种占位符*形式*各自如何被解析，以及在真实脚本中如何安全地组合使用它们。
+
+## 两种占位符形式
+
+|    形式     |                    用途                    |     解析方式      |
+|-----------|------------------------------------------|---------------|
+| `${name}` | 替换某个具名参数的值（内置 `system.*`、自定义、全局、本地或上游参数） | 在参数 Map 中按名查找 |
+| `$[expr]` | 基于实例基准时间计算一个日期/时间表达式                     | 时间表达式引擎       |
+
+两者不可互换：`${...}` 是在 Map 中按名查找，`$[...]` 则运行 [内置参数](built-in.md#衍生内置参数时间) 中描述的日期引擎。
+
+## 解析顺序（重要）
+
+当一个值同时包含两种形式时，DolphinScheduler 始终按固定顺序解析：
+
+1. **先**将参数 Map 中存在的 `${name}` 替换为其对应的值。
+2. **再**基于基准时间计算所有 `$[expr]`。
+
+这个顺序有一个值得记住的实际影响：`${...}` 引用会在日期引擎运行*之前*被替换，因此一个自定义参数的值本身可以是一个 `$[...]` 表达式，替换后仍会被正确计算。反之则不成立——`$[...]` 表达式的计算结果不会再被扫描 `${...}` 变量名。
+
+## 在 Shell 任务中组合内置参数
+
+最常见的用法是从同一个基准时间派生出多个相关日期。因为所有 `$[...]` 表达式共享实例的基准时间，即使在补数据（complement）运行时，这些日期也能保持一致：
+
+```shell
+# 三个日期都派生自同一个基准时间
+run_date=$[yyyy-MM-dd]
+prev_date=$[yyyy-MM-dd-1]
+month_start=$[month_first_day(yyyy-MM-dd,0)]
+
+echo "正在处理 ${system.workflow.definition.name}，业务日期 ${run_date}"
+echo "前一天    : ${prev_date}"
+echo "本月首日  : ${month_start}"
+
+# 用多种形式拼接输出路径
+out_dir="/data/warehouse/${system.project.name}/dt=$[yyyyMMdd]"
+echo "写入到 ${out_dir}"
+```
+
+这里的 `run_date`、`prev_date`、`month_start` 和 `out_dir` 是 Shell 变量。只要 DolphinScheduler 中没有定义同名参数，调度器就会保留这些 `${...}` 引用，交给 Shell 在脚本运行时展开。
+
+对于调度时间为 `2022-08-26` 的实例，解析结果为：
+
+```text
+正在处理 daily_etl，业务日期 2022-08-26
+前一天    : 2022-08-25
+本月首日  : 2022-08-01
+写入到 /data/warehouse/finance/dt=20220826
+```
+
+## 与自定义参数组合
+
+定义一个本地或全局参数，其值本身是一个时间表达式，然后按名引用它。因为 `${...}` 先被解析，替换出的 `$[...]` 随后仍会被计算。
+
+定义一个本地参数（方向为 `IN`）：
+
+- `partition_date` = `$[yyyyMMdd]`
+
+然后在 Shell 脚本中：
+
+```shell
+echo "partition = ${partition_date}"
+```
+
+`${partition_date}` 先被替换为字面量 `$[yyyyMMdd]`，随后日期引擎再将其计算为 `20220826`。
+
+## 在 SQL 任务中组合
+
+同样的规则适用于 SQL。内置参数和衍生参数常用于把查询限定到业务日期范围：
+
+```sql
+-- ${system.biz.date} 是基准日期减一天（yyyyMMdd）
+-- 下面的 $[...] 时间范围覆盖同一个前一自然日
+INSERT INTO dws_user_active_di
+SELECT
+    '${system.biz.date}'           AS stat_date,
+    count(DISTINCT user_id)        AS active_users
+FROM   dwd_user_event
+WHERE  dt = '${system.biz.date}'
+  AND  event_time >= '$[yyyy-MM-dd HH:mm:ss-1]'
+  AND  event_time <  '$[yyyy-MM-dd HH:mm:ss]';
+```
+
+对于调度时间为 `2022-08-26` 的实例，它会变成：
+
+```sql
+INSERT INTO dws_user_active_di
+SELECT
+    '20220825'                     AS stat_date,
+    count(DISTINCT user_id)        AS active_users
+FROM   dwd_user_event
+WHERE  dt = '20220825'
+  AND  event_time >= '2022-08-25 00:00:00'
+  AND  event_time <  '2022-08-26 00:00:00';
+```
+
+> SQL 中的日期值要加引号。`$[...]` 和 `${...}` 展开后都是纯文本，因此 `dt = '${system.biz.date}'` 需要外层引号才能生成合法的字符串字面量。
+
+## 将派生日期传递给下游任务
+
+你可以在一个任务中计算出日期，用 `setValue` 导出，下游任务再按名引用。结合 `$[...]` 可以让导出的值随业务日期变化。
+
+上游 Shell 任务（新增一个 `OUT` 自定义参数 `stat_date`）：
+
+```shell
+echo '#{setValue(stat_date=$[yyyyMMdd])}'
+```
+
+下游任务按普通的 `${stat_date}` 引用它。完整的 `setValue` 机制见 [参数传递](context.md)，同名冲突的处理规则见 [参数优先级](priority.md)。
+
+## 不支持的用法
+
+- **替换后不是合法时间表达式**——可以用变量拼出时间表达式，例如 `offset=-1` 时 `$[yyyyMMdd${offset}]` 会先变成 `$[yyyyMMdd-1]` 再解析；但替换完成后的 `$[...]` 内容必须符合日期引擎自己的格式/函数语法。
+- **把日期结果再当作变量名解析**——`$[...]` 的计算结果不会再被扫描 `${...}`，因为时间计算是最后一步。
+- **期望 `$[...]` 使用真实运行时间**——它始终使用实例的基准时间。如果确实需要真实执行时间，请在任务内使用 `date` 等 shell 命令。
+
+## 参见
+
+- [内置参数](built-in.md) —— `system.*` 变量和 `$[...]` 函数的完整列表。
+- [参数优先级](priority.md) —— 同名参数来自多个来源时以哪个为准。
+- [参数传递](context.md) —— 使用 `setValue` 在任务间传递参数。
+

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/parser/TimePlaceholderUtilsTest.java
@@ -130,6 +130,35 @@ public class TimePlaceholderUtilsTest {
     }
 
     @Test
+    public void timePlaceHolderForPeriodBoundariesWithDayOffset() {
+        assertEquals("20220801",
+                ParameterUtils.convertParameterPlaceholders("$[month_begin(yyyyMMdd,0)]", timeParams));
+        assertEquals("20220804",
+                ParameterUtils.convertParameterPlaceholders("$[month_begin(yyyyMMdd,3)]", timeParams));
+        assertEquals("20220831",
+                ParameterUtils.convertParameterPlaceholders("$[month_end(yyyyMMdd,0)]", timeParams));
+        assertEquals("20220830",
+                ParameterUtils.convertParameterPlaceholders("$[month_end(yyyyMMdd,-1)]", timeParams));
+        assertEquals("20220822",
+                ParameterUtils.convertParameterPlaceholders("$[week_begin(yyyyMMdd,0)]", timeParams));
+        assertEquals("20220823",
+                ParameterUtils.convertParameterPlaceholders("$[week_begin(yyyyMMdd,1)]", timeParams));
+        assertEquals("20220828",
+                ParameterUtils.convertParameterPlaceholders("$[week_end(yyyyMMdd,0)]", timeParams));
+        assertEquals("20220826",
+                ParameterUtils.convertParameterPlaceholders("$[week_end(yyyyMMdd,-2)]", timeParams));
+    }
+
+    @Test
+    public void timePlaceHolderForTimestamp() {
+        Date targetDate = DateUtils.parse("2022-08-26 00:00:00", "yyyy-MM-dd HH:mm:ss");
+        String expectedTimestamp = String.valueOf(targetDate.getTime() / 1000);
+
+        assertEquals(expectedTimestamp,
+                ParameterUtils.convertParameterPlaceholders("$[timestamp(yyyyMMddHHmmss)]", timeParams));
+    }
+
+    @Test
     void formatTimeExpressionWithInvalidExpression() {
         assertEquals("$[week_last_day(yyyy-MM-dd,0) - 1]",
                 TimePlaceholderUtils.formatTimeExpression("$[week_last_day(yyyy-MM-dd,0) - 1]", new Date(), true));

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ParameterUtilsTest.java
@@ -109,6 +109,23 @@ public class ParameterUtilsTest {
                 ParameterUtils.convertParameterPlaceholders(sql, paramsMap));
     }
 
+    @Test
+    public void convertParameterPlaceholdersResolvesNamedParametersBeforeTimeExpressions() {
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(DateConstants.PARAMETER_DATETIME, "20220826000000");
+        parameterMap.put(DateConstants.PARAMETER_BUSINESS_DATE, "20220825");
+        parameterMap.put("offset", "-1");
+        parameterMap.put("partition_date", "$[yyyyMMdd]");
+
+        String value = "partition=${partition_date}, nested=$[yyyyMMdd${offset}], "
+                + "biz=${system.biz.date}, previous=$[yyyy-MM-dd HH:mm:ss-1], "
+                + "next=$[yyyy-MM-dd HH:mm:ss+1]";
+
+        assertEquals("partition=20220826, nested=20220825, biz=20220825, "
+                + "previous=2022-08-25 00:00:00, next=2022-08-27 00:00:00",
+                ParameterUtils.convertParameterPlaceholders(value, parameterMap));
+    }
+
     /**
      * Test handleEscapes
      */


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The documentation structure, usage examples, and related test additions were assisted.

## Purpose of the pull request

Closes #18425.

The current built-in parameter guide lists variables and a subset of time expressions, but it does not explain their behavior across different trigger modes or how named parameters `${...}` and time expressions `$[...]` interact. This change documents the existing behavior without changing runtime semantics.

## Brief change log

- Explain every current `system.*` built-in parameter with Shell examples and scheduled, complement, and manual-run behavior.
- Document the benchmark time, date arithmetic, calendar boundary functions, and `timestamp(...)`.
- Add English and Chinese parameter-combination guides with Shell, SQL, custom parameter, and downstream parameter examples.
- Add the new guides to the documentation navigation.
- Add regression coverage for placeholder resolution order, period boundary functions, and timestamp conversion.

## Verify this pull request

This change added tests and can be verified as follows:

- `./mvnw spotless:apply`
- `./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-api -am clean test -DskipITs -Dtest=ParameterUtilsTest,TimePlaceholderUtilsTest -Dsurefire.failIfNoSpecifiedTests=false`
- Result: 16 tests passed with no failures or errors.

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)