### PR TITLE
[Fix-17634][UI] Fix misleading Workflow Relation empty-state message

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -225,9 +225,9 @@ export default {
     project_name: 'Project Name',
     project_tips: 'Please select project name',
     workflow_relation_no_data_result_title:
-      'Can not find any relations of workflows.',
+      'No workflow relations found',
     workflow_relation_no_data_result_desc:
-      'There is not any workflows. Please create a workflow, and then visit this page again.',
+      'Workflow Relation only shows workflows that are ONLINE and have an ONLINE schedule. Create or online a workflow and its schedule, then visit this page again.',
     failover: 'Failover',
     confirm_to_online: 'Confirm to make the workflow online?',
     confirm_to_offline: 'Confirm to make the workflow offline?',

--- a/dolphinscheduler-ui/src/locales/zh_CN/project.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/project.ts
@@ -222,9 +222,9 @@ export default {
     related_items: '关联项目',
     project_name: '项目名称',
     project_tips: '请选择项目',
-    workflow_relation_no_data_result_title: '工作流关系不存在',
+    workflow_relation_no_data_result_title: '未找到工作流关系',
     workflow_relation_no_data_result_desc:
-      '目前没有任何工作流，请先创建工作流，再访问该页面',
+      '工作流关系仅展示已上线且存在已上线定时的工作流。请创建或上线工作流及其定时后，再访问该页面。',
     failover: '恢复容错',
     confirm_to_online: '是否确定上线该工作流?',
     confirm_to_offline: '是否确定下线该工作流?',


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #17634

Replaces #18472 (closed for missing PR template).

Workflow Relation empty-state copy is misleading when workflows exist but are offline / without schedule.

## Brief change log

- Update empty-state English copy to mention online workflow and schedule requirements

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Manual: open Workflow Relation with offline/unscheduled workflows and check the empty-state text

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
