### PR TITLE
[Fix][UI] Fix Can not wording in workflow relations tip

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -225,7 +225,7 @@ export default {
     project_name: 'Project Name',
     project_tips: 'Please select project name',
     workflow_relation_no_data_result_title:
-      'Can not find any relations of workflows.',
+      'Cannot find any relations of workflows.',
     workflow_relation_no_data_result_desc:
       'There is not any workflows. Please create a workflow, and then visit this page again.',
     failover: 'Failover',


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Replaces #18487 (closed for missing PR template).

Workflow relations empty tip uses ``Can not find``.

## Brief change log

- Change tip to ``Cannot find any relations of workflows.``

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Open Workflow Relation empty state and confirm English tip

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
