### PR TITLE
[Fix-16789][Task] Treat already-exited process as successful kill

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtils.java
@@ -117,6 +117,14 @@ public final class ProcessUtils {
                 return true;
             }
 
+            // Process may have already exited before stop is handled (common for Flink client).
+            // Calling pstree on a dead PID fails with "No such process" and would incorrectly
+            // report kill failure; treat already-exited as success.
+            if (!isProcessAlive(processId, request.getTenantCode())) {
+                log.info("Process already exited, treat kill as success, processId: {}", processId);
+                return true;
+            }
+
             // Get all child processes
             List<Integer> pidList = getPidList(processId);
 
@@ -146,6 +154,11 @@ public final class ProcessUtils {
             return forceKillSuccess;
 
         } catch (Exception e) {
+            // Race: process exited between the alive check and pstree/kill
+            if (!isProcessAlive(request.getProcessId(), request.getTenantCode())) {
+                log.info("Process already exited, treat kill as success, processId: {}", request.getProcessId());
+                return true;
+            }
             log.error("Kill task instance error, processId: {}", request.getProcessId(), e);
             return false;
         }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/utils/ProcessUtilsTest.java
@@ -263,4 +263,27 @@ public class ProcessUtilsTest {
         // Assert
         Assertions.assertTrue(result);
     }
+
+    @Test
+    void testKillAlreadyExitedProcessBeforePstree() {
+        // Arrange: processId is still cached but the OS process has already exited
+        TaskExecutionContext taskRequest = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskRequest.getProcessId()).thenReturn(12345);
+        Mockito.when(taskRequest.getTenantCode()).thenReturn("testTenant");
+
+        mockedOSUtils.when(() -> OSUtils.getSudoCmd(Mockito.eq("testTenant"), Mockito.matches("kill -0.*")))
+                .thenReturn("kill -0 12345");
+        mockedOSUtils.when(() -> OSUtils.exeCmd(Mockito.matches(".*kill -0.*")))
+                .thenThrow(new RuntimeException("No such process"));
+
+        // Act
+        boolean result = ProcessUtils.kill(taskRequest);
+
+        // Assert: already-exited process should be treated as successful kill
+        Assertions.assertTrue(result);
+
+        // pstree must not be required when the root process is already gone
+        String pstreeCmd = SystemUtils.IS_OS_MAC ? "pstree -sp 12345" : "pstree -p 12345";
+        mockedOSUtils.verify(() -> OSUtils.exeCmd(pstreeCmd), Mockito.never());
+    }
 }


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #16789

Killing an already-exited process fails and can surface as task stop errors (e.g. Flink stop).

## Brief change log

- Treat an already-exited process as a successful kill in `ProcessUtils.kill`

## Verify this pull request

This pull request is already covered by existing tests, such as process kill/unit tests around `ProcessUtils`.
- Manual: stop a task whose process has already exited and confirm no false failure

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
