### PR TITLE
[Fix-16617] Replace deprecated --deploy-mode with --run-mode for SeaTunnel Flink task

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkParameters.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/flink/SeatunnelFlinkParameters.java
@@ -35,8 +35,8 @@ public class SeatunnelFlinkParameters extends SeatunnelParameters {
     public enum RunModeEnum {
 
         NONE("none"),
-        RUN("--deploy-mode run"),
-        RUN_APPLICATION("--deploy-mode run-application");
+        RUN("--run-mode run"),
+        RUN_APPLICATION("--run-mode run-application");
 
         private final String command;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace the deprecated `--deploy-mode` flag with `--run-mode` in `SeatunnelFlinkParameters.RunModeEnum` for the SeaTunnel Flink task plugin.

## Why are the changes needed?

Fixes #16617.

SeaTunnel 2.3.1+ deprecated `--deploy-mode` and `-e` for Flink engine, replacing them with `--run-mode` (`-r`). When running a SeaTunnel task with Flink engine on newer SeaTunnel versions (2.3.1+), DolphinScheduler generates the command with `--deploy-mode run` which causes SeaTunnel to fail with:

```
-e and --deploy-mode deprecated in 2.3.1, please use -m and --master instead of it
```

Note: The error message incorrectly mentions `-m` and `--master` (which are Spark-specific replacements), but the actual Flink replacement is `--run-mode` with values `run` or `run-application`.

Reference: [SeaTunnel 2.2.0-beta command usage docs](https://seatunnel.apache.org/docs/2.2.0-beta/command/usage) - Flink section shows `-r`/`--run-mode`.

## How was this patch tested?

- The change is a straightforward string replacement in an enum definition
- Build verification: `mvn compile -pl dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel -am`

## Related issues

Closes #16617