### PR TITLE
[Fix-18311] Fix isProcessAlive misclassifying processes that cannot be signalled

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -243,7 +243,30 @@ public final class ProcessUtils {
             // If the command executes successfully, the process exists
             return true;
         } catch (Exception e) {
-            // If the command fails, the process does not exist
+            // kill -0 may fail with non-zero stderr when the shell profile emits
+            // readonly variable warnings (ExitCodeException with exitCode 0).
+            if (e instanceof java.io.IOException) {
+                java.io.IOException ioe = (java.io.IOException) e;
+                if (e.getClass().getSimpleName().equals("ExitCodeException")) {
+                    try {
+                        int ec = e.getClass().getDeclaredField("exitCode").getInt(e);
+                        if (ec == 0) {
+                            return true;
+                        }
+                    } catch (Exception ignore) {
+                        // fall through
+                    }
+                }
+            }
+            // kill -0 may fail with "Operation not permitted" when the process exists
+            // but the current user does not have permission to signal it (e.g., root-owned
+            // sudo parent process). In this case, the process is still alive.
+            String message = e.getMessage();
+            if (message != null && message.contains("not permitted")) {
+                return true;
+            }
+            // If the command fails for other reasons (e.g., "No such process"),
+            // the process does not exist
             return false;
         }
     }


### PR DESCRIPTION
﻿## Summary

When stopping a workflow, `ProcessUtils.isProcessAlive()` uses `kill -0` to check if a process exists. Two scenarios cause false negatives:

1. **Permission denied**: When a child process runs under `sudo`, `kill -0 <pid>` may return "Operation not permitted" even though the process is alive. This causes the worker to skip sending kill signals to the remaining process tree, leaving the workflow stuck in `READY_STOP`.

2. **Non-empty stderr with exit code 0**: Shell profiles can emit readonly variable warnings to stderr even when `kill -0` succeeds (exit code 0). Since `AbstractShell` throws `ExitCodeException` when stderr is non-empty, the process is incorrectly marked as dead.

## Solution

In `ProcessUtils.isProcessAlive()`, when `kill -0` throws an exception:

- Check if the exception is an `ExitCodeException` with exit code 0 (stderr-only noise) → process is alive
- Check if the error message contains "not permitted" → process exists but cannot be signalled → alive
- Otherwise → process does not exist

This allows the kill flow to correctly identify and signal child processes that would otherwise be missed.

Closes #18311
