### PR TITLE
[Fix][UI] Fix incorrect MLflow data path empty tip

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -820,7 +820,7 @@ export default {
     mlflow_dataPath: 'Data Path',
     mlflow_dataPath_tips:
       ' The absolute path of the file or folder. Ends with .csv for file or contain train.csv and test.csv for folder',
-    mlflow_dataPath_error_tips: ' data data can not be empty ',
+    mlflow_dataPath_error_tips: 'Data path can not be empty',
     mlflow_experimentName: 'Experiment Name',
     mlflow_experimentName_tips: 'experiment_001',
     mlflow_registerModel: 'Register Model',


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

MLflow data-path empty tip shows incorrect text (`data data can not be empty`).

## Brief change log

- Correct `mlflow_dataPath_error_tips` English message

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Open MLflow task form, leave data path empty, confirm tip text

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
