### PR TITLE
[Fix-18520][api] Clarify task group name already-exists message

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -509,7 +509,7 @@ public enum Status {
     DELETE_CLUSTER_RELATED_NAMESPACE_EXISTS(120034, "this cluster has been used in namespace,so you can't delete it.",
             "该集群已经被命名空间使用，所以不能删除该集群信息"),
 
-    TASK_GROUP_NAME_EXSIT(130001, "this task group name is repeated in a project", "该任务组名称在一个项目中已经使用"),
+    TASK_GROUP_NAME_EXSIT(130001, "this task group name already exists in the project", "该任务组名称在一个项目中已经使用"),
     TASK_GROUP_SIZE_ERROR(130002, "task group size error", "任务组大小应该为大于1的整数"),
     TASK_GROUP_STATUS_ERROR(130003, "task group status error", "任务组已经被关闭"),
     TASK_GROUP_FULL(130004, "task group is full", "任务组已经满了"),


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

Yes, assisted by AI.

## Purpose of the pull request

Fixes #18520

Task group duplicate-name English message is unclear.

## Brief change log

- Clarify message to ``already exists in the project`` (enum name unchanged)

## Verify this pull request

This pull request is code cleanup without any test coverage.
- Create a duplicate task group name and confirm English error text

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
