### PR TITLE
[Improvement-18563][API] Refine datasource authorization list APIs

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/DataSourceController.java
@@ -39,6 +39,7 @@ import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.DataSourceService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.api.vo.DataSourceSimpleInfoVO;
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -286,7 +287,7 @@ public class DataSourceController extends BaseController {
      *
      * @param loginUser login user
      * @param userId user id
-     * @return a list of unauthorized DataSource objects
+     * @return a list of unauthorized data source summaries
      */
     @Operation(summary = "unauthorizedDatasource", description = "UNAUTHORIZED_DATA_SOURCE_NOTES")
     @Parameters({
@@ -295,10 +296,10 @@ public class DataSourceController extends BaseController {
     @GetMapping(value = "/unauth-datasource")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(UNAUTHORIZED_DATASOURCE)
-    public Result<Object> getUnauthorizedDatasourceList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                        @RequestParam("userId") Integer userId) {
+    public Result<List<DataSourceSimpleInfoVO>> getUnauthorizedDatasourceList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                              @RequestParam("userId") Integer userId) {
 
-        List<DataSource> unAuthDatasourceList = dataSourceService.unAuthDatasource(loginUser, userId);
+        List<DataSourceSimpleInfoVO> unAuthDatasourceList = dataSourceService.unAuthDatasource(loginUser, userId);
         return Result.success(unAuthDatasourceList);
     }
 
@@ -307,7 +308,7 @@ public class DataSourceController extends BaseController {
      *
      * @param loginUser login user
      * @param userId user id
-     * @return a list of authorized DataSource objects
+     * @return a list of authorized data source summaries
      */
     @Operation(summary = "authedDatasource", description = "AUTHORIZED_DATA_SOURCE_NOTES")
     @Parameters({
@@ -316,9 +317,9 @@ public class DataSourceController extends BaseController {
     @GetMapping(value = "/authed-datasource")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(AUTHORIZED_DATA_SOURCE)
-    public Result<Object> getAuthorizedDatasourceList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
-                                                      @RequestParam("userId") Integer userId) {
-        List<DataSource> authedDatasourceList = dataSourceService.authedDatasource(loginUser, userId);
+    public Result<List<DataSourceSimpleInfoVO>> getAuthorizedDatasourceList(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                                            @RequestParam("userId") Integer userId) {
+        List<DataSourceSimpleInfoVO> authedDatasourceList = dataSourceService.authedDatasource(loginUser, userId);
         return Result.success(authedDatasourceList);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.api.service;
 
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.api.vo.DataSourceSimpleInfoVO;
 import org.apache.dolphinscheduler.dao.entity.DataSource;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.plugin.datasource.api.datasource.BaseDataSourceParamDTO;
@@ -126,18 +127,18 @@ public interface DataSourceService {
      *
      * @param loginUser login user
      * @param userId    user id
-     * @return a list of {@link DataSource} objects that are available to be authorized to the target user
+     * @return a list of data sources that are available to be authorized to the target user
      */
-    List<DataSource> unAuthDatasource(User loginUser, Integer userId);
+    List<DataSourceSimpleInfoVO> unAuthDatasource(User loginUser, Integer userId);
 
     /**
      * query the list of data sources authorized for a specific user
      *
      * @param loginUser login user
      * @param userId    user id
-     * @return a list of {@link DataSource} objects that are authorized to the target user
+     * @return a list of data sources that are authorized to the target user
      */
-    List<DataSource> authedDatasource(User loginUser, Integer userId);
+    List<DataSourceSimpleInfoVO> authedDatasource(User loginUser, Integer userId);
 
     /**
      * query the list of tables from a specific database within a data source

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/DataSourceServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.service.DataSourceService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.api.vo.DataSourceSimpleInfoVO;
 import org.apache.dolphinscheduler.common.constants.Constants;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
@@ -315,15 +316,11 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
     }
 
     @Override
-    public List<DataSource> unAuthDatasource(User loginUser, Integer userId) {
-        List<DataSource> datasourceList;
-        if (canOperatorPermissions(loginUser, null, AuthorizationType.DATASOURCE, null)) {
-            // admin gets all data sources except userId
-            datasourceList = dataSourceDao.queryDatasourceExceptUserId(userId);
-        } else {
-            // non-admins users get their own data sources
-            datasourceList = dataSourceDao.queryByUserId(loginUser.getId());
+    public List<DataSourceSimpleInfoVO> unAuthDatasource(User loginUser, Integer userId) {
+        if (isNotAdmin(loginUser)) {
+            throw new ServiceException(Status.USER_NO_OPERATION_PERM);
         }
+        List<DataSource> datasourceList = dataSourceDao.queryDatasourceExceptUserId(userId);
         List<DataSource> resultList = new ArrayList<>();
         Set<DataSource> datasourceSet;
         if (datasourceList != null && !datasourceList.isEmpty()) {
@@ -338,13 +335,16 @@ public class DataSourceServiceImpl extends BaseServiceImpl implements DataSource
             }
             resultList = new ArrayList<>(datasourceSet);
         }
-        return resultList;
+        return resultList.stream().map(DataSourceSimpleInfoVO::new).collect(Collectors.toList());
     }
 
     @Override
-    public List<DataSource> authedDatasource(User loginUser, Integer userId) {
+    public List<DataSourceSimpleInfoVO> authedDatasource(User loginUser, Integer userId) {
+        if (isNotAdmin(loginUser)) {
+            throw new ServiceException(Status.USER_NO_OPERATION_PERM);
+        }
         List<DataSource> authedDatasourceList = dataSourceDao.queryAuthedDatasource(userId);
-        return authedDatasourceList;
+        return authedDatasourceList.stream().map(DataSourceSimpleInfoVO::new).collect(Collectors.toList());
     }
 
     @Override

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/vo/DataSourceSimpleInfoVO.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/vo/DataSourceSimpleInfoVO.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.vo;
+
+import org.apache.dolphinscheduler.dao.entity.DataSource;
+
+import lombok.Data;
+
+@Data
+public class DataSourceSimpleInfoVO {
+
+    private Integer id;
+
+    private String name;
+
+    public DataSourceSimpleInfoVO(DataSource dataSource) {
+        this.id = dataSource.getId();
+        this.name = dataSource.getName();
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
@@ -27,6 +27,7 @@ import org.apache.dolphinscheduler.api.permission.ResourcePermissionCheckService
 import org.apache.dolphinscheduler.api.service.impl.BaseServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.DataSourceServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.api.vo.DataSourceSimpleInfoVO;
 import org.apache.dolphinscheduler.common.enums.AuthorizationType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
@@ -49,8 +50,6 @@ import org.apache.dolphinscheduler.plugin.datasource.postgresql.param.PostgreSQL
 import org.apache.dolphinscheduler.spi.datasource.ConnectionParam;
 import org.apache.dolphinscheduler.spi.enums.DbConnectType;
 import org.apache.dolphinscheduler.spi.enums.DbType;
-
-import org.apache.commons.collections4.CollectionUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
@@ -320,50 +319,39 @@ public class DataSourceServiceTest {
 
     @Test
     public void testUnAuthDatasource() {
-        User loginUser = getAdminUser();
-        loginUser.setId(1);
-        loginUser.setUserType(UserType.ADMIN_USER);
         int userId = 3;
-        when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.DATASOURCE,
-                loginUser.getId(), null, baseServiceLogger)).thenReturn(true);
-        when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.DATASOURCE, null, 0,
-                baseServiceLogger)).thenReturn(true);
-        // test admin user
+
+        User generalUser = getGeneralUser();
+        assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
+                () -> dataSourceService.unAuthDatasource(generalUser, userId));
+        Mockito.verifyNoInteractions(dataSourceDao);
+
+        User adminUser = getAdminUser();
         when(dataSourceDao.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
         when(dataSourceDao.queryDatasourceExceptUserId(userId)).thenReturn(getDataSourceList());
-        List<DataSource> dataSources = dataSourceService.unAuthDatasource(loginUser, userId);
-        logger.info(dataSources.toString());
-        Assertions.assertTrue(CollectionUtils.isNotEmpty(dataSources));
+        List<DataSourceSimpleInfoVO> dataSources = dataSourceService.unAuthDatasource(adminUser, userId);
 
-        // test non-admin user
-        loginUser.setId(2);
-        loginUser.setUserType(UserType.GENERAL_USER);
-        when(dataSourceDao.queryByUserId(loginUser.getId()))
-                .thenReturn(getDataSourceList());
-        dataSources = dataSourceService.unAuthDatasource(loginUser, userId);
-        logger.info(dataSources.toString());
-        Assertions.assertTrue(CollectionUtils.isNotEmpty(dataSources));
+        Assertions.assertEquals(2, dataSources.size());
+        Assertions.assertTrue(dataSources.stream().noneMatch(dataSource -> dataSource.getId() == 3));
+        dataSources.forEach(this::assertDataSourceSimpleInfo);
     }
 
     @Test
     public void testAuthedDatasource() {
-        User loginUser = getAdminUser();
-        loginUser.setId(1);
-        loginUser.setUserType(UserType.ADMIN_USER);
         int userId = 3;
 
-        // test admin user
-        when(dataSourceDao.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
-        List<DataSource> dataSources = dataSourceService.authedDatasource(loginUser, userId);
-        logger.info(dataSources.toString());
-        Assertions.assertTrue(CollectionUtils.isNotEmpty(dataSources));
+        User generalUser = getGeneralUser();
+        assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
+                () -> dataSourceService.authedDatasource(generalUser, userId));
+        Mockito.verifyNoInteractions(dataSourceDao);
 
-        // test non-admin user
-        loginUser.setId(2);
-        loginUser.setUserType(UserType.GENERAL_USER);
-        dataSources = dataSourceService.authedDatasource(loginUser, userId);
-        logger.info(dataSources.toString());
-        Assertions.assertNotNull(dataSources);
+        User adminUser = getAdminUser();
+        when(dataSourceDao.queryAuthedDatasource(userId)).thenReturn(getSingleDataSourceList());
+        List<DataSourceSimpleInfoVO> dataSources = dataSourceService.authedDatasource(adminUser, userId);
+
+        Assertions.assertEquals(1, dataSources.size());
+        Assertions.assertEquals(3, dataSources.get(0).getId());
+        assertDataSourceSimpleInfo(dataSources.get(0));
     }
 
     @Test
@@ -442,6 +430,12 @@ public class DataSourceServiceTest {
 
     private List<DataSource> getSingleDataSourceList() {
         return Collections.singletonList(getOracleDataSource(3));
+    }
+
+    private void assertDataSourceSimpleInfo(DataSourceSimpleInfoVO dataSource) {
+        Assertions.assertNotNull(dataSource.getId());
+        Assertions.assertEquals("test", dataSource.getName());
+        Assertions.assertEquals(2, JSONUtils.parseObject(JSONUtils.toJsonString(dataSource)).size());
     }
 
     private DataSource getOracleDataSource() {

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/DataSourceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/DataSourceMapper.xml
@@ -68,13 +68,12 @@
         where name=#{name}
     </select>
     <select id="queryAuthedDatasource" resultType="org.apache.dolphinscheduler.dao.entity.DataSource">
-        select ds.id, ds.name, ds.note, ds.type, ds.user_id, ds.connection_params, ds.create_time, ds.update_time
+        select ds.id, ds.name
         from t_ds_datasource ds, t_ds_relation_datasource_user rel
         where ds.id = rel.datasource_id AND rel.user_id = #{userId}
     </select>
     <select id="queryDatasourceExceptUserId" resultType="org.apache.dolphinscheduler.dao.entity.DataSource">
-        select
-        <include refid="baseSql"/>
+        select id, name
         from t_ds_datasource
         where user_id <![CDATA[ <> ]]> #{userId}
     </select>

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/DataSourceMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/DataSourceMapperTest.java
@@ -189,7 +189,7 @@ public class DataSourceMapperTest extends BaseDaoTest {
         for (DataSource actualDataSource : actualDataSources) {
             DataSource expectedDataSource = expectedDataSourceMap.get(actualDataSource.getId());
             if (expectedDataSource != null) {
-                Assertions.assertEquals(expectedDataSource, actualDataSource);
+                assertDataSourceSimpleInfo(expectedDataSource, actualDataSource);
             }
         }
 
@@ -210,9 +210,19 @@ public class DataSourceMapperTest extends BaseDaoTest {
         for (DataSource actualDataSource : actualDataSources) {
             DataSource expectedDataSource = expectedDataSourceMap.get(actualDataSource.getId());
             if (expectedDataSource != null) {
-                Assertions.assertEquals(expectedDataSource, actualDataSource);
+                assertDataSourceSimpleInfo(expectedDataSource, actualDataSource);
             }
         }
+    }
+
+    private void assertDataSourceSimpleInfo(DataSource expectedDataSource, DataSource actualDataSource) {
+        Assertions.assertEquals(expectedDataSource.getId(), actualDataSource.getId());
+        Assertions.assertEquals(expectedDataSource.getName(), actualDataSource.getName());
+        Assertions.assertNull(actualDataSource.getConnectionParams());
+        Assertions.assertNull(actualDataSource.getNote());
+        Assertions.assertNull(actualDataSource.getType());
+        Assertions.assertNull(actualDataSource.getCreateTime());
+        Assertions.assertNull(actualDataSource.getUpdateTime());
     }
 
     /**


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The implementation and tests were assisted by AI and reviewed locally.

## Purpose of the pull request

Align the datasource authorization list APIs with the related grant operation and keep their responses focused on the user management page requirements.

Closes #18563.

## Brief change log

- Limit datasource authorization list APIs to administrators.
- Return only datasource id and name.
- Query only the fields required by the authorization page.
- Add regression coverage for permissions and response fields.

## Verify this pull request

This change added tests and can be verified with `DataSourceMapperTest`, `DataSourceServiceTest`, and `DataSourceControllerTest`.

