### PR TITLE
[Fix-18514][ui] Correct grammar for downstream dependent tasks warnings

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/project.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/project.ts
@@ -235,16 +235,16 @@ export default {
     time_to_offline: 'Confirm to make the Scheduler offline?',
     warning_dependent_tasks_title: 'Warning',
     warning_dependent_tasks_desc:
-      'The downstream dependent tasks exists. Are you sure to make the workflow offline?',
+      'The downstream dependent tasks exist. Are you sure to make the workflow offline?',
     warning_dependencies: 'Dependencies:',
     delete_validate_dependent_tasks_desc:
-      'The downstream dependent tasks exists. You can not delete the workflow.',
+      'The downstream dependent tasks exist. You can not delete the workflow.',
     warning_offline_scheduler_dependent_tasks_desc:
-      'The downstream dependent tasks exists. Are you sure to make the scheduler offline?',
+      'The downstream dependent tasks exist. Are you sure to make the scheduler offline?',
     delete_task_validate_dependent_tasks_desc:
-      'The downstream dependent tasks exists. You can not delete the task.',
+      'The downstream dependent tasks exist. You can not delete the task.',
     warning_delete_scheduler_dependent_tasks_desc:
-      'The downstream dependent tasks exists. Are you sure to delete the scheduler?',
+      'The downstream dependent tasks exist. Are you sure to delete the scheduler?',
     request_failed: 'Request failed, please retry',
     warning_too_large_parallelism_number:
       'The parallelism number is too large. It is better not to be over 10.'
@@ -316,7 +316,7 @@ export default {
     whether_dry_run: 'Whether Dry-Run',
     please_choose: 'Please Choose',
     delete_validate_dependent_tasks_desc:
-      'The downstream dependent tasks exists. You can not delete the task.'
+      'The downstream dependent tasks exist. You can not delete the task.'
   },
   dag: {
     create: 'Create Workflow',


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #18514

Dependent-tasks warning/delete messages use incorrect grammar.

## Brief change log

- Change ``tasks exists`` to ``tasks exist`` in en_US tips

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Trigger dependent-tasks warning/delete dialogs and confirm English text

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
