### PR TITLE
[Fix-18311] Fix isProcessAlive misclassifying alive processes as dead

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -243,7 +243,30 @@ public final class ProcessUtils {
             // If the command executes successfully, the process exists
             return true;
         } catch (Exception e) {
-            // If the command fails, the process does not exist
+            // kill -0 may fail with "Operation not permitted" when the process exists
+            // but is owned by a different user (e.g., root-owned sudo parent process
+            // when the task runs as a tenant). Try fallback mechanism to detect alive state.
+            log.debug("kill -0 failed for pid {}, checking via fallback. Error: {}", pid, e.getMessage());
+            return isProcessAliveByAlternativeCheck(pid);
+        }
+    }
+
+    /**
+     * Fallback check for process alive status when kill -0 fails due to permission issues.
+     * On Linux, checks /proc filesystem; on other OS, uses ps command.
+     */
+    private static boolean isProcessAliveByAlternativeCheck(int pid) {
+        try {
+            if (SystemUtils.IS_OS_LINUX) {
+                // On Linux, /proc/<pid> directory exists as long as the process is running
+                return new java.io.File("/proc/" + pid).exists();
+            }
+            // For non-Linux systems, use ps -p to check existence
+            String checkCmd = String.format("ps -p %d", pid);
+            OSUtils.exeCmd(checkCmd);
+            return true;
+        } catch (Exception e) {
+            log.debug("Fallback alive check also failed for pid {}. Error: {}", pid, e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
## What changes were made?

Fixed `ProcessUtils.isProcessAlive()` to properly handle the case where `kill -0` fails with "Operation not permitted" — which means the process exists but the current user doesn't have permission to signal it (e.g., root-owned `sudo` parent process when task runs as tenant user).

Previously, any exception from `kill -0` was treated as "process not alive", causing the worker to incorrectly report kill success while child processes remained alive and the workflow stuck in `READY_STOP`.

## Root Cause

- `ProcessUtils.isProcessAlive` treats every exception from `OSUtils.exeCmd("kill -0 <pid>")` as "not alive"
- When a tenant user checks a root-owned process, `kill -0` returns "Operation not permitted" (exit code 1), but the process IS alive
- This caused `sendKillSignal` to report all processes already terminated when they weren't

## Fix

Added `isProcessAliveByAlternativeCheck()` fallback method:
- On Linux: checks `/proc/<pid>` directory existence (no permission required)
- On other OS: uses `ps -p <pid>` command

## Related Issue

Closes #18311