### PR TITLE
[Fix-16789] Handle Yarn application already finished when stopping Flink job

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/am/YarnApplicationManager.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/am/YarnApplicationManager.java
@@ -50,8 +50,12 @@ public class YarnApplicationManager implements ApplicationManager<YarnApplicatio
             String cmd = getKerberosInitCommand() + "yarn application -kill " + String.join(Constants.SPACE, appIds);
             execYarnKillCommand(tenantCode, commandFile, cmd);
         } catch (Exception e) {
-            log.error("Kill yarn application [{}] failed", appIds, e);
-            throw new TaskException(e.getMessage());
+            if (isApplicationAlreadyFinished(e)) {
+                log.info("Yarn application [{}] is already finished, no need to kill", appIds);
+            } else {
+                log.error("Kill yarn application [{}] failed", appIds, e);
+                throw new TaskException(e.getMessage());
+            }
         }
 
         return true;
@@ -113,5 +117,25 @@ public class YarnApplicationManager implements ApplicationManager<YarnApplicatio
             log.info("kerberos init command: {}", kerberosCommandBuilder);
         }
         return kerberosCommandBuilder.toString();
+    }
+
+    /**
+     * Check if the exception indicates the Yarn application is already finished/killed.
+     * When stopping a Flink/Spark task, the application may have already completed,
+     * in which case the kill command fails with "application not found" or similar.
+     *
+     * @param e the exception thrown by yarn application -kill
+     * @return true if the application is already finished
+     */
+    private boolean isApplicationAlreadyFinished(Exception e) {
+        String message = e.getMessage();
+        if (message == null) {
+            return false;
+        }
+        return message.contains("doesn't exist")
+            || message.contains("not found")
+            || message.contains("No such process")
+            || message.contains("ApplicationNotFoundException")
+            || message.contains("not running");
     }
 }


### PR DESCRIPTION
﻿## Summary

When stopping a Flink task via the DolphinScheduler UI, if the Flink job has already finished (process exited or Yarn application completed), the `yarn application -kill` command fails with an error like "ApplicationNotFoundException" or "doesn't exist". This causes the task stop to report an error.

## Solution

Add a helper method `isApplicationAlreadyFinished()` in `YarnApplicationManager` to detect when the kill command failure is due to the application already being terminated. When this is detected, log at INFO level instead of ERROR and treat it as a success case.

## Changes

- Modified `YarnApplicationManager.killApplication()` catch block to check if the exception indicates the application is already finished
- Added `isApplicationAlreadyFinished()` method that checks for common "already finished" error messages: "doesn't exist", "not found", "No such process", "ApplicationNotFoundException", "not running"

Closes #16789
