### PR TITLE
fix(ui): Add null-check for workflowDefinition in dag index.tsx

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx
@@ -127,7 +127,7 @@ export default defineComponent({
       if (props.definition) {
         return (
           route.name === 'workflow-definition-detail' &&
-          props.definition!.workflowDefinition.releaseState === 'ONLINE'
+          props.definition?.workflowDefinition?.releaseState === 'ONLINE'
         )
       } else {
         return false
@@ -149,7 +149,7 @@ export default defineComponent({
           props.instance.state === 'STOP'
         )
       } else if (props.definition) {
-        return props.definition!.workflowDefinition.releaseState === 'OFFLINE'
+        return props.definition?.workflowDefinition?.releaseState === 'OFFLINE'
       } else {
         return false
       }


### PR DESCRIPTION
## Purpose

Fix \Cannot read properties of undefined (reading 'releaseState')\ when clicking Edit on a task in the DAG editor.

Closes #18448

## Changes

In \dolphinscheduler-ui/src/views/projects/workflow/components/dag/index.tsx\:

- \startDisplay\ computed: Changed \props.definition!.workflowDefinition.releaseState\ to \props.definition?.workflowDefinition?.releaseState\
- \menuDisplay\ computed: Changed \props.definition!.workflowDefinition.releaseState\ to \props.definition?.workflowDefinition?.releaseState\

## Root Cause

The TypeScript non-null assertion operator (\!\) has no runtime effect. When \workflowDefinition\ is \undefined\ (transient state, unsaved draft, etc.), accessing \.releaseState\ throws a runtime TypeError.

## Notes

- This aligns these two computed properties with the existing safe pattern already used in \dag-toolbar.tsx\ (lines 276 and 512 use \props.definition?.workflowDefinition?.releaseState\)