### PR TITLE
fix: return at most one task instance per task code in findLastTaskInstances to avoid duplicate key exception (#18543)

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -253,7 +253,7 @@
         </include>
         from t_ds_task_instance instance
         join (
-        select task_code, max(end_time) as max_end_time, workflow_instance_id
+        select task_code, max(id) as max_id, workflow_instance_id
         from t_ds_task_instance
         where 1=1
         and workflow_instance_id = #{workflowInstanceId}
@@ -268,7 +268,7 @@
         ) t_max
         on instance.workflow_instance_id = t_max.workflow_instance_id
         and instance.task_code = t_max.task_code
-        and instance.end_time = t_max.max_end_time
+        and instance.id = t_max.max_id
     </select>
     <select id="findLastTaskInstance" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
         select


### PR DESCRIPTION
Fixes #18543

## Problem
`findLastTaskInstances` was joining on `max(end_time)`, but `end_time` is a MySQL `datetime` without fractional seconds, so two task attempts finishing in the same second produce duplicate rows for the same task code. This causes `Collectors.toMap` to throw `IllegalStateException: Duplicate key` in `DependentExecute#dependResultByAllTaskOfWorkflowInstance.

## Fix
Use `max(id)` instead of `max(end_time)` — `id` is an auto-increment primary key, guaranteeing uniqueness per task code.