### PR TITLE
[Improvement-18439][API]Add composite index idx_project_start_time for workflow instance query

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
@@ -636,7 +636,8 @@ CREATE TABLE t_ds_workflow_instance
     var_pool                   longtext,
     dry_run                    int NULL DEFAULT 0,
     restart_time               datetime     DEFAULT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    INDEX idx_project_start_time (project_code, start_time)
 );
 
 -- ----------------------------

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_h2.sql
@@ -637,7 +637,7 @@ CREATE TABLE t_ds_workflow_instance
     dry_run                    int NULL DEFAULT 0,
     restart_time               datetime     DEFAULT NULL,
     PRIMARY KEY (id),
-    INDEX idx_project_start_time (project_code, start_time)
+    INDEX idx_project_start_time (project_code ASC, start_time DESC)
 );
 
 -- ----------------------------
@@ -937,9 +937,9 @@ CREATE TABLE t_ds_task_instance
     dry_run                 int NULL DEFAULT 0,
     cpu_quota               int(11) DEFAULT '-1' NOT NULL,
     memory_max              int(11) DEFAULT '-1' NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    INDEX idx_project_submit_time (project_code ASC, submit_time DESC)
 );
-CREATE INDEX idx_project_submit_time ON t_ds_task_instance (project_code, submit_time);
 
 -- ----------------------------
 -- Records of t_ds_task_instance

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
@@ -646,7 +646,8 @@ CREATE TABLE `t_ds_workflow_instance` (
   `restart_time` datetime DEFAULT NULL COMMENT 'workflow instance restart time',
   PRIMARY KEY (`id`),
   KEY `workflow_instance_index` (`workflow_definition_code`,`id`) USING BTREE,
-  KEY `start_time_index` (`start_time`,`end_time`) USING BTREE
+  KEY `start_time_index` (`start_time`,`end_time`) USING BTREE,
+  KEY `idx_project_start_time` (`project_code`, `start_time`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COLLATE = utf8_bin;
 
 -- ----------------------------

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_mysql.sql
@@ -647,7 +647,7 @@ CREATE TABLE `t_ds_workflow_instance` (
   PRIMARY KEY (`id`),
   KEY `workflow_instance_index` (`workflow_definition_code`,`id`) USING BTREE,
   KEY `start_time_index` (`start_time`,`end_time`) USING BTREE,
-  KEY `idx_project_start_time` (`project_code`, `start_time`) USING BTREE
+  KEY `idx_project_start_time` (`project_code` ASC, `start_time` DESC) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COLLATE = utf8_bin;
 
 -- ----------------------------
@@ -939,7 +939,7 @@ CREATE TABLE `t_ds_task_instance` (
   PRIMARY KEY (`id`),
   KEY `workflow_instance_id` (`workflow_instance_id`) USING BTREE,
   KEY `idx_code_version` (`task_code`, `task_definition_version`) USING BTREE,
-  KEY `idx_project_submit_time` (`project_code`, `submit_time`) USING BTREE
+  KEY `idx_project_submit_time` (`project_code` ASC, `submit_time` DESC) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COLLATE = utf8_bin;
 
 -- ----------------------------

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
@@ -589,7 +589,7 @@ CREATE TABLE t_ds_workflow_instance (
 
 create index workflow_instance_index on t_ds_workflow_instance (workflow_definition_code,id);
 create index start_time_index on t_ds_workflow_instance (start_time,end_time);
-create index idx_project_start_time on t_ds_workflow_instance (project_code, start_time);
+create index idx_project_start_time on t_ds_workflow_instance (project_code ASC, start_time DESC);
 
 --
 -- Table structure for table t_ds_project
@@ -860,7 +860,7 @@ CREATE TABLE t_ds_task_instance (
 ) ;
 
 create index idx_task_instance_code_version on t_ds_task_instance (task_code, task_definition_version);
-create index idx_project_submit_time on t_ds_task_instance (project_code, submit_time DESC);
+create index idx_project_submit_time on t_ds_task_instance (project_code ASC, submit_time DESC);
 
 --
 -- Table structure for t_ds_task_instance_context

--- a/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql
@@ -589,6 +589,7 @@ CREATE TABLE t_ds_workflow_instance (
 
 create index workflow_instance_index on t_ds_workflow_instance (workflow_definition_code,id);
 create index start_time_index on t_ds_workflow_instance (start_time,end_time);
+create index idx_project_start_time on t_ds_workflow_instance (project_code, start_time);
 
 --
 -- Table structure for table t_ds_project

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.5.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.5.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -16,4 +16,5 @@
 */
 
 ALTER TABLE `t_ds_task_instance` ADD INDEX idx_project_submit_time (project_code ASC, submit_time DESC);
+ALTER TABLE `t_ds_workflow_instance` ADD INDEX idx_project_start_time (project_code ASC, start_time DESC);
 

--- a/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.5.0_schema/postgresql/dolphinscheduler_ddl.sql
+++ b/dolphinscheduler-dao/src/main/resources/sql/upgrade/3.5.0_schema/postgresql/dolphinscheduler_ddl.sql
@@ -16,3 +16,4 @@
 */
 
 CREATE INDEX idx_project_submit_time ON t_ds_task_instance (project_code ASC, submit_time DESC);
+CREATE INDEX idx_project_start_time ON t_ds_workflow_instance (project_code ASC, start_time DESC);


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

NO

## Purpose of the pull request

close #18439 

## Brief change log

The queryWorkflowInstanceListPaging API is experiencing slow response times when querying workflow instances for projects with large amounts of historical data.
This commit adds a composite index (project_code, start_time) to the t_ds_workflow_instance table to optimize the common query pattern that filters by project_code and sorts by start_time.

Since project_code and start_time remain virtually unchanged after an instance is created, the index maintenance overhead is minimal. At the same time, it significantly boosts query performance for the most common scenarios.

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
