### PR TITLE
[Fix-18446][task-sql]Persist sqlSource and sqlResource fields when saving SQL task node

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts
@@ -205,6 +205,8 @@ export function formatParams(data: INodeData): {
     taskParams.type = data.type
     taskParams.datasource = data.datasource
     taskParams.sql = data.sql
+    taskParams.sqlSource = data.sqlSource
+    taskParams.sqlResource = data.sqlResource
     taskParams.sqlType = data.sqlType
     taskParams.preStatements = data.preStatements
     taskParams.postStatements = data.postStatements

--- a/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
+++ b/dolphinscheduler-ui/src/views/projects/task/components/node/types.ts
@@ -304,6 +304,8 @@ interface ITaskParams {
   type?: string
   datasource?: string
   sql?: string
+  sqlSource?: string
+  sqlResource?: string
   sqlType?: string
   sendEmail?: boolean
   displayRows?: number


### PR DESCRIPTION
## Summary

Fixes #18446

The SQL task node's "Resource File" mode (introduced in #18019) loses its `sqlSource` and `sqlResource` values after saving — the node reverts to "Script" mode and the selected SQL file path is empty on reopen. The two form fields are defined in `use-sql.ts` (lines ~65 and ~95) but are never written to `taskParams` by `formatParams()` in `format-data.ts`, so they are dropped on save.

## Changes

- `dolphinscheduler-ui/src/views/projects/task/components/node/format-data.ts`: serialize `sqlSource` and `sqlResource` into `taskParams` in the SQL branch of `formatParams()`.
- `dolphinscheduler-ui/src/views/projects/task/components/node/types.ts`: declare `sqlSource?: string` and `sqlResource?: string` on `ITaskParams`. Required because `strict: true` is set in `tsconfig.json` — otherwise `vue-tsc --noEmit` (part of `pnpm run build:prod`) fails the type check on `data.sqlSource` and `taskParams.sqlSource`.

Backfill works automatically — `formatModel()` already does `...omit(data.taskParams, ['resourceList', 'mainJar', 'localParams'])`, so any field written into `taskParams` is transparently restored on edit. No backfill-side change needed.

## Verification

- `pnpm run build:prod` passes (vue-tsc type check + Vite production build).
- Manual test on a 3.4.2 deployment: SQL node configured with "Resource File" mode + a selected SQL file → save → reopen → both `sqlSource` and `sqlResource` preserved. DevTools Network confirms `"sqlSource":"FILE"` and `"sqlResource":"..."` in `taskDefinitionJson.taskParams`.

## Reproduce steps (for reviewers)

1. Open a workflow definition for editing.
2. Add a SQL task node.
3. Set "SQL Source" to "File".
4. Pick a `.sql` resource file from the resource tree.
5. Save the node and the workflow definition.
6. Reopen the SQL task node — without this PR, "SQL Source" has reverted to "Script" and the resource path is empty; with this PR, both are preserved.
