### PR TITLE
fix(seatunnel): Replace deprecated --deploy-mode with --master in Zeta engine task

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/self/SeatunnelEngineTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/self/SeatunnelEngineTask.java
@@ -46,7 +46,7 @@ public class SeatunnelEngineTask extends SeatunnelTask {
     public List<String> buildOptions() throws Exception {
         List<String> args = super.buildOptions();
         if (!Objects.isNull(seatunnelParameters.getDeployMode())) {
-            args.add(Constants.DEPLOY_MODE_OPTIONS);
+            args.add(Constants.MASTER_OPTIONS);
             args.add(seatunnelParameters.getDeployMode().getCommand());
         }
         if (StringUtils.isNotBlank(seatunnelParameters.getOthers())) {


### PR DESCRIPTION
## Purpose

Fix Seatunnel task failure when running Seatunnel 2.3.1+ with Zeta engine.

Closes #16617

## Problem

SeaTunnel 2.3.1+ deprecated `-e`/`--deploy-mode` CLI flags in favor of `-m`/`--master`. The `SeatunnelEngineTask` (Zeta engine) was still passing `--deploy-mode` to the Seatunnel CLI, causing the warning/error:

```
-e and --deploy-mode deprecated in 2.3.1, please use -m and --master instead of it
```

## Changes

In `dolphinscheduler-task-plugin/dolphinscheduler-task-seatunnel/src/main/java/org/apache/dolphinscheduler/plugin/task/seatunnel/self/SeatunnelEngineTask.java`:

- Changed `Constants.DEPLOY_MODE_OPTIONS` to `Constants.MASTER_OPTIONS` in `buildOptions()`

The `MASTER_OPTIONS` constant (`"--master"`) already exists in `Constants.java` and is the correct CLI flag for Seatunnel 2.3.1+.

## Notes

- This fix only addresses the Zeta engine (`SeatunnelEngineTask`). The Spark engine (`SeatunnelSparkTask`) uses both `--deploy-mode` and `--master` for different purposes and may need a separate fix.