### PR TITLE
fix: handle negative depTaskCode in DependentItem.fromKey key parsing

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItem.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItem.java
@@ -44,6 +44,15 @@ public class DependentItem {
 
     public DependentItem fromKey(String key) {
         String[] parts = key.split("-");
+        if (parts.length == 5 && parts[1].isEmpty()) {
+            // depTaskCode is negative (e.g., -1 for DEPENDENT_ALL_TASK_CODE)
+            // key format: "2001--1-day-today" → ["2001", "", "1", "day", "today"]
+            setDefinitionCode(Long.parseLong(parts[0]));
+            setDepTaskCode(-Long.parseLong(parts[2]));
+            setCycle(parts[3]);
+            setDateValue(parts[4]);
+            return this;
+        }
         if (parts.length != 4) {
             throw new IllegalArgumentException("Invalid key format");
         }

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItemTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItemTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.model;
+
+import org.apache.dolphinscheduler.plugin.task.api.enums.DependResult;
+import org.apache.dolphinscheduler.plugin.task.api.enums.DependentType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DependentItemTest {
+
+    @Test
+    public void testFromKeyNormal() {
+        DependentItem item = new DependentItem().fromKey("2001-123-day-today");
+        Assertions.assertEquals(2001, item.getDefinitionCode());
+        Assertions.assertEquals(123, item.getDepTaskCode());
+        Assertions.assertEquals("day", item.getCycle());
+        Assertions.assertEquals("today", item.getDateValue());
+    }
+
+    @Test
+    public void testFromKeyWithNegativeDepTaskCode() {
+        // depTaskCode is -1 (DEPENDENT_ALL_TASK_CODE), getKey() produces "2001--1-day-today"
+        DependentItem item = new DependentItem().fromKey("2001--1-day-today");
+        Assertions.assertEquals(2001, item.getDefinitionCode());
+        Assertions.assertEquals(-1, item.getDepTaskCode());
+        Assertions.assertEquals("day", item.getCycle());
+        Assertions.assertEquals("today", item.getDateValue());
+    }
+
+    @Test
+    public void testFromKeyWithInvalidFormat() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new DependentItem().fromKey("invalid-key"));
+    }
+
+    @Test
+    public void testFromKeyWithTooManyParts() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new DependentItem().fromKey("1-2-3-4-5-6"));
+    }
+
+    @Test
+    public void testGetKeyNormal() {
+        DependentItem item = new DependentItem();
+        item.setDefinitionCode(2001);
+        item.setDepTaskCode(123);
+        item.setCycle("day");
+        item.setDateValue("today");
+        Assertions.assertEquals("2001-123-day-today", item.getKey());
+    }
+
+    @Test
+    public void testGetKeyWithNegativeDepTaskCode() {
+        DependentItem item = new DependentItem();
+        item.setDefinitionCode(2001);
+        item.setDepTaskCode(-1);
+        item.setCycle("day");
+        item.setDateValue("today");
+        Assertions.assertEquals("2001--1-day-today", item.getKey());
+    }
+
+    @Test
+    public void testRoundTripNormal() {
+        DependentItem item = new DependentItem();
+        item.setDefinitionCode(2001);
+        item.setDepTaskCode(123);
+        item.setCycle("day");
+        item.setDateValue("today");
+        String key = item.getKey();
+        DependentItem parsed = new DependentItem().fromKey(key);
+        Assertions.assertEquals(item.getDefinitionCode(), parsed.getDefinitionCode());
+        Assertions.assertEquals(item.getDepTaskCode(), parsed.getDepTaskCode());
+        Assertions.assertEquals(item.getCycle(), parsed.getCycle());
+        Assertions.assertEquals(item.getDateValue(), parsed.getDateValue());
+    }
+
+    @Test
+    public void testRoundTripWithNegativeDepTaskCode() {
+        DependentItem item = new DependentItem();
+        item.setDefinitionCode(2001);
+        item.setDepTaskCode(-1);
+        item.setCycle("day");
+        item.setDateValue("today");
+        String key = item.getKey();
+        DependentItem parsed = new DependentItem().fromKey(key);
+        Assertions.assertEquals(item.getDefinitionCode(), parsed.getDefinitionCode());
+        Assertions.assertEquals(item.getDepTaskCode(), parsed.getDepTaskCode());
+        Assertions.assertEquals(item.getCycle(), parsed.getCycle());
+        Assertions.assertEquals(item.getDateValue(), parsed.getDateValue());
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `DependentItem.fromKey()` to handle negative `depTaskCode` values (i.e., `-1` for `DEPENDENT_ALL_TASK_CODE`).

### Why are the changes needed?

When a Dependent task is configured with **Task Name** set to `ALL`, the UI assigns `depTaskCode: -1`. The `getKey()` method produces a key like `"2001--1-day-today"` (two consecutive hyphens). `fromKey()` splits on `-`, yielding 5 parts instead of the expected 4, causing:

```
java.lang.IllegalArgumentException: Invalid key format
    at DependentItem.fromKey(DependentItem.java:48)
    at DependentTaskTracker.isAllDependentTaskFinished(DependentTaskTracker.java:245)
```

### How were the changes tested?

Unit test covers:
- Normal key with positive depTaskCode: `"2001-123-day-today"` → 4 parts
- Negative depTaskCode: `"2001--1-day-today"` → 5 parts, correctly parsed as `depTaskCode = -1`
- Invalid key format still throws `IllegalArgumentException`

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): NO
- Anything that affects deployment: NO
- The core framework: NO

### Documentation

- Does this pull request introduce a new feature? NO

Closes #18576