### PR TITLE
[Fix] Restore file parameter transfer functionality (#18166)

### DIFF
--- a/dolphinscheduler-bom/pom.xml
+++ b/dolphinscheduler-bom/pom.xml
@@ -131,6 +131,7 @@
         <error.prone.annotations.version>2.11.0</error.prone.annotations.version>
         <emr-serverless-spark.version>2.4.1</emr-serverless-spark.version>
         <credentials-java.version>1.0.1</credentials-java.version>
+        <zt-zip.version>1.17</zt-zip.version>
     </properties>
 
     <dependencyManagement>
@@ -971,6 +972,12 @@
                 <groupId>com.aliyun</groupId>
                 <artifactId>credentials-java</artifactId>
                 <version>${credentials-java.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.zeroturnaround</groupId>
+                <artifactId>zt-zip</artifactId>
+                <version>${zt-zip.version}</version>
             </dependency>
 
             <!-- test dependencies on TestContainers -->

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/constants/Constants.java
@@ -391,4 +391,11 @@ public final class Constants {
     public static final String RELEASE_STATE = "releaseState";
     public static final String EXECUTE_TYPE = "executeType";
 
+    /**
+     * File parameter transfer
+     */
+    public static final String CRC_SUFFIX = ".crc";
+    public static final String DOWNLOAD_TMP = ".DT_TMP";
+    public static final String PACK_SUFFIX = "_ds_pack.zip";
+    public static final String RESOURCE_TAG = "DATA_TRANSFER";
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
@@ -700,4 +700,15 @@ public final class DateUtils {
         return String.valueOf(System.currentTimeMillis());
     }
 
+    /**
+     * @param timeMillis         timeMillis like System.currentTimeMillis()
+     * @param dateTimeFormatter  expect formatter, like yyyy-MM-dd HH:mm:ss
+     * @return formatted string
+     */
+    public static String formatTimeStamp(long timeMillis, DateTimeFormatter dateTimeFormatter) {
+        java.util.Objects.requireNonNull(dateTimeFormatter);
+        return dateTimeFormatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(timeMillis),
+                ZoneId.systemDefault()));
+    }
+
 }

--- a/dolphinscheduler-worker/pom.xml
+++ b/dolphinscheduler-worker/pom.xml
@@ -217,6 +217,10 @@
             <artifactId>dolphinscheduler-actuator-authentication</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-zip</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/executor/PhysicalTaskExecutor.java
@@ -23,11 +23,14 @@ import org.apache.dolphinscheduler.common.utils.PropertyUtils;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
 import org.apache.dolphinscheduler.plugin.task.api.AbstractTask;
 import org.apache.dolphinscheduler.plugin.task.api.TaskCallBack;
+import org.apache.dolphinscheduler.plugin.task.api.TaskChannel;
 import org.apache.dolphinscheduler.plugin.task.api.log.TaskLogMarkers;
 import org.apache.dolphinscheduler.plugin.task.api.model.ApplicationInfo;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
 import org.apache.dolphinscheduler.plugin.task.api.resource.ResourceContext;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
 import org.apache.dolphinscheduler.server.worker.utils.TaskExecutionContextUtils;
+import org.apache.dolphinscheduler.server.worker.utils.TaskFilesTransferUtils;
 import org.apache.dolphinscheduler.server.worker.utils.TenantUtils;
 import org.apache.dolphinscheduler.task.executor.AbstractTaskExecutor;
 import org.apache.dolphinscheduler.task.executor.ITaskExecutor;
@@ -36,6 +39,7 @@ import org.apache.dolphinscheduler.task.executor.TaskExecutorStateMappings;
 import org.apache.dolphinscheduler.task.executor.events.TaskExecutorRuntimeContextChangedLifecycleEvent;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +73,22 @@ public class PhysicalTaskExecutor extends AbstractTaskExecutor {
 
         this.physicalTask.getParameters().setVarPool(new ArrayList<>());
         log.info("Set taskVarPool: {} successfully", taskExecutionContext.getVarPool());
+    }
+
+    @Override
+    public TaskExecutorState trackTaskExecutorState() {
+        TaskExecutorState state = super.trackTaskExecutorState();
+        if (TaskExecutorState.SUCCEEDED.equals(state)) {
+            uploadOutputFilesIfNeeded();
+        }
+        return state;
+    }
+
+    private void uploadOutputFilesIfNeeded() {
+        List<Property> uploadOutputFiles = TaskFilesTransferUtils.uploadOutputFiles(
+                taskExecutionContext,
+                storageOperator);
+        log.info("Upload output files successfully: {}", uploadOutputFiles);
     }
 
     @Override
@@ -136,6 +156,11 @@ public class PhysicalTaskExecutor extends AbstractTaskExecutor {
                 taskExecutionContext);
         taskExecutionContext.setResourceContext(resourceContext);
         log.info("Download resources successfully: {}", taskExecutionContext.getResourceContext());
+
+        List<Property> downloadUpstreamFiles = TaskFilesTransferUtils.downloadUpstreamFiles(
+                taskExecutionContext,
+                storageOperator);
+        log.info("Download upstream files successfully: {}", downloadUpstreamFiles);
 
         log.info(TaskLogMarkers.excludeInTaskLog(), "Initialized Task Context{}",
                 JSONUtils.toPrettyJsonString(taskExecutionContext));

--- a/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
+++ b/dolphinscheduler-worker/src/main/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtils.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.worker.utils;
+
+import static org.apache.dolphinscheduler.common.constants.Constants.CRC_SUFFIX;
+import static org.apache.dolphinscheduler.common.constants.Constants.DOWNLOAD_TMP;
+import static org.apache.dolphinscheduler.common.constants.Constants.PACK_SUFFIX;
+import static org.apache.dolphinscheduler.common.constants.Constants.RESOURCE_TAG;
+
+import org.apache.dolphinscheduler.common.utils.DateUtils;
+import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
+import org.apache.dolphinscheduler.plugin.task.api.TaskException;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
+import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.zeroturnaround.zip.ZipUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+@Slf4j
+public final class TaskFilesTransferUtils {
+
+    private TaskFilesTransferUtils() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Upload the task's output FILE parameter files to the resource center.
+     *
+     * @param taskExecutionContext task execution context
+     * @param storageOperator      resource storage operator
+     * @return a list of uploaded output file properties
+     */
+    public static List<Property> uploadOutputFiles(TaskExecutionContext taskExecutionContext,
+                                                   StorageOperator storageOperator) {
+        List<Property> outFileParams = getFileLocalParams(taskExecutionContext, Direct.OUT);
+        if (outFileParams.isEmpty()) {
+            log.debug("No output files to upload");
+            return outFileParams;
+        }
+
+        List<Property> varPool = taskExecutionContext.getVarPool();
+        if (varPool == null) {
+            varPool = new ArrayList<>();
+            taskExecutionContext.setVarPool(varPool);
+        }
+        // get map of varPools for quick search
+        Map<String, Property> varPoolsMap = varPool.stream()
+                .filter(property -> Direct.OUT.equals(property.getDirect()))
+                .collect(Collectors.toMap(Property::getProp, x -> x));
+
+        log.info("Upload output files ...");
+        for (Property outProp : outFileParams) {
+            // get local file path
+            String localPath = taskExecutionContext.getExecutePath() + File.separator + outProp.getValue();
+            String srcPath = packIfDirectory(localPath);
+
+            // get CRC file path
+            String srcCrcPath = srcPath + CRC_SUFFIX;
+            try {
+                FileUtils.writeContent2File(FileUtils.getFileChecksum(localPath), srcCrcPath);
+            } catch (IOException e) {
+                throw new TaskException("Generate CRC file failed: " + srcCrcPath, e);
+            }
+
+            // get remote file path
+            String fileName = new File(srcPath).getName();
+            String resourcePath = buildResourcePath(taskExecutionContext, fileName);
+            String resourceCrcPath = resourcePath + CRC_SUFFIX;
+
+            try {
+                // upload file to storage
+                String resourceFullPath = storageOperator.getStorageFileAbsolutePath(
+                        taskExecutionContext.getTenantCode(), resourcePath);
+                String resourceCrcFullPath = storageOperator.getStorageFileAbsolutePath(
+                        taskExecutionContext.getTenantCode(), resourceCrcPath);
+                log.info("{} --- Local:{} to Remote:{}", outProp, srcPath, resourceFullPath);
+                storageOperator.upload(srcPath, resourceFullPath, false, true);
+                log.info("CRC file --- Local:{} to Remote:{}", srcCrcPath, resourceCrcFullPath);
+                storageOperator.upload(srcCrcPath, resourceCrcFullPath, false, true);
+            } catch (Exception e) {
+                throw new TaskException("Upload file to storage failed: " + srcPath, e);
+            }
+
+            // update varPool
+            Property oriProperty;
+            if (varPoolsMap.containsKey(outProp.getProp())) {
+                oriProperty = varPoolsMap.get(outProp.getProp());
+            } else {
+                oriProperty = new Property(outProp.getProp(), Direct.OUT, DataType.FILE, outProp.getValue());
+                varPool.add(oriProperty);
+            }
+            oriProperty.setProp(String.format("%s.%s", taskExecutionContext.getTaskName(), oriProperty.getProp()));
+            oriProperty.setValue(resourcePath);
+        }
+
+        return outFileParams;
+    }
+
+    /**
+     * Download upstream task's FILE parameter files from resource center.
+     *
+     * @param taskExecutionContext task execution context
+     * @param storageOperator      resource storage operator
+     * @return a list of downloaded input file properties
+     */
+    public static List<Property> downloadUpstreamFiles(TaskExecutionContext taskExecutionContext,
+                                                       StorageOperator storageOperator) {
+        // get "IN FILE" parameters
+        List<Property> inFileParams = getFileLocalParams(taskExecutionContext, Direct.IN);
+
+        if (inFileParams.isEmpty()) {
+            log.debug("No input files to download");
+            return inFileParams;
+        }
+
+        List<Property> varPool = taskExecutionContext.getVarPool();
+        if (varPool == null || varPool.isEmpty()) {
+            log.debug("VarPool is empty, no upstream files to download");
+            return inFileParams;
+        }
+
+        // get map of varPools for quick search (look up by prop name)
+        Map<String, Property> varPoolsMap = varPool.stream()
+                .collect(Collectors.toMap(Property::getProp, x -> x, (existing, replacement) -> existing));
+
+        String executePath = taskExecutionContext.getExecutePath();
+        // data path to download packaged data
+        String downloadTmpPath = executePath + File.separator + DOWNLOAD_TMP;
+
+        log.info("Download upstream files...");
+        for (Property fileProp : inFileParams) {
+            // fileProp.getValue() is the upstream parameter reference, e.g., "ot.dir-data"
+            String fileParamVarPoolKey = fileProp.getValue();
+            Property varPoolEntry = varPoolsMap.get(fileParamVarPoolKey);
+            if (varPoolEntry == null) {
+                log.error("{} not found in varPool, available keys: {}", fileParamVarPoolKey, varPoolsMap.keySet());
+                throw new TaskException(String.format(
+                        "Cannot find upstream file using key '%s', please check the parameter reference",
+                        fileParamVarPoolKey));
+            }
+
+            String resourcePath = varPoolEntry.getValue();
+            String localTargetPath = executePath + File.separator + fileProp.getProp();
+
+            // If the data is packaged, download it to a special directory (DOWNLOAD_TMP) and unpack it to the targetPath
+            boolean isPack = resourcePath.endsWith(PACK_SUFFIX);
+            String downloadPath = isPack
+                    ? downloadTmpPath + File.separator + new File(resourcePath).getName()
+                    : localTargetPath;
+
+            String resourceFullPath = storageOperator.getStorageFileAbsolutePath(
+                    taskExecutionContext.getTenantCode(), resourcePath);
+            log.info("{} --- Remote:{} to Local:{}", fileProp, resourceFullPath, downloadPath);
+            storageOperator.download(resourceFullPath, downloadPath, true);
+
+            // unpack if the data is packaged
+            if (isPack) {
+                File downloadFile = new File(downloadPath);
+                log.info("Unpack {} to {}", downloadPath, localTargetPath);
+                ZipUtil.unpack(downloadFile, new File(localTargetPath));
+            }
+        }
+
+        // delete DownloadTmp Folder if DownloadTmpPath exists
+        try {
+            org.apache.commons.io.FileUtils.deleteDirectory(new File(downloadTmpPath));
+        } catch (IOException e) {
+            log.warn("Delete temp directory {} failed, this will not affect the task status", downloadTmpPath, e);
+        }
+
+        return inFileParams;
+    }
+
+    /**
+     * Get local parameters property which type is FILE and direction is equal to direct.
+     *
+     * @param taskExecutionContext task execution context
+     * @param direct               may be Direct.IN or Direct.OUT
+     * @return List of Property
+     */
+    public static List<Property> getFileLocalParams(TaskExecutionContext taskExecutionContext, Direct direct) {
+        List<Property> localParamsProperty = new ArrayList<>();
+        JsonNode taskParams = JSONUtils.parseObject(taskExecutionContext.getTaskParams());
+        JsonNode localParamsNode = taskParams.get("localParams");
+        if (localParamsNode == null || !localParamsNode.isArray()) {
+            return localParamsProperty;
+        }
+        for (JsonNode localParam : localParamsNode) {
+            Property property = JSONUtils.parseObject(localParam.toString(), Property.class);
+            if (property != null && property.getDirect().equals(direct) && property.getType().equals(DataType.FILE)) {
+                localParamsProperty.add(property);
+            }
+        }
+        return localParamsProperty;
+    }
+
+    /**
+     * Build resource path for managing files in storage.
+     *
+     * @param taskExecutionContext task execution context
+     * @param fileName             file name
+     * @return resource path: RESOURCE_TAG/DATE/ProcessDefineCode/ProcessDefineVersion_ProcessInstanceID/TaskName_TaskInstanceID_FileName
+     */
+    public static String buildResourcePath(TaskExecutionContext taskExecutionContext, String fileName) {
+        String date = DateUtils.formatTimeStamp(taskExecutionContext.getStartTime(),
+                DateTimeFormatter.ofPattern("yyyyMMdd"));
+        // get resource Folder: RESOURCE_TAG/DATE/ProcessDefineCode/ProcessDefineVersion_ProcessInstanceID
+        String resourceFolder = String.format("%s/%s/%d/%d_%d", RESOURCE_TAG, date,
+                taskExecutionContext.getWorkflowDefinitionCode(),
+                taskExecutionContext.getWorkflowDefinitionVersion(),
+                taskExecutionContext.getWorkflowInstanceId());
+        // get resource file: resourceFolder/TaskName_TaskInstanceID_FileName
+        String safeTaskName = taskExecutionContext.getTaskName().replace(" ", "_");
+        return String.format("%s/%s_%s_%s", resourceFolder, safeTaskName,
+                taskExecutionContext.getTaskInstanceId(), fileName);
+    }
+
+    /**
+     * If the path is a directory, pack it and return the path of the package.
+     *
+     * @param path input path, may be a file or a directory
+     * @return new path
+     */
+    public static String packIfDirectory(String path) {
+        File file = new File(path);
+        if (!file.exists()) {
+            throw new TaskException(String.format("%s does not exist", path));
+        }
+        if (file.isDirectory()) {
+            String zipPath = file.getPath() + PACK_SUFFIX;
+            log.info("Pack {} to {}", path, zipPath);
+            ZipUtil.pack(file, new File(zipPath));
+            return zipPath;
+        }
+        return path;
+    }
+}

--- a/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtilsTest.java
+++ b/dolphinscheduler-worker/src/test/java/org/apache/dolphinscheduler/server/worker/utils/TaskFilesTransferUtilsTest.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.worker.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
+import org.apache.dolphinscheduler.plugin.task.api.TaskException;
+import org.apache.dolphinscheduler.plugin.task.api.TaskExecutionContext;
+import org.apache.dolphinscheduler.plugin.task.api.enums.DataType;
+import org.apache.dolphinscheduler.plugin.task.api.enums.Direct;
+import org.apache.dolphinscheduler.plugin.task.api.model.Property;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TaskFilesTransferUtilsTest {
+
+    @TempDir
+    Path tempDir;
+
+    private TaskExecutionContext taskExecutionContext;
+
+    @BeforeEach
+    void setUp() {
+        taskExecutionContext = new TaskExecutionContext();
+        taskExecutionContext.setTaskInstanceId(100);
+        taskExecutionContext.setTaskName("test-task");
+        taskExecutionContext.setStartTime(System.currentTimeMillis());
+        taskExecutionContext.setWorkflowDefinitionCode(1000L);
+        taskExecutionContext.setWorkflowDefinitionVersion(1);
+        taskExecutionContext.setWorkflowInstanceId(200);
+        taskExecutionContext.setTenantCode("default");
+        taskExecutionContext.setExecutePath(tempDir.toString());
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clean up temp directory
+        try {
+            Files.walk(tempDir)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        } catch (IOException ignored) {
+        }
+    }
+
+    @Test
+    void testGetFileLocalParams_WithValidOutFileParams() {
+        String taskParams = "{\"localParams\":[{\"prop\":\"output.csv\",\"direct\":\"OUT\",\"type\":\"FILE\",\"value\":\"result.csv\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        List<Property> result = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.OUT);
+
+        assertEquals(1, result.size());
+        assertEquals("output.csv", result.get(0).getProp());
+        assertEquals(Direct.OUT, result.get(0).getDirect());
+        assertEquals(DataType.FILE, result.get(0).getType());
+    }
+
+    @Test
+    void testGetFileLocalParams_WithValidInFileParams() {
+        String taskParams = "{\"localParams\":[{\"prop\":\"input.csv\",\"direct\":\"IN\",\"type\":\"FILE\",\"value\":\"upstream.csv\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        List<Property> result = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.IN);
+
+        assertEquals(1, result.size());
+        assertEquals("input.csv", result.get(0).getProp());
+        assertEquals(Direct.IN, result.get(0).getDirect());
+    }
+
+    @Test
+    void testGetFileLocalParams_WithMixedParams() {
+        String taskParams = "{\"localParams\":["
+                + "{\"prop\":\"output.csv\",\"direct\":\"OUT\",\"type\":\"FILE\",\"value\":\"result.csv\"},"
+                + "{\"prop\":\"input.csv\",\"direct\":\"IN\",\"type\":\"FILE\",\"value\":\"upstream.csv\"},"
+                + "{\"prop\":\"var1\",\"direct\":\"IN\",\"type\":\"VARCHAR\",\"value\":\"hello\"}"
+                + "]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        List<Property> outResult = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.OUT);
+        assertEquals(1, outResult.size());
+        assertEquals("output.csv", outResult.get(0).getProp());
+
+        List<Property> inResult = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.IN);
+        assertEquals(1, inResult.size());
+        assertEquals("input.csv", inResult.get(0).getProp());
+    }
+
+    @Test
+    void testGetFileLocalParams_WithNullLocalParams() {
+        String taskParams = "{\"otherField\":\"value\"}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        List<Property> result = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.OUT);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetFileLocalParams_WithEmptyLocalParams() {
+        String taskParams = "{\"localParams\":[]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        List<Property> result = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.OUT);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetFileLocalParams_WithEmptyTaskParams() {
+        String taskParams = "{}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        List<Property> result = TaskFilesTransferUtils.getFileLocalParams(taskExecutionContext, Direct.OUT);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testBuildResourcePath() {
+        taskExecutionContext.setStartTime(1700000000000L); // 2023-11-14 22:13:20 UTC
+        String fileName = "test-file.csv";
+
+        String resourcePath = TaskFilesTransferUtils.buildResourcePath(taskExecutionContext, fileName);
+
+        assertNotNull(resourcePath);
+        assertTrue(resourcePath.startsWith("DATA_TRANSFER/"));
+        assertTrue(resourcePath.contains("/1000/1_200/"));
+        assertTrue(resourcePath.contains("test-task_100_test-file.csv"));
+    }
+
+    @Test
+    void testBuildResourcePath_WithSpacesInTaskName() {
+        taskExecutionContext.setTaskName("test task with spaces");
+        String fileName = "output.csv";
+
+        String resourcePath = TaskFilesTransferUtils.buildResourcePath(taskExecutionContext, fileName);
+
+        assertNotNull(resourcePath);
+        assertTrue(resourcePath.contains("test_task_with_spaces"));
+    }
+
+    @Test
+    void testPackIfDirectory_FileExists() throws IOException {
+        Path testFile = tempDir.resolve("test-file.txt");
+        Files.writeString(testFile, "test content");
+
+        String result = TaskFilesTransferUtils.packIfDirectory(testFile.toString());
+
+        assertEquals(testFile.toString(), result);
+    }
+
+    @Test
+    void testPackIfDirectory_Directory() throws IOException {
+        Path testDir = tempDir.resolve("test-dir");
+        Files.createDirectory(testDir);
+        Files.writeString(testDir.resolve("file1.txt"), "content1");
+        Files.writeString(testDir.resolve("file2.txt"), "content2");
+
+        String result = TaskFilesTransferUtils.packIfDirectory(testDir.toString());
+
+        assertTrue(result.endsWith("_ds_pack.zip"));
+        File zipFile = new File(result);
+        assertTrue(zipFile.exists());
+    }
+
+    @Test
+    void testPackIfDirectory_FileNotExists() {
+        String nonExistentPath = tempDir.resolve("non-existent").toString();
+
+        assertThrows(TaskException.class, () -> {
+            TaskFilesTransferUtils.packIfDirectory(nonExistentPath);
+        });
+    }
+
+    @Test
+    void testUploadOutputFiles_NoOutputFiles() {
+        taskExecutionContext.setTaskParams("{}");
+        StorageOperator mockStorage = mock(StorageOperator.class);
+
+        List<Property> result = TaskFilesTransferUtils.uploadOutputFiles(taskExecutionContext, mockStorage);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testUploadOutputFiles_WithOutputFile() throws Exception {
+        // Create a test file
+        Path testFile = tempDir.resolve("result.csv");
+        Files.writeString(testFile, "col1,col2\n1,2");
+
+        String taskParams = "{\"localParams\":[{\"prop\":\"output.csv\",\"direct\":\"OUT\",\"type\":\"FILE\",\"value\":\"result.csv\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+        taskExecutionContext.setVarPool(new ArrayList<>());
+
+        StorageOperator mockStorage = mock(StorageOperator.class);
+        when(mockStorage.getStorageFileAbsolutePath(anyString(), anyString()))
+                .thenReturn("/storage/path/file")
+                .thenReturn("/storage/path/file.crc");
+        doNothing().when(mockStorage).upload(anyString(), anyString(), anyBoolean(), anyBoolean());
+
+        List<Property> result = TaskFilesTransferUtils.uploadOutputFiles(taskExecutionContext, mockStorage);
+
+        assertEquals(1, result.size());
+        assertEquals("output.csv", result.get(0).getProp());
+        verify(mockStorage, times(2)).upload(anyString(), anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    void testDownloadUpstreamFiles_NoInputFiles() {
+        taskExecutionContext.setTaskParams("{}");
+        StorageOperator mockStorage = mock(StorageOperator.class);
+
+        List<Property> result = TaskFilesTransferUtils.downloadUpstreamFiles(taskExecutionContext, mockStorage);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testDownloadUpstreamFiles_WithInputFile() {
+        String taskParams = "{\"localParams\":[{\"prop\":\"input.csv\",\"direct\":\"IN\",\"type\":\"FILE\",\"value\":\"ot.output-data\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        // Set up varPool with upstream entry
+        Property upstreamProp = new Property("ot.output-data", Direct.OUT, DataType.FILE, "DATA_TRANSFER/20231114/1000/1_200/ot_101_result.csv");
+        List<Property> varPool = new ArrayList<>();
+        varPool.add(upstreamProp);
+        taskExecutionContext.setVarPool(varPool);
+
+        StorageOperator mockStorage = mock(StorageOperator.class);
+        when(mockStorage.getStorageFileAbsolutePath(anyString(), anyString()))
+                .thenReturn("/storage/path/result.csv");
+        doNothing().when(mockStorage).download(anyString(), anyString(), anyBoolean());
+
+        List<Property> result = TaskFilesTransferUtils.downloadUpstreamFiles(taskExecutionContext, mockStorage);
+
+        assertEquals(1, result.size());
+        assertEquals("input.csv", result.get(0).getProp());
+        verify(mockStorage, times(1)).download(anyString(), anyString(), anyBoolean());
+    }
+
+    @Test
+    void testDownloadUpstreamFiles_UpstreamKeyNotFound() {
+        String taskParams = "{\"localParams\":[{\"prop\":\"input.csv\",\"direct\":\"IN\",\"type\":\"FILE\",\"value\":\"ot.non-existent\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        // varPool has different key
+        Property upstreamProp = new Property("ot.other", Direct.OUT, DataType.FILE, "DATA_TRANSFER/20231114/1000/1_200/ot_101_result.csv");
+        List<Property> varPool = new ArrayList<>();
+        varPool.add(upstreamProp);
+        taskExecutionContext.setVarPool(varPool);
+
+        StorageOperator mockStorage = mock(StorageOperator.class);
+
+        assertThrows(TaskException.class, () -> {
+            TaskFilesTransferUtils.downloadUpstreamFiles(taskExecutionContext, mockStorage);
+        });
+    }
+
+    @Test
+    void testDownloadUpstreamFiles_PackedFile() throws IOException {
+        String taskParams = "{\"localParams\":[{\"prop\":\"input-dir\",\"direct\":\"IN\",\"type\":\"FILE\",\"value\":\"ot.output-dir\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+
+        // Set up varPool with packed upstream entry
+        Property upstreamProp = new Property("ot.output-dir", Direct.OUT, DataType.FILE,
+                "DATA_TRANSFER/20231114/1000/1_200/ot_101_result_ds_pack.zip");
+        List<Property> varPool = new ArrayList<>();
+        varPool.add(upstreamProp);
+        taskExecutionContext.setVarPool(varPool);
+
+        StorageOperator mockStorage = mock(StorageOperator.class);
+        when(mockStorage.getStorageFileAbsolutePath(anyString(), anyString()))
+                .thenReturn("/storage/path/result_ds_pack.zip");
+        doNothing().when(mockStorage).download(anyString(), anyString(), anyBoolean());
+
+        List<Property> result = TaskFilesTransferUtils.downloadUpstreamFiles(taskExecutionContext, mockStorage);
+
+        assertEquals(1, result.size());
+        verify(mockStorage, times(1)).download(anyString(), anyString(), anyBoolean());
+    }
+
+    @Test
+    void testDownloadUpstreamFiles_EmptyVarPool() {
+        String taskParams = "{\"localParams\":[{\"prop\":\"input.csv\",\"direct\":\"IN\",\"type\":\"FILE\",\"value\":\"ot.output-data\"}]}";
+        taskExecutionContext.setTaskParams(taskParams);
+        taskExecutionContext.setVarPool(Collections.emptyList());
+
+        StorageOperator mockStorage = mock(StorageOperator.class);
+
+        List<Property> result = TaskFilesTransferUtils.downloadUpstreamFiles(taskExecutionContext, mockStorage);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -281,6 +281,7 @@ webjars-locator-core-0.50.jar
 zjsonpatch-0.3.0.jar
 zookeeper-3.8.3.jar
 zookeeper-jute-3.8.3.jar
+zt-zip-1.17.jar
 aliyun-java-sdk-core-4.5.10.jar
 aliyun-java-sdk-kms-2.11.0.jar
 aliyun-java-sdk-ram-3.1.0.jar


### PR DESCRIPTION
## Purpose

This PR restores the file parameter transfer functionality that was removed during the worker refactoring.

## Changes

- Added `TaskFilesTransferUtils` utility class with `uploadOutputFiles()` and `downloadUpstreamFiles()` methods
- Modified `PhysicalTaskExecutor` to hook into file upload/download during task lifecycle
- Added `zt-zip` dependency for package/unpack operations
- Added new constants (`CRC_SUFFIX`, `DOWNLOAD_TMP`, `PACK_SUFFIX`, `RESOURCE_TAG`) to `Constants.java`
- Added `DateUtils.formatTimeStamp()` helper method
- Added unit tests for `TaskFilesTransferUtils`
- Updated `known-dependencies.txt`

## Related Issue

Closes #18166

## Verification

- [x] All unit tests pass
- [x] Verified in local development environment