### PR TITLE
[Doc-18579] Fix malformed links in datasource and configuration docs

### DIFF
--- a/docs/docs/en/architecture/configuration.md
+++ b/docs/docs/en/architecture/configuration.md
@@ -175,7 +175,7 @@ The default configuration is as follows:
 | registry.zookeeper.session-timeout              | 30s                   | session timeout                                                                                                                                                                         |
 | registry.zookeeper.connection-timeout           | 30s                   | connection timeout                                                                                                                                                                      |
 | registry.zookeeper.block-until-connected        | 600ms                 | waiting time to block until the connection succeeds                                                                                                                                     |
-| registry.zookeeper.digest                       | {username}:{password} | digest of zookeeper to access znode, works only when acl is enabled, for more details please check [https://zookeeper.apache.org/doc/r3.4.14/zookeeperAdmin.html](Apache Zookeeper doc) |
+| registry.zookeeper.digest                       | {username}:{password} | digest of zookeeper to access znode, works only when acl is enabled, for more details please check [Apache Zookeeper doc](https://zookeeper.apache.org/doc/r3.4.14/zookeeperAdmin.html) |
 
 Note that DolphinScheduler also supports zookeeper related configuration through `bin/env/dolphinscheduler_env.sh`.
 

--- a/docs/docs/en/guide/installation/datasource-setting.md
+++ b/docs/docs/en/guide/installation/datasource-setting.md
@@ -131,7 +131,7 @@ restarting `api-server` and `worker-server`. Mount to container volume in the sa
 like Docker.
 
 > Note: If you only want to use MySQL in the datasource center, there is no requirement for the version of MySQL JDBC driver.
-> But if you want to use MySQL as the metabase of DolphinScheduler, it only supports [8.0.16 and above](https:/ /repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar) version.
+> But if you want to use MySQL as the metabase of DolphinScheduler, it only supports [8.0.16 and above](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar) version.
 
 [mysql]: https://downloads.MySQL.com/archives/c-j/
 

--- a/docs/docs/zh/architecture/configuration.md
+++ b/docs/docs/zh/architecture/configuration.md
@@ -174,7 +174,7 @@ DolphinScheduler默认使用Zookeeper进行集群管理、容错、事件监听�
 | registry.zookeeper.session-timeout              | 30s              | session超时时间                                                                                                                                                |
 | registry.zookeeper.connection-timeout           | 30s              | 连接超时时间                                                                                                                                                     |
 | registry.zookeeper.block-until-connected        | 600ms            | 阻塞直到连接成功的等待时间                                                                                                                                              |
-| registry.zookeeper.digest                       | {用户名:密码}         | 如果zookeeper打开了acl，则需要填写认证信息访问znode，认证信息格式为{用户名}:{密码}。关于Zookeeper ACL详见[https://zookeeper.apache.org/doc/r3.4.14/zookeeperAdmin.html](Apache Zookeeper官方文档) |
+| registry.zookeeper.digest                       | {用户名:密码}         | 如果zookeeper打开了acl，则需要填写认证信息访问znode，认证信息格式为{用户名}:{密码}。关于Zookeeper ACL详见[Apache Zookeeper官方文档](https://zookeeper.apache.org/doc/r3.4.14/zookeeperAdmin.html) |
 
 DolphinScheduler同样可以通过`bin/env/dolphinscheduler_env.sh`进行Zookeeper相关的配置。
 


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The malformed links were identified with the help of an automated documentation link scan; the actual changes are minimal link fixes reviewed by the contributor.

## Purpose of the pull request

Fixes #18579 — three malformed Markdown links in the English and Chinese documentation.

## Brief change log

- `docs/docs/en/guide/installation/datasource-setting.md`: removed the space in `https:/ /repo1.maven.org/...` so the link resolves
- `docs/docs/en/architecture/configuration.md`: swapped the reversed `[url](label)` link to `[Apache Zookeeper doc](url)`
- `docs/docs/zh/architecture/configuration.md`: same reversed-link fix for the Chinese counterpart

## Verify this pull request

This pull request is code cleanup without any test coverage.

(Doc-only change, verified by diff inspection.)