### PR TITLE
fix: stop flink job error by using flink cancel command before process kill

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkTask.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-flink/src/main/java/org/apache/dolphinscheduler/plugin/task/flink/FlinkTask.java
@@ -19,7 +19,9 @@ package org.apache.dolphinscheduler.plugin.task.flink;
 
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractYarnTask;
+import org.apache.dolphinscheduler.plugin.task.api.TaskCallBack;
 import org.apache.dolphinscheduler.plugin.task.api.TaskConstants;
+import org.apache.dolphinscheduler.plugin.task.api.TaskException;
 import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
 import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
@@ -116,5 +118,48 @@ public class FlinkTask extends AbstractYarnTask {
             return str.substring(6);
         }
         return null;
+    }
+
+    /**
+     * Cancel the Flink application.
+     * <p>
+     * This method first attempts to gracefully cancel the Flink job using the
+     * {@code flink cancel} command with the application ID. This ensures that
+     * the Flink job is properly stopped and resources are released. If the
+     * graceful cancel fails (e.g., the Flink CLI is unavailable or the job
+     * is already terminated), it falls back to the parent class's
+     * {@link #cancelApplication()} which uses process-level kill signals.
+     *
+     * @throws TaskException if both the Flink cancel and the fallback kill fail
+     */
+    @Override
+    public void cancelApplication() throws TaskException {
+        try {
+            String appIds = String.join(TaskConstants.COMMA, getApplicationIds());
+            if (StringUtils.isNotBlank(appIds)) {
+                log.info("Attempting to gracefully cancel Flink job with appId(s): {}", appIds);
+                List<String> cancelCommand = FlinkArgsUtils.buildCancelCommandLine(taskExecutionContext);
+                String command = String.join(" ", cancelCommand);
+                log.info("Executing Flink cancel command: {}", command);
+                ProcessBuilder processBuilder = new ProcessBuilder("/bin/sh", "-c", command);
+                Process cancelProcess = processBuilder.start();
+                boolean finished = cancelProcess.waitFor(30, java.util.concurrent.TimeUnit.SECONDS);
+                if (finished && cancelProcess.exitValue() == 0) {
+                    log.info("Flink job cancelled successfully via flink cancel command, appId(s): {}", appIds);
+                    return;
+                } else {
+                    log.warn("Flink cancel command did not succeed (exit code: {}, finished: {}), "
+                            + "falling back to process kill", 
+                            finished ? cancelProcess.exitValue() : -1, finished);
+                    cancelProcess.destroyForcibly();
+                }
+            } else {
+                log.info("No appIds found for Flink task, skipping flink cancel, falling back to process kill");
+            }
+        } catch (Exception e) {
+            log.warn("Failed to gracefully cancel Flink job, falling back to process kill", e);
+        }
+        // Fall back to the default process-level kill
+        super.cancelApplication();
     }
 }


### PR DESCRIPTION
## What this PR does

Fixes the issue where stopping Flink tasks from the DolphinScheduler page fails to send proper kill signals, causing errors in worker node logs.

### Root Cause

When a user clicks "Stop" on a Flink task, DolphinScheduler uses the generic `AbstractCommandExecutor.cancelApplication()` method, which sends OS-level kill signals (SIGINT → SIGTERM → SIGKILL) to the process tree. This approach does not properly stop the Flink job — it kills the shell process but fails to gracefully cancel the Flink application, leading to:
- Error logs in worker nodes
- Flink jobs not being properly terminated
- Resource leaks in the YARN/Kubernetes cluster

### Fix

Override `cancelApplication()` in `FlinkTask` to:

1. **First attempt graceful cancellation** using the `flink cancel <appId>` command (via `FlinkArgsUtils.buildCancelCommandLine()`). This method already existed in the codebase but was never called.
2. **Fall back to process-level kill** (the parent class implementation) if the Flink cancel command fails, times out (30s), or no appIds are available.

### Changes

- **`FlinkTask.java`**: Added `cancelApplication()` override that tries `flink cancel` first, then falls back to `super.cancelApplication()`
- Added imports: `TaskException`, `TaskCallBack`

### Issue Link

Fixes #16789

### Before

Stopping a Flink task from the page → `AbstractCommandExecutor.cancelApplication()` → `ProcessUtils.kill()` (SIGINT/SIGTERM/SIGKILL) → Flink job not properly cancelled, worker logs show errors

### After

Stopping a Flink task from the page → `FlinkTask.cancelApplication()` → `flink cancel <appId>` (graceful) → if fails → `super.cancelApplication()` (process kill as fallback)

### Checklist

- [x] I have searched the [issues](https://github.com/apache/dolphinscheduler/issues) of this repository and believe that this is not a duplicate.
- [x] I have checked that this modification does not cause CI to fail.
- [x] I will sign the Apache CLA if required.
- [x] The code follows the projects coding style.