### PR TITLE
Fix Master self-starvation deadlock when overloaded (#18570)

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/MasterSlotManager.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/cluster/MasterSlotManager.java
@@ -73,9 +73,12 @@ public class MasterSlotManager implements IMasterSlotReBalancer {
         }
         if (tmpCurrentSlot == -1) {
             log.warn(
-                    "Do rebalance failed, cannot found the current master: {} in the normal master clusters: {}. Please check the current master server status",
-                    masterConfig.getMasterAddress(), normalMasterServers);
-            currentSlot = -1;
+                    "Do rebalance failed, cannot found the current master: {} in the normal master clusters: {}. "
+                            + "The current master may be in BUSY state, keep the existing slot ({} -> {}) to avoid self-starvation deadlock.",
+                    masterConfig.getMasterAddress(), normalMasterServers, currentSlot, totalSlots);
+            // Keep the existing slot instead of setting to -1 to avoid self-starvation.
+            // The load protection at CommandEngine level already throttles
+            // command consumption when the server is overloaded.
             return;
         }
 

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/cluster/MasterSlotManagerTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/cluster/MasterSlotManagerTest.java
@@ -165,4 +165,40 @@ class MasterSlotManagerTest {
         assertThat(tMasterSlotManager.getCurrentMasterSlot()).isEqualTo(0);
         assertThat(tMasterSlotManager.getTotalMasterSlots()).isEqualTo(2);
     }
+
+    @Test
+    void doNotInvalidateSlotWhenCurrentMasterIsBusy() {
+        // Simulate: the current master becomes BUSY and is excluded from normalMasterServers.
+        // The slot should be preserved to avoid self-starvation deadlock.
+        // First, set up a known slot state.
+        MasterSlotManager tMasterSlotManager = new MasterSlotManager(masterConfig);
+        MasterServerMetadata normalMaster = MasterServerMetadata.builder()
+                .address(masterConfig.getMasterAddress())
+                .serverStatus(ServerStatus.NORMAL)
+                .build();
+        MasterServerMetadata otherNormalMaster = MasterServerMetadata.builder()
+                .address("127.0.0.2:5679")
+                .serverStatus(ServerStatus.NORMAL)
+                .build();
+
+        List<MasterServerMetadata> normalMasterServers = new ArrayList<>();
+        normalMasterServers.add(normalMaster);
+        normalMasterServers.add(otherNormalMaster);
+        tMasterSlotManager.doReBalance(normalMasterServers);
+
+        // Verify that the slot is valid
+        assertThat(tMasterSlotManager.checkSlotValid()).isTrue();
+        int preservedSlot = tMasterSlotManager.getCurrentMasterSlot();
+        int preservedTotalSlots = tMasterSlotManager.getTotalMasterSlots();
+
+        // Now simulate the current master becoming BUSY: only the other master is in the NORMAL list
+        List<MasterServerMetadata> busyMasterServers = new ArrayList<>();
+        busyMasterServers.add(otherNormalMaster);
+        tMasterSlotManager.doReBalance(busyMasterServers);
+
+        // The slot should NOT be invalidated — it should be preserved
+        assertThat(tMasterSlotManager.checkSlotValid()).isTrue();
+        assertThat(tMasterSlotManager.getCurrentMasterSlot()).isEqualTo(preservedSlot);
+        assertThat(tMasterSlotManager.getTotalMasterSlots()).isEqualTo(preservedTotalSlots);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix #18570: Master self-starvation deadlock when overloaded.

## Brief change log

When a Master becomes overloaded and reports BUSY status, it is excluded from the NORMAL server list in `MasterClusters.getNormalServers()`. This causes `MasterSlotManager.doReBalance()` to fail to find itself, setting `currentSlot = -1`. `IdSlotBasedCommandFetcher` then short-circuits and stops consuming commands permanently — a self-reinforcing deadlock because the condition that prevents command consumption (overload) is the same condition that prevents the master from recovering.

**Fix**: When the current master is not found in the `normalMasterServers` list, preserve the existing slot value instead of setting it to `-1`. The load protection at `CommandEngine` level already throttles command consumption when the server is overloaded.

**Changes**:
- `MasterSlotManager.doReBalance()`: Keep existing slot when current master is not found in the NORMAL server list (e.g., when BUSY)
- `MasterSlotManagerTest`: Added `doNotInvalidateSlotWhenCurrentMasterIsBusy` test

## Verify this pull request

- [ ] This change is already covered by existing tests
- [x] This change added tests and can be verified as follows:
  - Added `MasterSlotManagerTest.doNotInvalidateSlotWhenCurrentMasterIsBusy` to verify that slot is preserved when current master is BUSY

## Related issues

Closes #18570