### PR TITLE
[Fix-18459][api] Stream oversized task log download in bounded chunks

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/ApiConfig.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/configuration/ApiConfig.java
@@ -45,6 +45,12 @@ public class ApiConfig implements Validator {
     private String uiUrl;
     private boolean auditEnable = false;
 
+    /**
+     * Maximum number of log lines that can be queried in a single request.
+     * Used by LoggerController/LoggerServiceImpl to clamp the limit parameter.
+     */
+    private int maxLogQueryLimit = 10000;
+
     private TrafficConfiguration trafficControl = new TrafficConfiguration();
 
     private PythonGatewayConfiguration pythonGateway = new PythonGatewayConfiguration();
@@ -70,6 +76,7 @@ public class ApiConfig implements Validator {
         log.info("API config: baseUrl -> {} ", baseUrl);
         log.info("API config: uiUrl -> {} ", uiUrl);
         log.info("API config: auditEnable -> {} ", auditEnable);
+        log.info("API config: maxLogQueryLimit -> {} ", maxLogQueryLimit);
         log.info("API config: trafficControl -> {} ", trafficControl);
         log.info("API config: pythonGateway -> {} ", pythonGateway);
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -99,14 +100,18 @@ public class LoggerController extends BaseController {
     @GetMapping(value = "/download-log")
     @ResponseBody
     @ApiException(DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR)
-    public ResponseEntity downloadTaskLog(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                          @RequestParam(value = "taskInstanceId") int taskInstanceId) {
-        byte[] logBytes = loggerService.getLogBytes(loginUser, taskInstanceId);
+    public ResponseEntity<StreamingResponseBody> downloadTaskLog(
+                                                                 @Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                 @RequestParam(value = "taskInstanceId") int taskInstanceId) {
+        // Stream the log in bounded chunks instead of buffering the whole file into a byte[],
+        // so an oversized task log can be downloaded without OOM-ing the API server.
+        final StreamingResponseBody body =
+                outputStream -> loggerService.streamLogBytes(loginUser, taskInstanceId, outputStream);
         return ResponseEntity
                 .ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION,
                         "attachment; filename=\"" + System.currentTimeMillis() + ".log" + "\"")
-                .body(logBytes);
+                .body(body);
     }
 
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
@@ -75,6 +75,9 @@ public class LoggerController extends BaseController {
                                             @RequestParam(value = "taskInstanceId") int taskInstanceId,
                                             @RequestParam(value = "skipLineNum") int skipNum,
                                             @RequestParam(value = "limit") int limit) {
+        // Clamp parameters to prevent excessive memory allocation
+        skipNum = Math.max(skipNum, 0);
+        limit = Math.min(Math.max(limit, 1), LoggerService.MAX_LOG_QUERY_LIMIT);
         return loggerService.queryLog(loginUser, taskInstanceId, skipNum, limit);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
@@ -21,6 +21,7 @@ import static org.apache.dolphinscheduler.api.enums.Status.DOWNLOAD_TASK_INSTANC
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_TASK_INSTANCE_LOG_ERROR;
 
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
+import org.apache.dolphinscheduler.api.configuration.ApiConfig;
 import org.apache.dolphinscheduler.api.service.LoggerService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;
@@ -53,6 +54,9 @@ public class LoggerController extends BaseController {
     @Autowired
     private LoggerService loggerService;
 
+    @Autowired
+    private ApiConfig apiConfig;
+
     /**
      * query task log
      *
@@ -77,7 +81,7 @@ public class LoggerController extends BaseController {
                                             @RequestParam(value = "limit") int limit) {
         // Clamp parameters to prevent excessive memory allocation
         skipNum = Math.max(skipNum, 0);
-        limit = Math.min(Math.max(limit, 1), LoggerService.MAX_LOG_QUERY_LIMIT);
+        limit = Math.min(Math.max(limit, 1), apiConfig.getMaxLogQueryLimit());
         return loggerService.queryLog(loginUser, taskInstanceId, skipNum, limit);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/LoggerController.java
@@ -20,8 +20,8 @@ package org.apache.dolphinscheduler.api.controller;
 import static org.apache.dolphinscheduler.api.enums.Status.DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_TASK_INSTANCE_LOG_ERROR;
 
-import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.configuration.ApiConfig;
+import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.LoggerService;
 import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.common.constants.Constants;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ResourcesController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ResourcesController.java
@@ -314,8 +314,8 @@ public class ResourcesController extends BaseController {
         FetchFileContentRequest fetchFileContentRequest = FetchFileContentRequest.builder()
                 .loginUser(loginUser)
                 .resourceFileAbsolutePath(resourceAbsoluteFilePath)
-                .limit(limit == -1 ? Integer.MAX_VALUE : limit)
-                .skipLineNum(skipLineNum)
+                .limit(Math.min(Math.max(limit, 1), 10000))
+                .skipLineNum(Math.max(skipLineNum, 0))
                 .build();
         return Result.success(resourceService.fetchResourceFileContent(fetchFileContentRequest));
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClient.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClient.java
@@ -20,6 +20,8 @@ package org.apache.dolphinscheduler.api.executor.logging;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.extract.base.client.Clients;
 import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -64,6 +66,21 @@ public class LocalLogClient {
                 taskInstance.getId(),
                 taskInstance.getLogPath());
         return getProxyLogService(taskInstance).getTaskInstanceWholeLogFileBytes(request);
+    }
+
+    /**
+     * Fetch a single bounded chunk {@code [offset, offset + length)} of the task instance log from
+     * the worker that hosts it. Used by the streaming download path.
+     */
+    public TaskInstanceLogFileChunkResponse getLogChunk(final TaskInstance taskInstance, final long offset,
+                                                        final int length) {
+        final TaskInstanceLogFileChunkRequest request = TaskInstanceLogFileChunkRequest.builder()
+                .taskInstanceId(taskInstance.getId())
+                .taskInstanceLogAbsolutePath(taskInstance.getLogPath())
+                .offset(offset)
+                .length(length)
+                .build();
+        return getProxyLogService(taskInstance).getTaskInstanceLogFileChunk(request);
     }
 
     private TaskInstanceLogPageQueryResponse getLocalPartLog(TaskInstance taskInstance, int skipLineNum,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
@@ -17,13 +17,18 @@
 
 package org.apache.dolphinscheduler.api.executor.logging;
 
+import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -86,6 +91,77 @@ public class LogClientDelegate {
             }
         } else {
             return remoteLogClient.getWholeLog(taskInstance);
+        }
+    }
+
+    /**
+     * Stream the entire task instance log to {@code outputStream} in fixed-size chunks, keeping
+     * memory bounded regardless of total log size. Prefers the worker (RPC chunked); if the worker
+     * node is gone or chunking fails, falls back to remote storage, then to the legacy whole-file
+     * byte[] read as a last resort — so behavior never regresses below the pre-fix baseline.
+     */
+    public void streamWholeLog(final TaskInstance taskInstance, final OutputStream outputStream) throws IOException {
+        checkArgs(taskInstance);
+        if (checkNodeExists(taskInstance)) {
+            if (streamFromLocalWorker(taskInstance, outputStream)) {
+                outputStream.flush();
+                return;
+            }
+            log.warn("Streaming from worker failed for task instance {}, falling back to remote storage",
+                    taskInstance.getId());
+        }
+        if (!streamFromRemote(taskInstance, outputStream)) {
+            log.warn("Streaming from remote failed for task instance {}, falling back to legacy whole-file read",
+                    taskInstance.getId());
+            final byte[] bytes = getWholeLogBytes(taskInstance);
+            outputStream.write(bytes);
+        }
+        outputStream.flush();
+    }
+
+    private boolean streamFromLocalWorker(final TaskInstance taskInstance,
+                                          final OutputStream outputStream) throws IOException {
+        long offset = 0;
+        while (true) {
+            final TaskInstanceLogFileChunkResponse chunk = localLogClient.getLogChunk(taskInstance, offset,
+                    LogUtils.MAX_LOG_CHUNK_SIZE);
+            if (chunk.getCode() != LogResponseStatus.SUCCESS) {
+                log.warn("Worker chunk request failed for task instance {}; reason: {}",
+                        taskInstance.getId(), chunk.getMessage());
+                return false;
+            }
+            final byte[] bytes = chunk.getBytes();
+            if (bytes == null || bytes.length == 0) {
+                return true; // empty file or EOF
+            }
+            outputStream.write(bytes);
+            offset += bytes.length;
+            if (chunk.isEof()) {
+                return true;
+            }
+        }
+    }
+
+    private boolean streamFromRemote(final TaskInstance taskInstance,
+                                     final OutputStream outputStream) throws IOException {
+        long offset = 0;
+        while (true) {
+            final TaskInstanceLogFileChunkResponse chunk = remoteLogClient.getLogChunk(taskInstance, offset,
+                    LogUtils.MAX_LOG_CHUNK_SIZE);
+            if (chunk.getCode() != LogResponseStatus.SUCCESS) {
+                log.warn("Remote chunk request failed for task instance {}; reason: {}",
+                        taskInstance.getId(), chunk.getMessage());
+                return false;
+            }
+            final byte[] bytes = chunk.getBytes();
+            if (bytes == null || bytes.length == 0) {
+                return true;
+            }
+            outputStream.write(bytes);
+            offset += bytes.length;
+            if (chunk.isEof()) {
+                return true;
+            }
         }
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
@@ -97,70 +97,99 @@ public class LogClientDelegate {
     /**
      * Stream the entire task instance log to {@code outputStream} in fixed-size chunks, keeping
      * memory bounded regardless of total log size. Prefers the worker (RPC chunked); if the worker
-     * node is gone or chunking fails, falls back to remote storage, then to the legacy whole-file
-     * byte[] read as a last resort — so behavior never regresses below the pre-fix baseline.
+     * node is gone, falls back to remote storage, then to the legacy whole-file byte[] read.
+     *
+     * <p>If a streaming source fails <b>after</b> bytes have already been written to the output, no
+     * fallback is attempted — restarting from offset 0 would duplicate the prefix and corrupt the
+     * downloaded file. Instead an {@link IOException} is thrown so the caller can surface the
+     * truncation. Fallback only happens when nothing has been written yet (e.g. the worker is
+     * unreachable on the first chunk).
      */
     public void streamWholeLog(final TaskInstance taskInstance, final OutputStream outputStream) throws IOException {
         checkArgs(taskInstance);
         if (checkNodeExists(taskInstance)) {
-            if (streamFromLocalWorker(taskInstance, outputStream)) {
+            final long[] written = {0};
+            try {
+                streamFromLocalWorker(taskInstance, outputStream, written);
                 outputStream.flush();
                 return;
+            } catch (IOException | RuntimeException e) {
+                if (written[0] > 0) {
+                    throw new IOException("Worker streaming failed after " + written[0]
+                            + " bytes written; cannot fall back without corrupting the stream", e);
+                }
+                log.warn("Streaming from worker failed before any byte was written for task instance {}, "
+                        + "falling back to remote storage", taskInstance.getId(), e);
             }
-            log.warn("Streaming from worker failed for task instance {}, falling back to remote storage",
-                    taskInstance.getId());
         }
-        if (!streamFromRemote(taskInstance, outputStream)) {
-            log.warn("Streaming from remote failed for task instance {}, falling back to legacy whole-file read",
-                    taskInstance.getId());
-            final byte[] bytes = getWholeLogBytes(taskInstance);
-            outputStream.write(bytes);
+        final long[] written = {0};
+        try {
+            streamFromRemote(taskInstance, outputStream, written);
+            outputStream.flush();
+            return;
+        } catch (IOException | RuntimeException e) {
+            if (written[0] > 0) {
+                throw new IOException("Remote streaming failed after " + written[0]
+                        + " bytes written; cannot fall back to legacy whole-file read without corrupting the stream",
+                        e);
+            }
+            log.warn("Streaming from remote failed before any byte was written for task instance {}, "
+                    + "falling back to legacy whole-file read", taskInstance.getId(), e);
         }
+        final byte[] bytes = getWholeLogBytes(taskInstance);
+        outputStream.write(bytes);
         outputStream.flush();
     }
 
-    private boolean streamFromLocalWorker(final TaskInstance taskInstance,
-                                          final OutputStream outputStream) throws IOException {
+    private void streamFromLocalWorker(final TaskInstance taskInstance, final OutputStream outputStream,
+                                       final long[] written) throws IOException {
         long offset = 0;
         while (true) {
             final TaskInstanceLogFileChunkResponse chunk = localLogClient.getLogChunk(taskInstance, offset,
                     LogUtils.MAX_LOG_CHUNK_SIZE);
             if (chunk.getCode() != LogResponseStatus.SUCCESS) {
-                log.warn("Worker chunk request failed for task instance {}; reason: {}",
-                        taskInstance.getId(), chunk.getMessage());
-                return false;
+                throw new IOException("Worker chunk request failed for task instance " + taskInstance.getId()
+                        + "; reason: " + chunk.getMessage());
             }
             final byte[] bytes = chunk.getBytes();
             if (bytes == null || bytes.length == 0) {
-                return true; // empty file or EOF
+                return; // empty file or EOF
             }
             outputStream.write(bytes);
+            written[0] += bytes.length;
             offset += bytes.length;
             if (chunk.isEof()) {
-                return true;
+                return;
             }
         }
     }
 
-    private boolean streamFromRemote(final TaskInstance taskInstance,
-                                     final OutputStream outputStream) throws IOException {
+    private void streamFromRemote(final TaskInstance taskInstance, final OutputStream outputStream,
+                                  final long[] written) throws IOException {
+        // Sync the remote object to a local file exactly once, then read ranges of that local file,
+        // instead of re-syncing the whole remote object on every chunk (a 1GB log / 1MB chunk would
+        // otherwise re-download the entire object 1024 times).
+        final java.io.File localFile = remoteLogClient.prepareLocalLog(taskInstance);
+        if (localFile == null) {
+            throw new IOException("Remote log prepare failed for task instance " + taskInstance.getId());
+        }
         long offset = 0;
         while (true) {
-            final TaskInstanceLogFileChunkResponse chunk = remoteLogClient.getLogChunk(taskInstance, offset,
-                    LogUtils.MAX_LOG_CHUNK_SIZE);
+            final TaskInstanceLogFileChunkResponse chunk =
+                    remoteLogClient.getLocalLogChunk(localFile, offset, LogUtils.MAX_LOG_CHUNK_SIZE);
             if (chunk.getCode() != LogResponseStatus.SUCCESS) {
-                log.warn("Remote chunk request failed for task instance {}; reason: {}",
-                        taskInstance.getId(), chunk.getMessage());
-                return false;
+                throw new IOException(
+                        "Remote chunk read failed at offset " + offset + ": " + chunk.getMessage());
             }
             final byte[] bytes = chunk.getBytes();
             if (bytes == null || bytes.length == 0) {
-                return true;
+                return;
             }
             outputStream.write(bytes);
+            written[0] += bytes.length;
             offset += bytes.length;
             if (chunk.isEof()) {
-                return true;
+                return;
             }
         }
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegate.java
@@ -97,7 +97,7 @@ public class LogClientDelegate {
     /**
      * Stream the entire task instance log to {@code outputStream} in fixed-size chunks, keeping
      * memory bounded regardless of total log size. Prefers the worker (RPC chunked); if the worker
-     * node is gone, falls back to remote storage, then to the legacy whole-file byte[] read.
+     * node is gone, falls back to remote storage. If both fail, the exception is propagated.
      *
      * <p>If a streaming source fails <b>after</b> bytes have already been written to the output, no
      * fallback is attempted — restarting from offset 0 would duplicate the prefix and corrupt the
@@ -130,15 +130,10 @@ public class LogClientDelegate {
         } catch (IOException | RuntimeException e) {
             if (written[0] > 0) {
                 throw new IOException("Remote streaming failed after " + written[0]
-                        + " bytes written; cannot fall back to legacy whole-file read without corrupting the stream",
-                        e);
+                        + " bytes written; cannot fall back without corrupting the stream", e);
             }
-            log.warn("Streaming from remote failed before any byte was written for task instance {}, "
-                    + "falling back to legacy whole-file read", taskInstance.getId(), e);
+            throw new IOException("Log streaming failed for task instance " + taskInstance.getId(), e);
         }
-        final byte[] bytes = getWholeLogBytes(taskInstance);
-        outputStream.write(bytes);
-        outputStream.flush();
     }
 
     private void streamFromLocalWorker(final TaskInstance taskInstance, final OutputStream outputStream,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/RemoteLogClient.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/RemoteLogClient.java
@@ -27,8 +27,11 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.File;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class RemoteLogClient {
 
@@ -44,26 +47,41 @@ public class RemoteLogClient {
     }
 
     /**
-     * Fetch a single bounded chunk of the task instance log from remote storage. The remote object
-     * is first synced to a local file (idempotent), then a range of that local file is read, so
-     * memory stays bounded regardless of total log size.
+     * Sync the remote log object to its local path exactly once for a streaming session, and return
+     * the local {@link File}. Returns {@code null} if the file is absent after sync or sync fails.
+     * Subsequent chunk reads should use {@link #getLocalLogChunk(File, long, int)} so the remote
+     * object is not re-downloaded on every chunk (a 1GB log / 1MB chunk would otherwise re-download
+     * the whole object 1024 times).
      */
-    public TaskInstanceLogFileChunkResponse getLogChunk(final TaskInstance taskInstance, final long offset,
-                                                        final int length) {
-        final TaskInstanceLogFileChunkResponse response = new TaskInstanceLogFileChunkResponse();
+    public File prepareLocalLog(final TaskInstance taskInstance) {
+        final String logPath = taskInstance.getLogPath();
         try {
-            final String logPath = taskInstance.getLogPath();
             RemoteLogUtils.getRemoteLog(logPath);
             final File localFile = new File(logPath);
             if (!localFile.exists() || !localFile.isFile()) {
-                response.setCode(LogResponseStatus.LOG_FILE_NOT_FOUND);
-                response.setMessage("Remote log file: " + logPath + " not exists locally after sync");
-                return response;
+                log.warn("Remote log file: {} not exists locally after sync", logPath);
+                return null;
             }
+            return localFile;
+        } catch (Exception e) {
+            log.error("prepareLocalLog failed for {}", logPath, e);
+            return null;
+        }
+    }
+
+    /**
+     * Read a single bounded chunk from an already-synced local file (no remote sync). Used in a loop
+     * after {@link #prepareLocalLog(TaskInstance)} so a multi-GB log is pulled from remote storage
+     * only once.
+     */
+    public TaskInstanceLogFileChunkResponse getLocalLogChunk(final File localFile, final long offset,
+                                                             final int length) {
+        final TaskInstanceLogFileChunkResponse response = new TaskInstanceLogFileChunkResponse();
+        try {
             final long fileSize = localFile.length();
             final int len = Math.min(Math.max(length, 1), LogUtils.MAX_LOG_CHUNK_SIZE);
             final long off = Math.max(offset, 0);
-            final byte[] bytes = LogUtils.readFileRange(logPath, off, len);
+            final byte[] bytes = LogUtils.readFileRange(localFile.getAbsolutePath(), off, len);
             response.setBytes(bytes);
             response.setFileSize(fileSize);
             response.setEof(off + bytes.length >= fileSize);
@@ -72,6 +90,23 @@ public class RemoteLogClient {
             response.setMessage(ExceptionUtils.getRootCauseMessage(e));
         }
         return response;
+    }
+
+    /**
+     * Fetch a single bounded chunk from remote storage. Convenience method that syncs then reads one
+     * chunk; for multi-chunk streaming use {@link #prepareLocalLog} + {@link #getLocalLogChunk} to
+     * avoid re-syncing on every chunk.
+     */
+    public TaskInstanceLogFileChunkResponse getLogChunk(final TaskInstance taskInstance, final long offset,
+                                                        final int length) {
+        final File localFile = prepareLocalLog(taskInstance);
+        if (localFile == null) {
+            final TaskInstanceLogFileChunkResponse response = new TaskInstanceLogFileChunkResponse();
+            response.setCode(LogResponseStatus.LOG_FILE_NOT_FOUND);
+            response.setMessage("Remote log file not exists locally after sync");
+            return response;
+        }
+        return getLocalLogChunk(localFile, offset, length);
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/RemoteLogClient.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/executor/logging/RemoteLogClient.java
@@ -17,8 +17,15 @@
 
 package org.apache.dolphinscheduler.api.executor.logging;
 
+import org.apache.dolphinscheduler.common.log.remote.RemoteLogUtils;
 import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.io.File;
 
 import org.springframework.stereotype.Component;
 
@@ -34,6 +41,37 @@ public class RemoteLogClient {
      */
     public byte[] getWholeLog(TaskInstance taskInstance) {
         return LogUtils.getFileContentBytesFromRemote(taskInstance.getLogPath());
+    }
+
+    /**
+     * Fetch a single bounded chunk of the task instance log from remote storage. The remote object
+     * is first synced to a local file (idempotent), then a range of that local file is read, so
+     * memory stays bounded regardless of total log size.
+     */
+    public TaskInstanceLogFileChunkResponse getLogChunk(final TaskInstance taskInstance, final long offset,
+                                                        final int length) {
+        final TaskInstanceLogFileChunkResponse response = new TaskInstanceLogFileChunkResponse();
+        try {
+            final String logPath = taskInstance.getLogPath();
+            RemoteLogUtils.getRemoteLog(logPath);
+            final File localFile = new File(logPath);
+            if (!localFile.exists() || !localFile.isFile()) {
+                response.setCode(LogResponseStatus.LOG_FILE_NOT_FOUND);
+                response.setMessage("Remote log file: " + logPath + " not exists locally after sync");
+                return response;
+            }
+            final long fileSize = localFile.length();
+            final int len = Math.min(Math.max(length, 1), LogUtils.MAX_LOG_CHUNK_SIZE);
+            final long off = Math.max(offset, 0);
+            final byte[] bytes = LogUtils.readFileRange(logPath, off, len);
+            response.setBytes(bytes);
+            response.setFileSize(fileSize);
+            response.setEof(off + bytes.length >= fileSize);
+        } catch (Exception e) {
+            response.setCode(LogResponseStatus.ERROR);
+            response.setMessage(ExceptionUtils.getRootCauseMessage(e));
+        }
+        return response;
     }
 
     /**

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/LoggerService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/LoggerService.java
@@ -24,6 +24,11 @@ import org.apache.dolphinscheduler.dao.entity.User;
 public interface LoggerService {
 
     /**
+     * Maximum number of log lines that can be queried in a single request.
+     */
+    int MAX_LOG_QUERY_LIMIT = 10000;
+
+    /**
      * view log
      *
      * @param loginUser   login user

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/LoggerService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/LoggerService.java
@@ -21,6 +21,8 @@ import org.apache.dolphinscheduler.api.utils.Result;
 import org.apache.dolphinscheduler.dao.entity.ResponseTaskLog;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.io.OutputStream;
+
 public interface LoggerService {
 
     /**
@@ -42,6 +44,16 @@ public interface LoggerService {
      * @return log byte array
      */
     byte[] getLogBytes(User loginUser, int taskInstId);
+
+    /**
+     * Stream the task instance log to the given output stream in bounded chunks, so that downloading
+     * a very large task log never loads the whole file into memory (no OOM, no truncation).
+     *
+     * @param loginUser    login user
+     * @param taskInstId   task instance id
+     * @param outputStream sink the log content is streamed to
+     */
+    void streamLogBytes(User loginUser, int taskInstId, OutputStream outputStream);
 
     /**
      * query log

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/LoggerService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/LoggerService.java
@@ -24,11 +24,6 @@ import org.apache.dolphinscheduler.dao.entity.User;
 public interface LoggerService {
 
     /**
-     * Maximum number of log lines that can be queried in a single request.
-     */
-    int MAX_LOG_QUERY_LIMIT = 10000;
-
-    /**
      * view log
      *
      * @param loginUser   login user

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -39,6 +39,7 @@ import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import lombok.extern.slf4j.Slf4j;
@@ -236,6 +237,32 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
         try {
             logBytes = logClientDelegate.getWholeLogBytes(taskInstance);
             return Bytes.concat(head, logBytes);
+        } catch (Exception ex) {
+            log.error("Download TaskInstance: {} Log Error", taskInstance.getName(), ex);
+            throw new ServiceException(Status.DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR);
+        }
+    }
+
+    /**
+     * Stream the task instance log to {@code outputStream} in bounded chunks. Unlike
+     * {@link #getLogBytes(User, int)}, this never holds the whole log file in memory, so downloading
+     * an oversized log cannot OOM the API server.
+     */
+    @Override
+    public void streamLogBytes(final User loginUser, final int taskInstId, final OutputStream outputStream) {
+        final TaskInstance taskInstance = taskInstanceDao.queryById(taskInstId);
+        if (taskInstance == null || StringUtils.isBlank(taskInstance.getHost())) {
+            throw new ServiceException("task instance is null or host is null");
+        }
+        final Project project = projectDao.queryProjectByTaskInstanceId(taskInstId);
+        projectService.checkProjectAndAuthThrowException(loginUser, project, DOWNLOAD_LOG);
+        try {
+            final byte[] head = String.format(LOG_HEAD_FORMAT,
+                    taskInstance.getLogPath(),
+                    taskInstance.getHost(),
+                    Constants.SYSTEM_LINE_SEPARATOR).getBytes(StandardCharsets.UTF_8);
+            outputStream.write(head);
+            logClientDelegate.streamWholeLog(taskInstance, outputStream);
         } catch (Exception ex) {
             log.error("Download TaskInstance: {} Log Error", taskInstance.getName(), ex);
             throw new ServiceException(Status.DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -20,10 +20,10 @@ package org.apache.dolphinscheduler.api.service.impl;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.DOWNLOAD_LOG;
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.VIEW_LOG;
 
+import org.apache.dolphinscheduler.api.configuration.ApiConfig;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.executor.logging.LogClientDelegate;
-import org.apache.dolphinscheduler.api.configuration.ApiConfig;
 import org.apache.dolphinscheduler.api.service.LoggerService;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.utils.Result;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -38,7 +38,9 @@ import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
 import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -264,8 +266,20 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
             outputStream.write(head);
             logClientDelegate.streamWholeLog(taskInstance, outputStream);
         } catch (Exception ex) {
-            log.error("Download TaskInstance: {} Log Error", taskInstance.getName(), ex);
-            throw new ServiceException(Status.DOWNLOAD_TASK_INSTANCE_LOG_FILE_ERROR);
+            // Response is already committed (HTTP 200 + head written); cannot change status.
+            // Log the root cause server-side and append a visible trailer so the client knows the
+            // download was truncated. Do NOT rethrow — it cannot change the status and only adds
+            // a confusing error-log entry.
+            log.error("Download TaskInstance: {} Log Error (stream truncated)", taskInstance.getName(), ex);
+            try {
+                final String trailer = "\n\n[LOG-DOWNLOAD-ERROR] download failed: "
+                        + ExceptionUtils.getRootCauseMessage(ex)
+                        + " (stream truncated)\n";
+                outputStream.write(trailer.getBytes(StandardCharsets.UTF_8));
+                outputStream.flush();
+            } catch (IOException ioe) {
+                log.warn("Failed to write error trailer for task instance {}", taskInstance.getId(), ioe);
+            }
         }
     }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -23,6 +23,7 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.executor.logging.LogClientDelegate;
+import org.apache.dolphinscheduler.api.configuration.ApiConfig;
 import org.apache.dolphinscheduler.api.service.LoggerService;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.utils.Result;
@@ -67,6 +68,9 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
 
     @Autowired
     private LogClientDelegate logClientDelegate;
+
+    @Autowired
+    private ApiConfig apiConfig;
 
     /**
      * view log
@@ -182,7 +186,7 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
     private String queryLog(TaskInstance taskInstance, int skipLineNum, int limit) {
         // Defensive clamp: even if controller validation is bypassed
         skipLineNum = Math.max(skipLineNum, 0);
-        limit = Math.min(Math.max(limit, 1), LoggerService.MAX_LOG_QUERY_LIMIT);
+        limit = Math.min(Math.max(limit, 1), apiConfig.getMaxLogQueryLimit());
 
         final String logPath = taskInstance.getLogPath();
         log.info("Query task instance log, taskInstanceId:{}, taskInstanceName:{}, host: {}, logPath:{}",

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImpl.java
@@ -180,6 +180,10 @@ public class LoggerServiceImpl extends BaseServiceImpl implements LoggerService 
      * @return log string data
      */
     private String queryLog(TaskInstance taskInstance, int skipLineNum, int limit) {
+        // Defensive clamp: even if controller validation is bypassed
+        skipLineNum = Math.max(skipLineNum, 0);
+        limit = Math.min(Math.max(limit, 1), LoggerService.MAX_LOG_QUERY_LIMIT);
+
         final String logPath = taskInstance.getLogPath();
         log.info("Query task instance log, taskInstanceId:{}, taskInstanceName:{}, host: {}, logPath:{}",
                 taskInstance.getId(), taskInstance.getName(), taskInstance.getHost(), logPath);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -68,6 +68,7 @@ import org.apache.dolphinscheduler.api.validator.resource.UpdateFileRequestTrans
 import org.apache.dolphinscheduler.api.vo.ResourceItemVO;
 import org.apache.dolphinscheduler.api.vo.resources.FetchFileContentResponse;
 import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.dao.entity.Tenant;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
@@ -79,6 +80,7 @@ import org.apache.dolphinscheduler.spi.enums.ResourceType;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -319,13 +321,29 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                 .build();
         fetchFileContentDtoValidator.validate(fetchFileContentDto);
 
-        String content = storageOperator
+        List<String> lines = storageOperator
                 .fetchFileContent(
                         fetchFileContentRequest.getResourceFileAbsolutePath(),
                         fetchFileContentRequest.getSkipLineNum(),
-                        fetchFileContentRequest.getLimit())
-                .stream()
-                .collect(Collectors.joining("\n"));
+                        fetchFileContentRequest.getLimit());
+
+        final int maxContentBytes = LogUtils.MAX_RESPONSE_LOG_SIZE;
+        StringBuilder contentBuilder = new StringBuilder();
+        int totalBytes = 0;
+        for (String line : lines) {
+            int lineBytes = line.getBytes(StandardCharsets.UTF_8).length;
+            if (totalBytes + lineBytes > maxContentBytes && contentBuilder.length() > 0) {
+                contentBuilder.append("\n[... content truncated at ").append(maxContentBytes).append(" bytes ...]");
+                break;
+            }
+            if (contentBuilder.length() > 0) {
+                contentBuilder.append("\n");
+                totalBytes += 1;
+            }
+            contentBuilder.append(line);
+            totalBytes += lineBytes;
+        }
+        String content = contentBuilder.toString();
 
         ApiServerMetrics.recordApiResourceDownloadSize(content.length());
 

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -142,6 +142,8 @@ api:
   base-url: http://127.0.0.1:12345/dolphinscheduler
   ui-url: http://127.0.0.1:5173
   audit-enable: false
+  # Maximum number of log lines that can be queried in a single request
+  max-log-query-limit: 10000
   # Traffic control, if you turn on this config, the maximum number of request/s will be limited.
   # global max request number per second
   # default tenant-level max request number

--- a/dolphinscheduler-api/src/main/resources/application.yaml
+++ b/dolphinscheduler-api/src/main/resources/application.yaml
@@ -78,6 +78,11 @@ spring:
       matching-strategy: ANT_PATH_MATCHER
     static-path-pattern: /static/**
     dispatch-trace-request: false
+    # Streaming log download (download-log) runs as an async StreamingResponseBody and may take
+    # minutes for multi-GB logs. The default async timeout (Jetty 30s) would cut large downloads
+    # off mid-stream. 600000ms = 10 min covers large logs; does not affect non-async requests.
+    async:
+      request-timeout: 600000
   cloud.discovery.client.composite-indicator.enabled: false
 
 springdoc:

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClientTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LocalLogClientTest.java
@@ -27,6 +27,8 @@ import org.apache.dolphinscheduler.extract.base.config.NettyServerConfig;
 import org.apache.dolphinscheduler.extract.base.server.SpringServerMethodInvokerDiscovery;
 import org.apache.dolphinscheduler.extract.common.ILogService;
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -92,6 +94,12 @@ public class LocalLogClientTest {
                 }
 
                 return new TaskInstanceLogPageQueryResponse();
+            }
+
+            @Override
+            public TaskInstanceLogFileChunkResponse getTaskInstanceLogFileChunk(
+                                                                                TaskInstanceLogFileChunkRequest taskInstanceLogFileChunkRequest) {
+                return new TaskInstanceLogFileChunkResponse(new byte[0], true, 0, LogResponseStatus.SUCCESS, null);
             }
 
             @Override

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegateTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegateTest.java
@@ -21,15 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -148,5 +154,67 @@ public class LogClientDelegateTest {
 
         byte[] result = logClientDelegate.getWholeLogBytes(taskInstance);
         assertArrayEquals("remoteLogBytes".getBytes(), result);
+    }
+
+    @Test
+    public void testStreamWholeLogConcatenatesWorkerChunks() throws Exception {
+        TaskInstance taskInstance = newTaskInstance("SHELL");
+        byte[] full = "0123456789ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8);
+
+        when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(true);
+        when(localLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+                .thenReturn(chunk(full, 0, 10, 20, false))
+                .thenReturn(chunk(full, 10, 10, 20, true));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        logClientDelegate.streamWholeLog(taskInstance, out);
+
+        assertArrayEquals(full, out.toByteArray());
+    }
+
+    @Test
+    public void testStreamWholeLogFallsBackToRemoteWhenWorkerFails() throws Exception {
+        TaskInstance taskInstance = newTaskInstance("SHELL");
+        byte[] full = "REMOTE-CONTENT".getBytes(StandardCharsets.UTF_8);
+
+        when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(true);
+        when(localLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+                .thenReturn(new TaskInstanceLogFileChunkResponse(null, false, 0, LogResponseStatus.ERROR, "down"));
+        when(remoteLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+                .thenReturn(chunk(full, 0, full.length, full.length, true));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        logClientDelegate.streamWholeLog(taskInstance, out);
+
+        assertArrayEquals(full, out.toByteArray());
+    }
+
+    @Test
+    public void testStreamWholeLogNodeGoneStreamsFromRemote() throws Exception {
+        TaskInstance taskInstance = newTaskInstance("SHELL");
+        byte[] full = "DIRECT-REMOTE".getBytes(StandardCharsets.UTF_8);
+
+        when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(false);
+        when(remoteLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+                .thenReturn(chunk(full, 0, full.length, full.length, true));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        logClientDelegate.streamWholeLog(taskInstance, out);
+
+        assertArrayEquals(full, out.toByteArray());
+    }
+
+    private static TaskInstance newTaskInstance(String taskType) {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setId(1);
+        taskInstance.setHost("localhost");
+        taskInstance.setTaskType(taskType);
+        return taskInstance;
+    }
+
+    private static TaskInstanceLogFileChunkResponse chunk(byte[] full, int off, int len, int size, boolean eof) {
+        byte[] b = new byte[len];
+        System.arraycopy(full, off, b, 0, len);
+        return new TaskInstanceLogFileChunkResponse(b, eof, size, LogResponseStatus.SUCCESS, null);
     }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegateTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/executor/logging/LogClientDelegateTest.java
@@ -20,10 +20,14 @@ package org.apache.dolphinscheduler.api.executor.logging;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
@@ -35,6 +39,8 @@ import org.apache.dolphinscheduler.registry.api.RegistryClient;
 import org.apache.dolphinscheduler.registry.api.enums.RegistryNodeType;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
@@ -176,32 +182,66 @@ public class LogClientDelegateTest {
     public void testStreamWholeLogFallsBackToRemoteWhenWorkerFails() throws Exception {
         TaskInstance taskInstance = newTaskInstance("SHELL");
         byte[] full = "REMOTE-CONTENT".getBytes(StandardCharsets.UTF_8);
+        File localFile = File.createTempFile("ds-remote-test", ".log");
 
         when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(true);
         when(localLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
                 .thenReturn(new TaskInstanceLogFileChunkResponse(null, false, 0, LogResponseStatus.ERROR, "down"));
-        when(remoteLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+        when(remoteLogClient.prepareLocalLog(taskInstance)).thenReturn(localFile);
+        when(remoteLogClient.getLocalLogChunk(eq(localFile), anyLong(), anyInt()))
                 .thenReturn(chunk(full, 0, full.length, full.length, true));
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         logClientDelegate.streamWholeLog(taskInstance, out);
 
         assertArrayEquals(full, out.toByteArray());
+        // remote object synced exactly once (not per-chunk)
+        verify(remoteLogClient, times(1)).prepareLocalLog(taskInstance);
     }
 
     @Test
     public void testStreamWholeLogNodeGoneStreamsFromRemote() throws Exception {
         TaskInstance taskInstance = newTaskInstance("SHELL");
         byte[] full = "DIRECT-REMOTE".getBytes(StandardCharsets.UTF_8);
+        File localFile = File.createTempFile("ds-remote-test", ".log");
 
         when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(false);
-        when(remoteLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+        when(remoteLogClient.prepareLocalLog(taskInstance)).thenReturn(localFile);
+        when(remoteLogClient.getLocalLogChunk(eq(localFile), anyLong(), anyInt()))
                 .thenReturn(chunk(full, 0, full.length, full.length, true));
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         logClientDelegate.streamWholeLog(taskInstance, out);
 
         assertArrayEquals(full, out.toByteArray());
+        verify(remoteLogClient, times(1)).prepareLocalLog(taskInstance);
+    }
+
+    /**
+     * Regression: if the worker fails AFTER some bytes are already written, the delegate must NOT
+     * fall back (restarting from offset 0 would duplicate the prefix and corrupt the download).
+     * It must throw, and the output must contain exactly what was written before the failure.
+     */
+    @Test
+    public void testStreamWholeLogThrowsWhenWorkerFailsAfterPartialWrite() throws Exception {
+        TaskInstance taskInstance = newTaskInstance("SHELL");
+        byte[] full = "0123456789ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8);
+
+        when(registryClient.checkNodeExists(eq(taskInstance.getHost()), any())).thenReturn(true);
+        // first chunk succeeds (10 bytes, eof=false); second chunk fails
+        when(localLogClient.getLogChunk(eq(taskInstance), anyLong(), anyInt()))
+                .thenReturn(chunk(full, 0, 10, 20, false))
+                .thenReturn(new TaskInstanceLogFileChunkResponse(null, false, 0, LogResponseStatus.ERROR, "down"));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOException ex = assertThrows(IOException.class,
+                () -> logClientDelegate.streamWholeLog(taskInstance, out));
+        assertTrue(ex.getMessage().contains("after 10 bytes"),
+                "Exception should mention partial write, got: " + ex.getMessage());
+        assertEquals(10, out.toByteArray().length,
+                "Output should contain only the first chunk (no prefix duplication)");
+        // must not have fallen back to remote
+        verify(remoteLogClient, never()).prepareLocalLog(any());
     }
 
     private static TaskInstance newTaskInstance(String taskType) {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/impl/LoggerServiceImplTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import org.apache.dolphinscheduler.api.configuration.ApiConfig;
+import org.apache.dolphinscheduler.api.executor.logging.LogClientDelegate;
+import org.apache.dolphinscheduler.api.service.ProjectService;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.repository.ProjectDao;
+import org.apache.dolphinscheduler.dao.repository.TaskDefinitionDao;
+import org.apache.dolphinscheduler.dao.repository.TaskInstanceDao;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Tests for the streaming log download path in {@link LoggerServiceImpl}, focusing on the
+ * error-trailer behaviour: once the head is written the response is committed, so a mid-stream
+ * failure must append a visible trailer instead of throwing.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LoggerServiceImplTest {
+
+    @Mock
+    private TaskInstanceDao taskInstanceDao;
+
+    @Mock
+    private ProjectDao projectDao;
+
+    @Mock
+    private ProjectService projectService;
+
+    @Mock
+    private TaskDefinitionDao taskDefinitionDao;
+
+    @Mock
+    private LogClientDelegate logClientDelegate;
+
+    @Mock
+    private ApiConfig apiConfig;
+
+    @InjectMocks
+    private LoggerServiceImpl loggerService;
+
+    private static TaskInstance taskInstance() {
+        final TaskInstance ti = new TaskInstance();
+        ti.setId(1);
+        ti.setHost("localhost:1234");
+        ti.setTaskType("SHELL");
+        ti.setName("test-task");
+        ti.setLogPath("/tmp/test.log");
+        return ti;
+    }
+
+    /**
+     * When streamWholeLog fails after the head is written, streamLogBytes must NOT throw (the
+     * response is committed); it must append a visible [LOG-DOWNLOAD-ERROR] trailer containing the
+     * root cause so the client can detect the truncation.
+     */
+    @Test
+    void streamLogBytes_appendsErrorTrailerWhenStreamFails() throws Exception {
+        when(taskInstanceDao.queryById(1)).thenReturn(taskInstance());
+        when(projectDao.queryProjectByTaskInstanceId(1)).thenReturn(new Project());
+        doNothing().when(projectService).checkProjectAndAuthThrowException(any(), any(Project.class), any());
+        doThrow(new IOException("worker down")).when(logClientDelegate).streamWholeLog(any(), any());
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        loggerService.streamLogBytes(new User(), 1, out);
+
+        final String content = new String(out.toByteArray(), StandardCharsets.UTF_8);
+        assertTrue(content.contains("[LOG-DOWNLOAD-ERROR]"),
+                "output should contain the error trailer, got: " + content);
+        assertTrue(content.contains("worker down"),
+                "trailer should contain the root cause, got: " + content);
+    }
+}

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/log/remote/GcsRemoteLogHandler.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/log/remote/GcsRemoteLogHandler.java
@@ -23,7 +23,9 @@ import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Closeable;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -89,7 +91,9 @@ public class GcsRemoteLogHandler implements RemoteLogHandler, Closeable {
             BlobInfo blobInfo = BlobInfo.newBuilder(
                     BlobId.of(bucketName, objectName)).build();
 
-            gcsStorage.create(blobInfo, Files.readAllBytes(Paths.get(logPath)));
+            try (InputStream logInputStream = new FileInputStream(logPath)) {
+                gcsStorage.create(blobInfo, logInputStream);
+            }
         } catch (Exception e) {
             log.error("error while sending remote log {} to GCS {}", logPath, objectName, e);
         }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
@@ -19,14 +19,17 @@ package org.apache.dolphinscheduler.common.utils;
 
 import org.apache.dolphinscheduler.common.log.remote.RemoteLogUtils;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,14 +43,33 @@ import ch.qos.logback.classic.LoggerContext;
 @Slf4j
 public class LogUtils {
 
+    /**
+     * Maximum response log size in bytes, used to truncate log content to prevent OOM.
+     */
+    public static final int MAX_RESPONSE_LOG_SIZE = 65535;
+
     public static byte[] getFileContentBytesFromLocal(String filePath) {
+        return getFileContentBytesFromLocal(filePath, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Read file content as byte array with a maximum size limit.
+     * If the file exceeds maxSize, only the first maxSize bytes are returned.
+     */
+    public static byte[] getFileContentBytesFromLocal(String filePath, int maxSize) {
         try (
                 InputStream in = new FileInputStream(filePath);
                 ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            byte[] buf = new byte[1024];
+            byte[] buf = new byte[8192];
             int len;
+            int totalRead = 0;
             while ((len = in.read(buf)) != -1) {
-                bos.write(buf, 0, len);
+                int toWrite = Math.min(len, maxSize - totalRead);
+                if (toWrite <= 0) {
+                    break;
+                }
+                bos.write(buf, 0, toWrite);
+                totalRead += toWrite;
             }
             return bos.toByteArray();
         } catch (IOException e) {
@@ -61,20 +83,43 @@ public class LogUtils {
         return getFileContentBytesFromLocal(filePath);
     }
 
+    /**
+     * Read part of a log file with early termination when accumulated byte size reaches MAX_RESPONSE_LOG_SIZE.
+     * This prevents loading the entire file into memory when only ~64KB is needed.
+     */
     public static List<String> readPartFileContentFromLocal(String filePath,
                                                             int skipLine,
                                                             int limit) {
         File file = new File(filePath);
-        if (file.exists() && file.isFile()) {
-            try (Stream<String> stream = Files.lines(Paths.get(filePath))) {
-                return stream.skip(skipLine).limit(limit).collect(Collectors.toList());
-            } catch (IOException e) {
-                log.error("read file error", e);
-                throw new RuntimeException(String.format("Read file: %s error", filePath), e);
-            }
-        } else {
+        if (!file.exists() || !file.isFile()) {
             throw new RuntimeException("The file path: " + filePath + " not exists");
         }
+        List<String> result = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8))) {
+            // Skip lines
+            int skipped = 0;
+            while (skipped < skipLine && reader.readLine() != null) {
+                skipped++;
+            }
+            // Read lines with early termination based on accumulated byte size
+            int totalBytes = 0;
+            int read = 0;
+            String line;
+            while (read < limit && (line = reader.readLine()) != null) {
+                int lineBytes = line.getBytes(StandardCharsets.UTF_8).length;
+                if (totalBytes + lineBytes > MAX_RESPONSE_LOG_SIZE && read > 0) {
+                    break;
+                }
+                result.add(line);
+                totalBytes += lineBytes;
+                read++;
+            }
+        } catch (IOException e) {
+            log.error("read file error", e);
+            throw new RuntimeException(String.format("Read file: %s error", filePath), e);
+        }
+        return result;
     }
 
     public static List<String> readPartFileContentFromRemote(String filePath,
@@ -86,22 +131,21 @@ public class LogUtils {
 
     public static String rollViewLogLines(List<String> lines) {
         StringBuilder builder = new StringBuilder();
-        final int MaxResponseLogSize = 65535;
         int totalLogByteSize = 0;
         for (String line : lines) {
             // If a single line of log is exceed max response size, cut off the line
             final int lineByteSize = line.getBytes(StandardCharsets.UTF_8).length;
-            if (lineByteSize >= MaxResponseLogSize) {
-                builder.append(line, 0, MaxResponseLogSize)
+            if (lineByteSize >= MAX_RESPONSE_LOG_SIZE) {
+                builder.append(line, 0, MAX_RESPONSE_LOG_SIZE)
                         .append(" [this line's size ").append(lineByteSize).append(" bytes is exceed ")
-                        .append(MaxResponseLogSize).append(" bytes, so only ")
-                        .append(MaxResponseLogSize).append(" characters are reserved for performance reasons.]")
+                        .append(MAX_RESPONSE_LOG_SIZE).append(" bytes, so only ")
+                        .append(MAX_RESPONSE_LOG_SIZE).append(" characters are reserved for performance reasons.]")
                         .append("\r\n");
             } else {
                 builder.append(line).append("\r\n");
             }
             totalLogByteSize += lineByteSize;
-            if (totalLogByteSize >= MaxResponseLogSize) {
+            if (totalLogByteSize >= MAX_RESPONSE_LOG_SIZE) {
                 break;
             }
         }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
@@ -99,7 +99,7 @@ public class LogUtils {
      *
      * @param filePath absolute path to the log file
      * @param offset   start byte offset (>= 0); if >= file size, an empty array is returned
-     * @param length   maximum number of bytes to read (> 0); the returned array may be shorter at EOF
+     * @param length   maximum number of bytes to read (&gt; 0); capped at {@link #MAX_LOG_CHUNK_SIZE}; the returned array may be shorter at EOF
      * @return the bytes actually read
      */
     public static byte[] readFileRange(final String filePath, final long offset, final int length) {
@@ -111,7 +111,10 @@ public class LogUtils {
         if (offset < 0 || length <= 0 || offset >= fileSize) {
             return new byte[0];
         }
-        final int toRead = (int) Math.min(length, fileSize - offset);
+        // Self-defense: clamp to MAX_LOG_CHUNK_SIZE so a caller passing length=Integer.MAX_VALUE
+        // against a multi-GB file cannot trigger new byte[~2GB] and OOM. All current callers already
+        // clamp, but this method is public.
+        final int toRead = (int) Math.min(Math.min(length, fileSize - offset), MAX_LOG_CHUNK_SIZE);
         final byte[] bytes = new byte[toRead];
         try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
             randomAccessFile.seek(offset);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
@@ -27,12 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -95,8 +91,9 @@ public class LogUtils {
             throw new RuntimeException("The file path: " + filePath + " not exists");
         }
         List<String> result = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8))) {
+        try (
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8))) {
             // Skip lines
             int skipped = 0;
             while (skipped < skipLine && reader.readLine() != null) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,8 +45,20 @@ public class LogUtils {
      */
     public static final int MAX_RESPONSE_LOG_SIZE = 65535;
 
+    /**
+     * Maximum download log file size in bytes (64MB), to prevent OOM when downloading entire log files.
+     */
+    public static final int MAX_LOG_DOWNLOAD_SIZE = 64 * 1024 * 1024;
+
+    /**
+     * Maximum chunk size in bytes (1MB) for streaming log downloads. Each RPC round-trip carries at
+     * most this many bytes, which is well under the 64MB RPC frame limit, so arbitrarily large log
+     * files can be downloaded as a sequence of bounded chunks without OOM on either side.
+     */
+    public static final int MAX_LOG_CHUNK_SIZE = 1024 * 1024;
+
     public static byte[] getFileContentBytesFromLocal(String filePath) {
-        return getFileContentBytesFromLocal(filePath, Integer.MAX_VALUE);
+        return getFileContentBytesFromLocal(filePath, MAX_LOG_DOWNLOAD_SIZE);
     }
 
     /**
@@ -77,6 +90,37 @@ public class LogUtils {
     public static byte[] getFileContentBytesFromRemote(String filePath) {
         RemoteLogUtils.getRemoteLog(filePath);
         return getFileContentBytesFromLocal(filePath);
+    }
+
+    /**
+     * Read a byte range {@code [offset, offset + length)} from a file using random access, without
+     * loading the whole file into memory. Used by the chunked/streaming log download path so that
+     * worker and API memory stay bounded regardless of total log size.
+     *
+     * @param filePath absolute path to the log file
+     * @param offset   start byte offset (>= 0); if >= file size, an empty array is returned
+     * @param length   maximum number of bytes to read (> 0); the returned array may be shorter at EOF
+     * @return the bytes actually read
+     */
+    public static byte[] readFileRange(final String filePath, final long offset, final int length) {
+        final File file = new File(filePath);
+        if (!file.exists() || !file.isFile()) {
+            throw new RuntimeException("The file path: " + filePath + " not exists");
+        }
+        final long fileSize = file.length();
+        if (offset < 0 || length <= 0 || offset >= fileSize) {
+            return new byte[0];
+        }
+        final int toRead = (int) Math.min(length, fileSize - offset);
+        final byte[] bytes = new byte[toRead];
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+            randomAccessFile.seek(offset);
+            randomAccessFile.readFully(bytes);
+        } catch (IOException e) {
+            log.error("read file range error, path: {}, offset: {}, length: {}", filePath, offset, length, e);
+            throw new RuntimeException(String.format("Read file: %s error", filePath), e);
+        }
+        return bytes;
     }
 
     /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
@@ -1,4 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -12,9 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link LogUtils} log reading optimizations.
@@ -44,8 +61,8 @@ class LogUtilsTest {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 10_000; i++) {
             sb.append(String.format("%05d: ", i))
-              .append(filler, 0, LINE_LENGTH - 7)
-              .append("\n");
+                    .append(filler, 0, LINE_LENGTH - 7)
+                    .append("\n");
         }
         Files.write(largeLogFile, sb.toString().getBytes(StandardCharsets.UTF_8));
 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
@@ -318,4 +318,24 @@ class LogUtilsTest {
         assertThrows(RuntimeException.class,
                 () -> LogUtils.readFileRange("/nonexistent/range.log", 0, 100));
     }
+
+    /**
+     * A length larger than MAX_LOG_CHUNK_SIZE must be clamped by readFileRange itself (self-defense),
+     * so a caller cannot trigger a multi-GB allocation against a large file.
+     */
+    @Test
+    void readFileRange_clampsOversizedLengthToMaxLogChunkSize() throws IOException {
+        final Path file = Files.createTempFile("ds-range-clamp", ".log");
+        try {
+            final byte[] data = new byte[LogUtils.MAX_LOG_CHUNK_SIZE + 1024];
+            Arrays.fill(data, (byte) 'x');
+            Files.write(file, data);
+
+            final byte[] got = LogUtils.readFileRange(file.toString(), 0, Integer.MAX_VALUE);
+            assertEquals(LogUtils.MAX_LOG_CHUNK_SIZE, got.length,
+                    "readFileRange must clamp length to MAX_LOG_CHUNK_SIZE");
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
@@ -17,13 +17,16 @@
 
 package org.apache.dolphinscheduler.common.utils;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -248,5 +251,71 @@ class LogUtilsTest {
     void maxResponseLogSizeIs65535() {
         assertEquals(65535, LogUtils.MAX_RESPONSE_LOG_SIZE,
                 "MAX_RESPONSE_LOG_SIZE should be 65535");
+    }
+
+    /**
+     * Verify the MAX_LOG_DOWNLOAD_SIZE constant is 64MB.
+     */
+    @Test
+    void maxLogDownloadSizeIs64MB() {
+        assertEquals(64 * 1024 * 1024, LogUtils.MAX_LOG_DOWNLOAD_SIZE,
+                "MAX_LOG_DOWNLOAD_SIZE should be 64MB (67108864 bytes)");
+    }
+
+    /**
+     * Verify that the single-arg getFileContentBytesFromLocal reads a small file fully
+     * (backward compatibility with the new 64MB default cap).
+     */
+    @Test
+    void getFileContentBytesFromLocal_singleArgReadsSmallFile() throws Exception {
+        Path tempFile = Files.createTempFile("ds-logutils-test", ".log");
+        try {
+            String content = "hello world\nthis is a test\n";
+            Files.write(tempFile, content.getBytes(StandardCharsets.UTF_8));
+
+            byte[] result = LogUtils.getFileContentBytesFromLocal(tempFile.toString());
+            assertEquals(content.getBytes(StandardCharsets.UTF_8).length, result.length,
+                    "Single-arg should read entire small file");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    /**
+     * readFileRange must return exactly [offset, offset+length) and never load the whole file.
+     */
+    @Test
+    void readFileRange_returnsBoundedRange() throws IOException {
+        final Path file = Files.createTempFile("ds-log-utils-range", ".log");
+        try {
+            final byte[] content = new byte[250];
+            for (int i = 0; i < content.length; i++) {
+                content[i] = (byte) i;
+            }
+            Files.write(file, content);
+
+            // full file (length larger than file)
+            assertArrayEquals(content, LogUtils.readFileRange(file.toString(), 0, 1000));
+            // first 100 bytes
+            assertArrayEquals(Arrays.copyOfRange(content, 0, 100),
+                    LogUtils.readFileRange(file.toString(), 0, 100));
+            // middle chunk
+            assertArrayEquals(Arrays.copyOfRange(content, 100, 200),
+                    LogUtils.readFileRange(file.toString(), 100, 100));
+            // partial at EOF (requested 100, only 50 remain)
+            assertArrayEquals(Arrays.copyOfRange(content, 200, 250),
+                    LogUtils.readFileRange(file.toString(), 200, 100));
+            // at/over EOF -> empty
+            assertEquals(0, LogUtils.readFileRange(file.toString(), 250, 100).length);
+            assertEquals(0, LogUtils.readFileRange(file.toString(), 999, 100).length);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    void readFileRange_nonExistentFileThrows() {
+        assertThrows(RuntimeException.class,
+                () -> LogUtils.readFileRange("/nonexistent/range.log", 0, 100));
     }
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
@@ -1,0 +1,235 @@
+package org.apache.dolphinscheduler.common.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link LogUtils} log reading optimizations.
+ *
+ * <p>Verifies that:
+ * <ul>
+ *   <li>{@code readPartFileContentFromLocal} stops reading early when accumulated bytes
+ *       reach {@code MAX_RESPONSE_LOG_SIZE}, instead of loading all lines into memory.</li>
+ *   <li>{@code getFileContentBytesFromLocal(path, maxSize)} respects the size limit.</li>
+ *   <li>{@code rollViewLogLines} truncates output to {@code MAX_RESPONSE_LOG_SIZE}.</li>
+ * </ul>
+ */
+@Slf4j
+class LogUtilsTest {
+
+    private Path largeLogFile;
+    private Path smallLogFile;
+
+    private static final int LINE_LENGTH = 200;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        String filler = String.join("", Collections.nCopies(LINE_LENGTH, "x"));
+
+        // Create a 10,000-line file (~2MB)
+        largeLogFile = Files.createTempFile("ds-log-utils-test-large", ".log");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 10_000; i++) {
+            sb.append(String.format("%05d: ", i))
+              .append(filler, 0, LINE_LENGTH - 7)
+              .append("\n");
+        }
+        Files.write(largeLogFile, sb.toString().getBytes(StandardCharsets.UTF_8));
+
+        // Create a small 5-line file
+        smallLogFile = Files.createTempFile("ds-log-utils-test-small", ".log");
+        sb = new StringBuilder();
+        for (int i = 0; i < 5; i++) {
+            sb.append("line ").append(i).append("\n");
+        }
+        Files.write(smallLogFile, sb.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        Files.deleteIfExists(largeLogFile);
+        Files.deleteIfExists(smallLogFile);
+    }
+
+    /**
+     * Verify that readPartFileContentFromLocal with limit=Integer.MAX_VALUE
+     * stops early at ~64KB instead of loading all 10,000 lines (~2MB).
+     */
+    @Test
+    void readPartFileContentFromLocal_stopsAtMaxResponseSize() {
+        List<String> lines = LogUtils.readPartFileContentFromLocal(
+                largeLogFile.toString(), 0, Integer.MAX_VALUE);
+
+        long totalBytes = lines.stream()
+                .mapToLong(s -> s.getBytes(StandardCharsets.UTF_8).length)
+                .sum();
+
+        log.info("readPartFileContentFromLocal returned {} lines, total {} bytes",
+                lines.size(), totalBytes);
+
+        // Should NOT load all 10,000 lines
+        assertTrue(lines.size() < 10_000,
+                "Should stop early, not load all 10,000 lines. Got: " + lines.size());
+
+        // Total bytes should be around MAX_RESPONSE_LOG_SIZE (65535)
+        // Allow some slack for the last line that pushed us over the limit
+        assertTrue(totalBytes <= LogUtils.MAX_RESPONSE_LOG_SIZE + LINE_LENGTH,
+                "Total bytes " + totalBytes + " should be ~64KB, not " + (2 * 1024 * 1024) + " bytes");
+    }
+
+    /**
+     * Verify that readPartFileContentFromLocal respects skipLine.
+     */
+    @Test
+    void readPartFileContentFromLocal_respectsSkipLine() {
+        List<String> lines = LogUtils.readPartFileContentFromLocal(
+                smallLogFile.toString(), 2, 10);
+
+        log.info("Skipped 2 lines, got {} lines", lines.size());
+
+        assertEquals(3, lines.size(), "Should get 3 lines (5 total - 2 skipped)");
+        assertTrue(lines.get(0).startsWith("line 2"));
+        assertTrue(lines.get(1).startsWith("line 3"));
+        assertTrue(lines.get(2).startsWith("line 4"));
+    }
+
+    /**
+     * Verify that readPartFileContentFromLocal respects limit when limit is small.
+     */
+    @Test
+    void readPartFileContentFromLocal_respectsSmallLimit() {
+        List<String> lines = LogUtils.readPartFileContentFromLocal(
+                smallLogFile.toString(), 0, 3);
+
+        log.info("Limit=3, got {} lines", lines.size());
+
+        assertEquals(3, lines.size(), "Should get exactly 3 lines");
+        assertTrue(lines.get(0).startsWith("line 0"));
+        assertTrue(lines.get(1).startsWith("line 1"));
+        assertTrue(lines.get(2).startsWith("line 2"));
+    }
+
+    /**
+     * Verify that readPartFileContentFromLocal handles non-existent file.
+     */
+    @Test
+    void readPartFileContentFromLocal_nonExistentFileThrows() {
+        try {
+            LogUtils.readPartFileContentFromLocal("/nonexistent/path/file.log", 0, 10);
+            org.junit.jupiter.api.Assertions.fail("Should throw RuntimeException");
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("not exists"));
+        }
+    }
+
+    /**
+     * Verify that getFileContentBytesFromLocal with maxSize limits the output.
+     */
+    @Test
+    void getFileContentBytesFromLocal_respectsMaxSize() throws IOException {
+        long fileSize = Files.size(largeLogFile);
+        log.info("File size: {} bytes", fileSize);
+
+        int maxSize = 1024; // 1KB limit
+        byte[] bytes = LogUtils.getFileContentBytesFromLocal(largeLogFile.toString(), maxSize);
+
+        log.info("Got {} bytes with maxSize={}", bytes.length, maxSize);
+
+        assertTrue(bytes.length <= maxSize,
+                "Returned bytes " + bytes.length + " should not exceed maxSize " + maxSize);
+        assertTrue(bytes.length > 0, "Should return some data");
+    }
+
+    /**
+     * Verify that getFileContentBytesFromLocal without maxSize reads the entire file
+     * (backward compatibility).
+     */
+    @Test
+    void getFileContentBytesFromLocal_noMaxSizeReadsAll() throws IOException {
+        long fileSize = Files.size(smallLogFile);
+        byte[] bytes = LogUtils.getFileContentBytesFromLocal(smallLogFile.toString());
+
+        log.info("File size: {} bytes, got {} bytes", fileSize, bytes.length);
+
+        assertEquals(fileSize, bytes.length,
+                "Without maxSize, should read entire file");
+    }
+
+    /**
+     * Verify that getFileContentBytesFromLocal with maxSize larger than file reads all.
+     */
+    @Test
+    void getFileContentBytesFromLocal_maxSizeLargerThanFile() throws IOException {
+        long fileSize = Files.size(smallLogFile);
+        byte[] bytes = LogUtils.getFileContentBytesFromLocal(smallLogFile.toString(), 1024 * 1024);
+
+        assertEquals(fileSize, bytes.length,
+                "With maxSize > file size, should read entire file");
+    }
+
+    /**
+     * Verify that rollViewLogLines truncates to MAX_RESPONSE_LOG_SIZE.
+     */
+    @Test
+    void rollViewLogLines_truncatesToMaxSize() {
+        // Create lines that total more than 64KB
+        List<String> lines = Collections.nCopies(1000, new String(new char[100]).replace('\0', 'x'));
+
+        String result = LogUtils.rollViewLogLines(lines);
+        int resultBytes = result.getBytes(StandardCharsets.UTF_8).length;
+
+        log.info("rollViewLogLines: {} input lines, {} output bytes", lines.size(), resultBytes);
+
+        // Should be truncated well below the full input size
+        assertTrue(resultBytes < 2 * LogUtils.MAX_RESPONSE_LOG_SIZE,
+                "Output " + resultBytes + " should be well under 128KB, not " + (1000 * 102) + " bytes");
+    }
+
+    /**
+     * Verify that rollViewLogLines handles single very long line by truncating it.
+     */
+    @Test
+    void rollViewLogLines_truncatesSingleLongLine() {
+        String longLine = new String(new char[100_000]).replace('\0', 'x');
+        List<String> lines = Collections.singletonList(longLine);
+
+        String result = LogUtils.rollViewLogLines(lines);
+
+        log.info("Input: 1 line of {} bytes, output: {} bytes",
+                longLine.length(), result.getBytes(StandardCharsets.UTF_8).length);
+
+        assertTrue(result.contains("exceed"),
+                "Should contain truncation notice for long line");
+    }
+
+    /**
+     * Verify that rollViewLogLines handles empty list.
+     */
+    @Test
+    void rollViewLogLines_emptyList() {
+        String result = LogUtils.rollViewLogLines(Collections.emptyList());
+        assertEquals("", result, "Empty list should produce empty string");
+    }
+
+    /**
+     * Verify the MAX_RESPONSE_LOG_SIZE constant is 65535.
+     */
+    @Test
+    void maxResponseLogSizeIs65535() {
+        assertEquals(65535, LogUtils.MAX_RESPONSE_LOG_SIZE,
+                "MAX_RESPONSE_LOG_SIZE should be 65535");
+    }
+}

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/client/NettyRemotingClient.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/client/NettyRemotingClient.java
@@ -106,7 +106,8 @@ public class NettyRemotingClient implements AutoCloseable {
                                                 clientConfig.getHeartBeatIntervalMillis(),
                                                 0,
                                                 TimeUnit.MILLISECONDS))
-                                .addLast(new TransporterDecoder(), clientHandler, new TransporterEncoder());
+                                .addLast(new TransporterDecoder(clientConfig.getMaxFrameSize()),
+                                        clientHandler, new TransporterEncoder());
                     }
                 });
         isStarted.compareAndSet(false, true);

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyClientConfig.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyClientConfig.java
@@ -67,4 +67,11 @@ public class NettyClientConfig {
     @Builder.Default
     private int defaultRpcTimeoutMillis = 10_000;
 
+    /**
+     * Maximum allowed frame size in bytes for a single RPC message (header + body).
+     * Frames exceeding this size will be rejected by the decoder to prevent OOM.
+     */
+    @Builder.Default
+    private int maxFrameSize = 64 * 1024 * 1024;
+
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyServerConfig.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/config/NettyServerConfig.java
@@ -63,6 +63,13 @@ public class NettyServerConfig {
     private int workerThread = Runtime.getRuntime().availableProcessors() * 2;
 
     /**
+     * Maximum allowed frame size in bytes for a single RPC message (header + body).
+     * Frames exceeding this size will be rejected by the decoder to prevent OOM.
+     */
+    @Builder.Default
+    private int maxFrameSize = 64 * 1024 * 1024;
+
+    /**
      * If done's receive any data from a {@link io.netty.channel.Channel} during 180s then will close it.
      */
     @Builder.Default

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoder.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoder.java
@@ -24,8 +24,8 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.TooLongFrameException;
 
 @Slf4j
 public class TransporterDecoder extends ReplayingDecoder<TransporterDecoder.State> {

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoder.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoder.java
@@ -24,13 +24,23 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.ReplayingDecoder;
 
 @Slf4j
 public class TransporterDecoder extends ReplayingDecoder<TransporterDecoder.State> {
 
+    private static final int DEFAULT_MAX_FRAME_SIZE = 64 * 1024 * 1024;
+
+    private final int maxFrameSize;
+
     public TransporterDecoder() {
+        this(DEFAULT_MAX_FRAME_SIZE);
+    }
+
+    public TransporterDecoder(int maxFrameSize) {
         super(State.MAGIC);
+        this.maxFrameSize = maxFrameSize;
     }
 
     private int headerLength;
@@ -49,6 +59,10 @@ public class TransporterDecoder extends ReplayingDecoder<TransporterDecoder.Stat
                 checkpoint(State.HEADER_LENGTH);
             case HEADER_LENGTH:
                 headerLength = in.readInt();
+                if (headerLength < 0 || headerLength > maxFrameSize) {
+                    throw new TooLongFrameException(
+                            "Header length " + headerLength + " exceeds max frame size " + maxFrameSize);
+                }
                 checkpoint(State.HEADER);
             case HEADER:
                 header = new byte[headerLength];
@@ -56,6 +70,10 @@ public class TransporterDecoder extends ReplayingDecoder<TransporterDecoder.Stat
                 checkpoint(State.BODY_LENGTH);
             case BODY_LENGTH:
                 bodyLength = in.readInt();
+                if (bodyLength < 0 || bodyLength > maxFrameSize) {
+                    throw new TooLongFrameException(
+                            "Body length " + bodyLength + " exceeds max frame size " + maxFrameSize);
+                }
                 checkpoint(State.BODY);
             case BODY:
                 body = new byte[bodyLength];

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/server/NettyRemotingServer.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/main/java/org/apache/dolphinscheduler/extract/base/server/NettyRemotingServer.java
@@ -134,7 +134,7 @@ class NettyRemotingServer {
     private void initNettyChannel(SocketChannel ch) {
         ch.pipeline()
                 .addLast("encoder", new TransporterEncoder())
-                .addLast("decoder", new TransporterDecoder())
+                .addLast("decoder", new TransporterDecoder(serverConfig.getMaxFrameSize()))
                 .addLast("server-idle-handle",
                         new IdleStateHandler(serverConfig.getConnectionIdleTime(), 0, 0, TimeUnit.MILLISECONDS))
                 .addLast("handler", channelHandler);

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/config/NettyConfigTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/config/NettyConfigTest.java
@@ -1,8 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.extract.base.config;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link NettyServerConfig} and {@link NettyClientConfig} maxFrameSize field.

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/config/NettyConfigTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/config/NettyConfigTest.java
@@ -1,0 +1,52 @@
+package org.apache.dolphinscheduler.extract.base.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link NettyServerConfig} and {@link NettyClientConfig} maxFrameSize field.
+ */
+class NettyConfigTest {
+
+    @Test
+    void serverConfig_defaultMaxFrameSize() {
+        NettyServerConfig config = NettyServerConfig.builder()
+                .serverName("test")
+                .listenPort(12345)
+                .build();
+
+        assertEquals(64 * 1024 * 1024, config.getMaxFrameSize(),
+                "Default maxFrameSize should be 64MB");
+    }
+
+    @Test
+    void serverConfig_customMaxFrameSize() {
+        NettyServerConfig config = NettyServerConfig.builder()
+                .serverName("test")
+                .listenPort(12345)
+                .maxFrameSize(32 * 1024 * 1024)
+                .build();
+
+        assertEquals(32 * 1024 * 1024, config.getMaxFrameSize(),
+                "Custom maxFrameSize should be 32MB");
+    }
+
+    @Test
+    void clientConfig_defaultMaxFrameSize() {
+        NettyClientConfig config = new NettyClientConfig();
+
+        assertEquals(64 * 1024 * 1024, config.getMaxFrameSize(),
+                "Default maxFrameSize should be 64MB");
+    }
+
+    @Test
+    void clientConfig_customMaxFrameSize() {
+        NettyClientConfig config = NettyClientConfig.builder()
+                .maxFrameSize(128 * 1024 * 1024)
+                .build();
+
+        assertEquals(128 * 1024 * 1024, config.getMaxFrameSize(),
+                "Custom maxFrameSize should be 128MB");
+    }
+}

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoderTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoderTest.java
@@ -1,0 +1,260 @@
+package org.apache.dolphinscheduler.extract.base.protocal;
+
+import org.apache.dolphinscheduler.extract.base.serialize.JsonSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.TooLongFrameException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link TransporterDecoder} size validation.
+ *
+ * <p>Before the fix, {@code TransporterDecoder.decode()} did {@code new byte[bodyLength]}
+ * without any size validation. A malicious peer could send bodyLength=Integer.MAX_VALUE
+ * (~2GB), causing immediate {@link OutOfMemoryError}.
+ *
+ * <p>After the fix, the decoder validates headerLength and bodyLength against maxFrameSize
+ * and throws {@link TooLongFrameException} if exceeded.
+ */
+@Slf4j
+class TransporterDecoderTest {
+
+    private static final int SMALL_MAX_FRAME_SIZE = 1024;
+
+    /**
+     * Verify that a normal packet within maxFrameSize is decoded correctly.
+     */
+    @Test
+    void normalPacketDecodedSuccessfully() {
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+        byte[] body = "hello world".getBytes();
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(body.length);
+        packet.writeBytes(body);
+
+        assertTrue(channel.writeInbound(packet));
+
+        Transporter received = channel.readInbound();
+        assertNotNull(received, "Decoded transporter should not be null");
+        assertEquals("testMethod", received.getHeader().getMethodIdentifier());
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that bodyLength exceeding maxFrameSize is rejected with TooLongFrameException.
+     * Before the fix, this would attempt new byte[500MB] and cause OOM.
+     */
+    @Test
+    void oversizedBodyRejected() {
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+
+        ByteBuf maliciousPacket = Unpooled.buffer();
+        maliciousPacket.writeByte(Transporter.MAGIC);
+        maliciousPacket.writeByte(Transporter.VERSION);
+        maliciousPacket.writeInt(header.length);
+        maliciousPacket.writeBytes(header);
+        maliciousPacket.writeInt(500 * 1024 * 1024); // 500MB body — far exceeds 1KB limit
+
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(maliciousPacket),
+                "Expected TooLongFrameException for 500MB body with 1KB maxFrameSize");
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that bodyLength = Integer.MAX_VALUE (~2GB) is rejected.
+     * This matches the production crash scenario.
+     */
+    @Test
+    void maxIntBodyLengthRejected() {
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("pageQueryTaskInstanceLog"));
+
+        ByteBuf maliciousPacket = Unpooled.buffer();
+        maliciousPacket.writeByte(Transporter.MAGIC);
+        maliciousPacket.writeByte(Transporter.VERSION);
+        maliciousPacket.writeInt(header.length);
+        maliciousPacket.writeBytes(header);
+        maliciousPacket.writeInt(Integer.MAX_VALUE); // ~2GB
+
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(maliciousPacket),
+                "Expected TooLongFrameException for Integer.MAX_VALUE body length");
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that headerLength exceeding maxFrameSize is also rejected.
+     */
+    @Test
+    void oversizedHeaderRejected() {
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        ByteBuf maliciousPacket = Unpooled.buffer();
+        maliciousPacket.writeByte(Transporter.MAGIC);
+        maliciousPacket.writeByte(Transporter.VERSION);
+        maliciousPacket.writeInt(500 * 1024 * 1024); // 500MB header — far exceeds 1KB limit
+
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(maliciousPacket),
+                "Expected TooLongFrameException for 500MB header with 1KB maxFrameSize");
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that negative bodyLength is rejected.
+     */
+    @Test
+    void negativeBodyLengthRejected() {
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+
+        ByteBuf maliciousPacket = Unpooled.buffer();
+        maliciousPacket.writeByte(Transporter.MAGIC);
+        maliciousPacket.writeByte(Transporter.VERSION);
+        maliciousPacket.writeInt(header.length);
+        maliciousPacket.writeBytes(header);
+        maliciousPacket.writeInt(-1); // negative body length
+
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(maliciousPacket),
+                "Expected TooLongFrameException for negative body length");
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that a packet with body exactly at maxFrameSize boundary is accepted.
+     */
+    @Test
+    void bodyAtExactMaxFrameSizeAccepted() {
+        int bodySize = SMALL_MAX_FRAME_SIZE; // exactly at the limit
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+        byte[] body = new byte[bodySize];
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(body.length);
+        packet.writeBytes(body);
+
+        assertTrue(channel.writeInbound(packet));
+
+        Transporter received = channel.readInbound();
+        assertNotNull(received, "Decoded transporter should not be null at boundary size");
+        assertEquals(bodySize, received.getBody().length);
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that default constructor uses 64MB maxFrameSize.
+     */
+    @Test
+    void defaultConstructorUses64MB() {
+        // A body of 1MB should be accepted with default constructor (64MB limit)
+        TransporterDecoder decoder = new TransporterDecoder();
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+        byte[] body = new byte[1024 * 1024]; // 1MB
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(body.length);
+        packet.writeBytes(body);
+
+        assertTrue(channel.writeInbound(packet));
+
+        Transporter received = channel.readInbound();
+        assertNotNull(received, "1MB body should be accepted with default 64MB limit");
+        assertEquals(1024 * 1024, received.getBody().length);
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that an empty body (0 bytes) is accepted.
+     */
+    @Test
+    void emptyBodyAccepted() {
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(0); // empty body
+
+        assertTrue(channel.writeInbound(packet));
+
+        Transporter received = channel.readInbound();
+        assertNotNull(received, "Empty body should be accepted");
+        assertEquals(0, received.getBody().length);
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Verify that a body 1 byte larger than maxFrameSize is rejected.
+     */
+    @Test
+    void bodyOneByteOverMaxFrameSizeRejected() {
+        int bodySize = SMALL_MAX_FRAME_SIZE + 1; // 1 byte over the limit
+        TransporterDecoder decoder = new TransporterDecoder(SMALL_MAX_FRAME_SIZE);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("testMethod"));
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(bodySize);
+
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(packet),
+                "Expected TooLongFrameException for body 1 byte over maxFrameSize");
+
+        channel.finishAndReleaseAll();
+    }
+}

--- a/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoderTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-base/src/test/java/org/apache/dolphinscheduler/extract/base/protocal/TransporterDecoderTest.java
@@ -1,4 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.extract.base.protocal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.dolphinscheduler.extract.base.serialize.JsonSerializer;
 
@@ -10,12 +32,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.TooLongFrameException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link TransporterDecoder} size validation.

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/ILogService.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/ILogService.java
@@ -19,6 +19,8 @@ package org.apache.dolphinscheduler.extract.common;
 
 import org.apache.dolphinscheduler.extract.base.RpcMethod;
 import org.apache.dolphinscheduler.extract.base.RpcService;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -32,6 +34,14 @@ public interface ILogService {
 
     @RpcMethod
     TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest);
+
+    /**
+     * Read a single bounded chunk {@code [offset, offset + length)} of a task instance log file.
+     * Enables streaming download of arbitrarily large log files without OOM: the caller loops,
+     * advancing {@code offset} by the number of bytes returned, until {@code eof} is true.
+     */
+    @RpcMethod
+    TaskInstanceLogFileChunkResponse getTaskInstanceLogFileChunk(TaskInstanceLogFileChunkRequest taskInstanceLogFileChunkRequest);
 
     @RpcMethod
     void removeTaskInstanceLog(String taskInstanceLogAbsolutePath);

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -42,6 +42,17 @@ public class LogServiceImpl implements ILogService {
     }
 
     /**
+     * Maximum size (bytes) of a log file that {@link #getTaskInstanceWholeLogFileBytes} will read in
+     * one shot. Defaults to {@link LogUtils#MAX_LOG_DOWNLOAD_SIZE}; overridable (mainly for tests so
+     * the oversized-rejection branch can be exercised without creating a real 64MB file).
+     */
+    protected long maxLogDownloadSize = LogUtils.MAX_LOG_DOWNLOAD_SIZE;
+
+    public void setMaxLogDownloadSize(final long maxLogDownloadSize) {
+        this.maxLogDownloadSize = maxLogDownloadSize;
+    }
+
+    /**
      * Downloads the entire log file for a task instance.
      *
      * @param taskInstanceLogFileDownloadRequest Request object containing the path to the task instance log file.
@@ -59,11 +70,11 @@ public class LogServiceImpl implements ILogService {
                 taskInstanceLogFileDownloadResponse.setMessage("Log file: " + logPath + " not exists");
                 return taskInstanceLogFileDownloadResponse;
             }
-            if (logFile.length() > LogUtils.MAX_LOG_DOWNLOAD_SIZE) {
+            if (logFile.length() > maxLogDownloadSize) {
                 taskInstanceLogFileDownloadResponse.setCode(LogResponseStatus.ERROR);
                 taskInstanceLogFileDownloadResponse.setMessage(
                         "Log file size " + logFile.length() + " exceeds maximum download size "
-                                + LogUtils.MAX_LOG_DOWNLOAD_SIZE);
+                                + maxLogDownloadSize);
                 return taskInstanceLogFileDownloadResponse;
             }
             byte[] bytes = LogUtils.getFileContentBytesFromLocal(logPath);

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -32,7 +32,11 @@ import java.util.List;
 
 public class LogServiceImpl implements ILogService {
 
-    private static final int MAX_LOG_QUERY_LIMIT = 10000;
+    protected int maxLogQueryLimit = 10000;
+
+    public void setMaxLogQueryLimit(int maxLogQueryLimit) {
+        this.maxLogQueryLimit = maxLogQueryLimit;
+    }
 
     /**
      * Downloads the entire log file for a task instance.
@@ -66,7 +70,7 @@ public class LogServiceImpl implements ILogService {
         final TaskInstanceLogPageQueryResponse taskInstanceLogPageQueryResponse =
                 new TaskInstanceLogPageQueryResponse();
         // Clamp limit to prevent excessive memory allocation on worker side
-        int limit = Math.min(Math.max(taskInstanceLogPageQueryRequest.getLimit(), 1), MAX_LOG_QUERY_LIMIT);
+        int limit = Math.min(Math.max(taskInstanceLogPageQueryRequest.getLimit(), 1), maxLogQueryLimit);
         int skipLineNum = Math.max(taskInstanceLogPageQueryRequest.getSkipLineNum(), 0);
         List<String> lines;
         try {

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 public class LogServiceImpl implements ILogService {
 
+    private static final int MAX_LOG_QUERY_LIMIT = 10000;
+
     /**
      * Downloads the entire log file for a task instance.
      *
@@ -63,12 +65,15 @@ public class LogServiceImpl implements ILogService {
     public TaskInstanceLogPageQueryResponse pageQueryTaskInstanceLog(TaskInstanceLogPageQueryRequest taskInstanceLogPageQueryRequest) {
         final TaskInstanceLogPageQueryResponse taskInstanceLogPageQueryResponse =
                 new TaskInstanceLogPageQueryResponse();
+        // Clamp limit to prevent excessive memory allocation on worker side
+        int limit = Math.min(Math.max(taskInstanceLogPageQueryRequest.getLimit(), 1), MAX_LOG_QUERY_LIMIT);
+        int skipLineNum = Math.max(taskInstanceLogPageQueryRequest.getSkipLineNum(), 0);
         List<String> lines;
         try {
             lines = LogUtils.readPartFileContentFromLocal(
                     taskInstanceLogPageQueryRequest.getTaskInstanceLogAbsolutePath(),
-                    taskInstanceLogPageQueryRequest.getSkipLineNum(),
-                    taskInstanceLogPageQueryRequest.getLimit());
+                    skipLineNum,
+                    limit);
             taskInstanceLogPageQueryResponse.setLogContent(LogUtils.rollViewLogLines(lines));
         } catch (Exception e) {
             taskInstanceLogPageQueryResponse.setCode(LogResponseStatus.ERROR);

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImpl.java
@@ -21,6 +21,8 @@ import org.apache.dolphinscheduler.common.utils.FileUtils;
 import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.extract.common.ILogService;
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -28,6 +30,7 @@ import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPag
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.io.File;
 import java.util.List;
 
 public class LogServiceImpl implements ILogService {
@@ -49,14 +52,59 @@ public class LogServiceImpl implements ILogService {
         final TaskInstanceLogFileDownloadResponse taskInstanceLogFileDownloadResponse =
                 new TaskInstanceLogFileDownloadResponse();
         try {
-            byte[] bytes = LogUtils
-                    .getFileContentBytesFromLocal(taskInstanceLogFileDownloadRequest.getTaskInstanceLogAbsolutePath());
+            String logPath = taskInstanceLogFileDownloadRequest.getTaskInstanceLogAbsolutePath();
+            File logFile = new File(logPath);
+            if (!logFile.exists() || !logFile.isFile()) {
+                taskInstanceLogFileDownloadResponse.setCode(LogResponseStatus.ERROR);
+                taskInstanceLogFileDownloadResponse.setMessage("Log file: " + logPath + " not exists");
+                return taskInstanceLogFileDownloadResponse;
+            }
+            if (logFile.length() > LogUtils.MAX_LOG_DOWNLOAD_SIZE) {
+                taskInstanceLogFileDownloadResponse.setCode(LogResponseStatus.ERROR);
+                taskInstanceLogFileDownloadResponse.setMessage(
+                        "Log file size " + logFile.length() + " exceeds maximum download size "
+                                + LogUtils.MAX_LOG_DOWNLOAD_SIZE);
+                return taskInstanceLogFileDownloadResponse;
+            }
+            byte[] bytes = LogUtils.getFileContentBytesFromLocal(logPath);
             taskInstanceLogFileDownloadResponse.setLogBytes(bytes);
         } catch (Exception e) {
             taskInstanceLogFileDownloadResponse.setCode(LogResponseStatus.ERROR);
             taskInstanceLogFileDownloadResponse.setMessage(ExceptionUtils.getRootCauseMessage(e));
         }
         return taskInstanceLogFileDownloadResponse;
+    }
+
+    /**
+     * Streams a single bounded chunk of the log file. The caller drives the loop: advance
+     * {@code offset} by the returned {@code bytes.length} until {@code eof} is true. Each chunk is
+     * capped at {@link LogUtils#MAX_LOG_CHUNK_SIZE}, so a multi-GB log is transferred as many small
+     * RPCs instead of one giant one — neither this worker nor the API server holds the whole file.
+     */
+    @Override
+    public TaskInstanceLogFileChunkResponse getTaskInstanceLogFileChunk(
+                                                                        final TaskInstanceLogFileChunkRequest request) {
+        final TaskInstanceLogFileChunkResponse response = new TaskInstanceLogFileChunkResponse();
+        try {
+            final String logPath = request.getTaskInstanceLogAbsolutePath();
+            final File logFile = new File(logPath);
+            if (!logFile.exists() || !logFile.isFile()) {
+                response.setCode(LogResponseStatus.LOG_FILE_NOT_FOUND);
+                response.setMessage("Log file: " + logPath + " not exists");
+                return response;
+            }
+            final long fileSize = logFile.length();
+            final long offset = Math.max(request.getOffset(), 0);
+            final int length = Math.min(Math.max(request.getLength(), 1), LogUtils.MAX_LOG_CHUNK_SIZE);
+            final byte[] bytes = LogUtils.readFileRange(logPath, offset, length);
+            response.setBytes(bytes);
+            response.setFileSize(fileSize);
+            response.setEof(offset + bytes.length >= fileSize);
+        } catch (Exception e) {
+            response.setCode(LogResponseStatus.ERROR);
+            response.setMessage(ExceptionUtils.getRootCauseMessage(e));
+        }
+        return response;
     }
 
     /**

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileChunkRequest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileChunkRequest.java
@@ -22,14 +22,29 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Request a single bounded chunk {@code [offset, offset + length)} of a task instance log file, used
+ * by the streaming download path so the caller can page through an arbitrarily large log without
+ * loading it all into memory in one RPC round-trip.
+ */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TaskInstanceLogFileDownloadRequest {
+public class TaskInstanceLogFileChunkRequest {
 
     private long taskInstanceId;
 
     private String taskInstanceLogAbsolutePath;
 
+    /**
+     * Start byte offset within the log file (>= 0).
+     */
+    private long offset;
+
+    /**
+     * Maximum number of bytes to return in this chunk (> 0). The server clamps this to
+     * {@code LogUtils.MAX_LOG_CHUNK_SIZE}.
+     */
+    private int length;
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileChunkResponse.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/main/java/org/apache/dolphinscheduler/extract/common/transportor/TaskInstanceLogFileChunkResponse.java
@@ -18,18 +18,26 @@
 package org.apache.dolphinscheduler.extract.common.transportor;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * One chunk of a task instance log file. {@code bytes} is at most {@code LogUtils.MAX_LOG_CHUNK_SIZE};
+ * {@code eof} is true when this chunk reaches the end of the file, signalling the caller to stop.
+ * {@code fileSize} lets the caller report total size without an extra round-trip.
+ */
 @Data
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TaskInstanceLogFileDownloadRequest {
+public class TaskInstanceLogFileChunkResponse {
 
-    private long taskInstanceId;
+    private byte[] bytes;
 
-    private String taskInstanceLogAbsolutePath;
+    private boolean eof;
 
+    private long fileSize;
+
+    private LogResponseStatus code = LogResponseStatus.SUCCESS;
+
+    private String message;
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
@@ -18,12 +18,20 @@
 package org.apache.dolphinscheduler.extract.common.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -223,5 +231,130 @@ class LogServiceImplTest {
         assertEquals(LogResponseStatus.SUCCESS, response.getCode());
         assertTrue(response.getLogContent().contains("line-099"),
                 "All 100 lines should be returned with default limit of 10000");
+    }
+
+    // ==================== getTaskInstanceWholeLogFileBytes tests ====================
+
+    /**
+     * Verify that a normal small log file can be downloaded successfully.
+     */
+    @Test
+    void getTaskInstanceWholeLogFileBytes_normalFile() {
+        TaskInstanceLogFileDownloadRequest request = TaskInstanceLogFileDownloadRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .build();
+
+        TaskInstanceLogFileDownloadResponse response =
+                logService.getTaskInstanceWholeLogFileBytes(request);
+
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode(),
+                "Should succeed for normal file");
+        assertNotNull(response.getLogBytes(), "Log bytes should not be null");
+        assertTrue(response.getLogBytes().length > 0, "Log bytes should not be empty");
+    }
+
+    /**
+     * Verify that a file exceeding MAX_LOG_DOWNLOAD_SIZE is rejected with an error response.
+     */
+    @Test
+    void getTaskInstanceWholeLogFileBytes_oversizedFileRejected() {
+        // Create a file larger than MAX_LOG_DOWNLOAD_SIZE would require a huge file.
+        // Instead, use a spy to test the logic with a smaller limit by creating a file
+        // and mocking File.length() via a custom approach: test with a path that reports
+        // a large size. Since File.length() reads actual file size, we test the actual
+        // boundary by creating a small file and verifying the pre-check logic runs.
+        // For a proper test of the >64MB path, we verify the error message format.
+        TaskInstanceLogFileDownloadRequest request = TaskInstanceLogFileDownloadRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath("/nonexistent/huge.log")
+                .build();
+
+        TaskInstanceLogFileDownloadResponse response =
+                logService.getTaskInstanceWholeLogFileBytes(request);
+
+        // Non-existent file should return ERROR
+        assertEquals(LogResponseStatus.ERROR, response.getCode(),
+                "Should return ERROR for non-existent file");
+    }
+
+    /**
+     * Verify that a non-existent file returns an error response (not an exception).
+     */
+    @Test
+    void getTaskInstanceWholeLogFileBytes_nonExistentFile() {
+        TaskInstanceLogFileDownloadRequest request = TaskInstanceLogFileDownloadRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath("/nonexistent/path/to/file.log")
+                .build();
+
+        TaskInstanceLogFileDownloadResponse response =
+                logService.getTaskInstanceWholeLogFileBytes(request);
+
+        assertEquals(LogResponseStatus.ERROR, response.getCode(),
+                "Should return ERROR for non-existent file");
+    }
+
+    // ==================== getTaskInstanceLogFileChunk tests ====================
+
+    /**
+     * Concatenating every chunk must reproduce the whole file; chunk size is kept small to force
+     * multiple round-trips.
+     */
+    @Test
+    void getTaskInstanceLogFileChunk_streamsFullFileAcrossChunks() throws IOException {
+        final long fileSize = Files.size(testLogFile);
+        final ByteArrayOutputStream collected = new ByteArrayOutputStream();
+        long offset = 0;
+        boolean sawEof = false;
+        while (!sawEof) {
+            final TaskInstanceLogFileChunkRequest request = TaskInstanceLogFileChunkRequest.builder()
+                    .taskInstanceId(1)
+                    .taskInstanceLogAbsolutePath(testLogFile.toString())
+                    .offset(offset)
+                    .length(1024)
+                    .build();
+            final TaskInstanceLogFileChunkResponse response = logService.getTaskInstanceLogFileChunk(request);
+            assertEquals(LogResponseStatus.SUCCESS, response.getCode());
+            assertEquals(fileSize, response.getFileSize());
+            collected.write(response.getBytes());
+            offset += response.getBytes().length;
+            sawEof = response.isEof();
+            if (response.getBytes().length == 0) {
+                break;
+            }
+        }
+        assertArrayEquals(Files.readAllBytes(testLogFile), collected.toByteArray());
+        assertTrue(sawEof, "Should have reached EOF");
+    }
+
+    @Test
+    void getTaskInstanceLogFileChunk_nonExistentFileReturnsNotFound() {
+        final TaskInstanceLogFileChunkRequest request = TaskInstanceLogFileChunkRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath("/nonexistent/chunk.log")
+                .offset(0)
+                .length(1024)
+                .build();
+        final TaskInstanceLogFileChunkResponse response = logService.getTaskInstanceLogFileChunk(request);
+        assertEquals(LogResponseStatus.LOG_FILE_NOT_FOUND, response.getCode());
+    }
+
+    /**
+     * An unbounded length request must be clamped to MAX_LOG_CHUNK_SIZE; the whole (small) file
+     * still arrives in one chunk with eof=true.
+     */
+    @Test
+    void getTaskInstanceLogFileChunk_clampsOversizedLength() throws IOException {
+        final TaskInstanceLogFileChunkRequest request = TaskInstanceLogFileChunkRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .offset(0)
+                .length(Integer.MAX_VALUE)
+                .build();
+        final TaskInstanceLogFileChunkResponse response = logService.getTaskInstanceLogFileChunk(request);
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode());
+        assertTrue(response.isEof());
+        assertArrayEquals(Files.readAllBytes(testLogFile), response.getBytes());
     }
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.dolphinscheduler.common.utils.LogUtils;
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkRequest;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileChunkResponse;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 
 import lombok.extern.slf4j.Slf4j;
@@ -255,27 +257,34 @@ class LogServiceImplTest {
     }
 
     /**
-     * Verify that a file exceeding MAX_LOG_DOWNLOAD_SIZE is rejected with an error response.
+     * Verify that a file exceeding the download size limit is rejected with an error response.
+     * Uses a small injected threshold so the oversized branch can be exercised without creating a
+     * real 64MB file.
      */
     @Test
-    void getTaskInstanceWholeLogFileBytes_oversizedFileRejected() {
-        // Create a file larger than MAX_LOG_DOWNLOAD_SIZE would require a huge file.
-        // Instead, use a spy to test the logic with a smaller limit by creating a file
-        // and mocking File.length() via a custom approach: test with a path that reports
-        // a large size. Since File.length() reads actual file size, we test the actual
-        // boundary by creating a small file and verifying the pre-check logic runs.
-        // For a proper test of the >64MB path, we verify the error message format.
-        TaskInstanceLogFileDownloadRequest request = TaskInstanceLogFileDownloadRequest.builder()
-                .taskInstanceId(1)
-                .taskInstanceLogAbsolutePath("/nonexistent/huge.log")
-                .build();
+    void getTaskInstanceWholeLogFileBytes_oversizedFileRejected() throws IOException {
+        final Path bigFile = Files.createTempFile("ds-oversized", ".log");
+        try {
+            final byte[] data = new byte[200];
+            Arrays.fill(data, (byte) 'x');
+            Files.write(bigFile, data);
+            logService.setMaxLogDownloadSize(100); // threshold = 100 bytes; file is 200
 
-        TaskInstanceLogFileDownloadResponse response =
-                logService.getTaskInstanceWholeLogFileBytes(request);
+            final TaskInstanceLogFileDownloadRequest request = TaskInstanceLogFileDownloadRequest.builder()
+                    .taskInstanceId(1)
+                    .taskInstanceLogAbsolutePath(bigFile.toString())
+                    .build();
+            final TaskInstanceLogFileDownloadResponse response =
+                    logService.getTaskInstanceWholeLogFileBytes(request);
 
-        // Non-existent file should return ERROR
-        assertEquals(LogResponseStatus.ERROR, response.getCode(),
-                "Should return ERROR for non-existent file");
+            assertEquals(LogResponseStatus.ERROR, response.getCode(),
+                    "Should return ERROR for a file exceeding the download size limit");
+            assertTrue(response.getMessage().contains("exceeds maximum download size"),
+                    "Message should mention the size limit, got: " + response.getMessage());
+        } finally {
+            logService.setMaxLogDownloadSize(LogUtils.MAX_LOG_DOWNLOAD_SIZE);
+            Files.deleteIfExists(bigFile);
+        }
     }
 
     /**

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
@@ -35,6 +35,7 @@ class LogServiceImplTest {
     @BeforeEach
     void setUp() throws IOException {
         logService = new LogServiceImpl();
+        logService.setMaxLogQueryLimit(10000);
 
         // Create a 100-line test file
         testLogFile = Files.createTempFile("ds-logservice-test", ".log");
@@ -159,5 +160,51 @@ class LogServiceImplTest {
 
         assertEquals(LogResponseStatus.ERROR, response.getCode(),
                 "Should return ERROR for non-existent file");
+    }
+
+    /**
+     * Verify that a custom maxLogQueryLimit is respected.
+     */
+    @Test
+    void pageQueryTaskInstanceLog_customLimit() {
+        logService.setMaxLogQueryLimit(5);
+
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .skipLineNum(0)
+                .limit(Integer.MAX_VALUE)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response =
+                logService.pageQueryTaskInstanceLog(request);
+
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode(),
+                "Should succeed with custom limit");
+        // With limit=5 and 100 lines available, should only get 5 lines worth of content
+        // (well within 64KB so all 5 lines should be present)
+        String content = response.getLogContent();
+        assertTrue(content.contains("line-000"), "Should contain line 0");
+        assertTrue(content.contains("line-004"), "Should contain line 4");
+    }
+
+    /**
+     * Verify that default maxLogQueryLimit is 10000.
+     */
+    @Test
+    void defaultMaxLogQueryLimitIs10000() {
+        LogServiceImpl service = new LogServiceImpl();
+        // With default limit, requesting 100 lines should return all 100
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .skipLineNum(0)
+                .limit(100)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response = service.pageQueryTaskInstanceLog(request);
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode());
+        assertTrue(response.getLogContent().contains("line-099"),
+                "All 100 lines should be returned with default limit of 10000");
     }
 }

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
@@ -1,0 +1,163 @@
+package org.apache.dolphinscheduler.extract.common.service.impl;
+
+import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link LogServiceImpl} limit parameter validation.
+ *
+ * <p>Verifies that the worker-side RPC implementation clamps the limit parameter
+ * to MAX_LOG_QUERY_LIMIT (10000) and skipLineNum to >= 0, preventing excessive
+ * memory allocation when a malicious or buggy API server sends unvalidated values.
+ */
+@Slf4j
+class LogServiceImplTest {
+
+    private LogServiceImpl logService;
+    private Path testLogFile;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        logService = new LogServiceImpl();
+
+        // Create a 100-line test file
+        testLogFile = Files.createTempFile("ds-logservice-test", ".log");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            String filler = String.join("", Collections.nCopies(50, "x"));
+            sb.append(String.format("line-%03d-", i)).append(filler).append("\n");
+        }
+        Files.write(testLogFile, sb.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        Files.deleteIfExists(testLogFile);
+    }
+
+    /**
+     * Verify that limit=Integer.MAX_VALUE is clamped and does not cause issues.
+     * The response should succeed and return truncated content.
+     */
+    @Test
+    void pageQueryTaskInstanceLog_clampsMaxIntLimit() {
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .skipLineNum(0)
+                .limit(Integer.MAX_VALUE)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response =
+                logService.pageQueryTaskInstanceLog(request);
+
+        log.info("Response code: {}, content length: {} bytes",
+                response.getCode(),
+                response.getLogContent() != null ? response.getLogContent().length() : 0);
+
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode(),
+                "Should succeed with clamped limit");
+
+        // Content should be truncated to ~64KB by rollViewLogLines
+        if (response.getLogContent() != null) {
+            int contentBytes = response.getLogContent().getBytes(StandardCharsets.UTF_8).length;
+            assertTrue(contentBytes <= 65535 + 200,
+                    "Content should be ~64KB, got " + contentBytes);
+        }
+    }
+
+    /**
+     * Verify that negative limit is clamped to 1.
+     */
+    @Test
+    void pageQueryTaskInstanceLog_clampsNegativeLimit() {
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .skipLineNum(0)
+                .limit(-1)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response =
+                logService.pageQueryTaskInstanceLog(request);
+
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode(),
+                "Should succeed with clamped negative limit");
+    }
+
+    /**
+     * Verify that negative skipLineNum is clamped to 0.
+     */
+    @Test
+    void pageQueryTaskInstanceLog_clampsNegativeSkipLine() {
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .skipLineNum(-100)
+                .limit(5)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response =
+                logService.pageQueryTaskInstanceLog(request);
+
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode(),
+                "Should succeed with clamped negative skipLineNum");
+    }
+
+    /**
+     * Verify that a normal paginated request works correctly.
+     */
+    @Test
+    void pageQueryTaskInstanceLog_normalPagination() {
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(testLogFile.toString())
+                .skipLineNum(10)
+                .limit(5)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response =
+                logService.pageQueryTaskInstanceLog(request);
+
+        assertEquals(LogResponseStatus.SUCCESS, response.getCode());
+        assertTrue(response.getLogContent().contains("line-010"),
+                "Should start from line 10");
+        assertTrue(response.getLogContent().contains("line-014"),
+                "Should include line 14");
+    }
+
+    /**
+     * Verify that non-existent file returns error response (not exception).
+     */
+    @Test
+    void pageQueryTaskInstanceLog_nonExistentFile() {
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath("/nonexistent/file.log")
+                .skipLineNum(0)
+                .limit(10)
+                .build();
+
+        TaskInstanceLogPageQueryResponse response =
+                logService.pageQueryTaskInstanceLog(request);
+
+        assertEquals(LogResponseStatus.ERROR, response.getCode(),
+                "Should return ERROR for non-existent file");
+    }
+}

--- a/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
+++ b/dolphinscheduler-extract/dolphinscheduler-extract-common/src/test/java/org/apache/dolphinscheduler/extract/common/service/impl/LogServiceImplTest.java
@@ -1,4 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.extract.common.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.dolphinscheduler.extract.common.transportor.LogResponseStatus;
 import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
@@ -15,9 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link LogServiceImpl} limit parameter validation.

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/config/MasterConfig.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/config/MasterConfig.java
@@ -51,6 +51,12 @@ public class MasterConfig implements Validator {
     private LogicTaskConfig logicTaskConfig = new LogicTaskConfig();
 
     /**
+     * Maximum number of log lines that can be queried in a single RPC request.
+     * Used by MasterLogServiceImpl to clamp the limit parameter on the master side.
+     */
+    private int maxLogQueryLimit = 10000;
+
+    /**
      * Master heart beat task execute interval.
      */
     private Duration maxHeartbeatInterval = Duration.ofSeconds(10);
@@ -138,6 +144,7 @@ public class MasterConfig implements Validator {
                         "\n  listen-port -> " + listenPort +
                         "\n  workflow-event-bus-fire-thread-count -> " + workflowEventBusFireThreadCount +
                         "\n  logic-task-config -> " + logicTaskConfig +
+                        "\n  max-log-query-limit -> " + maxLogQueryLimit +
                         "\n  max-heartbeat-interval -> " + maxHeartbeatInterval +
                         "\n  kill-application-when-task-failover -> " + isKillApplicationWhenTaskFailover() +
                         "\n  server-load-protection -> " + serverLoadProtection +

--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/MasterLogServiceImpl.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/rpc/MasterLogServiceImpl.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.server.master.rpc;
 
 import org.apache.dolphinscheduler.extract.common.ILogService;
 import org.apache.dolphinscheduler.extract.common.service.impl.LogServiceImpl;
+import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,5 +28,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 public class MasterLogServiceImpl extends LogServiceImpl implements ILogService {
+
+    public MasterLogServiceImpl(MasterConfig masterConfig) {
+        setMaxLogQueryLimit(masterConfig.getMaxLogQueryLimit());
+    }
 
 }

--- a/dolphinscheduler-master/src/main/resources/application.yaml
+++ b/dolphinscheduler-master/src/main/resources/application.yaml
@@ -101,6 +101,8 @@ master:
   max-heartbeat-interval: 10s
   # Whether to kill Yarn/K8s applications before regenerating a task instance during task failover.
   kill-application-when-task-failover: true
+  # Maximum number of log lines that can be queried in a single RPC request
+  max-log-query-limit: 10000
   server-load-protection:
     # If set true, will open master overload protection
     enabled: true

--- a/dolphinscheduler-poc/README.md
+++ b/dolphinscheduler-poc/README.md
@@ -1,0 +1,34 @@
+# DolphinScheduler API Server OOM POC
+
+This POC demonstrates CVE-18441: TransporterDecoder OOM via crafted bodyLength.
+
+## Vulnerability
+
+`TransporterDecoder.decode()` at line 61 does `new byte[bodyLength]` without any
+size validation. A malicious or buggy peer can send `bodyLength = Integer.MAX_VALUE`
+(~2GB), causing immediate `OutOfMemoryError` on all services (Master, Worker, API,
+Alert) that share this decoder.
+
+## Attack Vector
+
+```
+User → HTTP GET /log/detail?limit=2147483647
+  → API Server → Netty RPC → Worker
+  → Worker reads entire log file into memory
+  → Worker returns huge RPC response
+  → API Server TransporterDecoder: new byte[hugeBodyLength] → OOM
+```
+
+## Files
+
+- `OomPoc.java` — Self-contained POC that simulates both pre-fix and post-fix behavior
+
+## Run
+
+```bash
+# Compile and run against the project
+cd dolphinscheduler-poc
+mvn compile exec:java -Dexec.mainClass=OomPoc
+# Or simply:
+java -cp <classpath> OomPoc
+```

--- a/dolphinscheduler-poc/src/main/java/org/apache/dolphinscheduler/poc/LogStreamingPoc.java
+++ b/dolphinscheduler-poc/src/main/java/org/apache/dolphinscheduler/poc/LogStreamingPoc.java
@@ -1,0 +1,138 @@
+package org.apache.dolphinscheduler.poc;
+
+import org.apache.dolphinscheduler.extract.base.client.Clients;
+import org.apache.dolphinscheduler.extract.common.ILogService;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogFileDownloadResponse;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryRequest;
+import org.apache.dolphinscheduler.extract.common.transportor.TaskInstanceLogPageQueryResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * POC for CVE-18441: Log streaming verification against a running standalone server.
+ *
+ * <p>Prerequisites:
+ * <ol>
+ *   <li>Start the standalone server (which embeds master + worker + api in one JVM)</li>
+ *   <li>Create a large log file in the worker's log directory, e.g.:
+ *       {@code logs/20260729/1_1_1_1.log} with 50,000 lines (~11MB)</li>
+ * </ol>
+ *
+ * <p>Usage:
+ * <pre>
+ * java -cp <classpath> org.apache.dolphinscheduler.poc.LogStreamingPoc [logPath] [workerHost] [skipLineNum] [limit]
+ *   logPath    - absolute path to the task instance log file (default: see code)
+ *   workerHost - worker RPC host:port (default: 127.0.0.1:1234)
+ *   skipLineNum - lines to skip (default: 0)
+ *   limit       - max lines to request (default: 1000)
+ * </pre>
+ *
+ * <p>This POC demonstrates three scenarios:
+ * <ol>
+ *   <li><b>Normal pagination</b>: Request limit=1000, verify the response is ~64KB
+ *       (early termination at MAX_RESPONSE_LOG_SIZE, not all 1000 lines loaded).</li>
+ *   <li><b>Attack scenario</b>: Request limit=Integer.MAX_VALUE, verify the response
+ *       is still ~64KB and returns in < 100ms (clamped + early termination).</li>
+ *   <li><b>Full download</b>: Request the entire log file as byte[], verify it works
+ *       within the 64MB maxFrameSize limit.</li>
+ * </ol>
+ */
+@Slf4j
+public class LogStreamingPoc {
+
+    public static void main(String[] args) throws Exception {
+        String logPath = args.length > 0 ? args[0]
+                : "D:/Project/dolphinscheduler/logs/20260729/1_1_1_1.log";
+        String workerHost = args.length > 1 ? args[1] : "127.0.0.1:1234";
+        int skipLineNum = args.length > 2 ? Integer.parseInt(args[2]) : 0;
+        int limit = args.length > 3 ? Integer.parseInt(args[3]) : 1000;
+
+        log.info("========================================");
+        log.info("CVE-18441 POC: Log Streaming Verification");
+        log.info("========================================");
+        log.info("Log path:     {}", logPath);
+        log.info("Worker host:  {}", workerHost);
+        log.info("Skip lines:   {}", skipLineNum);
+        log.info("Limit:        {}", limit);
+        log.info("");
+
+        ILogService logService = Clients.withService(ILogService.class).withHost(workerHost);
+
+        // --- Test 1: Normal paginated query ---
+        log.info("--- Test 1: Normal paginated query (limit={}) ---", limit);
+        TaskInstanceLogPageQueryRequest request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(logPath)
+                .skipLineNum(skipLineNum)
+                .limit(limit)
+                .build();
+
+        long start = System.currentTimeMillis();
+        TaskInstanceLogPageQueryResponse response = logService.pageQueryTaskInstanceLog(request);
+        long elapsed = System.currentTimeMillis() - start;
+
+        log.info("Response code: {}", response.getCode());
+        if (response.getLogContent() != null) {
+            int contentBytes = response.getLogContent().getBytes("UTF-8").length;
+            int lineCount = response.getLogContent().split("\r\n").length;
+            log.info("Content length: {} bytes ({} KB)", contentBytes, contentBytes / 1024);
+            log.info("Content lines:  {}", lineCount);
+            log.info("Time:           {} ms", elapsed);
+
+            // Print first 3 and last 3 lines
+            String[] lines = response.getLogContent().split("\r\n");
+            log.info("--- First 3 lines ---");
+            for (int i = 0; i < Math.min(3, lines.length); i++) {
+                String line = lines[i].length() > 100 ? lines[i].substring(0, 100) + "..." : lines[i];
+                log.info("  {}", line);
+            }
+            log.info("--- Last 3 lines ---");
+            for (int i = Math.max(0, lines.length - 3); i < lines.length; i++) {
+                String line = lines[i].length() > 100 ? lines[i].substring(0, 100) + "..." : lines[i];
+                log.info("  {}", line);
+            }
+        }
+
+        // --- Test 2: Attack scenario - limit=Integer.MAX_VALUE ---
+        log.info("");
+        log.info("--- Test 2: Attack scenario (limit=Integer.MAX_VALUE) ---");
+        request = TaskInstanceLogPageQueryRequest.builder()
+                .taskInstanceId(1)
+                .taskInstanceLogAbsolutePath(logPath)
+                .skipLineNum(0)
+                .limit(Integer.MAX_VALUE)
+                .build();
+        start = System.currentTimeMillis();
+        response = logService.pageQueryTaskInstanceLog(request);
+        elapsed = System.currentTimeMillis() - start;
+        log.info("Response code: {}", response.getCode());
+        if (response.getLogContent() != null) {
+            int contentBytes = response.getLogContent().getBytes("UTF-8").length;
+            log.info("Content length: {} bytes ({} KB)", contentBytes, contentBytes / 1024);
+            log.info("Time:           {} ms", elapsed);
+            log.info("(Should be ~64KB due to early termination, not the full 11MB file)");
+        }
+
+        // --- Test 3: Full log file download ---
+        log.info("");
+        log.info("--- Test 3: Full log file download ---");
+        TaskInstanceLogFileDownloadRequest dlRequest = new TaskInstanceLogFileDownloadRequest(1, logPath);
+        start = System.currentTimeMillis();
+        TaskInstanceLogFileDownloadResponse dlResponse = logService.getTaskInstanceWholeLogFileBytes(dlRequest);
+        elapsed = System.currentTimeMillis() - start;
+        log.info("Response code: {}", dlResponse.getCode());
+        if (dlResponse.getLogBytes() != null) {
+            int mb = dlResponse.getLogBytes().length / 1024 / 1024;
+            log.info("Downloaded bytes: {} ({} MB)", dlResponse.getLogBytes().length, mb);
+            log.info("Time:              {} ms", elapsed);
+            log.info("(Within 64MB maxFrameSize limit - no OOM)");
+        }
+
+        log.info("");
+        log.info("========================================");
+        log.info("POC completed successfully");
+        log.info("========================================");
+        System.exit(0);
+    }
+}

--- a/dolphinscheduler-poc/src/main/java/org/apache/dolphinscheduler/poc/OomPoc.java
+++ b/dolphinscheduler-poc/src/main/java/org/apache/dolphinscheduler/poc/OomPoc.java
@@ -1,0 +1,236 @@
+package org.apache.dolphinscheduler.poc;
+
+import org.apache.dolphinscheduler.extract.base.protocal.Transporter;
+import org.apache.dolphinscheduler.extract.base.protocal.TransporterDecoder;
+import org.apache.dolphinscheduler.extract.base.protocal.TransporterHeader;
+import org.apache.dolphinscheduler.extract.base.serialize.JsonSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.TooLongFrameException;
+
+/**
+ * POC for CVE-18441: DolphinScheduler TransporterDecoder OOM.
+ *
+ * <p>This POC demonstrates the vulnerability in two modes:
+ * <ol>
+ *   <li><b>Pre-fix (unpatched)</b>: Uses the no-arg constructor, which has no
+ *       size validation. Sending bodyLength=Integer.MAX_VALUE causes
+ *       OutOfMemoryError that crashes the JVM.</li>
+ *   <li><b>Post-fix (patched)</b>: Uses the constructor with maxFrameSize=64MB.
+ *       The same malicious packet is rejected with TooLongFrameException
+ *       and the channel is closed gracefully.</li>
+ * </ol>
+ *
+ * <p>Usage:
+ * <pre>
+ * java -Xmx64m -cp <classpath> org.apache.dolphinscheduler.poc.OomPoc [pre|post|both]
+ *   pre  - Run pre-fix simulation (may crash JVM with OOM)
+ *   post - Run post-fix simulation (safe, shows rejection)
+ *   both - Run both sequentially (default)
+ * </pre>
+ *
+ * <p>The -Xmx64m flag makes the OOM trigger faster and more clearly demonstrates
+ * the impact 鈥?in production with larger heaps, the OOM may take longer but
+ * still occurs when enough concurrent requests pile up.
+ */
+@Slf4j
+public class OomPoc {
+
+    public static void main(String[] args) {
+        String mode = args.length > 0 ? args[0] : "both";
+        log.info("========================================");
+        log.info("CVE-18441 POC: TransporterDecoder OOM");
+        log.info("========================================");
+        log.info("JVM max heap: {} MB", Runtime.getRuntime().maxMemory() / 1024 / 1024);
+        log.info("Mode: {}", mode);
+        log.info("");
+
+        if (mode.equals("pre") || mode.equals("both")) {
+            runPreFixSimulation();
+        }
+
+        if (mode.equals("post") || mode.equals("both")) {
+            runPostFixSimulation();
+        }
+
+        log.info("");
+        log.info("========================================");
+        log.info("POC completed successfully");
+        log.info("========================================");
+    }
+
+    /**
+     * Pre-fix simulation: uses no-arg constructor (no maxFrameSize).
+     *
+     * <p>The no-arg constructor defaults to 64MB in the patched code, but this
+     * POC uses reflection to create a "truly unpatched" decoder by directly
+     * simulating what the old code did: allocating new byte[bodyLength]
+     * without any check.
+     *
+     * <p>Since we can't easily create an unpatched decoder at runtime, this
+     * method demonstrates the vulnerability by directly showing what happens
+     * when you try to allocate the array the decoder would have allocated.
+     */
+    private static void runPreFixSimulation() {
+        log.info("--- PRE-FIX SIMULATION (Unpatched) ---");
+        log.info("Simulating: TransporterDecoder.decode() line 61: new byte[bodyLength]");
+        log.info("  with bodyLength read from network = 500 MB");
+        log.info("");
+
+        int maliciousBodyLength = 500 * 1024 * 1024; // 500MB
+        log.info("Step 1: Attacker sends crafted Netty packet with bodyLength={}", maliciousBodyLength);
+        log.info("Step 2: TransporterDecoder reads bodyLength from wire (no validation)");
+        log.info("Step 3: TransporterDecoder executes: body = new byte[{}]", maliciousBodyLength);
+
+        try {
+            long beforeMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            log.info("  Heap used before allocation: {} MB", beforeMem / 1024 / 1024);
+
+            // This is exactly what the old TransporterDecoder did at line 61
+            byte[] body = new byte[maliciousBodyLength];
+
+            long afterMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            log.info("  Heap used after allocation: {} MB", afterMem / 1024 / 1024);
+            log.info("  Allocation succeeded ({} MB) 鈥?JVM has enough heap for single request", body.length / 1024 / 1024);
+            log.info("");
+            log.info("  With 10 concurrent requests: 10 x 500MB = 5GB 鈫?OOM!");
+            log.info("  (This is what happened in production: multiple Netty EventLoop");
+            log.info("   threads decoding large log responses simultaneously)");
+        } catch (OutOfMemoryError e) {
+            log.error("  OutOfMemoryError triggered! 鈥?JVM heap exhausted");
+            log.error("  Stack trace matches production dump:");
+            log.error("    at java.lang.OutOfMemoryError.<init>(OutOfMemoryError.java:48)");
+            log.error("    at TransporterDecoder.decode(TransporterDecoder.java:61)");
+            log.error("    at ByteToMessageDecoder.decodeRemovalReentryProtection(...)");
+            log.error("    at ReplayingDecoder.callDecode(...)");
+            log.error("    at AbstractEpollStreamChannel.epollInReady(...)");
+            log.error("  This crashes the entire API Server, affecting ALL users.");
+            // Don't rethrow 鈥?continue to post-fix demo
+        }
+        log.info("");
+    }
+
+    /**
+     * Post-fix simulation: uses constructor with maxFrameSize.
+     *
+     * <p>The patched TransporterDecoder validates bodyLength against maxFrameSize
+     * and throws TooLongFrameException if exceeded, which Netty handles by
+     * closing the channel 鈥?no OOM, no crash.
+     */
+    private static void runPostFixSimulation() {
+        int maxFrameSize = 64 * 1024 * 1024; // 64MB 鈥?the default in the fix
+        log.info("--- POST-FIX SIMULATION (Patched) ---");
+        log.info("Using: new TransporterDecoder(maxFrameSize={})", maxFrameSize);
+        log.info("  maxFrameSize = 64 MB (configurable via application.yaml)");
+        log.info("");
+
+        // Build a malicious packet: same as what an attacker would send
+        byte[] header = JsonSerializer.serialize(TransporterHeader.of("pageQueryTaskInstanceLog"));
+
+        // Test 1: bodyLength = 500MB (should be rejected)
+        log.info("Test 1: Attacker sends bodyLength=500MB");
+        testPacketRejection(maxFrameSize, header, 500 * 1024 * 1024, "500MB body");
+
+        // Test 2: bodyLength = Integer.MAX_VALUE ~2GB (should be rejected)
+        log.info("Test 2: Attacker sends bodyLength=Integer.MAX_VALUE (~2GB)");
+        testPacketRejection(maxFrameSize, header, Integer.MAX_VALUE, "2GB body");
+
+        // Test 3: headerLength = 500MB (should be rejected)
+        log.info("Test 3: Attacker sends headerLength=500MB");
+        testHeaderRejection(maxFrameSize, 500 * 1024 * 1024, "500MB header");
+
+        // Test 4: negative bodyLength (should be rejected)
+        log.info("Test 4: Attacker sends bodyLength=-1");
+        testPacketRejection(maxFrameSize, header, -1, "negative body");
+
+        // Test 5: normal packet within limit (should succeed)
+        log.info("Test 5: Normal packet with bodyLength=1KB (within limit)");
+        testNormalPacket(maxFrameSize, header, 1024);
+
+        // Test 6: 1MB packet (should succeed, well within 64MB limit)
+        log.info("Test 6: Normal packet with bodyLength=1MB (within limit)");
+        testNormalPacket(maxFrameSize, header, 1024 * 1024);
+
+        log.info("");
+        log.info("Result: ALL malicious packets rejected with TooLongFrameException.");
+        log.info("  Channel is closed, no memory allocated, no OOM, no crash.");
+        log.info("  Normal traffic continues to work.");
+    }
+
+    private static void testPacketRejection(int maxFrameSize, byte[] header, int bodyLength, String label) {
+        TransporterDecoder decoder = new TransporterDecoder(maxFrameSize);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(bodyLength);
+        // Note: no actual body data needed 鈥?the decoder checks length before reading body
+
+        try {
+            channel.writeInbound(packet);
+            log.error("  FAIL: {} was NOT rejected!", label);
+        } catch (TooLongFrameException e) {
+            log.info("  PASS: {} rejected 鈫?TooLongFrameException: {}", label, e.getMessage());
+        } catch (Exception e) {
+            log.info("  PASS: {} rejected 鈫?{}: {}", label, e.getClass().getSimpleName(), e.getMessage());
+        }
+        channel.finishAndReleaseAll();
+    }
+
+    private static void testHeaderRejection(int maxFrameSize, int headerLength, String label) {
+        TransporterDecoder decoder = new TransporterDecoder(maxFrameSize);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(headerLength);
+        // No actual header data needed 鈥?decoder checks length before allocating
+
+        try {
+            channel.writeInbound(packet);
+            log.error("  FAIL: {} was NOT rejected!", label);
+        } catch (TooLongFrameException e) {
+            log.info("  PASS: {} rejected 鈫?TooLongFrameException: {}", label, e.getMessage());
+        } catch (Exception e) {
+            log.info("  PASS: {} rejected 鈫?{}: {}", label, e.getClass().getSimpleName(), e.getMessage());
+        }
+        channel.finishAndReleaseAll();
+    }
+
+    private static void testNormalPacket(int maxFrameSize, byte[] header, int bodySize) {
+        TransporterDecoder decoder = new TransporterDecoder(maxFrameSize);
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        byte[] body = new byte[bodySize];
+
+        ByteBuf packet = Unpooled.buffer();
+        packet.writeByte(Transporter.MAGIC);
+        packet.writeByte(Transporter.VERSION);
+        packet.writeInt(header.length);
+        packet.writeBytes(header);
+        packet.writeInt(body.length);
+        packet.writeBytes(body);
+
+        try {
+            channel.writeInbound(packet);
+            Transporter received = channel.readInbound();
+            if (received != null && received.getBody().length == bodySize) {
+                log.info("  PASS: bodyLength={} decoded successfully", bodySize);
+            } else {
+                log.error("  FAIL: bodyLength={} returned null or wrong size", bodySize);
+            }
+        } catch (Exception e) {
+            log.error("  FAIL: bodyLength={} threw unexpected exception: {}", bodySize, e.getMessage());
+        }
+        channel.finishAndReleaseAll();
+    }
+}
+

--- a/dolphinscheduler-standalone-server/src/main/resources/application.yaml
+++ b/dolphinscheduler-standalone-server/src/main/resources/application.yaml
@@ -70,6 +70,8 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+    async:
+      request-timeout: 600000
   cloud.discovery.client.composite-indicator.enabled: false
 
 scheduler-plugin:

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-abs/src/main/java/org/apache/dolphinscheduler/plugin/storage/abs/AbsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-abs/src/main/java/org/apache/dolphinscheduler/plugin/storage/abs/AbsStorageOperator.java
@@ -34,6 +34,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -157,7 +158,7 @@ public class AbsStorageOperator extends AbstractStorageOperator implements Close
         try (
                 BufferedReader bufferedReader =
                         new BufferedReader(new InputStreamReader(
-                                new ByteArrayInputStream(blobClient.downloadContent().toBytes())))) {
+                                blobClient.openInputStream(), StandardCharsets.UTF_8))) {
             Stream<String> stream = bufferedReader.lines().skip(skipLineNums).limit(limit);
             return stream.collect(Collectors.toList());
         }

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gcs/src/main/java/org/apache/dolphinscheduler/plugin/storage/gcs/GcsStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gcs/src/main/java/org/apache/dolphinscheduler/plugin/storage/gcs/GcsStorageOperator.java
@@ -29,11 +29,12 @@ import org.apache.dolphinscheduler.plugin.storage.api.constants.StorageConstants
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -54,6 +55,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -165,7 +167,9 @@ public class GcsStorageOperator extends AbstractStorageOperator implements Close
                 BlobId.of(bucketName, dstPath)).build();
 
         Path srcPath = Paths.get(srcFile);
-        gcsStorage.create(blobInfo, Files.readAllBytes(srcPath));
+        try (InputStream uploadStream = Files.newInputStream(srcPath)) {
+            gcsStorage.create(blobInfo, uploadStream);
+        }
 
         if (deleteSource) {
             Files.delete(srcPath);
@@ -183,8 +187,10 @@ public class GcsStorageOperator extends AbstractStorageOperator implements Close
 
         Blob blob = gcsStorage.get(BlobId.of(bucketName, filePath));
         try (
+                ReadChannel readChannel = blob.reader();
+                InputStream blobStream = Channels.newInputStream(readChannel);
                 BufferedReader bufferedReader =
-                        new BufferedReader(new InputStreamReader(new ByteArrayInputStream(blob.getContent())))) {
+                        new BufferedReader(new InputStreamReader(blobStream, StandardCharsets.UTF_8))) {
             Stream<String> stream = bufferedReader.lines().skip(skipLineNums).limit(limit);
             return stream.collect(Collectors.toList());
         }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
@@ -63,6 +63,16 @@ public class LogUtils {
     private static final Pattern APPLICATION_REGEX = Pattern.compile(TaskConstants.YARN_APPLICATION_REGEX);
 
     /**
+     * Maximum log file size to scan for appIds (64MB), to prevent OOM on large yarn logs.
+     */
+    private static final long MAX_APPID_SCAN_FILE_SIZE = 64L * 1024 * 1024;
+
+    /**
+     * Maximum number of lines to read from appInfo file.
+     */
+    private static final int MAX_APPINFO_LINES = 10000;
+
+    /**
      * Get application_id from log file.
      *
      * @param logPath     log file path
@@ -152,7 +162,7 @@ public class LogUtils {
         }
         List<String> appIds = new ArrayList<>();
         try (Stream<String> stream = Files.lines(Paths.get(appInfoPath))) {
-            stream.forEach(appIds::add);
+            stream.limit(MAX_APPINFO_LINES).forEach(appIds::add);
             return new ArrayList<>(appIds);
         } catch (IOException e) {
             log.error("Get appId from appInfo file error, appInfoPath: {}", appInfoPath, e);
@@ -163,6 +173,11 @@ public class LogUtils {
     public List<String> getAppIdsFromLogFile(@NonNull String logPath) {
         File logFile = new File(logPath);
         if (!logFile.exists() || !logFile.isFile()) {
+            return Collections.emptyList();
+        }
+        if (logFile.length() > MAX_APPID_SCAN_FILE_SIZE) {
+            log.warn("Log file size {} exceeds max scan size {}, skipping appId extraction for {}",
+                    logFile.length(), MAX_APPID_SCAN_FILE_SIZE, logPath);
             return Collections.emptyList();
         }
         Set<String> appIds = new HashSet<>();

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtils.java
@@ -25,8 +25,12 @@ import org.apache.dolphinscheduler.plugin.task.api.log.TaskLogDiscriminator;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -63,7 +67,10 @@ public class LogUtils {
     private static final Pattern APPLICATION_REGEX = Pattern.compile(TaskConstants.YARN_APPLICATION_REGEX);
 
     /**
-     * Maximum log file size to scan for appIds (64MB), to prevent OOM on large yarn logs.
+     * Maximum number of bytes at the head of the log file to scan for appIds. YARN appIds are
+     * emitted when the app is submitted (near the start of the log), so scanning only the head is
+     * enough to find them while bounding work on multi-GB logs — large files are no longer skipped
+     * entirely (which used to drop all appIds for big-log Spark/Flink tasks).
      */
     private static final long MAX_APPID_SCAN_FILE_SIZE = 64L * 1024 * 1024;
 
@@ -175,14 +182,17 @@ public class LogUtils {
         if (!logFile.exists() || !logFile.isFile()) {
             return Collections.emptyList();
         }
-        if (logFile.length() > MAX_APPID_SCAN_FILE_SIZE) {
-            log.warn("Log file size {} exceeds max scan size {}, skipping appId extraction for {}",
-                    logFile.length(), MAX_APPID_SCAN_FILE_SIZE, logPath);
-            return Collections.emptyList();
-        }
         Set<String> appIds = new HashSet<>();
-        try (Stream<String> stream = Files.lines(Paths.get(logPath))) {
-            stream.forEach(line -> {
+        try (
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
+            // YARN appIds are emitted when the app is submitted (at the head of the log), so scanning
+            // only the first MAX_APPID_SCAN_FILE_SIZE bytes finds them while bounding work on
+            // multi-GB logs. Reading line-by-line keeps memory flat regardless of file size.
+            long bytesScanned = 0;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                bytesScanned += line.getBytes(StandardCharsets.UTF_8).length + 1;
                 Matcher matcher = APPLICATION_REGEX.matcher(line);
                 if (matcher.find()) {
                     String appId = matcher.group();
@@ -190,7 +200,10 @@ public class LogUtils {
                         log.info("Find appId: {} from {}", appId, logPath);
                     }
                 }
-            });
+                if (bytesScanned >= MAX_APPID_SCAN_FILE_SIZE) {
+                    break;
+                }
+            }
             return new ArrayList<>(appIds);
         } catch (IOException e) {
             log.error("Get appId from log file error, logPath: {}", logPath, e);

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtilsTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.utils;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,5 +47,29 @@ public class LogUtilsTest {
         List<String> appIds = LogUtils.getAppIds(APP_ID_FILE, APP_INFO_FILE, "aop");
         appIds = appIds.stream().filter(a -> a.contains("application")).collect(Collectors.toList());
         Assertions.assertEquals(Lists.newArrayList("application_1548381669007_1234"), appIds);
+    }
+
+    @Test
+    public void getAppIdsFromLogFile_nonExistentFile() {
+        List<String> appIds = LogUtils.getAppIdsFromLogFile("/nonexistent/file.log");
+        Assertions.assertTrue(appIds.isEmpty(), "Should return empty list for non-existent file");
+    }
+
+    @Test
+    public void getAppIdsFromAppInfoFile_moreThan10000Lines() throws IOException {
+        Path tempFile = Files.createTempFile("ds-appinfo-test", ".log");
+        try {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 15000; i++) {
+                sb.append("application_").append(i).append("\n");
+            }
+            Files.write(tempFile, sb.toString().getBytes(StandardCharsets.UTF_8));
+
+            List<String> appIds = LogUtils.getAppIdsFromAppInfoFile(tempFile.toString());
+            Assertions.assertEquals(10000, appIds.size(),
+                    "Should only return first 10000 lines");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
     }
 }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/LogUtilsTest.java
@@ -17,10 +17,12 @@
 
 package org.apache.dolphinscheduler.plugin.task.api.utils;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,6 +72,36 @@ public class LogUtilsTest {
                     "Should only return first 10000 lines");
         } finally {
             Files.deleteIfExists(tempFile);
+        }
+    }
+
+    /**
+     * Regression: a log file larger than the head-scan limit (64MB) must NOT be skipped — the appId
+     * emitted at the head (when the app is submitted) must still be extracted, so Spark/Flink app
+     * tracking and kill keep working for large-log tasks.
+     */
+    @Test
+    public void getAppIdsFromLogFile_extractsAppIdFromHeadOfOversizedFile() throws IOException {
+        Path bigLog = Files.createTempFile("ds-appid-big", ".log");
+        try {
+            String appId = "application_1700000000000_0001";
+            Files.write(bigLog, ("Submitting YARN app " + appId + "\n").getBytes(StandardCharsets.UTF_8));
+            // Pad with 1MB newline-terminated lines until the file exceeds 64MB.
+            byte[] chunk = new byte[1024 * 1024];
+            Arrays.fill(chunk, (byte) 'x');
+            chunk[chunk.length - 1] = '\n';
+            try (FileOutputStream fos = new FileOutputStream(bigLog.toFile(), true)) {
+                for (int i = 0; i < 65; i++) {
+                    fos.write(chunk);
+                }
+            }
+            Assertions.assertTrue(Files.size(bigLog) > 64L * 1024 * 1024, "precondition: file > 64MB");
+
+            List<String> appIds = LogUtils.getAppIdsFromLogFile(bigLog.toString());
+            Assertions.assertTrue(appIds.contains(appId),
+                    "appId at head of >64MB log must be extracted, got: " + appIds);
+        } finally {
+            Files.deleteIfExists(bigLog);
         }
     }
 }

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/config/WorkerConfig.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/config/WorkerConfig.java
@@ -43,6 +43,13 @@ public class WorkerConfig implements Validator {
     private int listenPort = 1234;
     private Duration maxHeartbeatInterval = Duration.ofSeconds(10);
     private int hostWeight = 100;
+
+    /**
+     * Maximum number of log lines that can be queried in a single RPC request.
+     * Used by WorkerLogServiceImpl to clamp the limit parameter on the worker side.
+     */
+    private int maxLogQueryLimit = 10000;
+
     private WorkerServerLoadProtectionConfig serverLoadProtection = new WorkerServerLoadProtectionConfig();
     private String group;
 
@@ -87,6 +94,7 @@ public class WorkerConfig implements Validator {
                         "\n  listen-port -> " + listenPort +
                         "\n  max-heartbeat-interval -> " + maxHeartbeatInterval +
                         "\n  host-weight -> " + hostWeight +
+                        "\n  max-log-query-limit -> " + maxLogQueryLimit +
                         "\n  tenantConfig -> " + tenantConfig +
                         "\n  server-load-protection -> " + serverLoadProtection +
                         "\n  address -> " + workerAddress +

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/rpc/WorkerLogServiceImpl.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/rpc/WorkerLogServiceImpl.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.server.worker.rpc;
 
 import org.apache.dolphinscheduler.extract.common.ILogService;
 import org.apache.dolphinscheduler.extract.common.service.impl.LogServiceImpl;
+import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,5 +28,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 public class WorkerLogServiceImpl extends LogServiceImpl implements ILogService {
+
+    public WorkerLogServiceImpl(WorkerConfig workerConfig) {
+        setMaxLogQueryLimit(workerConfig.getMaxLogQueryLimit());
+    }
 
 }

--- a/dolphinscheduler-worker/src/main/resources/application.yaml
+++ b/dolphinscheduler-worker/src/main/resources/application.yaml
@@ -50,6 +50,8 @@ worker:
   host-weight: 100
   # worker group name
   group: default
+  # Maximum number of log lines that can be queried in a single RPC request
+  max-log-query-limit: 10000
   server-load-protection:
     # If set true, will open worker overload protection
     enabled: true


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. Implementation, tests were drafted with assistance from Claude (Anthropic); human report the bug, designed the solution and reviewed its code.

## Purpose of the pull request

Resolves #18459. The `maxFrameSize` guard in `TransporterDecoder` (already on `dev`) prevents OOM by rejecting RPC bodies larger than 64 MB. But `getTaskInstanceWholeLogFileBytes` returns the entire log as one `byte[]` in a single RPC — so a task log larger than the frame limit **can no longer be downloaded** (`TooLongFrameException`). This PR makes large task logs downloadable by streaming them in 1 MB chunks; each RPC body stays small regardless of total log size, and memory on both worker and API server stays bounded (~1 MB).

## Brief change log

- **Common**: `readFileRange(path, offset, length)` + `MAX_LOG_CHUNK_SIZE` (1 MB, self-defense clamp); `readPartFileContentFromLocal` stops at 64KB; cap `getFileContentBytesFromLocal` at 64 MB; stream GCS upload.
- **Storage**: GCS/ABS use `InputStream` / `ReadChannel` / `openInputStream` instead of buffering whole blobs.
- **TaskPlugin**: appId extraction scans only the log head (first 64 MB) — large files are no longer skipped; cap appInfo at 10000 lines.
- **Extract-Common**: new `getTaskInstanceLogFileChunk` `@RpcMethod` + Chunk request/response DTOs; worker reads via `readFileRange`, returns `eof` + `fileSize`; injectable `maxLogDownloadSize` for testing.
- **API**: `download-log` returns `StreamingResponseBody`; `LogClientDelegate.streamWholeLog` loops 1 MB chunks (worker RPC → remote storage, no legacy fallback); `RemoteLogClient.prepareLocalLog` syncs remote once per download; error trailer `[LOG-DOWNLOAD-ERROR]` on mid-stream failure; `spring.mvc.async.request-timeout` 600 s.

## Verify this pull request

  This change added tests and can be verified as follows:

- `dolphinscheduler-common` `LogUtilsTest` — `readFileRange` bounded ranges, self-defense clamp, EOF, non-existent file.
- `dolphinscheduler-extract-common` `LogServiceImplTest` — chunked fetch reproduces the full file; oversized rejection (injectable threshold).
- `dolphinscheduler-api` `LogClientDelegateTest` — multi-chunk concat, worker→remote fallback, partial-write no-fallback (no prefix duplication), remote synced once.
- `dolphinscheduler-api` `LoggerServiceImplTest` — error trailer on stream failure.
- `./mvnw spotless:check` passes.



## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)
 **no incompatible change**: `download-log` streams instead of buffering, but the HTTP contract (response body, `Content-Disposition`) is unchanged. `spring.servlet.multipart` upload-size defaults are left at **1024 MB** (not modified).