### PR TITLE
[Fix-18518][ui] Rename emial_correct_tips to email_correct_tips

### DIFF
--- a/dolphinscheduler-ui/src/locales/en_US/security.ts
+++ b/dolphinscheduler-ui/src/locales/en_US/security.ts
@@ -176,7 +176,7 @@ export default {
     queue_tips: 'Please select a queue',
     email: 'Email',
     email_empty_tips: 'Please enter email',
-    emial_correct_tips: 'Please enter the correct email format',
+    email_correct_tips: 'Please enter the correct email format',
     phone: 'Phone',
     phone_empty_tips: 'Please enter phone number',
     phone_correct_tips: 'Please enter the correct mobile phone format',

--- a/dolphinscheduler-ui/src/locales/zh_CN/security.ts
+++ b/dolphinscheduler-ui/src/locales/zh_CN/security.ts
@@ -172,7 +172,7 @@ export default {
     queue_tips: '默认为租户关联队列',
     email: '邮件',
     email_empty_tips: '请输入邮箱',
-    emial_correct_tips: '请输入正确的邮箱格式',
+    email_correct_tips: '请输入正确的邮箱格式',
     phone: '手机',
     phone_empty_tips: '请输入手机号码',
     phone_correct_tips: '请输入正确的手机格式',

--- a/dolphinscheduler-ui/src/views/security/user-manage/components/use-user-detail.ts
+++ b/dolphinscheduler-ui/src/views/security/user-manage/components/use-user-detail.ts
@@ -95,7 +95,7 @@ export function useUserDetail() {
             value
           )
         ) {
-          return new Error(t('security.user.emial_correct_tips'))
+          return new Error(t('security.user.email_correct_tips'))
         }
       }
     },


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #18518

Email validation i18n key is misspelled.

## Brief change log

- Rename key to ``email_correct_tips`` in locales and user detail validator

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Open user create/edit form with invalid email and confirm tip still shows

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
