### PR TITLE
[Fix-18596][API] Enforce permission checks for sub-workflow references

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionChecker.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionChecker.java
@@ -74,9 +74,12 @@ public class TaskSubWorkflowPermissionChecker {
 
         List<WorkflowDefinition> subWorkflowDefinitions =
                 workflowDefinitionDao.queryByCodes(subWorkflowDefinitionCodes);
-        Set<Long> existingSubWorkflowDefinitionCodes = subWorkflowDefinitions == null
-                ? new HashSet<>()
-                : subWorkflowDefinitions.stream().map(WorkflowDefinition::getCode).collect(Collectors.toSet());
+        if (subWorkflowDefinitions == null) {
+            log.warn("Referenced sub workflow is unavailable, userId:{}.", loginUser.getId());
+            throw new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION);
+        }
+        Set<Long> existingSubWorkflowDefinitionCodes =
+                subWorkflowDefinitions.stream().map(WorkflowDefinition::getCode).collect(Collectors.toSet());
         if (!existingSubWorkflowDefinitionCodes.containsAll(subWorkflowDefinitionCodes)) {
             log.warn("Referenced sub workflow is unavailable, userId:{}.", loginUser.getId());
             throw new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionChecker.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionChecker.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.service.ProjectService;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
+import org.apache.dolphinscheduler.plugin.task.api.parameters.SubWorkflowParameters;
+import org.apache.dolphinscheduler.plugin.task.api.utils.TaskTypeUtils;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TaskSubWorkflowPermissionChecker {
+
+    private final WorkflowDefinitionDao workflowDefinitionDao;
+    private final ProjectService projectService;
+
+    public TaskSubWorkflowPermissionChecker(WorkflowDefinitionDao workflowDefinitionDao,
+                                            ProjectService projectService) {
+        this.workflowDefinitionDao = workflowDefinitionDao;
+        this.projectService = projectService;
+    }
+
+    public void checkPermission(User loginUser, Collection<? extends TaskDefinition> taskDefinitions) {
+        if (taskDefinitions == null || taskDefinitions.isEmpty()) {
+            return;
+        }
+
+        Set<Long> subWorkflowDefinitionCodes = new HashSet<>();
+        for (TaskDefinition taskDefinition : taskDefinitions) {
+            if (!TaskTypeUtils.isSubWorkflowTask(taskDefinition.getTaskType())) {
+                continue;
+            }
+            SubWorkflowParameters subWorkflowParameters =
+                    JSONUtils.parseObject(taskDefinition.getTaskParams(), SubWorkflowParameters.class);
+            if (subWorkflowParameters.getWorkflowDefinitionCode() > 0) {
+                subWorkflowDefinitionCodes.add(subWorkflowParameters.getWorkflowDefinitionCode());
+            }
+        }
+
+        if (subWorkflowDefinitionCodes.isEmpty()) {
+            return;
+        }
+
+        List<WorkflowDefinition> subWorkflowDefinitions =
+                workflowDefinitionDao.queryByCodes(subWorkflowDefinitionCodes);
+        Set<Long> existingSubWorkflowDefinitionCodes = subWorkflowDefinitions == null
+                ? new HashSet<>()
+                : subWorkflowDefinitions.stream().map(WorkflowDefinition::getCode).collect(Collectors.toSet());
+        if (!existingSubWorkflowDefinitionCodes.containsAll(subWorkflowDefinitionCodes)) {
+            log.warn("Referenced sub workflow is unavailable, userId:{}.", loginUser.getId());
+            throw new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION);
+        }
+
+        Set<Long> subWorkflowProjectCodes = subWorkflowDefinitions.stream()
+                .map(WorkflowDefinition::getProjectCode)
+                .collect(Collectors.toSet());
+        try {
+            for (Long projectCode : subWorkflowProjectCodes) {
+                projectService.checkHasProjectWritePermissionThrowException(loginUser, projectCode);
+            }
+        } catch (ServiceException ex) {
+            log.warn("Referenced sub workflow is unavailable, userId:{}.", loginUser.getId());
+            throw new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION);
+        }
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/TaskDefinitionServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.PermissionCheck;
 import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
+import org.apache.dolphinscheduler.api.permission.TaskSubWorkflowPermissionChecker;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.TaskDefinitionService;
 import org.apache.dolphinscheduler.api.service.WorkflowTaskRelationService;
@@ -101,6 +102,10 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
 
     @Autowired
     private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    @Autowired
+    private TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
+
     /**
      * query task definition
      *
@@ -206,6 +211,7 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
         TaskDefinitionLog taskDefinitionUpdate =
                 taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(taskCode, version);
         taskDatasourcePermissionChecker.checkPermission(loginUser, Collections.singletonList(taskDefinitionUpdate));
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, Collections.singletonList(taskDefinitionUpdate));
         taskDefinitionUpdate.setUserId(loginUser.getId());
         taskDefinitionUpdate.setUpdateTime(new Date());
         taskDefinitionUpdate.setId(taskDefinition.getId());
@@ -353,6 +359,8 @@ public class TaskDefinitionServiceImpl extends BaseServiceImpl implements TaskDe
                 break;
             case ONLINE:
                 taskDatasourcePermissionChecker.checkPermission(loginUser,
+                        Collections.singletonList(taskDefinitionLog));
+                taskSubWorkflowPermissionChecker.checkPermission(loginUser,
                         Collections.singletonList(taskDefinitionLog));
                 String resourceIds = taskDefinition.getResourceIds();
                 if (StringUtils.isNotBlank(resourceIds)) {

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.dolphinscheduler.api.dto.workflow.WorkflowDefinitionVariablesD
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
+import org.apache.dolphinscheduler.api.permission.TaskSubWorkflowPermissionChecker;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.SchedulerService;
 import org.apache.dolphinscheduler.api.service.TaskDefinitionLogService;
@@ -210,6 +211,9 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
     @Autowired
     private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
 
+    @Autowired
+    private TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
+
     /**
      * create workflow definition
      *
@@ -273,6 +277,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                  WorkflowDefinition workflowDefinition,
                                                  List<TaskDefinitionLog> taskDefinitionLogs) {
         taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         int saveTaskResult = processService.saveTaskDefine(loginUser, workflowDefinition.getProjectCode(),
                 taskDefinitionLogs, Boolean.TRUE);
         if (saveTaskResult == Constants.EXIT_CODE_SUCCESS) {
@@ -697,6 +702,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                                                  WorkflowDefinition workflowDefinitionDeepCopy,
                                                  List<TaskDefinitionLog> taskDefinitionLogs) {
         taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         int saveTaskResult = processService.saveTaskDefine(loginUser, workflowDefinition.getProjectCode(),
                 taskDefinitionLogs, Boolean.TRUE);
         if (saveTaskResult == Constants.EXIT_CODE_SUCCESS) {
@@ -1610,6 +1616,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                             return Stream.of(taskDefinitionLog);
                         }).collect(Collectors.toList()));
         taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogList);
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, taskDefinitionLogList);
 
         int switchVersion = processService.switchVersion(workflowDefinition, workflowDefinitionLog);
         if (switchVersion <= 0) {
@@ -1870,6 +1877,7 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
         List<TaskDefinitionLog> taskDefinitionLogs =
                 taskDefinitionLogDao.queryTaskDefineLogList(workflowTaskRelations);
         taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         // todo : check Workflow is validate
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowInstanceServiceImpl.java
@@ -33,6 +33,7 @@ import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVari
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
+import org.apache.dolphinscheduler.api.permission.TaskSubWorkflowPermissionChecker;
 import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.service.TaskInstanceService;
 import org.apache.dolphinscheduler.api.service.UsersService;
@@ -165,6 +166,9 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
 
     @Autowired
     private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    @Autowired
+    private TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
 
     @Override
     public List<WorkflowInstanceSummaryVO> queryTopNLongestRunningWorkflowInstance(User loginUser, long projectCode,
@@ -420,6 +424,7 @@ public class WorkflowInstanceServiceImpl extends BaseServiceImpl implements Work
             }
         }
         taskDatasourcePermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, taskDefinitionLogs);
         int saveTaskResult = processService.saveTaskDefine(loginUser, projectCode, taskDefinitionLogs, syncDefine);
         if (saveTaskResult == Constants.DEFINITION_FAILURE) {
             log.error("Update task definition error, projectCode:{}, workflowInstanceId:{}", projectCode,

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionCheckerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionCheckerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.api.permission;
+
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ServiceException;
+import org.apache.dolphinscheduler.api.service.ProjectService;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
+import org.apache.dolphinscheduler.dao.repository.WorkflowDefinitionDao;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskSubWorkflowPermissionCheckerTest {
+
+    private static final int USER_ID = 1;
+    private static final long SUB_WORKFLOW_CODE = 42L;
+    private static final long ANOTHER_SUB_WORKFLOW_CODE = 43L;
+    private static final long SUB_WORKFLOW_PROJECT_CODE = 99L;
+
+    @Mock
+    private WorkflowDefinitionDao workflowDefinitionDao;
+
+    @Mock
+    private ProjectService projectService;
+
+    private TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
+
+    private User loginUser;
+
+    @BeforeEach
+    public void setUp() {
+        taskSubWorkflowPermissionChecker =
+                new TaskSubWorkflowPermissionChecker(workflowDefinitionDao, projectService);
+        loginUser = new User();
+        loginUser.setId(USER_ID);
+        loginUser.setUserType(UserType.GENERAL_USER);
+    }
+
+    @Test
+    public void shouldRejectMissingSubWorkflow() {
+        Mockito.when(workflowDefinitionDao.queryByCodes(Mockito.anyCollection()))
+                .thenReturn(Collections.emptyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> taskSubWorkflowPermissionChecker.checkPermission(
+                        loginUser, Collections.singletonList(getSubWorkflowTaskDefinition(SUB_WORKFLOW_CODE))));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verifyNoInteractions(projectService);
+    }
+
+    @Test
+    public void shouldRejectUnavailableSubWorkflowProject() {
+        Mockito.when(workflowDefinitionDao.queryByCodes(Mockito.anyCollection()))
+                .thenReturn(Collections.singletonList(getWorkflowDefinition(SUB_WORKFLOW_CODE)));
+        Mockito.doThrow(new ServiceException(Status.USER_NO_WRITE_PROJECT_PERM))
+                .when(projectService)
+                .checkHasProjectWritePermissionThrowException(loginUser, SUB_WORKFLOW_PROJECT_CODE);
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> taskSubWorkflowPermissionChecker.checkPermission(
+                        loginUser, Collections.singletonList(getSubWorkflowTaskDefinition(SUB_WORKFLOW_CODE))));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+    }
+
+    @Test
+    public void shouldAllowAvailableSubWorkflowsAndCheckEachProjectOnce() {
+        Mockito.when(workflowDefinitionDao.queryByCodes(Mockito.anyCollection()))
+                .thenReturn(Arrays.asList(
+                        getWorkflowDefinition(SUB_WORKFLOW_CODE),
+                        getWorkflowDefinition(ANOTHER_SUB_WORKFLOW_CODE)));
+
+        Assertions.assertDoesNotThrow(() -> taskSubWorkflowPermissionChecker.checkPermission(
+                loginUser,
+                Arrays.asList(
+                        getSubWorkflowTaskDefinition(SUB_WORKFLOW_CODE),
+                        getSubWorkflowTaskDefinition(ANOTHER_SUB_WORKFLOW_CODE))));
+
+        Mockito.verify(projectService, Mockito.times(1))
+                .checkHasProjectWritePermissionThrowException(loginUser, SUB_WORKFLOW_PROJECT_CODE);
+    }
+
+    @Test
+    public void shouldSkipTaskWithoutSubWorkflow() {
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setTaskType("SHELL");
+        taskDefinition.setTaskParams("{\"rawScript\":\"echo test\"}");
+
+        taskSubWorkflowPermissionChecker.checkPermission(loginUser, Collections.singletonList(taskDefinition));
+
+        Mockito.verifyNoInteractions(workflowDefinitionDao, projectService);
+    }
+
+    private TaskDefinition getSubWorkflowTaskDefinition(long workflowDefinitionCode) {
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setTaskType("SUB_WORKFLOW");
+        taskDefinition.setTaskParams("{\"workflowDefinitionCode\":" + workflowDefinitionCode + "}");
+        return taskDefinition;
+    }
+
+    private WorkflowDefinition getWorkflowDefinition(long workflowDefinitionCode) {
+        WorkflowDefinition workflowDefinition = new WorkflowDefinition();
+        workflowDefinition.setCode(workflowDefinitionCode);
+        workflowDefinition.setProjectCode(SUB_WORKFLOW_PROJECT_CODE);
+        return workflowDefinition;
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionCheckerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/permission/TaskSubWorkflowPermissionCheckerTest.java
@@ -78,6 +78,19 @@ public class TaskSubWorkflowPermissionCheckerTest {
     }
 
     @Test
+    public void shouldRejectWhenSubWorkflowQueryReturnsNull() {
+        Mockito.when(workflowDefinitionDao.queryByCodes(Mockito.anyCollection()))
+                .thenReturn(null);
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> taskSubWorkflowPermissionChecker.checkPermission(
+                        loginUser, Collections.singletonList(getSubWorkflowTaskDefinition(SUB_WORKFLOW_CODE))));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verifyNoInteractions(projectService);
+    }
+
+    @Test
     public void shouldRejectUnavailableSubWorkflowProject() {
         Mockito.when(workflowDefinitionDao.queryByCodes(Mockito.anyCollection()))
                 .thenReturn(Collections.singletonList(getWorkflowDefinition(SUB_WORKFLOW_CODE)));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TaskDefinitionServiceImplTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
+import org.apache.dolphinscheduler.api.permission.TaskSubWorkflowPermissionChecker;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.TaskDefinitionServiceImpl;
 import org.apache.dolphinscheduler.common.constants.Constants;
@@ -108,6 +109,9 @@ public class TaskDefinitionServiceImplTest {
 
     @Mock
     private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    @Mock
+    private TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
 
     @Mock
     private WorkflowTaskRelationLogMapper workflowTaskRelationLogMapper;
@@ -192,6 +196,26 @@ public class TaskDefinitionServiceImplTest {
                 .thenReturn(new TaskDefinitionLog());
         doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
                 .when(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
+
+        assertThrowsServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION,
+                () -> taskDefinitionService.switchVersion(user, PROJECT_CODE, TASK_CODE, VERSION));
+
+        Mockito.verify(taskDefinitionDao, Mockito.never()).updateById(any(TaskDefinition.class));
+    }
+
+    @Test
+    public void switchVersionShouldRejectUnavailableSubWorkflow() {
+        Project project = getProject();
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(user, project);
+
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setProjectCode(PROJECT_CODE);
+        when(taskDefinitionDao.queryByCode(TASK_CODE)).thenReturn(taskDefinition);
+        when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(TASK_CODE, VERSION))
+                .thenReturn(new TaskDefinitionLog());
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(user), anyList());
 
         assertThrowsServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION,
                 () -> taskDefinitionService.switchVersion(user, PROJECT_CODE, TASK_CODE, VERSION));
@@ -300,6 +324,31 @@ public class TaskDefinitionServiceImplTest {
         assertThrowsServiceException(Status.REQUEST_PARAMS_NOT_VALID_ERROR,
                 () -> taskDefinitionService.releaseTaskDefinition(user, PROJECT_CODE, TASK_CODE,
                         ReleaseState.getEnum(2)));
+    }
+
+    @Test
+    public void releaseTaskDefinitionShouldRejectUnavailableSubWorkflow() {
+        Project project = getProject();
+        when(projectDao.queryByCode(PROJECT_CODE)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(user, project);
+
+        TaskDefinition taskDefinition = new TaskDefinition();
+        taskDefinition.setProjectCode(PROJECT_CODE);
+        taskDefinition.setVersion(VERSION);
+        taskDefinition.setCode(TASK_CODE);
+        when(taskDefinitionDao.queryByCode(TASK_CODE)).thenReturn(taskDefinition);
+        TaskDefinitionLog taskDefinitionLog = new TaskDefinitionLog();
+        when(taskDefinitionLogMapper.queryByDefinitionCodeAndVersion(TASK_CODE, VERSION))
+                .thenReturn(taskDefinitionLog);
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(user), anyList());
+
+        assertThrowsServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION,
+                () -> taskDefinitionService.releaseTaskDefinition(
+                        user, PROJECT_CODE, TASK_CODE, ReleaseState.ONLINE));
+
+        Mockito.verify(taskDefinitionDao, Mockito.never()).updateById(any(TaskDefinition.class));
+        Mockito.verify(taskDefinitionLogMapper, Mockito.never()).updateById(any(TaskDefinitionLog.class));
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
+import org.apache.dolphinscheduler.api.permission.TaskSubWorkflowPermissionChecker;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.WorkflowDefinitionServiceImpl;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
@@ -184,6 +185,9 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
     @Mock
     private TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    @Mock
+    private TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
 
     @Mock
     private TaskDefinitionService taskDefinitionService;
@@ -951,6 +955,26 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     }
 
     @Test
+    public void testCreateWorkflowDefinitionShouldRejectUnavailableSubWorkflow() {
+        Project project = getProject(projectCode);
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
+        when(workflowDefinitionDao.verifyByDefineName(projectCode, name)).thenReturn(null);
+        when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.createWorkflowDefinition(
+                        user, projectCode, name, description, "[]", "[]", timeout,
+                        taskRelationJson, taskDefinitionJson, null, WorkflowExecutionTypeEnum.PARALLEL));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(processService, Mockito.never())
+                .saveTaskDefine(eq(user), eq(projectCode), anyList(), eq(Boolean.TRUE));
+    }
+
+    @Test
     public void testSwitchWorkflowDefinitionVersionShouldRejectUnauthorizedDatasource() {
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         WorkflowDefinitionLog workflowDefinitionLog = new WorkflowDefinitionLog();
@@ -980,6 +1004,35 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
     }
 
     @Test
+    public void testSwitchWorkflowDefinitionVersionShouldRejectUnavailableSubWorkflow() {
+        WorkflowDefinition workflowDefinition = getWorkflowDefinition();
+        WorkflowDefinitionLog workflowDefinitionLog = new WorkflowDefinitionLog();
+        workflowDefinitionLog.setCode(processDefinitionCode);
+        workflowDefinitionLog.setProjectCode(projectCode);
+        workflowDefinitionLog.setVersion(1);
+        WorkflowTaskRelation workflowTaskRelation =
+                getWorkflowTaskRelation(1, 1, projectCode, processDefinitionCode, 0, 0, 123456789L, 1);
+
+        when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(workflowDefinition));
+        when(workflowDefinitionLogMapper.queryByDefinitionCodeAndVersion(processDefinitionCode, 1))
+                .thenReturn(workflowDefinitionLog);
+        when(workflowTaskRelationDao.queryWorkflowTaskRelationsByWorkflowDefinitionCode(processDefinitionCode, 1))
+                .thenReturn(Collections.singletonList(workflowTaskRelation));
+        when(taskDefinitionLogMapper.queryByTaskDefinitions(anyList()))
+                .thenReturn(Collections.singletonList(new TaskDefinitionLog()));
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.switchWorkflowDefinitionVersion(
+                        user, projectCode, processDefinitionCode, 1));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(processService, Mockito.never())
+                .switchVersion(any(WorkflowDefinition.class), any(WorkflowDefinitionLog.class));
+    }
+
+    @Test
     public void testOnlineWorkflowDefinitionShouldRejectUnauthorizedDatasource() {
         WorkflowDefinition workflowDefinition = getWorkflowDefinition();
         WorkflowTaskRelation workflowTaskRelation =
@@ -991,6 +1044,26 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
                 .thenReturn(Collections.singletonList(new TaskDefinitionLog()));
         doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
                 .when(taskDatasourcePermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.onlineWorkflowDefinition(user, projectCode, processDefinitionCode));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(workflowDefinitionDao, Mockito.never()).updateById(any(WorkflowDefinition.class));
+    }
+
+    @Test
+    public void testOnlineWorkflowDefinitionShouldRejectUnavailableSubWorkflow() {
+        WorkflowDefinition workflowDefinition = getWorkflowDefinition();
+        WorkflowTaskRelation workflowTaskRelation =
+                getWorkflowTaskRelation(1, 1, projectCode, processDefinitionCode, 0, 0, 123456789L, 1);
+        when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(workflowDefinition));
+        when(workflowTaskRelationDao.queryByWorkflowDefinitionCode(processDefinitionCode))
+                .thenReturn(Collections.singletonList(workflowTaskRelation));
+        when(taskDefinitionLogDao.queryTaskDefineLogList(anyList()))
+                .thenReturn(Collections.singletonList(new TaskDefinitionLog()));
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(user), anyList());
 
         ServiceException exception = Assertions.assertThrows(ServiceException.class,
                 () -> workflowDefinitionService.onlineWorkflowDefinition(user, projectCode, processDefinitionCode));
@@ -1023,6 +1096,29 @@ public class WorkflowDefinitionServiceTest extends BaseServiceTestTool {
 
         Assertions.assertNotNull(resultDefinition);
         Assertions.assertEquals(2, resultDefinition.getVersion());
+    }
+
+    @Test
+    public void testUpdateWorkflowDefinitionShouldRejectUnavailableSubWorkflow() {
+        Project project = getProject(projectCode);
+        WorkflowDefinition workflowDefinition = getWorkflowDefinition();
+        workflowDefinition.setName("origin-name");
+        when(projectDao.queryByCode(projectCode)).thenReturn(project);
+        Mockito.doNothing().when(projectService).checkHasProjectWritePermissionThrowException(eq(user), eq(project));
+        when(processService.transformTask(anyList(), anyList())).thenReturn(getTaskNodeList());
+        when(workflowDefinitionDao.queryByCode(processDefinitionCode)).thenReturn(Optional.of(workflowDefinition));
+        when(workflowDefinitionDao.verifyByDefineName(projectCode, name)).thenReturn(null);
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(user), anyList());
+
+        ServiceException exception = Assertions.assertThrows(ServiceException.class,
+                () -> workflowDefinitionService.updateWorkflowDefinition(
+                        user, projectCode, name, processDefinitionCode, description, "[]", "[]", timeout,
+                        taskRelationJson, taskDefinitionJson, WorkflowExecutionTypeEnum.PARALLEL));
+
+        Assertions.assertEquals(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION.getCode(), exception.getCode());
+        Mockito.verify(processService, Mockito.never())
+                .saveTaskDefine(eq(user), eq(projectCode), anyList(), eq(Boolean.TRUE));
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/WorkflowInstanceServiceTest.java
@@ -30,6 +30,7 @@ import org.apache.dolphinscheduler.api.dto.workflowInstance.WorkflowInstanceVari
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ServiceException;
 import org.apache.dolphinscheduler.api.permission.TaskDatasourcePermissionChecker;
+import org.apache.dolphinscheduler.api.permission.TaskSubWorkflowPermissionChecker;
 import org.apache.dolphinscheduler.api.service.impl.LoggerServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
 import org.apache.dolphinscheduler.api.service.impl.WorkflowInstanceServiceImpl;
@@ -145,6 +146,9 @@ public class WorkflowInstanceServiceTest {
 
     @Mock
     TaskDatasourcePermissionChecker taskDatasourcePermissionChecker;
+
+    @Mock
+    TaskSubWorkflowPermissionChecker taskSubWorkflowPermissionChecker;
 
     @Mock
     private TaskInstanceContextDao taskInstanceContextDao;
@@ -626,6 +630,37 @@ public class WorkflowInstanceServiceTest {
         }
         Mockito.verify(taskDatasourcePermissionChecker, Mockito.times(3))
                 .checkPermission(eq(loginUser), Mockito.anyList());
+        Mockito.verify(taskSubWorkflowPermissionChecker, Mockito.times(3))
+                .checkPermission(eq(loginUser), Mockito.anyList());
+    }
+
+    @Test
+    public void testUpdateWorkflowInstanceShouldRejectUnavailableSubWorkflow() {
+        long projectCode = 1L;
+        User loginUser = getAdminUser();
+        WorkflowInstance workflowInstance = getProcessInstance();
+        workflowInstance.setProjectCode(projectCode);
+        workflowInstance.setState(WorkflowExecutionStatus.SUCCESS);
+
+        doNothing().when(projectService).checkHasProjectWritePermissionThrowException(loginUser, projectCode);
+        when(processService.findWorkflowInstanceDetailById(1)).thenReturn(Optional.of(workflowInstance));
+        doThrow(new ServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION))
+                .when(taskSubWorkflowPermissionChecker).checkPermission(eq(loginUser), Mockito.anyList());
+
+        try (
+                MockedStatic<TaskPluginManager> taskPluginManagerMockedStatic =
+                        Mockito.mockStatic(TaskPluginManager.class)) {
+            taskPluginManagerMockedStatic
+                    .when(() -> TaskPluginManager.checkTaskParameters(Mockito.any(), Mockito.any()))
+                    .thenReturn(true);
+
+            assertThrowsServiceException(Status.RESOURCE_NOT_EXIST_OR_NO_PERMISSION,
+                    () -> workflowInstanceService.updateWorkflowInstance(loginUser, projectCode, 1,
+                            taskRelationJson, taskDefinitionJson, "2020-02-21 00:00:00", true, "", "", 0));
+        }
+
+        Mockito.verify(processService, Mockito.never())
+                .saveTaskDefine(eq(loginUser), eq(projectCode), Mockito.anyList(), eq(Boolean.TRUE));
     }
 
     @Test


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The implementation and regression tests were assisted by AI.

## Purpose of the pull request

Enforce permission checks when a sub-workflow reference is created, changed, or activated. The user must have write permission for the project that owns every referenced sub-workflow.

Execution does not recheck the executing user's direct write permission for each referenced project after the reference has been validly bound. Pre-execution validation for a sub-workflow that later becomes unavailable is outside the scope of this permission fix and remains part of the existing runtime failure behavior.

close #18596

## Brief change log

- Add a permission checker that resolves referenced sub-workflows and verifies write permission for their projects.
- Reject unresolved references or unauthorized target projects with the existing generic `RESOURCE_NOT_EXIST_OR_NO_PERMISSION` result.
- Apply the permission check to workflow creation and updates, workflow-instance updates, version switches, and online or release operations.
- Add unit and service-level regression tests.

## Verify this pull request

This change added tests and can be verified as follows:

- `./mvnw verify -B -pl dolphinscheduler-api -DskipE2E=true -DskipITs -Dmaven.test.skip=false -DskipUT=false -Danalyze.skip=true`
- API module result: 735 tests run, 0 failures, 0 errors, 10 skipped.

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join-pull-request.md)
