### PR TITLE
[Fix][API] Fix can not wording in unfinished workflow message

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -418,7 +418,7 @@ public enum Status {
             "批量修改工作流任务关系错误"),
     UPSTREAM_TASK_NOT_EXISTS(50071, "upstream task want to set dependence do not exists {0}", "指定的上游任务 {0} 不存在"),
 
-    WORKFLOW_INSTANCE_IS_NOT_FINISHED(50071, "the workflow instance is not finished, can not do this operation",
+    WORKFLOW_INSTANCE_IS_NOT_FINISHED(50071, "the workflow instance is not finished, cannot do this operation",
             "工作流实例未结束，不能执行此操作"),
 
     TASK_PARALLELISM_PARAMS_ERROR(50080, "task parallelism parameter is not valid", "任务并行度参数无效"),


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Replaces #18486 (closed for missing PR template).

Unfinished workflow instance English status uses ``can not``.

## Brief change log

- Update ``WORKFLOW_INSTANCE_IS_NOT_FINISHED`` to use ``cannot``

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Trigger the unfinished-instance operation path and confirm English status text

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
