### PR TITLE
[Fix-18538][Master] Schedule task retry at endTime + retryInterval

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRetryLifecycleEvent.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRetryLifecycleEvent.java
@@ -43,7 +43,7 @@ public class TaskRetryLifecycleEvent extends AbstractTaskLifecycleEvent {
     public static TaskRetryLifecycleEvent of(final ITaskExecution taskExecution) {
         final TaskInstance taskInstance = taskExecution.getTaskInstance();
         checkState(taskInstance != null, "The task instance must be initialized before retrying.");
-        final int delayTime = taskInstance.getRetryInterval();
+        final int retryInterval = taskInstance.getRetryInterval();
 
         final int retryTimes = taskInstance.getRetryTimes();
         final int maxRetryTimes = taskInstance.getMaxRetryTimes();
@@ -51,8 +51,11 @@ public class TaskRetryLifecycleEvent extends AbstractTaskLifecycleEvent {
                 "The task retry times: %s must smaller then maxRetryTimes: %s.",
                 retryTimes,
                 maxRetryTimes);
-        final long remainingTime =
-                TimeUnit.MINUTES.toMillis(delayTime) + System.currentTimeMillis() - taskInstance.getEndTime().getTime();
+        // The task should be retried at (endTime + retryInterval), so the remaining delay is the retry interval
+        // minus the time which has already elapsed since the task ended. When the retry interval has already
+        // passed, e.g. the event is created during failover, the task should be retried immediately.
+        final long elapsedTime = System.currentTimeMillis() - taskInstance.getEndTime().getTime();
+        final long remainingTime = Math.max(0, TimeUnit.MINUTES.toMillis(retryInterval) - elapsedTime);
         return new TaskRetryLifecycleEvent(taskExecution, remainingTime);
     }
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRetryLifecycleEventTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/task/lifecycle/event/TaskRetryLifecycleEventTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TaskRetryLifecycleEventTest {
+
+    private static final int RETRY_INTERVAL_MINUTES = 5;
+
+    private static final int MAX_RETRY_TIMES = 3;
+
+    @Mock
+    private ITaskExecution taskExecution;
+
+    @Test
+    @DisplayName("Test the retry is delayed until (endTime + retryInterval) when the interval has not elapsed")
+    void testOf_retryIntervalNotElapsed_delayUntilRetryIntervalIsOver() {
+        final long elapsedTime = TimeUnit.SECONDS.toMillis(30);
+        when(taskExecution.getTaskInstance()).thenReturn(createFailedTaskInstance(elapsedTime));
+
+        final TaskRetryLifecycleEvent event = TaskRetryLifecycleEvent.of(taskExecution);
+
+        final long expectedDelay = TimeUnit.MINUTES.toMillis(RETRY_INTERVAL_MINUTES) - elapsedTime;
+        assertThat(event.getDelay(TimeUnit.MILLISECONDS)).isAtMost(expectedDelay);
+        assertThat(event.getDelay(TimeUnit.MILLISECONDS))
+                .isAtLeast(expectedDelay - TimeUnit.SECONDS.toMillis(10));
+    }
+
+    @Test
+    @DisplayName("Test the retry is triggered immediately when the retry interval has already elapsed")
+    void testOf_retryIntervalAlreadyElapsed_triggerRetryImmediately() {
+        // This happens when the retry event is recreated long after the task failed, e.g. the master which owned
+        // the workflow crashed and another master takes the workflow over by failover.
+        final long elapsedTime = TimeUnit.HOURS.toMillis(2);
+        when(taskExecution.getTaskInstance()).thenReturn(createFailedTaskInstance(elapsedTime));
+
+        final TaskRetryLifecycleEvent event = TaskRetryLifecycleEvent.of(taskExecution);
+
+        assertThat(event.getDelay(TimeUnit.MILLISECONDS)).isAtMost(0L);
+    }
+
+    @Test
+    @DisplayName("Test creating the retry event failed when the task has no remaining retry times")
+    void testOf_retryTimesExhausted_throwIllegalStateException() {
+        final TaskInstance taskInstance = createFailedTaskInstance(0);
+        taskInstance.setRetryTimes(MAX_RETRY_TIMES);
+        when(taskExecution.getTaskInstance()).thenReturn(taskInstance);
+
+        assertThrows(IllegalStateException.class, () -> TaskRetryLifecycleEvent.of(taskExecution));
+    }
+
+    private TaskInstance createFailedTaskInstance(final long elapsedTimeSinceTaskEnded) {
+        final TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setRetryTimes(0);
+        taskInstance.setMaxRetryTimes(MAX_RETRY_TIMES);
+        taskInstance.setRetryInterval(RETRY_INTERVAL_MINUTES);
+        taskInstance.setEndTime(new Date(System.currentTimeMillis() - elapsedTimeSinceTaskEnded));
+        return taskInstance;
+    }
+}


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?

YES. The faulty expression was located and the fix and unit tests were drafted with AI
assistance (Claude Code); the reasoning, the failover impact analysis and the final code
were reviewed and verified by me.

## Purpose of the pull request

Closes #18538.

`TaskRetryLifecycleEvent#of` computes the delay before a failed task is retried. The
intent is to retry at `endTime + retryInterval`, so the remaining delay is
`retryInterval - (now - endTime)`. The expression instead evaluated to
`retryInterval + (now - endTime)` — the elapsed time was added rather than subtracted:

```java
final long remainingTime =
        TimeUnit.MINUTES.toMillis(delayTime) + System.currentTimeMillis() - taskInstance.getEndTime().getTime();
```

In the common path `now - endTime` is a few milliseconds, so the error is invisible. It
matters when the retry event is created long after the task actually ended — most
notably on **master failover**: `WorkflowFailoverCommandHandler` rebuilds the execution
graph from the existing task instances, so a task left in `FAILURE` with retries
remaining keeps its old `endTime`; `TaskFailureStateAction#onStartEvent` then republishes
the failure event with that stale `endTime`, and the retry gets postponed by the whole
outage duration on top of the configured interval instead of firing immediately.

## Brief change log

- `TaskRetryLifecycleEvent#of`: subtract the elapsed time since `endTime` from the retry
  interval, and clamp the result to `0` so an already-overdue retry is triggered
  immediately.
- Renamed the local `delayTime` to `retryInterval` — it holds the configured retry
  interval and shadowed the inherited `AbstractDelayEvent#delayTime` field, which is what
  made the wrong expression easy to miss.
- Added `TaskRetryLifecycleEventTest`.

## Verify this pull request

This change added tests and can be verified as follows:

- Added `TaskRetryLifecycleEventTest` with three cases:
  - retry interval **not** elapsed → the event is delayed for the remaining interval;
  - retry interval **already** elapsed (the failover case, `endTime` two hours in the
    past) → the event is ready immediately. This case fails on `dev` with a delay of
    ~2h05m;
  - retry times exhausted → `IllegalStateException`, guarding the existing `checkState`.

```bash
./mvnw -pl dolphinscheduler-master -am clean test \
    -Dtest=TaskRetryLifecycleEventTest \
    -Dsurefire.failIfNoSpecifiedTests=false
```

Verified locally:

- The new tests fail on `dev` and pass with this change. On `dev` the failover case reports
  a delay of `7499999` ms (~2h05m) where `0` is expected, and the normal case reports
  `330016` ms where at most `270000` ms is expected.
- The full `dolphinscheduler-master` suite was run (98 tests). The only non-passing test was
  `WorkflowStartTimeoutTestCase#testStartWorkflow_withTimeoutWarnFailedTask`, which is
  unrelated timing flakiness under the 4-way parallel forks: its fixture defines no
  `failRetryTimes`, so `maxRetryTimes` is `0`, `isTaskInstanceCanRetry()` is false and
  `TaskRetryLifecycleEvent#of` is never reached. The class passes 5/5 when re-run in
  isolation.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
