### PR TITLE
[Fix-18570][Master] Detect wrapped CommandDuplicateHandleException in bootstrapError (#18570)

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/CommandEngine.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/command/CommandEngine.java
@@ -193,7 +193,9 @@ public class CommandEngine extends BaseDaemonThread implements AutoCloseable {
     }
 
     private Void bootstrapError(Command command, Throwable throwable) {
-        if (throwable instanceof CommandDuplicateHandleException) {
+        // The exception is raised inside a CompletableFuture chain, so it arrives here wrapped in
+        // CompletionException, which a direct instanceof check cannot see through. See #18570.
+        if (ExceptionUtils.throwableOfType(throwable, CommandDuplicateHandleException.class) != null) {
             log.warn("Handle command failed, the command: {} has been handled by other master",
                     command,
                     throwable);

--- a/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/command/CommandEngineTest.java
+++ b/dolphinscheduler-master/src/test/java/org/apache/dolphinscheduler/server/master/engine/command/CommandEngineTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.master.engine.command;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.dolphinscheduler.common.enums.WorkflowExecutionStatus;
+import org.apache.dolphinscheduler.dao.entity.Command;
+import org.apache.dolphinscheduler.dao.repository.WorkflowInstanceDao;
+import org.apache.dolphinscheduler.server.master.engine.exceptions.CommandDuplicateHandleException;
+import org.apache.dolphinscheduler.service.command.CommandService;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CommandEngineTest {
+
+    @Mock
+    private WorkflowInstanceDao workflowInstanceDao;
+
+    @Mock
+    private CommandService commandService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @InjectMocks
+    private CommandEngine commandEngine;
+
+    /**
+     * Execute the transaction callback inline, so that reaching the non-duplicate branch produces a
+     * clear verification failure instead of a NullPointerException.
+     */
+    @BeforeEach
+    void setUp() {
+        when(transactionTemplate.execute(any()))
+                .thenAnswer(invocation -> {
+                    final TransactionCallback<?> callback = invocation.getArgument(0);
+                    return callback.doInTransaction(null);
+                });
+    }
+
+    private static Command duplicatedCommand() {
+        final Command command = new Command();
+        command.setId(520266);
+        command.setWorkflowInstanceId(516982);
+        return command;
+    }
+
+    private void invokeBootstrapError(Command command, Throwable throwable) {
+        ReflectionTestUtils.invokeMethod(commandEngine, "bootstrapError", command, throwable);
+    }
+
+    private void assertWorkflowWasNotForceFailed() {
+        verify(workflowInstanceDao, never())
+                .forceUpdateWorkflowInstanceState(anyInt(), any(WorkflowExecutionStatus.class));
+        verify(commandService, never()).moveToErrorCommand(any(Command.class), anyString());
+    }
+
+    /**
+     * The duplicate-handle exception is raised inside a CompletableFuture chain and therefore reaches
+     * bootstrapError wrapped in CompletionException. It must still be recognised, otherwise the healthy
+     * first execution has its workflow instance force-failed underneath it, can never complete, never
+     * leaves the in-memory workflow repository, and permanently pins the instance count that
+     * MasterServerLoadProtection uses - deadlocking command consumption. See #18570.
+     */
+    @Test
+    void bootstrapErrorShouldNotFailWorkflowWhenDuplicateExceptionIsWrapped() {
+        final Command command = duplicatedCommand();
+
+        invokeBootstrapError(command, new CompletionException(new CommandDuplicateHandleException(command)));
+
+        assertWorkflowWasNotForceFailed();
+    }
+
+    /**
+     * Deeply nested wrapping must be handled as well.
+     */
+    @Test
+    void bootstrapErrorShouldNotFailWorkflowWhenDuplicateExceptionIsNestedTwice() {
+        final Command command = duplicatedCommand();
+
+        invokeBootstrapError(command,
+                new CompletionException(new RuntimeException(new CommandDuplicateHandleException(command))));
+
+        assertWorkflowWasNotForceFailed();
+    }
+
+    /**
+     * The unwrapped case must keep behaving exactly as before.
+     */
+    @Test
+    void bootstrapErrorShouldNotFailWorkflowWhenDuplicateExceptionIsDirect() {
+        final Command command = duplicatedCommand();
+
+        invokeBootstrapError(command, new CommandDuplicateHandleException(command));
+
+        assertWorkflowWasNotForceFailed();
+    }
+}


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The investigation, the one-line change and the unit test were produced with the help of Claude (Anthropic), working from production logs of my own 3.4.2 deployment. Everything was compiled and tested locally before submitting, and the fix direction was proposed by @ruanwenjun in #18570.

## Purpose of the pull request

Closes #18570.

`CommandDuplicateHandleException` is raised inside a `CompletableFuture` chain and therefore reaches `CommandEngine.bootstrapError` wrapped in `CompletionException`. The direct `instanceof` check cannot see through the wrapper, so the duplicate branch is never taken and the workflow instance is force-failed instead.

Why this matters beyond a wrong log line: `forceUpdateWorkflowInstanceState(..., FAILURE)` only updates the DB row. It does not remove the execution from `workflowRepository` nor deregister its event bus. The still-running **first** execution then has a FAILURE row underneath it:

```
UnsupportedOperationException: The WorkflowInstance: 516982 state is FAILURE, no need to notify
```

so it can never complete and never leaves the in-memory repository. Since `MasterServerLoadProtection` reads

```java
int currentWorkflowInstanceCount = workflowRepository.getAll().size();
```

the count can no longer fall and `CommandEngine` keeps refusing to consume commands. In our production incident the logged count sat at exactly 25 against a limit of 20 for two hours (`25 x 7194` log lines in a single hour, no other value), 553 of the 573 workflow instances created in that window never got a single task instance row, and only a restart recovered it.

## Brief change log

- `CommandEngine.bootstrapError`: use `ExceptionUtils.throwableOfType(...)` instead of `instanceof` so the exception is still recognised when wrapped. `ExceptionUtils` was already imported in this file, so no new import is required.
- Add `CommandEngineTest` covering the wrapped, doubly-nested and unwrapped cases.

## Verify this pull request

Covered by the new unit test. Reverting only the production line makes exactly the two wrapped cases fail while the unwrapped case still passes:

```
with fix:     Tests run: 3, Failures: 0, Errors: 0    BUILD SUCCESS
without fix:  Tests run: 3, Failures: 2, Errors: 0    BUILD FAILURE
              CommandEngineTest.bootstrapErrorShouldNotFailWorkflowWhenDuplicateExceptionIsWrapped
              CommandEngineTest.bootstrapErrorShouldNotFailWorkflowWhenDuplicateExceptionIsNestedTwice
```

Verified against the `dev` branch with Maven 3.9.6 / JDK 8u492 (`mvn -pl dolphinscheduler-master -am install -DskipTests`, then `mvn -pl dolphinscheduler-master test -Dtest=CommandEngineTest`).

The failure is a Mockito verification failure on `workflowInstanceDao.forceUpdateWorkflowInstanceState`, i.e. it points directly at the workflow being wrongly force-failed.

## Notes for reviewers

- `bootstrapError` is private, so the test invokes it through `ReflectionTestUtils`. If that is not acceptable here, dropping `private` and marking it visible-for-testing works equally well and needs no test change.
- `transactionTemplate` is mocked to run its callback inline. Without that the non-duplicate branch throws NPE instead of producing a clear verification failure; the test still distinguishes fixed from unfixed either way.
- This change only addresses the duplicate command being misclassified. I have **not** verified whether it also resolves `IllegalStateException: WorkflowExecuteRunnable(...) already registered` (reproducible by re-running individual tasks of a finished workflow instance in quick succession), nor whether executions already wedged in `workflowRepository` get cleaned up.
