### PR TITLE
[Fix-18601][Alert] Align Alert Script test-send behavior

### DIFF
--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-script/src/main/java/org/apache/dolphinscheduler/plugin/alert/script/ScriptSender.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-script/src/main/java/org/apache/dolphinscheduler/plugin/alert/script/ScriptSender.java
@@ -30,9 +30,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class ScriptSender {
 
-    private static final String ALERT_TITLE_OPTION = " -t ";
-    private static final String ALERT_CONTENT_OPTION = " -c ";
-    private static final String ALERT_USER_PARAMS_OPTION = " -p ";
+    private static final String ALERT_TITLE_OPTION = "-t";
+    private static final String ALERT_CONTENT_OPTION = "-c";
+    private static final String ALERT_USER_PARAMS_OPTION = "-p";
     private final String scriptPath;
     private final String scriptType;
     private final String userParams;
@@ -74,7 +74,7 @@ public final class ScriptSender {
             return alertResult;
         }
 
-        // validate script path in case of injections
+        // validate script path
         File shellScriptFile = new File(scriptPath);
         // validate existence
         if (!shellScriptFile.exists()) {
@@ -89,25 +89,8 @@ public final class ScriptSender {
             return alertResult;
         }
 
-        // avoid command injection (RCE vulnerability)
-        if (userParams.contains("'")) {
-            log.error("shell script illegal user params : {}", userParams);
-            alertResult.setMessage("shell script illegal user params : " + userParams);
-            return alertResult;
-        }
-        if (title.contains("'")) {
-            log.error("shell script illegal title : {}", title);
-            alertResult.setMessage("shell script illegal title : " + title);
-            return alertResult;
-        }
-        if (content.contains("'")) {
-            log.error("shell script illegal content : {}", content);
-            alertResult.setMessage("shell script illegal content : " + content);
-            return alertResult;
-        }
-
-        String[] cmd = {"/bin/sh", "-c", scriptPath + ALERT_TITLE_OPTION + "'" + title + "'" + ALERT_CONTENT_OPTION
-                + "'" + content + "'" + ALERT_USER_PARAMS_OPTION + "'" + userParams + "'"};
+        String[] cmd = {scriptPath, ALERT_TITLE_OPTION, title, ALERT_CONTENT_OPTION, content, ALERT_USER_PARAMS_OPTION,
+                userParams};
         int exitCode = ProcessUtils.executeScript(cmd);
 
         if (exitCode == 0) {

--- a/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-script/src/test/java/org/apache/dolphinscheduler/plugin/alert/script/ScriptSenderTest.java
+++ b/dolphinscheduler-alert/dolphinscheduler-alert-plugins/dolphinscheduler-alert-script/src/test/java/org/apache/dolphinscheduler/plugin/alert/script/ScriptSenderTest.java
@@ -21,12 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.dolphinscheduler.alert.api.AlertResult;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ScriptSenderTest {
 
@@ -53,11 +59,40 @@ public class ScriptSenderTest {
     }
 
     @Test
-    public void testScriptSenderInjectionTest() {
-        scriptConfig.put(ScriptParamsConstants.NAME_SCRIPT_USER_PARAMS, "' ; calc.exe ; '");
-        ScriptSender scriptSender = new ScriptSender(scriptConfig);
-        AlertResult alertResult = scriptSender.sendScriptAlert("test title Kris", "test content");
-        Assertions.assertFalse(alertResult.isSuccess());
+    public void testScriptArgumentsArePassedLiterally(@TempDir Path tempDir) throws IOException {
+        Path scriptPath = tempDir.resolve("capture-arguments.sh");
+        Path argumentsPath = tempDir.resolve("capture-arguments.sh.args");
+        Path unexpectedCommandMarker = tempDir.resolve("unexpected-command");
+        Files.write(scriptPath, Arrays.asList("#!/bin/sh", "printf '%s\\n' \"$@\" > \"$0.args\""),
+                StandardCharsets.UTF_8);
+        Assertions.assertTrue(scriptPath.toFile().setExecutable(true));
+
+        String title = "Bob's workflow failed";
+        String content = "content $(touch " + unexpectedCommandMarker + ")";
+        String userParams = "' ; touch " + unexpectedCommandMarker + " ; #";
+        Map<String, String> config = new HashMap<>(scriptConfig);
+        config.put(ScriptParamsConstants.NAME_SCRIPT_PATH, scriptPath.toString());
+        config.put(ScriptParamsConstants.NAME_SCRIPT_USER_PARAMS, userParams);
+
+        AlertResult alertResult = new ScriptSender(config).sendScriptAlert(title, content);
+
+        Assertions.assertTrue(alertResult.isSuccess());
+        Assertions.assertFalse(Files.exists(unexpectedCommandMarker));
+        Assertions.assertEquals(Arrays.asList("-t", title, "-c", content, "-p", userParams),
+                Files.readAllLines(argumentsPath, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testScriptPathWithSpecialCharacters(@TempDir Path tempDir) throws IOException {
+        Path scriptPath = tempDir.resolve("script path$(:).sh");
+        Files.write(scriptPath, Arrays.asList("#!/bin/sh", "exit 0"), StandardCharsets.UTF_8);
+        Assertions.assertTrue(scriptPath.toFile().setExecutable(true));
+
+        Map<String, String> config = new HashMap<>(scriptConfig);
+        config.put(ScriptParamsConstants.NAME_SCRIPT_PATH, scriptPath.toString());
+
+        AlertResult alertResult = new ScriptSender(config).sendScriptAlert("test title", "test content");
+        Assertions.assertTrue(alertResult.isSuccess());
     }
 
     @Test

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceController.java
@@ -106,9 +106,10 @@ public class AlertPluginInstanceController extends BaseController {
     @PostMapping(value = "/test-send")
     @ResponseStatus(HttpStatus.OK)
     @ApiException(SEND_TEST_ALERT_PLUGIN_INSTANCE_ERROR)
-    public Result<Boolean> testSendAlertPluginInstance(@RequestParam(value = "pluginDefineId") int pluginDefineId,
+    public Result<Boolean> testSendAlertPluginInstance(@Parameter(hidden = true) @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                       @RequestParam(value = "pluginDefineId") int pluginDefineId,
                                                        @RequestParam(value = "pluginInstanceParams") String pluginInstanceParams) {
-        alertPluginInstanceService.testSend(pluginDefineId, pluginInstanceParams);
+        alertPluginInstanceService.testSend(loginUser, pluginDefineId, pluginInstanceParams);
         return Result.success(true);
     }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceService.java
@@ -95,5 +95,5 @@ public interface AlertPluginInstanceService {
      */
     PageInfo<AlertPluginInstanceVO> listPaging(User loginUser, String searchVal, int pageNo, int pageSize);
 
-    void testSend(int pluginDefineId, String pluginInstanceParams);
+    void testSend(User loginUser, int pluginDefineId, String pluginInstanceParams);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/AlertPluginInstanceServiceImpl.java
@@ -298,7 +298,11 @@ public class AlertPluginInstanceServiceImpl extends BaseServiceImpl implements A
     }
 
     @Override
-    public void testSend(int pluginDefineId, String pluginInstanceParams) {
+    public void testSend(User loginUser, int pluginDefineId, String pluginInstanceParams) {
+        if (!canOperatorPermissions(loginUser, null, AuthorizationType.ALERT_PLUGIN_INSTANCE, ALERT_INSTANCE_CREATE)) {
+            throw new ServiceException(Status.USER_NO_OPERATION_PERM);
+        }
+
         Optional<Host> alertServerAddressOptional = getAlertServerAddress();
         if (!alertServerAddressOptional.isPresent()) {
             throw new ServiceException(Status.ALERT_SERVER_NOT_EXIST);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/AlertPluginInstanceControllerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -101,7 +102,8 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
         paramsMap.add("pluginDefineId", String.valueOf(pluginDefineId));
         paramsMap.add("pluginInstanceParams", pluginInstanceParams);
 
-        doNothing().when(alertPluginInstanceService).testSend(eq(pluginDefineId), eq(pluginInstanceParams));
+        doNothing().when(alertPluginInstanceService).testSend(any(User.class), eq(pluginDefineId),
+                eq(pluginInstanceParams));
 
         // When
         final MvcResult mvcResult = mockMvc.perform(post("/alert-plugin-instances/test-send")
@@ -116,6 +118,7 @@ public class AlertPluginInstanceControllerTest extends AbstractControllerTest {
                 JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
         assertThat(actualResponseContent.getMsg()).isEqualTo(expectResponseContent.getMsg());
         assertThat(actualResponseContent.getCode()).isEqualTo(expectResponseContent.getCode());
+        verify(alertPluginInstanceService).testSend(any(User.class), eq(pluginDefineId), eq(pluginInstanceParams));
     }
 
     @Test

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/AlertPluginInstanceServiceTest.java
@@ -210,9 +210,18 @@ public class AlertPluginInstanceServiceTest {
 
     @Test
     public void testSendAlert() {
+        when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.ALERT_PLUGIN_INSTANCE,
+                noPermUser.getId(), ALERT_INSTANCE_CREATE, baseServiceLogger)).thenReturn(false);
+        assertThrowsServiceException(Status.USER_NO_OPERATION_PERM,
+                () -> alertPluginInstanceService.testSend(noPermUser, 1, uiParams));
+
+        when(resourcePermissionCheckService.operationPermissionCheck(AuthorizationType.ALERT_PLUGIN_INSTANCE,
+                user.getId(), ALERT_INSTANCE_CREATE, baseServiceLogger)).thenReturn(true);
+        when(resourcePermissionCheckService.resourcePermissionCheck(AuthorizationType.ALERT_PLUGIN_INSTANCE,
+                null, 0, baseServiceLogger)).thenReturn(true);
         Mockito.when(registryClient.getServerList(RegistryNodeType.ALERT_SERVER)).thenReturn(new ArrayList<>());
         assertThrowsServiceException(Status.ALERT_SERVER_NOT_EXIST,
-                () -> alertPluginInstanceService.testSend(1, uiParams));
+                () -> alertPluginInstanceService.testSend(user, 1, uiParams));
         Server server = new Server();
         server.setPort(50052);
         server.setHost("127.0.0.1");
@@ -220,7 +229,7 @@ public class AlertPluginInstanceServiceTest {
         Mockito.when(registryClient.getServerList(RegistryNodeType.ALERT_SERVER))
                 .thenReturn(Collections.singletonList(server));
         assertThrowsServiceException(Status.ALERT_TEST_SENDING_FAILED,
-                () -> alertPluginInstanceService.testSend(1, uiParams));
+                () -> alertPluginInstanceService.testSend(user, 1, uiParams));
     }
 
     @Test


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The implementation and tests were assisted by OpenAI Codex and reviewed and validated locally.

## Purpose of the pull request

Fixes #18601.

Align Alert Script test sending so configured script paths and arguments are passed literally, and the existing alert-plugin-instance create operation check is applied consistently.

## Brief change log

- Execute the configured Alert Script with separate process arguments.
- Pass the logged-in user through test-send and reuse the existing alert instance create operation check.
- Add regression coverage for literal script paths and permission checks.

## Verify this pull request

This change added tests and can be verified as follows:

- ScriptSenderTest and ProcessUtilsTest pass with 8 tests in total.
- AlertPluginInstanceControllerTest and AlertPluginInstanceServiceTest pass with 24 tests in total.
- Spotless and git diff check pass.