### PR TITLE
[Fix-18217][DataX] Escape single quotes in custom parameters

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/main/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTask.java
@@ -377,7 +377,12 @@ public class DataxTask extends AbstractTask {
         }
         StringBuilder customParameters = new StringBuilder("-p \"");
         for (Map.Entry<String, Property> entry : paramsMap.entrySet()) {
-            customParameters.append(String.format(CUSTOM_PARAM, entry.getKey(), entry.getValue().getValue()));
+            String value = entry.getValue().getValue();
+            // Escape single quotes for shell safety: ' -> '\'' (bash standard escape)
+            // Prevents shell quoting conflicts when value contains single quotes, e.g.
+            // AND create_data > '2026-05-06 10:59:09' -> AND create_data > '\''2026-05-06 10:59:09'\''
+            String escapedValue = value == null ? "" : value.replace("'", "'\\''");
+            customParameters.append(String.format(CUSTOM_PARAM, entry.getKey(), escapedValue));
         }
         customParameters.replace(4, 5, "");
         customParameters.append("\"");

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/test/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTaskTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-datax/src/test/java/org/apache/dolphinscheduler/plugin/task/datax/DataxTaskTest.java
@@ -166,6 +166,24 @@ public class DataxTaskTest {
     }
 
     @Test
+    public void testBuildCommandEscapesSingleQuotesInCustomParameters() {
+        Map<String, Property> paramsMap = new HashMap<>();
+        Property conditionProperty = new Property();
+        conditionProperty.setProp("ds_incr_condition");
+        conditionProperty.setDirect(Direct.IN);
+        conditionProperty.setType(DataType.VARCHAR);
+        conditionProperty.setValue("AND create_data > '2026-05-06 10:59:09'");
+        paramsMap.put("ds_incr_condition", conditionProperty);
+
+        String command = dataxTask.buildCommand("/tmp/execution/app-id_job.json", paramsMap);
+        Assertions.assertEquals(
+                "${PYTHON_LAUNCHER} ${DATAX_LAUNCHER} --jvm=\"-Xms1G -Xmx1G\" "
+                        + "-p \"-Dds_incr_condition='AND create_data > '\\''2026-05-06 10:59:09'\\'''\" "
+                        + "/tmp/execution/app-id_job.json",
+                command);
+    }
+
+    @Test
     public void testHandleInterruptedException() throws Exception {
         String parameters = JSONUtils.toJsonString(createDataxParameters());
         TaskExecutionContext taskExecutionContext = buildTestTaskExecutionContext();


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #18217

Custom DataX `-D` parameter values that contain single quotes break the generated shell command.

## Brief change log

- Escape single quotes in DataX custom parameter values
- Add unit coverage for the escaping behavior

## Verify this pull request

This change added tests and can be verified as follows:
- Run the DataX-related unit tests covering custom parameter escaping

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
