### PR TITLE
[Fix][UI] Use an image in image pull policy tip

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -409,7 +409,7 @@ export default {
     image: 'Image',
     image_tips: 'Please enter image',
     image_pull_policy: 'Image pull policy',
-    image_pull_policy_tips: 'Please select a image pull policy (required)',
+    image_pull_policy_tips: 'Please select an image pull policy (required)',
     pull_secret: 'Pull secret',
     pull_secret_tips: 'Please enter pull secret',
     command: 'Command',


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Replaces #18480 (closed for missing PR template).

Image pull policy tip uses incorrect article (``a image``).

## Brief change log

- Change tip to ``an image pull policy``

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Open K8s task form and confirm image pull policy tip

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
