### PR TITLE
[Doc-18551][Integration] Document community MCP integrations

### DIFF
--- a/docs/configs/docsdev.js
+++ b/docs/configs/docsdev.js
@@ -511,6 +511,10 @@ export default {
                         title: 'integration',
                         children: [
                             {
+                                title: 'Community MCP Integrations',
+                                link: '/en-us/docs/dev/user_doc/guide/integration/mcp.html',
+                            },
+                            {
                                 title: 'Rainbond Deployment',
                                 link: '/en-us/docs/dev/user_doc/guide/integration/rainbond.html',
                             },
@@ -1222,6 +1226,10 @@ export default {
                     {
                         title: '集成',
                         children: [
+                            {
+                                title: '社区 MCP 集成',
+                                link: '/zh-cn/docs/dev/user_doc/guide/integration/mcp.html',
+                            },
                             {
                                 title: '基于Rainbond部署(Cluster)',
                                 link: '/zh-cn/docs/dev/user_doc/guide/integration/rainbond.html',

--- a/docs/docs/en/guide/integration/mcp.md
+++ b/docs/docs/en/guide/integration/mcp.md
@@ -1,0 +1,25 @@
+# Community MCP Integrations
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) allows AI applications to call external systems through structured tools. A DolphinScheduler MCP server translates those tool calls into requests to the DolphinScheduler [Open API](../api/open-api.md).
+
+> The integrations on this page are maintained by their respective communities. They are not Apache DolphinScheduler components, and listing them here does not imply endorsement by the Apache Software Foundation. Check each project's compatibility, security, and support policy before using it.
+
+## Available Integrations
+
+|                                       Project                                       |                                                                    Focus                                                                    |                                           Authentication                                            |
+|-------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| [iflytek/dolphin-mcp-pilot](https://github.com/iflytek/dolphin-mcp-pilot)           | Curated tools for projects, workflow and DAG creation, schedules, instances, resources, logs, monitoring, and raw API access                | DolphinScheduler API token or user name and password; supports per-request credentials in HTTP mode |
+| [ocean-zhc/dolphinscheduler-mcp](https://github.com/ocean-zhc/dolphinscheduler-mcp) | Tools that expose DolphinScheduler REST API operations, including project, process, task, schedule, resource, and administration operations | DolphinScheduler API token                                                                          |
+
+Follow the installation and client configuration instructions in the selected project's repository. Those instructions are versioned with the integration and are more likely to match its current transport and DolphinScheduler compatibility requirements.
+
+## Before You Connect an AI Client
+
+1. Confirm that the integration supports your DolphinScheduler and MCP client versions.
+2. Create dedicated DolphinScheduler credentials with only the permissions required for the intended tools. Avoid using an administrator account for routine agent access.
+3. Keep the MCP endpoint on a trusted network. If remote access is required, protect it with TLS, authentication, and network access controls.
+4. Store credentials in environment variables or a secret manager, and never commit them to a repository or shared client configuration.
+5. Review or restrict tools that mutate state. Workflow execution, resource updates, force-success operations, and deletion can have production impact.
+6. Enable appropriate DolphinScheduler and gateway audit logs, and rotate credentials according to your organization's policy.
+
+For problems in an MCP server or its setup, use that project's issue tracker. Use the Apache DolphinScheduler issue tracker only when the underlying behavior can be reproduced against DolphinScheduler itself.

--- a/docs/docs/zh/guide/integration/mcp.md
+++ b/docs/docs/zh/guide/integration/mcp.md
@@ -1,0 +1,25 @@
+# 社区 MCP 集成
+
+[模型上下文协议（Model Context Protocol，MCP）](https://modelcontextprotocol.io/) 允许 AI 应用通过结构化工具调用外部系统。DolphinScheduler MCP 服务会将工具调用转换为 DolphinScheduler [Open API](../api/open-api.md) 请求。
+
+> 本页所列集成由各自社区维护，不属于 Apache DolphinScheduler 组件。列入本文档不代表 Apache 软件基金会为其背书。使用前，请检查相应项目的兼容性、安全策略和支持政策。
+
+## 可用集成
+
+|                                         项目                                          |                            侧重点                            |                        认证方式                         |
+|-------------------------------------------------------------------------------------|-----------------------------------------------------------|-----------------------------------------------------|
+| [iflytek/dolphin-mcp-pilot](https://github.com/iflytek/dolphin-mcp-pilot)           | 为项目、工作流与 DAG 创建、调度、实例、资源、日志、监控和原始 API 访问提供经过整理的工具         | DolphinScheduler API Token 或用户名和密码；HTTP 模式支持按请求传递凭据 |
+| [ocean-zhc/dolphinscheduler-mcp](https://github.com/ocean-zhc/dolphinscheduler-mcp) | 将 DolphinScheduler REST API 操作暴露为工具，覆盖项目、流程、任务、调度、资源和管理操作 | DolphinScheduler API Token                          |
+
+请按照所选项目仓库中的安装和客户端配置说明进行操作。这些说明会随集成版本更新，能够更准确地反映当前传输方式及 DolphinScheduler 兼容性要求。
+
+## 连接 AI 客户端前的检查
+
+1. 确认集成支持当前使用的 DolphinScheduler 和 MCP 客户端版本。
+2. 创建专用的 DolphinScheduler 凭据，并且只授予目标工具所需的权限。日常 Agent 访问应避免使用管理员账号。
+3. 将 MCP 端点限制在可信网络内。如需远程访问，请使用 TLS、身份认证和网络访问控制进行保护。
+4. 使用环境变量或密钥管理服务保存凭据，切勿将凭据提交到代码仓库或共享的客户端配置中。
+5. 审查或限制会修改状态的工具。执行工作流、更新资源、强制任务成功和删除操作都可能影响生产环境。
+6. 按需启用 DolphinScheduler 和网关审计日志，并根据组织安全策略轮换凭据。
+
+如果问题来自 MCP 服务或其配置，请在相应项目的 Issue Tracker 中反馈。只有在能够直接通过 DolphinScheduler 复现底层问题时，才应使用 Apache DolphinScheduler Issue Tracker。


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. AI assisted with repository research, drafting the bilingual documentation, and selecting validation commands. The resulting diff and referenced project capabilities were verified against the current source repositories.

## Purpose of the pull request

Closes #18551.

Add a discoverable, neutral entry point for community-maintained Model Context Protocol integrations without presenting third-party projects as Apache DolphinScheduler components.

## Brief change log

- Add English and Chinese community MCP integration pages.
- List iflytek/dolphin-mcp-pilot and ocean-zhc/dolphinscheduler-mcp with their different focus and authentication options.
- Document third-party maintenance boundaries and security guidance for AI-agent access.
- Add both pages to the English and Chinese integration navigation.

## Verify this pull request

This documentation-only change was verified as follows:

- .\mvnw.cmd -N spotless:check
- python -X utf8 img_utils.py -v dev-syntax
- node --check docs\configs\docsdev.js
- Verified both relative Open API links resolve to existing English and Chinese documents.

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)