### PR TITLE
[Fix-18565][API] Validate datasource access for task definitions

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/TaskDatasourcePermissionChecker.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/TaskDatasourcePermissionChecker.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager;
+import org.apache.dolphinscheduler.plugin.task.api.enums.ResourceType;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.AbstractParameters;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.AbstractResourceParameters;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.resource.ResourceParametersHelper;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TaskDatasourcePermissionChecker {
+
+    private final ResourcePermissionCheckService resourcePermissionCheckService;
+
+    public TaskDatasourcePermissionChecker(ResourcePermissionCheckService resourcePermissionCheckService) {
+        this.resourcePermissionCheckService = resourcePermissionCheckService;
+    }
+
+    public void checkPermission(User loginUser, Collection<? extends TaskDefinition> taskDefinitions) {
+        if (taskDefinitions == null || taskDefinitions.isEmpty()) {
+            return;
+        }
+
+        Set<Integer> datasourceIds = new HashSet<>();
+        for (TaskDefinition taskDefinition : taskDefinitions) {
+            AbstractParameters taskParameters = TaskPluginManager.parseTaskParameters(
+                    taskDefinition.getTaskType(), taskDefinition.getTaskParams());
+            ResourceParametersHelper resources = taskParameters.getResources();
+            if (resources == null) {
+                continue;
+            }
+            Map<Integer, AbstractResourceParameters> datasourceResources =
+                    resources.getResourceMap(ResourceType.DATASOURCE);
+            if (datasourceResources == null) {
+                continue;
+            }
+            datasourceResources.keySet().stream()
+                    .filter(datasourceId -> datasourceId != null && datasourceId > 0)
+                    .forEach(datasourceIds::add);
+        }
+
+        if (datasourceIds.isEmpty()) {
+            return;
+        }
+
+        int userId = loginUser.getUserType() == UserType.ADMIN_USER ? 0 : loginUser.getId();
+        Integer[] datasourceIdArray = datasourceIds.toArray(new Integer[0]);
+        if (!resourcePermissionCheckService.resourcePermissionCheck(
+                AuthorizationType.DATASOURCE, datasourceIdArray, userId, log)) {
+            log.warn("User does not have permission to use datasource referenced by task, userId:{}.",
+                    loginUser.getId());
+            throw new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION);
+        }
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -367,7 +367,6 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                         notExistTaskCodes);
                 throw new ServiceException(Status.TASK_DEFINE_NOT_EXIST, notExistTaskCodes);
             }
-            taskDatasourcePermissionChecker.checkPermission(loginUser, upstreamTaskDefinitionList);
         } else {
             queryUpStreamTaskCodeMap = new HashMap<>();
         }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -25,6 +25,7 @@ import static org.apache.dolphinscheduler.plugin.task.api.TaskPluginManager.chec
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.PermissionCheck;
+import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.TaskDefinitionService;
 import org.apache.dolphinscheduler.api.service.WorkflowTaskRelationService;
@@ -116,6 +117,9 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
 
     @Autowired
     private WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
+
+    @Autowired
+    private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
 
     /**
      * query task definition
@@ -223,19 +227,20 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         }
         TaskDefinitionLog taskDefinitionToUpdate =
                 JSONUtils.parseObject(taskDefinitionJsonObj, TaskDefinitionLog.class);
-        if (TimeoutFlag.CLOSE == taskDefinition.getTimeoutFlag()) {
-            taskDefinition.setTimeoutNotifyStrategy(null);
-        }
-        if (taskDefinition.equals(taskDefinitionToUpdate)) {
-            log.warn("Task definition does not need update because no change, taskDefinitionCode:{}.", taskCode);
-            return null;
-        }
         if (taskDefinitionToUpdate == null) {
             log.warn("Parameter taskDefinitionJson is invalid.");
             throw new ServiceException(Status.DATA_IS_NOT_VALID, taskDefinitionJsonObj);
         }
         if (!checkTaskParameters(taskDefinitionToUpdate.getTaskType(), taskDefinitionToUpdate.getTaskParams())) {
             throw new ServiceException(Status.WORKFLOW_NODE_S_PARAMETER_INVALID, taskDefinitionToUpdate.getName());
+        }
+        taskDatasourcePermissionChecker.checkPermission(loginUser, Collections.singletonList(taskDefinitionToUpdate));
+        if (TimeoutFlag.CLOSE == taskDefinition.getTimeoutFlag()) {
+            taskDefinition.setTimeoutNotifyStrategy(null);
+        }
+        if (taskDefinition.equals(taskDefinitionToUpdate)) {
+            log.warn("Task definition does not need update because no change, taskDefinitionCode:{}.", taskCode);
+            return null;
         }
         Integer version = taskDefinitionLogMapper.queryMaxVersionForDefinition(taskCode);
         if (version == null || version == 0) {
@@ -362,6 +367,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                         notExistTaskCodes);
                 throw new ServiceException(Status.TASK_DEFINE_NOT_EXIST, notExistTaskCodes);
             }
+            taskDatasourcePermissionChecker.checkPermission(loginUser, upstreamTaskDefinitionList);
         } else {
             queryUpStreamTaskCodeMap = new HashMap<>();
         }
@@ -518,6 +524,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         }
         TaskDefinitionLog taskDefinitionUpdate =
                 taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(taskCode, version);
+        taskDatasourcePermissionChecker.checkPermission(loginUser, Collections.singletonList(taskDefinitionUpdate));
         taskDefinitionUpdate.setUserId(loginUser.getId());
         taskDefinitionUpdate.setUpdateTime(new Date());
         taskDefinitionUpdate.setId(taskDefinition.getId());
@@ -665,6 +672,8 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                 taskDefinitionLog.setFlag(Flag.NO);
                 break;
             case ONLINE:
+                taskDatasourcePermissionChecker.checkPermission(loginUser,
+                        Collections.singletonList(taskDefinitionLog));
                 String resourceIds = taskDefinition.getResourceIds();
                 if (StringUtils.isNotBlank(resourceIds)) {
                     Integer[] resourceIdArray =

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -40,6 +40,7 @@ import org.apache.dolphinscheduler.api.dto.treeview.TreeViewDto;
 import org.apache.dolphinscheduler.api.dto.workflow.WorkflowDefinitionVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.SchedulerService;
 import org.apache.dolphinscheduler.api.service.TaskDefinitionLogService;
@@ -209,6 +210,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     @Autowired
     private GlobalParamsValidator globalParamsValidator;
 
+    @Autowired
+    private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
     /**
      * create workflow definition
      *
@@ -271,6 +275,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                  List<WorkflowTaskRelationLog> taskRelationList,
                                                  WorkflowDefinition workflowDefinition,
                                                  List<TaskDefinitionLog> taskDefinitionLogs) {
+        taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         int saveTaskResult = processService.saveTaskDefine(loginUser, workflowDefinition.getProjectCode(),
                 taskDefinitionLogs, Boolean.TRUE);
         if (saveTaskResult == Constants.EXIT_CODE_SUCCESS) {
@@ -694,6 +699,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                  WorkflowDefinition workflowDefinition,
                                                  WorkflowDefinition workflowDefinitionDeepCopy,
                                                  List<TaskDefinitionLog> taskDefinitionLogs) {
+        taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         int saveTaskResult = processService.saveTaskDefine(loginUser, workflowDefinition.getProjectCode(),
                 taskDefinitionLogs, Boolean.TRUE);
         if (saveTaskResult == Constants.EXIT_CODE_SUCCESS) {
@@ -1585,14 +1591,6 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                     Status.SWITCH_WORKFLOW_DEFINITION_VERSION_NOT_EXIST_WORKFLOW_DEFINITION_VERSION_ERROR,
                     workflowDefinition.getCode(), version);
         }
-        int switchVersion = processService.switchVersion(workflowDefinition, workflowDefinitionLog);
-        if (switchVersion <= 0) {
-            log.error(
-                    "Switch workflow definition version error, projectCode:{}, workflowDefinitionCode:{}, version:{}.",
-                    projectCode, code, version);
-            throw new ServiceException(Status.SWITCH_WORKFLOW_DEFINITION_VERSION_ERROR);
-        }
-
         List<WorkflowTaskRelation> workflowTaskRelationList = workflowTaskRelationDao
                 .queryWorkflowTaskRelationsByWorkflowDefinitionCode(workflowDefinitionLog.getCode(),
                         workflowDefinitionLog.getVersion());
@@ -1605,6 +1603,16 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                             taskDefinitionLog.setVersion(taskCodeVersionDto.getVersion());
                             return Stream.of(taskDefinitionLog);
                         }).collect(Collectors.toList()));
+        taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogList);
+
+        int switchVersion = processService.switchVersion(workflowDefinition, workflowDefinitionLog);
+        if (switchVersion <= 0) {
+            log.error(
+                    "Switch workflow definition version error, projectCode:{}, workflowDefinitionCode:{}, version:{}.",
+                    projectCode, code, version);
+            throw new ServiceException(Status.SWITCH_WORKFLOW_DEFINITION_VERSION_ERROR);
+        }
+
         saveWorkflowLineage(workflowDefinitionLog.getProjectCode(), workflowDefinitionLog.getCode(),
                 workflowDefinitionLog.getVersion(), taskDefinitionLogList);
 
@@ -1747,7 +1755,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
             return;
         }
 
-        checkWorkflowDefinitionIsValidated(workflowDefinition.getCode());
+        checkWorkflowDefinitionIsValidated(loginUser, workflowDefinition.getCode());
         checkAllSubWorkflowDefinitionIsOnline(workflowDefinition.getCode());
 
         workflowDefinition.setReleaseState(ReleaseState.ONLINE);
@@ -1840,13 +1848,16 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         return localUserDefParams;
     }
 
-    private void checkWorkflowDefinitionIsValidated(Long workflowDefinitionCode) {
+    private void checkWorkflowDefinitionIsValidated(User loginUser, Long workflowDefinitionCode) {
         // todo: build dag check if the dag is validated
         List<WorkflowTaskRelation> workflowTaskRelations =
                 workflowTaskRelationDao.queryByWorkflowDefinitionCode(workflowDefinitionCode);
         if (CollectionUtils.isEmpty(workflowTaskRelations)) {
             throw new ServiceException(Status.WORKFLOW_DAG_IS_EMPTY);
         }
+        List<TaskDefinitionLog> taskDefinitionLogs =
+                taskDefinitionLogDao.queryTaskDefineLogList(workflowTaskRelations);
+        taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         // todo : check Workflow is validate
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -33,6 +33,7 @@ import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceTask
 import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.TaskInstanceService;
 import org.apache.dolphinscheduler.api.service.UsersService;
@@ -160,6 +161,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Autowired
     private TaskInstanceContextDao taskInstanceContextDao;
+
+    @Autowired
+    private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
 
     @Override
     public List<WorkflowInstance> queryTopNLongestRunningWorkflowInstance(User loginUser, long projectCode, int size,
@@ -411,6 +415,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
                 throw new ServiceException(Status.WORKFLOW_NODE_S_PARAMETER_INVALID, taskDefinitionLog.getName());
             }
         }
+        taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         int saveTaskResult = processService.saveTaskDefine(loginUser, projectCode, taskDefinitionLogs, syncDefine);
         if (saveTaskResult == Constants.DEFINITION_FAILURE) {
             log.error("Update task definition error, projectCode:{}, workflowInstanceId:{}", projectCode,

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskDatasourcePermissionCheckerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskDatasourcePermissionCheckerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.common.enums.AuthorizationType;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.User;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskDatasourcePermissionCheckerTest {
+
+    private static final int USER_ID = 1;
+    private static final int DATASOURCE_ID = 42;
+
+    @Mock
+    private ResourcePermissionCheckService resourcePermissionCheckService;
+
+    private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    private User loginUser;
+
+    @BeforeEach
+    public void setUp() {
+        taskDatasourcePermissionChecker = new TaskDatasourcePermissionChecker(resourcePermissionCheckService);
+        loginUser = new User();
+        loginUser.setId(USER_ID);
+        loginUser.setUserType(UserType.GENERAL_USER);
+    }
+
+    @Test
+    public void shouldRejectUnauthorizedDatasourceReferencedByTask() {
+        Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(
+                eq(AuthorizationType.DATASOURCE), any(Object[].class), eq(USER_ID), any(Logger.class)))
+                .thenReturn(false);
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> taskDatasourcePermissionChecker.checkPermission(
+                        loginUser, Collections.singletonList(getRemoteShellTaskDefinition())));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        ArgumentCaptor<Object[]> datasourceIdsCaptor = ArgumentCaptor.forClass(Object[].class);
+        Mockito.verify(resourcePermissionCheckService).resourcePermissionCheck(
+                eq(AuthorizationType.DATASOURCE), datasourceIdsCaptor.capture(), eq(USER_ID), any(Logger.class));
+        Assertions.assertArrayEquals(new Integer[]{DATASOURCE_ID}, datasourceIdsCaptor.getValue());
+    }
+
+    @Test
+    public void shouldAllowAuthorizedDatasourceReferencedByTask() {
+        Mockito.when(resourcePermissionCheckService.resourcePermissionCheck(
+                eq(AuthorizationType.DATASOURCE), any(Object[].class), eq(USER_ID), any(Logger.class)))
+                .thenReturn(true);
+
+        Assertions.assertDoesNotThrow(() -> taskDatasourcePermissionChecker.checkPermission(
+                loginUser, Collections.singletonList(getRemoteShellTaskDefinition())));
+    }
+
+    @Test
+    public void shouldSkipPermissionCheckForTaskWithoutDatasource() {
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setTaskType("SHELL");
+        taskDefinition.setTaskParams("{\"rawScript\":\"echo test\"}");
+
+        taskDatasourcePermissionChecker.checkPermission(loginUser, Collections.singletonList(taskDefinition));
+
+        Mockito.verifyNoInteractions(resourcePermissionCheckService);
+    }
+
+    private TaskDefinition getRemoteShellTaskDefinition() {
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setTaskType("REMOTESHELL");
+        taskDefinition.setTaskParams(
+                "{\"rawScript\":\"echo test\",\"type\":\"SSH\",\"datasource\":" + DATASOURCE_ID + "}");
+        return taskDefinition;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationCon
 import static org.apache.dolphinscheduler.api.constants.ApiFuncIdentificationConstant.WORKFLOW_SWITCH_TO_THIS_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.TaskDefinitionServiceImpl;
 import org.apache.dolphinscheduler.common.constants.Constants;
@@ -110,6 +112,9 @@ public class TaskDefinitionServiceImplTest {
     private WorkflowDefinitionLogMapper workflowDefinitionLogMapper;
 
     @Mock
+    private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    @Mock
     private WorkflowTaskRelationLogMapper workflowTaskRelationLogMapper;
 
     @Mock
@@ -182,6 +187,27 @@ public class TaskDefinitionServiceImplTest {
 
         Assertions.assertDoesNotThrow(
                 () -> taskDefinitionService.switchVersion(user, PROJECT_CODE, TASK_CODE, VERSION));
+    }
+
+    @Test
+    public void switchVersionShouldRejectUnauthorizedDatasource() {
+        Project project = getProject();
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
+        Mockito.doNothing().when(projectService)
+                .checkProjectAndAuthThrowException(user, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
+
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setProjectCode(PROJECT_CODE);
+        when(taskDefinitionDao.queryByCode(TASK_CODE)).thenReturn(taskDefinition);
+        when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(TASK_CODE, VERSION))
+                .thenReturn(new TaskDefinitionLog());
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
+
+        assertThrowsServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION,
+                () -> taskDefinitionService.switchVersion(user, PROJECT_CODE, TASK_CODE, VERSION));
+
+        Mockito.verify(taskDefinitionDao, Mockito.never()).updateById(any(TaskDefinition.class));
     }
 
     @Test
@@ -383,6 +409,7 @@ public class TaskDefinitionServiceImplTest {
             Long updatedTaskCode = taskDefinitionService.updateTaskWithUpstream(user, PROJECT_CODE, TASK_CODE,
                     taskDefinitionJson, UPSTREAM_CODE);
             assertEquals(TASK_CODE, updatedTaskCode);
+            Mockito.verify(taskDatasourcePermissionChecker, Mockito.times(2)).checkPermission(eq(user), anyList());
             user.setUserType(UserType.GENERAL_USER);
         }
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -409,7 +409,7 @@ public class TaskDefinitionServiceImplTest {
             Long updatedTaskCode = taskDefinitionService.updateTaskWithUpstream(user, PROJECT_CODE, TASK_CODE,
                     taskDefinitionJson, UPSTREAM_CODE);
             assertEquals(TASK_CODE, updatedTaskCode);
-            Mockito.verify(taskDatasourcePermissionChecker, Mockito.times(2)).checkPermission(eq(user), anyList());
+            Mockito.verify(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
             user.setUserType(UserType.GENERAL_USER);
         }
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -191,8 +191,7 @@ public class TaskDefinitionServiceImplTest {
     public void switchVersionShouldRejectUnauthorizedDatasource() {
         Project project = getProject();
         when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
-        Mockito.doNothing().when(projectService)
-                .checkProjectAndAuthThrowException(user, project, WORKFLOW_SWITCH_TO_THIS_VERSION);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(user, project);
 
         TaskDefinition taskDefinition = new TaskDefinition();
         taskDefinition.setProjectCode(PROJECT_CODE);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.WorkflowDefinitionServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
@@ -59,6 +60,7 @@ import org.apache.dolphinscheduler.dao.entity.TaskMainInfo;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.UserWithWorkflowDefinitionCode;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelation;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
 import org.apache.dolphinscheduler.dao.mapper.WorkflowDefinitionLogMapper;
@@ -181,6 +183,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Mock
     private TaskDefinitionLogMapper taskDefinitionLogMapper;
+
+    @Mock
+    private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
 
     @Mock
     private TaskDefinitionService taskDefinitionService;
@@ -843,6 +848,75 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         Assertions.assertNotNull(workflowDefinition);
         Assertions.assertEquals(1, workflowDefinition.getVersion());
+    }
+
+    @Test
+    public void testCreateWorkflowDefinitionShouldRejectUnauthorizedDatasource() {
+        Project project = getProject(projectCode);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
+        when(workflowDefinitionDao.verifyByDefineName(projectCode, name)).thenReturn(null);
+        when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.createWorkflowDefinition(
+                        user, projectCode, name, description, "[]", "[]", timeout,
+                        taskRelationJson, taskDefinitionJson, null, WorkflowExecutionTypeEnum.PARALLEL));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(processService, Mockito.never())
+                .saveTaskDefine(eq(user), eq(projectCode), anyList(), eq(Boolean.TRUE));
+    }
+
+    @Test
+    public void testSwitchWorkflowDefinitionVersionShouldRejectUnauthorizedDatasource() {
+        WorkflowDefinition workflowDefinition = getWorkflowDefinition();
+        WorkflowDefinitionLog workflowDefinitionLog = new WorkflowDefinitionLog();
+        workflowDefinitionLog.setCode(processDefinitionCode);
+        workflowDefinitionLog.setProjectCode(projectCode);
+        workflowDefinitionLog.setVersion(1);
+        WorkflowTaskRelation workflowTaskRelation =
+                getWorkflowTaskRelation(1, 1, projectCode, processDefinitionCode, 0, 0, 123456789L, 1);
+
+        when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(workflowDefinition));
+        when(workflowDefinitionLogMapper.queryByDefinitionCodeAndVersion(processDefinitionCode, 1))
+                .thenReturn(workflowDefinitionLog);
+        when(workflowTaskRelationDao.queryWorkflowTaskRelationsByWorkflowDefinitionCode(processDefinitionCode, 1))
+                .thenReturn(Collections.singletonList(workflowTaskRelation));
+        when(taskDefinitionLogMapper.queryByTaskDefinitions(anyList()))
+                .thenReturn(Collections.singletonList(new TaskDefinitionLog()));
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.switchWorkflowDefinitionVersion(
+                        user, projectCode, processDefinitionCode, 1));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(processService, Mockito.never())
+                .switchVersion(any(WorkflowDefinition.class), any(WorkflowDefinitionLog.class));
+    }
+
+    @Test
+    public void testOnlineWorkflowDefinitionShouldRejectUnauthorizedDatasource() {
+        WorkflowDefinition workflowDefinition = getWorkflowDefinition();
+        WorkflowTaskRelation workflowTaskRelation =
+                getWorkflowTaskRelation(1, 1, projectCode, processDefinitionCode, 0, 0, 123456789L, 1);
+        when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(workflowDefinition));
+        when(workflowTaskRelationDao.queryByWorkflowDefinitionCode(processDefinitionCode))
+                .thenReturn(Collections.singletonList(workflowTaskRelation));
+        when(taskDefinitionLogDao.queryTaskDefineLogList(anyList()))
+                .thenReturn(Collections.singletonList(new TaskDefinitionLog()));
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.onlineWorkflowDefinition(user, projectCode, processDefinitionCode));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(workflowDefinitionDao, Mockito.never()).updateById(any(WorkflowDefinition.class));
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -30,6 +30,7 @@ import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceTask
 import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVariablesDTO;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
 import org.apache.dolphinscheduler.api.service.impl.LoggerServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.WorkflowInstanceServiceImpl;
@@ -140,6 +141,9 @@ public class WorkflowInstanceServiceTest {
 
     @Mock
     TaskDefinitionDao taskDefinitionDao;
+
+    @Mock
+    TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
 
     @Mock
     private TaskInstanceContextDao taskInstanceContextDao;
@@ -615,6 +619,8 @@ public class WorkflowInstanceServiceTest {
                     taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", Boolean.FALSE, "", "", 0);
             Assertions.assertNotNull(successRes);
         }
+        Mockito.verify(taskDatasourcePermissionChecker, Mockito.times(3))
+                .checkPermission(eq(loginUser), Mockito.anyList());
     }
 
     @Test


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The implementation and tests were assisted by AI and reviewed locally.

## Purpose of the pull request

Validate datasource access consistently before task definitions are saved or activated.

Closes #18565.

## Brief change log

- Add a shared checker for datasource resources declared by task plugins.
- Apply the check to task and workflow save, version switch, online, and instance update paths.
- Add regression tests for the checker and affected API paths.

## Verify this pull request

This change added tests and can be verified as follows:

- Run `./mvnw -pl dolphinscheduler-api -DskipE2E=true -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dtest=TaskDatasourcePermissionCheckerTest,TaskDefinitionServiceImplTest,WorkflowDefinitionServiceTest,WorkflowInstanceServiceTest test`.
- 68 tests pass.
- `./mvnw -pl dolphinscheduler-api -DskipTests spotless:check` passes.