### PR TITLE
[Fix-16789] Check process alive before getting pid list in ProcessUtils.kill()

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -117,6 +117,13 @@ public final class ProcessUtils {
                 return true;
             }
 
+            // Check if process is still alive before getting pid list from pstree
+            // If the process has already exited, pstree will throw an exception
+            if (!isProcessAlive(processId, request.getTenantCode())) {
+                log.info("Process {} has already exited, no need to kill", processId);
+                return true;
+            }
+
             // Get all child processes
             List<Integer> pidList = getPidList(processId);
 


### PR DESCRIPTION
## Purpose
Fix issue #16789: When stopping a Flink task, the worker node reports an error and fails to send the kill signal.

## Root Cause
In `ProcessUtils.kill()`, the `getPidList()` method (which internally runs `pstree -p <pid>`) is called without checking whether the process is still alive. If the process has already exited naturally, `pstree` throws an exception, causing the entire kill operation to fail and return false.

## Fix
Add an `isProcessAlive()` guard before calling `getPidList()`. If the process has already exited, return true immediately since the process is effectively "killed".

close #16789