### PR TITLE
[Fix-18448][UI] Add null-check for workflowDefinition in dag component computed properties

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx
@@ -127,7 +127,7 @@ export default defineComponent({
       if (props.definition) {
         return (
           route.name === 'workflow-definition-detail' &&
-          props.definition!.workflowDefinition.releaseState === 'ONLINE'
+          props.definition?.workflowDefinition?.releaseState === 'ONLINE'
         )
       } else {
         return false
@@ -149,7 +149,7 @@ export default defineComponent({
           props.instance.state === 'STOP'
         )
       } else if (props.definition) {
-        return props.definition!.workflowDefinition.releaseState === 'OFFLINE'
+        return props.definition?.workflowDefinition?.releaseState === 'OFFLINE'
       } else {
         return false
       }


### PR DESCRIPTION
## Purpose

Fixes #18448

When the DAG component renders, the \startDisplay\ and \menuDisplay\ computed properties throw \TypeError: Cannot read properties of undefined (reading 'releaseState')\ because \workflowDefinition\ can be \undefined\ on the \props.definition\ object.

## Root Cause

In \dag/index.tsx\, \startDisplay\ and \menuDisplay\ use:
\\\	s
props.definition!.workflowDefinition.releaseState
\\\

The non-null assertion operator (\!\) has no runtime effect. When \props.definition.workflowDefinition\ is \undefined\, accessing \.releaseState\ throws \TypeError\.

## Changes

Replace non-null assertions with optional chaining (\?.\) for safe property access:

\\\diff
- props.definition!.workflowDefinition.releaseState === 'ONLINE'
+ props.definition?.workflowDefinition?.releaseState === 'ONLINE'
\\\

\\\diff
- props.definition!.workflowDefinition.releaseState === 'OFFLINE'
+ props.definition?.workflowDefinition?.releaseState === 'OFFLINE'
\\\

This matches the pattern already used in \dag-toolbar.tsx\ (\props.definition?.workflowDefinition?.releaseState\).