### PR TITLE
fix: avoid duplicate task instances in findLastTaskInstances by joining on id

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -253,7 +253,7 @@
         </include>
         from t_ds_task_instance instance
         join (
-        select task_code, max(end_time) as max_end_time, workflow_instance_id
+        select task_code, max(end_time) as max_end_time, max(id) as max_id, workflow_instance_id
         from t_ds_task_instance
         where 1=1
         and workflow_instance_id = #{workflowInstanceId}
@@ -268,7 +268,7 @@
         ) t_max
         on instance.workflow_instance_id = t_max.workflow_instance_id
         and instance.task_code = t_max.task_code
-        and instance.end_time = t_max.max_end_time
+        and instance.id = t_max.max_id
     </select>
     <select id="findLastTaskInstance" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
         select


### PR DESCRIPTION
## Purpose of the pull request

Fixes #18543

`TaskInstanceMapper#findLastTaskInstances` is supposed to return the **last** task instance per task code of a workflow instance. It resolves "last" by joining on the maximum `end_time`:

```sql
join (
  select task_code, max(end_time) as max_end_time, workflow_instance_id
  from t_ds_task_instance
  ...
  group by task_code
) t_max
on ... and instance.end_time = t_max.max_end_time
```

`end_time` is **not unique**. On MySQL it is `datetime` without fractional seconds, so when two attempts of the same task share the same `end_time` (e.g. a task that fails and is retried quickly within the same second), both rows match `instance.end_time = t_max.max_end_time` and the query returns **two rows for one task code**.

## What this PR changes

The subquery now additionally selects `max(id) as max_id` (the primary key, which is strictly increasing), and the join is changed from `instance.end_time = t_max.max_end_time` to `instance.id = t_max.max_id`. This guarantees exactly one (the latest) task instance per task code, eliminating the duplicate rows.

## Verification

- Query now returns at most one row per `task_code` per `workflow_instance_id`.
- No behavior change for the common case where `end_time` values are distinct.

Closes #18543
