### PR TITLE
[Docs] Add curl command-line examples to Open API documentation

### DIFF
--- a/docs/docs/en/guide/api/open-api.md
+++ b/docs/docs/en/guide/api/open-api.md
@@ -18,6 +18,8 @@ Generally, projects and processes are created through pages, but considering the
 
 ### Examples
 
+In the following examples, replace `{API_SERVER_IP}` with your DolphinScheduler API server address, and `{TOKEN}` with the token you generated.
+
 #### Query project list
 
 1. Open the API documentation
@@ -30,7 +32,15 @@ Generally, projects and processes are created through pages, but considering the
 
    > projects/list
 
-3. Open `Postman`, fill in the API address, enter the `Token` in `Headers`, and then send the request to view the result:
+3. Use `curl` command to query the project list:
+
+   ```bash
+   curl -X GET \
+     http://{API_SERVER_IP}:12345/dolphinscheduler/projects/list \
+     -H "token: {TOKEN}"
+   ```
+
+4. Or use `Postman`, fill in the API address, enter the `Token` in `Headers`, and then send the request to view the result:
 
    ```
    token: The Token just generated
@@ -49,6 +59,19 @@ By consulting the api documentation, configure the KEY as Accept and VALUE as th
 And then configure the required projectName and description parameters in Body.
 
 ![create-project02](../../../../img/new_ui/dev/open-api/create_project02.png)
+
+Use `curl` command to create a project:
+
+```bash
+curl -X POST \
+  http://{API_SERVER_IP}:12345/dolphinscheduler/projects \
+  -H "token: {TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectName": "my-project",
+    "description": "My project description"
+  }'
+```
 
 Check the post request result.
 

--- a/docs/docs/zh/guide/api/open-api.md
+++ b/docs/docs/zh/guide/api/open-api.md
@@ -18,6 +18,8 @@
 
 ### 使用案例
 
+以下示例中，请将 `{API_SERVER_IP}` 替换为您的 DolphinScheduler API 服务器地址，`{TOKEN}` 替换为您生成的令牌。
+
 #### 查询项目列表信息
 
 1. 打开 API 文档页面
@@ -30,7 +32,15 @@
 
 > projects/list
 
-3. 打开 Postman，填写接口地址，并在 Headers 中填写 Token，发送请求后即可查看结果
+3. 使用 `curl` 命令查询项目列表：
+
+   ```bash
+   curl -X GET \
+     http://{API_SERVER_IP}:12345/dolphinscheduler/projects/list \
+     -H "token: {TOKEN}"
+   ```
+
+4. 也可以使用 Postman，填写接口地址，并在 Headers 中填写 Token，发送请求后即可查看结果
 
    ```
    token: 刚刚生成的 Token
@@ -49,6 +59,19 @@
 然后再 Body 中配置所需的 projectName 和 description 参数。
 
 ![create-project02](../../../../img/new_ui/dev/open-api/create_project02.png)
+
+使用 `curl` 命令创建项目：
+
+```bash
+curl -X POST \
+  http://{API_SERVER_IP}:12345/dolphinscheduler/projects \
+  -H "token: {TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectName": "my-project",
+    "description": "My project description"
+  }'
+```
 
 检查 post 请求结果。
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds curl command-line examples to the Open API documentation, addressing the suggestion from issue #6535 (DSIP-2: Refactor the document).

Currently, the Open API docs only provide Postman-based examples with screenshots. This PR adds curl command-line equivalents that users can directly copy and use, making the API documentation more accessible for scripting and automation scenarios.

## Changes

- **English docs** (`docs/docs/en/guide/api/open-api.md`): Add curl examples for querying project list and creating a project
- **Chinese docs** (`docs/docs/zh/guide/api/open-api.md`): Add curl examples for querying project list and creating a project

## Related Issue

Closes #6535

## Verification

Both English and Chinese docs have been updated with consistent curl examples. The existing Postman-based examples are preserved alongside the new curl examples to provide multiple options for users.