### PR TITLE
[Improvement-18372][UI] Keep valid environment when switching worker group

### DIFF
--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/start-modal.tsx
@@ -249,8 +249,18 @@ export default defineComponent({
       }
     }
 
-    const updateWorkerGroup = () => {
-      startState.startForm.environmentCode = null
+    const updateWorkerGroup = (workerGroup: string) => {
+      const current = startState.startForm.environmentCode
+      if (!current) {
+        return
+      }
+      const stillValid = variables.environmentList.some(
+        (item: any) =>
+          item.value === current && item.workerGroups?.includes(workerGroup)
+      )
+      if (!stillValid) {
+        startState.startForm.environmentCode = null
+      }
     }
 
     const addStartParams = () => {

--- a/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
+++ b/dolphinscheduler-ui/src/views/projects/workflow/definition/components/timing-modal.tsx
@@ -180,8 +180,18 @@ export default defineComponent({
       ]
     }
 
-    const updateWorkerGroup = () => {
-      timingState.timingForm.environmentCode = null
+    const updateWorkerGroup = (workerGroup: string) => {
+      const current = timingState.timingForm.environmentCode
+      if (!current) {
+        return
+      }
+      const stillValid = variables.environmentList.some(
+        (item: any) =>
+          item.value === current && item.workerGroups?.includes(workerGroup)
+      )
+      if (!stillValid) {
+        timingState.timingForm.environmentCode = null
+      }
     }
 
     const handlePreview = () => {


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #18372

Replaces #18471 (closed for missing PR template).

Switching worker group clears a still-valid environment and forces users to reselect it.

## Brief change log

- Keep the selected environment when it remains valid for the new worker group

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Manual: start/timing dialog, switch worker group to one that still supports the current environment, confirm environment is kept

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
