### PR TITLE
[Feature-18592][storage] Support Gitlab as resource storage backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ docs/superpowers/
 .claude/worktrees
 CLAUDE.local.md
 AGENT.local.md
+.workbuddy

--- a/config/plugins_config
+++ b/config/plugins_config
@@ -72,6 +72,7 @@ dolphinscheduler-storage-hdfs
 dolphinscheduler-storage-obs
 dolphinscheduler-storage-oss
 dolphinscheduler-storage-s3
+dolphinscheduler-storage-gitlab
 --end--
 
 --task-plugins--

--- a/deploy/kubernetes/dolphinscheduler/templates/ingress.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/ingress.yaml
@@ -33,6 +33,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.class | default "default" }}
   rules:
   - host: "{{ .Values.ingress.host }}"
     http:

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -296,6 +296,18 @@ conf:
     # -- You need to set this parameter when private cloud s3. If S3 uses public cloud, you only need to set resource.aws.region or set to the endpoint of a public cloud such as S3.cn-north-1.amazonaws.com.cn
     aws.s3.endpoint: http://minio:9000
 
+    # -- gitlab resource storage, host
+    resource.gitlab.storage.host: ""
+
+    # --gitlab resource storage, private-token
+    resource.gitlab.storage.private-token: ""
+
+    # --gitlab resource storage, project-id
+    resource.gitlab.storage.project-id: ""
+
+    # --gitlab resource storage, branch-ref
+    resource.gitlab.storage.branch-ref: ""
+
     # -- alibaba cloud access key id, required if you set resource.storage.type=OSS
     resource.alibaba.cloud.access.key.id: <your-access-key-id>
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ResourcesServiceImpl.java
@@ -163,7 +163,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     @Override
     public void createDirectory(CreateDirectoryRequest createDirectoryRequest) {
         CreateDirectoryDto createDirectoryDto = createDirectoryRequestTransformer.transform(createDirectoryRequest);
-        createDirectoryDtoValidator.validate(createDirectoryDto);
+        createDirectoryDtoValidator.doValidate(createDirectoryDto);
 
         storageOperator.createStorageDir(createDirectoryDto.getDirectoryAbsolutePath());
         log.info("Success create directory: {}", createDirectoryRequest.getParentAbsoluteDirectory());
@@ -172,7 +172,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     @Override
     public void createFile(CreateFileRequest createFileRequest) {
         CreateFileDto createFileDto = createFileRequestTransformer.transform(createFileRequest);
-        createFileDtoValidator.validate(createFileDto);
+        createFileDtoValidator.doValidate(createFileDto);
 
         // todo: use storage proxy
         MultipartFile file = createFileDto.getFile();
@@ -193,7 +193,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     public void createFileFromContent(CreateFileFromContentRequest createFileFromContentRequest) {
         CreateFileFromContentDto createFileFromContentDto =
                 createFileFromContentRequestTransformer.transform(createFileFromContentRequest);
-        createFileFromContentDtoValidator.validate(createFileFromContentDto);
+        createFileFromContentDtoValidator.doValidate(createFileFromContentDto);
 
         // todo: use storage proxy
         String fileContent = createFileFromContentDto.getFileContent();
@@ -213,7 +213,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     @Override
     public void renameDirectory(RenameDirectoryRequest renameDirectoryRequest) {
         RenameDirectoryDto renameDirectoryDto = renameDirectoryRequestTransformer.transform(renameDirectoryRequest);
-        renameDirectoryDtoValidator.validate(renameDirectoryDto);
+        renameDirectoryDtoValidator.doValidate(renameDirectoryDto);
 
         String originDirectoryAbsolutePath = renameDirectoryDto.getOriginDirectoryAbsolutePath();
         String targetDirectoryAbsolutePath = renameDirectoryDto.getTargetDirectoryAbsolutePath();
@@ -224,7 +224,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     @Override
     public void renameFile(RenameFileRequest renameFileRequest) {
         RenameFileDto renameFileDto = renameFileRequestTransformer.transform(renameFileRequest);
-        renameFileDtoValidator.validate(renameFileDto);
+        renameFileDtoValidator.doValidate(renameFileDto);
 
         String originFileAbsolutePath = renameFileDto.getOriginFileAbsolutePath();
         String targetFileAbsolutePath = renameFileDto.getTargetFileAbsolutePath();
@@ -235,7 +235,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     @Override
     public void updateFile(UpdateFileRequest updateFileRequest) {
         UpdateFileDto updateFileDto = updateFileRequestTransformer.transform(updateFileRequest);
-        updateFileDtoValidator.validate(updateFileDto);
+        updateFileDtoValidator.doValidate(updateFileDto);
 
         String srcLocalTmpFileAbsolutePath = copyFileToLocal(updateFileDto.getFile());
         try {
@@ -259,6 +259,9 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
         }
 
         for (String resourceAbsolutePath : resourceAbsolutePaths) {
+            if (createDirectoryDtoValidator.ignoreValid()) {
+                continue;
+            }
             createDirectoryDtoValidator.exceptionResourceAbsolutePathInvalidated(resourceAbsolutePath);
             createDirectoryDtoValidator.exceptionUserNoResourcePermission(pagingResourceItemRequest.getLoginUser(),
                     resourceAbsolutePath);
@@ -305,7 +308,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                 .loginUser(deleteResourceRequest.getLoginUser())
                 .resourceAbsolutePath(deleteResourceRequest.getResourceAbsolutePath())
                 .build();
-        deleteResourceDtoValidator.validate(deleteResourceDto);
+        deleteResourceDtoValidator.doValidate(deleteResourceDto);
         storageOperator.delete(deleteResourceDto.getResourceAbsolutePath(), true);
     }
 
@@ -317,7 +320,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                 .skipLineNum(fetchFileContentRequest.getSkipLineNum())
                 .limit(fetchFileContentRequest.getLimit())
                 .build();
-        fetchFileContentDtoValidator.validate(fetchFileContentDto);
+        fetchFileContentDtoValidator.doValidate(fetchFileContentDto);
 
         String content = storageOperator
                 .fetchFileContent(
@@ -338,7 +341,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
     public void updateFileFromContent(UpdateFileFromContentRequest updateFileContentRequest) {
         UpdateFileFromContentDto updateFileFromContentDto =
                 updateFileFromContentRequestTransformer.transform(updateFileContentRequest);
-        updateFileFromContentDtoValidator.validate(updateFileFromContentDto);
+        updateFileFromContentDtoValidator.doValidate(updateFileFromContentDto);
 
         String srcLocalTmpFileAbsolutePath = copyFileToLocal(updateFileFromContentDto.getFileContent());
         try {
@@ -346,6 +349,9 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                     true);
             ApiServerMetrics.recordApiResourceUploadSize(updateFileFromContentDto.getFileContent().length());
             log.info("Success upload resource file: {} complete.", updateFileFromContentDto.getFileAbsolutePath());
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            // the resource file managed by gitlab throw this exception
+            throw unsupportedOperationException;
         } catch (Exception ex) {
             // If exception, clear the tmp path
             FileUtils.deleteFile(srcLocalTmpFileAbsolutePath);
@@ -360,7 +366,7 @@ public class ResourcesServiceImpl extends BaseServiceImpl implements ResourcesSe
                 .loginUser(downloadFileRequest.getLoginUser())
                 .fileAbsolutePath(downloadFileRequest.getFileAbsolutePath())
                 .build();
-        downloadFileDtoValidator.validate(downloadFileDto);
+        downloadFileDtoValidator.doValidate(downloadFileDto);
 
         String fileName = new File(downloadFileDto.getFileAbsolutePath()).getName();
         String localTmpFileAbsolutePath = FileUtils.getDownloadFilename(fileName);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/validator/resource/AbstractResourceValidator.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/validator/resource/AbstractResourceValidator.java
@@ -28,6 +28,7 @@ import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.repository.TenantDao;
 import org.apache.dolphinscheduler.plugin.storage.api.ResourceMetadata;
 import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
+import org.apache.dolphinscheduler.plugin.storage.gitlab.GitlabStorageOperator;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -53,8 +54,28 @@ public abstract class AbstractResourceValidator<T> implements IValidator<T> {
         this.tenantDao = tenantDao;
     }
 
+    /**
+     * if the resource files managed by GitLab, the validation can ignore, because Gitlab resourceAbsolutePath is blank
+     * @return bool
+     */
+    public boolean ignoreValid() {
+        return storageOperator instanceof GitlabStorageOperator;
+    }
+
+    /**
+     * check ignoreValid
+     * @param t t
+     */
+    public void doValidate(T t) {
+        if (!ignoreValid()) {
+            validate(t);
+        }
+    }
+
     public void exceptionResourceAbsolutePathInvalidated(String resourceAbsolutePath) {
         if (StringUtils.isBlank(resourceAbsolutePath)) {
+            // if the resource files managed by GitLab, the validation can ignore, because Gitlab resourceAbsolutePath
+            // is blank
             throw new ServiceException("The resource path is null");
         }
         if (!resourceAbsolutePath.startsWith(storageOperator.getStorageBaseDirectory())) {
@@ -86,7 +107,7 @@ public abstract class AbstractResourceValidator<T> implements IValidator<T> {
 
     public void exceptionResourceNotExists(String resourceAbsolutePath) {
         if (!storageOperator.exists(resourceAbsolutePath)) {
-            throw new ServiceException("Thr resource is not exists: " + resourceAbsolutePath);
+            throw new ServiceException("The resource is not exists: " + resourceAbsolutePath);
         }
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/validator/resource/PagingResourceItemRequestTransformer.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/validator/resource/PagingResourceItemRequestTransformer.java
@@ -67,6 +67,9 @@ public class PagingResourceItemRequestTransformer implements ITransformer<Paging
             List<String> resourceAbsolutePaths = tenantDao.queryAll()
                     .stream()
                     .map(tenant -> storageOperator.getStorageBaseDirectory(tenant.getTenantCode(), resourceType))
+                    // GitLab does not support tenant-based isolation of resource files，all tenant users base directory
+                    // are same，need distinct
+                    .distinct()
                     .collect(Collectors.toList());
             return QueryResourceDto.builder()
                     .resourceAbsolutePaths(resourceAbsolutePaths)

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Optional;
 import java.util.Set;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
@@ -293,27 +294,24 @@ public class FileUtils {
         if (paths.length == 0) {
             throw new IllegalArgumentException("At least one path should be provided");
         }
-        StringBuilder finalPath = new StringBuilder(paths[0]);
-        if (StringUtils.isEmpty(finalPath)) {
-            throw new IllegalArgumentException("The path should not be empty");
-        }
+        StringBuilder firstPath = new StringBuilder(Optional.ofNullable(paths[0]).orElse(StringUtils.EMPTY));
         String separator = File.separator;
         for (int i = 1; i < paths.length; i++) {
             String path = paths[i];
             if (StringUtils.isEmpty(path)) {
-                throw new IllegalArgumentException("The path should not be empty");
-            }
-            if (finalPath.toString().endsWith(separator) && path.startsWith(separator)) {
-                finalPath.append(path.substring(separator.length()));
                 continue;
             }
-            if (!finalPath.toString().endsWith(separator) && !path.startsWith(separator)) {
-                finalPath.append(separator).append(path);
+            if (firstPath.toString().endsWith(separator) && path.startsWith(separator)) {
+                firstPath.append(path.substring(separator.length()));
                 continue;
             }
-            finalPath.append(path);
+            if (!firstPath.toString().endsWith(separator) && !path.startsWith(separator)) {
+                firstPath.append(separator).append(path);
+                continue;
+            }
+            firstPath.append(path);
         }
-        return finalPath.toString();
+        return firstPath.toString();
     }
 
     /**
@@ -323,4 +321,23 @@ public class FileUtils {
     public static void copyInputStreamToFile(InputStream inputStream, String destFilename) {
         org.apache.commons.io.FileUtils.copyInputStreamToFile(inputStream, new File(destFilename));
     }
+
+    /**
+     * get parent Path
+     * @param pathStr pathStr
+     * @return Path
+     */
+    public static Path getParentPath(String pathStr) {
+        return getParentPath(Paths.get(pathStr));
+    }
+
+    /**
+     * get parent Path
+     * @param path pth
+     * @return Path
+     */
+    public static Path getParentPath(Path path) {
+        return Optional.ofNullable(path.getParent()).orElse(Paths.get(StringUtils.EMPTY));
+    }
+
 }

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -24,11 +24,19 @@ data.basedir.path=/tmp/dolphinscheduler
 # resource storage type: LOCAL, HDFS, S3, OSS, GCS, ABS, OBS, COS. LOCAL type is default type, and it's a specific type of HDFS with "resource.hdfs.fs.defaultFS = file:///" configuration
 # please notice that LOCAL mode does not support reading and writing in distributed mode, which mean you can only use your resource in one machine, unless
 # use shared file mount point
-resource.storage.type=LOCAL
+resource.storage.type=GITLAB
 # resource store on HDFS/S3 path, resource file will store to this base path, self configuration, please make sure the directory exists on hdfs and have read write permissions. "/dolphinscheduler" is recommended
 resource.storage.upload.base.path=/tmp/dolphinscheduler
 # The query interval
 resource.query.interval=10000
+# -- gitlab resource storage, host
+resource.gitlab.storage.host=http://10.10.25.30/
+# --gitlab resource storage, private-token
+resource.gitlab.storage.private-token=xK2LsZcZijfMMV7be2U_
+# --gitlab resource storage, project-id
+resource.gitlab.storage.project-id=262
+# --gitlab resource storage, branch-ref
+resource.gitlab.storage.branch-ref=master
 
 # if resource.storage.type=HDFS, the user must have the permission to create directories under the HDFS root path
 resource.hdfs.root.user=hdfs

--- a/dolphinscheduler-common/src/main/resources/resource-center.yaml
+++ b/dolphinscheduler-common/src/main/resources/resource-center.yaml
@@ -78,3 +78,16 @@ resource:
         bucket:
           name: dolphinscheduler
         endpoint: obs.cn-southwest-2.huaweicloud.com
+
+  # Gitlab Storage (GITLAB), required if you set resource.storage.type=GITLAB
+  gitlab:
+    storage:
+      # GitLab server host url, e.g. https://gitlab.example.com
+      host:
+      # GitLab personal/project access token, sent as the PRIVATE-TOKEN header.
+      private-token:
+      # GitLab project id (e.g. 123).
+      project-id:
+      # branch used to list the repository tree.
+      branch-ref:
+

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/AbstractStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/AbstractStorageOperator.java
@@ -50,7 +50,7 @@ public abstract class AbstractStorageOperator implements StorageOperator {
                 .isDirectory(Files.getFileExtension(resourceAbsolutePath).isEmpty())
                 .tenant(segments[0])
                 .resourceType(ResourceType.FILE)
-                .resourceRelativePath(segments.length == 2 ? "/" : segments[2])
+                .resourceRelativePath(segments.length == 2 ? segments[1] : segments[2])
                 .resourceParentAbsolutePath(StringUtils.substringBeforeLast(resourceAbsolutePath, File.separator))
                 .build();
     }

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/constants/StorageConstants.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-api/src/main/java/org/apache/dolphinscheduler/plugin/storage/api/constants/StorageConstants.java
@@ -66,4 +66,9 @@ public final class StorageConstants {
     public static final String HUAWEI_CLOUD_OBS_BUCKET_NAME = "resource.huawei.cloud.obs.bucket.name";
     public static final String HUAWEI_CLOUD_OBS_END_POINT = "resource.huawei.cloud.obs.endpoint";
 
+    public static final String GITLAB_STORAGE_HOST = "resource.gitlab.storage.host";
+    public static final String GITLAB_STORAGE_PRIVATE_TOKEN = "resource.gitlab.storage.private-token";
+    public static final String GITLAB_STORAGE_PROJECT_ID = "resource.gitlab.storage.project-id";
+    public static final String GITLAB_STORAGE_BRANCH_REF = "resource.gitlab.storage.branch-ref";
+
 }

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/pom.xml
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/pom.xml
@@ -24,54 +24,55 @@
         <version>dev-SNAPSHOT</version>
     </parent>
 
-    <artifactId>dolphinscheduler-storage-all</artifactId>
+    <artifactId>dolphinscheduler-storage-gitlab</artifactId>
+
+    <properties>
+        <plugin.name>storage.gitlab</plugin.name>
+        <gitlab4j.version>5.8.1</gitlab4j.version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
+            <artifactId>dolphinscheduler-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.dolphinscheduler</groupId>
             <artifactId>dolphinscheduler-storage-api</artifactId>
-            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-s3</artifactId>
-            <version>${project.version}</version>
+            <artifactId>dolphinscheduler-common</artifactId>
+            <scope>provided</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-hdfs</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.gitlab4j</groupId>
+            <artifactId>gitlab4j-api</artifactId>
+            <version>${gitlab4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-oss</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-gcs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-abs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-obs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-cos</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dolphinscheduler</groupId>
-            <artifactId>dolphinscheduler-storage-gitlab</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/GitlabStorageOperator.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/GitlabStorageOperator.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.storage.gitlab;
+
+import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.plugin.storage.api.AbstractStorageOperator;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageEntity;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
+import org.apache.dolphinscheduler.plugin.storage.gitlab.api.RepositoryFileTreeApi;
+import org.apache.dolphinscheduler.plugin.storage.gitlab.dto.GitlabFileNode;
+import org.apache.dolphinscheduler.spi.enums.ResourceType;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.models.RepositoryFile;
+
+@Slf4j
+public class GitlabStorageOperator extends AbstractStorageOperator implements Closeable, StorageOperator {
+
+    private final String BRANCH;
+    private final int PROJECT_ID;
+    private final RepositoryFileTreeApi repositoryFileTreeApi;
+    private final static String UNSUPPORTED_OPERATION_MSG =
+            "The operation is not supported when resource file was managed by Gitlab";
+
+    public GitlabStorageOperator(String resourceBasePath, GitLabApi gitLabApi, int projectId, String branch) {
+        super(resourceBasePath);
+        if (log.isInfoEnabled()) {
+            gitLabApi.enableRequestResponseLogging(Level.INFO);
+        }
+        this.repositoryFileTreeApi = new RepositoryFileTreeApi(gitLabApi);
+        this.BRANCH = branch;
+        this.PROJECT_ID = projectId;
+
+    }
+
+    @Override
+    public String getStorageBaseDirectory() {
+        // gitlab storage base dir is empty.
+        return resourceBaseAbsolutePath;
+    }
+
+    @Override
+    public String getStorageBaseDirectory(String tenantCode, ResourceType resourceType) {
+        // GitLab does not support tenant-based isolation of resource files
+        return getStorageBaseDirectory();
+    }
+
+    @SneakyThrows
+    @Override
+    public List<StorageEntity> listFileStorageEntityRecursively(String resourceAbsolutePath) {
+        return repositoryFileTreeApi.getFileTreeRecursive(PROJECT_ID, BRANCH)
+                .stream()
+                .map(transformGitlabTreeNodeToStorageEntity())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void close() throws IOException {
+        // ignore
+    }
+
+    @Override
+    public void createStorageDir(String directoryAbsolutePath) {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);
+    }
+
+    @Override
+    public boolean exists(String resourceAbsolutePath) {
+        // GitLab REST API v4 没有一个“直接判断路径是文件还是目录”的接口，得靠两个 api 的「404 语义 + 类型字段」来区分
+        try {
+            // 如果查询文件信息接口没有抛异常，说明这是一个文件，且存在
+            repositoryFileTreeApi.getFileInfo(PROJECT_ID, BRANCH, resourceAbsolutePath);
+            return true;
+        } catch (GitLabApiException e) {
+            // 出现异常，说明不是文件，此时再查看是否文件夹
+            List<StorageEntity> storageEntities = this.listStorageEntity(resourceAbsolutePath);
+            return CollectionUtils.isNotEmpty(storageEntities);
+        }
+    }
+
+    @Override
+    public void delete(String resourceAbsolutePath, boolean recursive) {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);
+    }
+
+    @Override
+    public void copy(String srcAbsolutePath, String dstAbsolutePath, boolean deleteSource, boolean overwrite) {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);
+    }
+
+    @Override
+    public void upload(String srcLocalFileAbsolutePath, String dstAbsolutePath, boolean deleteSource,
+                       boolean overwrite) {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);
+    }
+
+    @SneakyThrows
+    @Override
+    public void download(String srcFileAbsolutePath, String dstAbsoluteFile, boolean overwrite) {
+        File file = new File(dstAbsoluteFile);
+        if (file.exists() && !overwrite) {
+            throw new RuntimeException("the destination file " + dstAbsoluteFile + " already exists");
+        }
+        try (InputStream in = repositoryFileTreeApi.getRawFile(PROJECT_ID, BRANCH, srcFileAbsolutePath)) {
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    @SneakyThrows
+    @Override
+    public List<String> fetchFileContent(String fileAbsolutePath, int skipLineNums, int limit) {
+        try (
+                InputStream inputStream = repositoryFileTreeApi.getRawFile(PROJECT_ID, BRANCH, fileAbsolutePath);
+                BufferedReader bufferedReader =
+                        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            return bufferedReader.lines()
+                    .skip(skipLineNums)
+                    .limit(limit)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @SneakyThrows
+    @Override
+    public List<StorageEntity> listStorageEntity(String resourceAbsolutePath) {
+        return repositoryFileTreeApi.getFileTree(PROJECT_ID, resourceAbsolutePath, BRANCH)
+                .stream()
+                .map(transformGitlabTreeNodeToStorageEntity())
+                .collect(Collectors.toList());
+    }
+
+    @SneakyThrows
+    @Override
+    public StorageEntity getStorageEntity(String resourceAbsolutePath) {
+        RepositoryFile fileInfo = repositoryFileTreeApi.getFileInfo(PROJECT_ID, resourceAbsolutePath, BRANCH);
+        StorageEntity storageEntity = new StorageEntity();
+        storageEntity.setFileName(fileInfo.getFileName());
+        storageEntity.setSize(fileInfo.getSize());
+        storageEntity.setType(ResourceType.FILE);
+        storageEntity.setFullName(fileInfo.getFilePath());
+        storageEntity.setPfullName(FileUtils.getParentPath(fileInfo.getFilePath()).toString());
+        return storageEntity;
+    }
+
+    /**
+     * transform GitlabFileNode to StorageEntity
+     */
+    private Function<GitlabFileNode, StorageEntity> transformGitlabTreeNodeToStorageEntity() {
+        return gitlabFileNode -> {
+            StorageEntity storageEntity = new StorageEntity();
+            storageEntity.setFileName(gitlabFileNode.getName());
+            storageEntity.setFullName(gitlabFileNode.getPath());
+            storageEntity.setPfullName(FileUtils.getParentPath(gitlabFileNode.getPath()).toString());
+            storageEntity.setType(ResourceType.FILE);
+            // tree is directory, blob is file
+            storageEntity.setDirectory(gitlabFileNode.isDirectory());
+            return storageEntity;
+        };
+    }
+
+}

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/GitlabStorageOperatorFactory.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/GitlabStorageOperatorFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.storage.gitlab;
+
+import org.apache.dolphinscheduler.common.utils.PropertyUtils;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperator;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageOperatorFactory;
+import org.apache.dolphinscheduler.plugin.storage.api.StorageType;
+import org.apache.dolphinscheduler.plugin.storage.api.constants.StorageConstants;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.gitlab4j.api.GitLabApi;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(StorageOperatorFactory.class)
+public class GitlabStorageOperatorFactory implements StorageOperatorFactory {
+
+    @Override
+    public StorageOperator createStorageOperate() {
+        int projectId = PropertyUtils.getInt(StorageConstants.GITLAB_STORAGE_PROJECT_ID, 0);
+        String branchRef = PropertyUtils.getString(StorageConstants.GITLAB_STORAGE_BRANCH_REF, StringUtils.EMPTY);
+        // gitlab storage base dir is empty.
+        return new GitlabStorageOperator(StringUtils.EMPTY, getGitLabApi(), projectId, branchRef);
+    }
+
+    private GitLabApi getGitLabApi() {
+        String gitlabHost = PropertyUtils.getString(StorageConstants.GITLAB_STORAGE_HOST, "localhost");
+        String privateToken = PropertyUtils.getString(StorageConstants.GITLAB_STORAGE_PRIVATE_TOKEN, StringUtils.EMPTY);
+        return new GitLabApi(GitLabApi.ApiVersion.V4, gitlabHost, privateToken);
+    }
+
+    @Override
+    public StorageType getStorageOperate() {
+        return StorageType.GITLAB;
+    }
+}

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/api/RepositoryFileTreeApi.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/api/RepositoryFileTreeApi.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.storage.gitlab.api;
+
+import org.apache.dolphinscheduler.plugin.storage.gitlab.dto.GitlabFileNode;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.RepositoryFileApi;
+
+@Slf4j
+public class RepositoryFileTreeApi extends RepositoryFileApi {
+
+    public RepositoryFileTreeApi(GitLabApi gitLabApi) {
+        super(gitLabApi);
+    }
+
+    /**
+     * 提取gitlab项目指定文件夹下的目录树
+     */
+    public List<GitlabFileNode> getFileTree(Object projectIdOrPath, String filePath,
+                                            String ref) throws GitLabApiException {
+
+        Form form = new Form();
+        addFormParam(form, "path", filePath);
+        addFormParam(form, "ref", urlEncode(ref));
+
+        return getGitlabTreeNodes(projectIdOrPath, form);
+    }
+
+    /**
+     * 提取gitlab项目下的目录树（全量）
+     */
+    public List<GitlabFileNode> getFileTreeRecursive(Object projectIdOrPath, String ref) throws GitLabApiException {
+
+        Form form = new Form();
+        addFormParam(form, "recursive", true);
+        addFormParam(form, "ref", urlEncode(ref));
+
+        return getGitlabTreeNodes(projectIdOrPath, form);
+    }
+
+    private List<GitlabFileNode> getGitlabTreeNodes(Object projectIdOrPath, Form form) {
+        try (
+                Response response = get(Response.Status.OK, form.asMap(), "projects",
+                        getProjectIdOrPath(projectIdOrPath), "repository", "tree")) {
+            return response.readEntity(new GenericType<List<GitlabFileNode>>() {
+            });
+        } catch (Exception e) {
+            log.error("get gitlab repository file tree error", e);
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/dto/GitlabFileNode.java
+++ b/dolphinscheduler-storage-plugin/dolphinscheduler-storage-gitlab/src/main/java/org/apache/dolphinscheduler/plugin/storage/gitlab/dto/GitlabFileNode.java
@@ -15,27 +15,44 @@
  * limitations under the License.
  */
 
-package org.apache.dolphinscheduler.plugin.storage.api;
+package org.apache.dolphinscheduler.plugin.storage.gitlab.dto;
 
-import java.util.Optional;
+import lombok.Data;
 
-public enum StorageType {
+/**
+ * A single node returned by the GitLab repository tree API
+ * {@code GET /api/v4/projects/:id/repository/tree}.
+ *
+ * <pre>
+ * [
+ *   {
+ *     "id": "a1e8f8d7...",
+ *     "name": "src",
+ *     "type": "tree",        // "tree" (directory) or "blob" (file)
+ *     "path": "src",
+ *     "mode": "040000"
+ *   }
+ * ]
+ * </pre>
+ */
+@Data
+public class GitlabFileNode {
 
-    LOCAL,
-    HDFS,
-    OSS,
-    S3,
-    GITLAB,
-    GCS,
-    ABS,
-    OBS,
-    COS;
+    private String id;
 
-    public static Optional<StorageType> getStorageType(String name) {
-        try {
-            return Optional.of(StorageType.valueOf(name));
-        } catch (IllegalArgumentException | NullPointerException ex) {
-            return Optional.empty();
-        }
+    private String name;
+
+    // tree is directory, blob is file
+    private String type;
+
+    private String path;
+
+    private String mode;
+
+    private boolean directory;
+
+    public boolean isDirectory() {
+        return type.equals("tree");
     }
+
 }

--- a/dolphinscheduler-storage-plugin/pom.xml
+++ b/dolphinscheduler-storage-plugin/pom.xml
@@ -37,6 +37,7 @@
         <module>dolphinscheduler-storage-abs</module>
         <module>dolphinscheduler-storage-obs</module>
         <module>dolphinscheduler-storage-cos</module>
+        <module>dolphinscheduler-storage-gitlab</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
<!--Thanks very much for contributing to Apache DolphinScheduler, we are happy that you want to help us improve DolphinScheduler! -->

## Was this PR generated or assisted by AI?
No
<!--(Please answer YES or NO. If YES, please specify which parts were generated or assisted by AI)-->

## Purpose of the pull request
This pull request add Gitlab as resource storage backend
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
- 新增dolphinscheduler-storage-gitlab模块，使用GitLab4J API提供的sdk调用Gitlab REST API [https://github.com/gitlab4j/gitlab4j-api/tree/5.8.1](url)
- 新增相关配置项: Gitlab host, private-token, project-id, branch-ref
- 引入gitlab管理资源文件的目的是规范管理SQL等文件，开发者应该在git上操作文件的增删改，因此Gitlab StorageOperator的上传、更新、删除等操作已禁用
- 由于gitlab是文件版本管理，不同于常规的文件存储系统，无法适配DolphinScheduler的租户隔离资源文件的架构设计，为此修改了以下文件：
   - org.apache.dolphinscheduler.api.validator.resource.AbstractResourceValidator
   - org.apache.dolphinscheduler.api.service.impl.ResourcesServiceImpl
   - org.apache.dolphinscheduler.api.validator.resource.PagingResourceItemRequestTransformer

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added dolphinscheduler-dao tests for end-to-end.*
- *Added CronUtilsTest to verify the change.*
- *Manually verified the change by testing locally.* -->

(or)

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If your pull request contains incompatible change, you should also add it to `docs/docs/en/guide/upgrade/incompatible.md`
