### PR TITLE
[Fix-16789] Ignore 'No such process' error when Flink task process already exited

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -117,6 +117,12 @@ public final class ProcessUtils {
                 return true;
             }
 
+            // Check if process has already exited naturally
+            if (!isProcessAlive(processId, request.getTenantCode())) {
+                log.info("Task instance process has already exited, processId: {}", processId);
+                return true;
+            }
+
             // Get all child processes
             List<Integer> pidList = getPidList(processId);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When stopping a Flink task from the UI, if the underlying process has already exited naturally before the kill signal is sent, the `pstree` command fails with a "No such process" error, causing the kill operation to report failure.

This PR adds a process liveness check (`isProcessAlive`) before attempting to get the PID list via `pstree`, so that already-terminated processes are treated as successfully killed rather than as errors.

## Why are the changes needed?

Fixes #16789 - stop Flink job error when process already exited.

The root cause: in `ProcessUtils.kill()`, after verifying `processId != 0`, it immediately calls `getPidList(processId)` which executes `pstree -p <pid>`. If the process has already exited, `pstree` fails and throws an exception, which is caught by the outer catch block and returns `false`, leading to an error log "Failed to kill process tree".

## How was this patch tested?

- Logic verification: `isProcessAlive()` uses `kill -0 <pid>` which is a standard POSIX method to check process existence without sending a signal. If the process doesn't exist, it returns false.
- The fix is a safe early return: if the process has already exited, we skip the kill signal cascade entirely and report success.

## Related issues

Closes #16789