### PR TITLE
fix: add maxFrameSize check to TransporterDecoder to prevent OOM (#18459)

### DIFF
--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/client/NettyRemotingClient.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/client/NettyRemotingClient.java
@@ -106,7 +106,7 @@ public class NettyRemotingClient implements AutoCloseable {
                                                 clientConfig.getHeartBeatIntervalMillis(),
                                                 0,
                                                 TimeUnit.MILLISECONDS))
-                                .addLast(new TransporterDecoder(), clientHandler, new TransporterEncoder());
+                                .addLast(new TransporterDecoder(clientConfig.getMaxFrameSize()), clientHandler, new TransporterEncoder());
                     }
                 });
         isStarted.compareAndSet(false, true);

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyClientConfig.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyClientConfig.java
@@ -55,6 +55,9 @@ public class NettyClientConfig {
     private int receiveBufferSize = 65535;
 
     @Builder.Default
+    private int maxFrameSize = 100 * 1024 * 1024;
+
+    @Builder.Default
     private int connectTimeoutMillis = 3000;
 
     /**

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyServerConfig.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyServerConfig.java
@@ -56,6 +56,9 @@ public class NettyServerConfig {
     @Builder.Default
     private int receiveBufferSize = 65535;
 
+    @Builder.Default
+    private int maxFrameSize = 100 * 1024 * 1024;
+
     /**
      * worker threads，default get machine cpus
      */

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoder.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoder.java
@@ -29,8 +29,15 @@ import io.netty.handler.codec.ReplayingDecoder;
 @Slf4j
 public class TransporterDecoder extends ReplayingDecoder<TransporterDecoder.State> {
 
+    private final int maxFrameSize;
+
     public TransporterDecoder() {
+        this(100 * 1024 * 1024);  // default 100MB
+    }
+
+    public TransporterDecoder(int maxFrameSize) {
         super(State.MAGIC);
+        this.maxFrameSize = maxFrameSize;
     }
 
     private int headerLength;
@@ -56,6 +63,10 @@ public class TransporterDecoder extends ReplayingDecoder<TransporterDecoder.Stat
                 checkpoint(State.BODY_LENGTH);
             case BODY_LENGTH:
                 bodyLength = in.readInt();
+                if (bodyLength > maxFrameSize) {
+                    throw new IllegalArgumentException(
+                            "body length " + bodyLength + " exceeds max frame size " + maxFrameSize);
+                }
                 checkpoint(State.BODY);
             case BODY:
                 body = new byte[bodyLength];

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/server/NettyRemotingServer.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/server/NettyRemotingServer.java
@@ -134,7 +134,7 @@ class NettyRemotingServer {
     private void initNettyChannel(SocketChannel ch) {
         ch.pipeline()
                 .addLast("encoder", new TransporterEncoder())
-                .addLast("decoder", new TransporterDecoder())
+                .addLast("decoder", new TransporterDecoder(serverConfig.getMaxFrameSize()))
                 .addLast("server-idle-handle",
                         new IdleStateHandler(serverConfig.getConnectionIdleTime(), 0, 0, TimeUnit.MILLISECONDS))
                 .addLast("handler", channelHandler);


### PR DESCRIPTION
## Description

Fix #18459 — Add `maxFrameSize` check to `TransporterDecoder` to prevent OOM when processing large RPC responses.

### Problem

`TransporterDecoder` allocates `new byte[bodyLength]` without any size validation. When a large task log response (>200MB) is received, the JVM can run out of memory attempting to allocate the byte array.

### Changes

1. **TransporterDecoder.java**: Added `maxFrameSize` field (default 100MB) with a configurable constructor. The `BODY_LENGTH` case now throws `IllegalArgumentException` if `bodyLength > maxFrameSize`.

2. **NettyServerConfig.java**: Added `maxFrameSize` field (default 100MB).

3. **NettyClientConfig.java**: Added `maxFrameSize` field (default 100MB).

4. **NettyRemotingServer.java**: Passes `serverConfig.getMaxFrameSize()` to the decoder.

5. **NettyRemotingClient.java**: Passes `clientConfig.getMaxFrameSize()` to the decoder.

### Note

This PR addresses the OOM prevention (frame size guard). The second concern from the issue — streaming large task logs in chunks rather than a single RPC — is a separate enhancement and is not covered here.