### PR TITLE
[Fix-18519][api] Clarify CLUSTER_NOT_EXISTS English message

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -505,7 +505,7 @@ public enum Status {
     UPDATE_CLUSTER_WORKFLOW_DEFINITION_RELATION_ERROR(1200032,
             "You can't modify the workflow definition, because the workflow definition [{0}] and this cluster [{1}] already be used in the task [{2}]",
             "您不能修改集群选项，因为该工作流组 [{0}] 和 该集群 [{1}] 已经被用在任务 [{2}] 中"),
-    CLUSTER_NOT_EXISTS(120033, "this cluster can not found in db.", "集群配置数据库里查询不到为空"),
+    CLUSTER_NOT_EXISTS(120033, "this cluster cannot be found in db.", "集群配置数据库里查询不到为空"),
     DELETE_CLUSTER_RELATED_NAMESPACE_EXISTS(120034, "this cluster has been used in namespace,so you can't delete it.",
             "该集群已经被命名空间使用，所以不能删除该集群信息"),
 


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #18519

``CLUSTER_NOT_EXISTS`` English message is ungrammatical.

## Brief change log

- Change message to ``cannot be found``

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Trigger missing-cluster API path and confirm English status text

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
