### PR TITLE
[Feature] Add read-only task search API and DB TLS Helm Chart support

### DIFF
--- a/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
+++ b/deploy/kubernetes/dolphinscheduler/templates/_helpers.tpl
@@ -186,6 +186,69 @@ Create a database environment variables.
   {{- else }}
   value: {{ .Values.externalDatabase.driverClassName | quote }}
   {{- end }}
+{{- include "dolphinscheduler.database.ssl.env_vars" . }}
+{{- end -}}
+
+{{/*
+Create a database SSL environment variables for external database TLS connections.
+*/}}
+{{- define "dolphinscheduler.database.ssl.env_vars" -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.mysql.enabled) .Values.externalDatabase.ssl.enabled }}
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_SSLROOTCERT
+  value: "/opt/dolphinscheduler/db-ssl/ca-certificate"
+{{- if .Values.externalDatabase.ssl.clientCertificate }}
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_SSLCERT
+  value: "/opt/dolphinscheduler/db-ssl/client-certificate"
+{{- end }}
+{{- if .Values.externalDatabase.ssl.clientKey }}
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_SSLKEY
+  value: "/opt/dolphinscheduler/db-ssl/client-key"
+{{- end }}
+{{- if eq .Values.externalDatabase.type "postgresql" }}
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_SSLMODE
+  value: "verify-ca"
+{{- end }}
+{{- if eq .Values.externalDatabase.type "mysql" }}
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_USESSL
+  value: "true"
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_REQUIRESSL
+  value: "true"
+- name: SPRING_DATASOURCE_HIKARI_DATA-SOURCE-PROPERTIES_VERIFYSERVERCERTIFICATE
+  value: "true"
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create a database SSL volume.
+*/}}
+{{- define "dolphinscheduler.database.ssl.volume" -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.mysql.enabled) .Values.externalDatabase.ssl.enabled }}
+- name: db-ssl
+  secret:
+    secretName: {{ include "dolphinscheduler.fullname" . }}-db-ssl
+{{- end }}
+{{- end -}}
+
+{{/*
+Create a database SSL volumeMount.
+*/}}
+{{- define "dolphinscheduler.database.ssl.volumeMount" -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.mysql.enabled) .Values.externalDatabase.ssl.enabled }}
+- mountPath: "/opt/dolphinscheduler/db-ssl/ca-certificate"
+  name: db-ssl
+  subPath: ca-certificate
+{{- if .Values.externalDatabase.ssl.clientCertificate }}
+- mountPath: "/opt/dolphinscheduler/db-ssl/client-certificate"
+  name: db-ssl
+  subPath: client-certificate
+{{- end }}
+{{- if .Values.externalDatabase.ssl.clientKey }}
+- mountPath: "/opt/dolphinscheduler/db-ssl/client-key"
+  name: db-ssl
+  subPath: client-key
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/deploy/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-alert.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-alert.yaml
@@ -168,6 +168,7 @@ spec:
               mountPath: /opt/dolphinscheduler/conf/application.yaml
               subPath: application.yaml
             {{- end }}
+            {{- include "dolphinscheduler.database.ssl.volumeMount" . | nindent 12 }}
       volumes:
         - name: {{ include "dolphinscheduler.fullname" . }}-alert
           {{- if .Values.alert.persistentVolumeClaim.enabled }}
@@ -184,4 +185,5 @@ spec:
           configMap:
             name: {{ include "dolphinscheduler.fullname" . }}-alert
         {{- end }}
+        {{- include "dolphinscheduler.database.ssl.volume" . | nindent 8 }}
 {{- end }}

--- a/deploy/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
@@ -178,6 +178,7 @@ spec:
             {{- include "dolphinscheduler.fsFileResource.volumeMount" . | nindent 12 }}
             {{- include "dolphinscheduler.ldap.ssl.volumeMount" . | nindent 12 }}
             {{- include "dolphinscheduler.etcd.ssl.volumeMount" . | nindent 12 }}
+            {{- include "dolphinscheduler.database.ssl.volumeMount" . | nindent 12 }}
       volumes:
         - name: {{ include "dolphinscheduler.fullname" . }}-api
           {{- if .Values.api.persistentVolumeClaim.enabled }}
@@ -198,4 +199,5 @@ spec:
         {{- include "dolphinscheduler.fsFileResource.volume" . | nindent 8 }}
         {{- include "dolphinscheduler.ldap.ssl.volume" . | nindent 8 }}
         {{- include "dolphinscheduler.etcd.ssl.volume" . | nindent 8 }}
+        {{- include "dolphinscheduler.database.ssl.volume" . | nindent 8 }}
 {{- end }}

--- a/deploy/kubernetes/dolphinscheduler/templates/job-dolphinscheduler-schema-initializer.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/job-dolphinscheduler-schema-initializer.yaml
@@ -53,4 +53,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "dolphinscheduler.fullname" . }}-common
+          volumeMounts:
+            {{- include "dolphinscheduler.database.ssl.volumeMount" . | nindent 12 }}
+      volumes:
+        {{- include "dolphinscheduler.database.ssl.volume" . | nindent 8 }}
 {{- end }}

--- a/deploy/kubernetes/dolphinscheduler/templates/secret-external-database-ssl.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/secret-external-database-ssl.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if and (not .Values.postgresql.enabled) (not .Values.mysql.enabled) .Values.externalDatabase.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dolphinscheduler.fullname" . }}-db-ssl
+  labels:
+    app.kubernetes.io/name: {{ include "dolphinscheduler.fullname" . }}-db-ssl
+    {{- include "dolphinscheduler.common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ca-certificate: {{ .Files.Get .Values.externalDatabase.ssl.caCertificate | b64enc | quote }}
+  {{- if .Values.externalDatabase.ssl.clientCertificate }}
+  client-certificate: {{ .Files.Get .Values.externalDatabase.ssl.clientCertificate | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.externalDatabase.ssl.clientKey }}
+  client-key: {{ .Files.Get .Values.externalDatabase.ssl.clientKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-master.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-master.yaml
@@ -168,6 +168,7 @@ spec:
               mountPath: /opt/dolphinscheduler/conf/common.properties
               subPath: common.properties
             {{- include "dolphinscheduler.etcd.ssl.volumeMount" . | nindent 12 }}
+            {{- include "dolphinscheduler.database.ssl.volumeMount" . | nindent 12 }}
       volumes:
         - name: {{ include "dolphinscheduler.fullname" . }}-master
           {{- if .Values.master.persistentVolumeClaim.enabled }}
@@ -186,6 +187,7 @@ spec:
           configMap:
             name: {{ include "dolphinscheduler.fullname" . }}-configs
         {{- include "dolphinscheduler.etcd.ssl.volume" . | nindent 8 }}
+        {{- include "dolphinscheduler.database.ssl.volume" . | nindent 8 }}
   {{- if .Values.master.persistentVolumeClaim.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
+++ b/deploy/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
@@ -185,6 +185,7 @@ spec:
             {{- include "dolphinscheduler.sharedStorage.volumeMount" . | nindent 12 }}
             {{- include "dolphinscheduler.fsFileResource.volumeMount" . | nindent 12 }}
             {{- include "dolphinscheduler.etcd.ssl.volumeMount" . | nindent 12 }}
+            {{- include "dolphinscheduler.database.ssl.volumeMount" . | nindent 12 }}
             {{- if .Values.worker.extraVolumeMounts }}
             {{- toYaml .Values.worker.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -221,6 +222,7 @@ spec:
         {{- include "dolphinscheduler.sharedStorage.volume" . | nindent 8 }}
         {{- include "dolphinscheduler.fsFileResource.volume" . | nindent 8 }}
         {{- include "dolphinscheduler.etcd.ssl.volume" . | nindent 8 }}
+        {{- include "dolphinscheduler.database.ssl.volume" . | nindent 8 }}
         {{- if .Values.worker.extraVolumes }}
         {{- toYaml .Values.worker.extraVolumes | nindent 8 }}
         {{- end }}

--- a/deploy/kubernetes/dolphinscheduler/values.yaml
+++ b/deploy/kubernetes/dolphinscheduler/values.yaml
@@ -152,6 +152,15 @@ externalDatabase:
   params: "characterEncoding=utf8"
   # -- The driverClassName of external database
   driverClassName: "org.postgresql.Driver"
+  ssl:
+    # -- Enable TLS/SSL connection to external database. If true, you must provide the CA certificate and optionally client certificates.
+    enabled: false
+    # -- Path to the CA certificate file (e.g., "db-certs/ca.crt")
+    caCertificate: "db-certs/ca.crt"
+    # -- Path to the client certificate file (optional, e.g., "db-certs/client.crt")
+    clientCertificate: "db-certs/client.crt"
+    # -- Path to the client key file (optional, e.g., "db-certs/client.key")
+    clientKey: "db-certs/client.key"
 
 zookeeper:
   # -- If not exists external registry, the zookeeper registry will be used by default.

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowDefinitionController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/WorkflowDefinitionController.java
@@ -31,6 +31,7 @@ import static org.apache.dolphinscheduler.api.enums.Status.QUERY_WORKFLOW_DEFINI
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_WORKFLOW_DEFINITION_LIST_PAGING_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.QUERY_WORKFLOW_DEFINITION_VERSIONS_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.RELEASE_WORKFLOW_DEFINITION_ERROR;
+import static org.apache.dolphinscheduler.api.enums.Status.SEARCH_TASK_DEFINITIONS_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.SWITCH_WORKFLOW_DEFINITION_VERSION_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_WORKFLOW_DEFINITION_ERROR;
 import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_WORKFLOW_DEFINITION_NAME_UNIQUE_ERROR;
@@ -49,6 +50,7 @@ import org.apache.dolphinscheduler.common.enums.WorkflowExecutionTypeEnum;
 import org.apache.dolphinscheduler.dao.entity.DagData;
 import org.apache.dolphinscheduler.dao.entity.DependentSimplifyDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.TaskSearchResult;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.plugin.task.api.utils.ParameterUtils;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -402,6 +402,7 @@ public enum Status {
     CREATE_TASK_DEFINITION_LOG_ERROR(50061, "create task definition log {0} error", "创建任务操作记录 {0} 错误"),
     DELETE_TASK_DEFINE_BY_CODE_MSG_ERROR(50062, "delete task definition {0} error", "删除任务定义 {0} 错误"),
     TASK_DEFINITION_NOT_EXISTS(50064, "task definition {0} do not exists", "任务定义 {0} 不存在"),
+    SEARCH_TASK_DEFINITIONS_ERROR(50063, "search task definitions error", "搜索任务定义错误"),
     WORKFLOW_TASK_RELATION_NOT_EXPECT(50067, "workflow task relation number not expect, expect {0} but get {1}",
             "工作流任务关系数量不符合预期，预期 {0} 但是实际 {1}"),
     WORKFLOW_TASK_RELATION_BATCH_DELETE_ERROR(50068, "batch delete workflow task relation {0} error",

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/WorkflowDefinitionService.java
@@ -26,6 +26,7 @@ import org.apache.dolphinscheduler.dao.entity.DagData;
 import org.apache.dolphinscheduler.dao.entity.DependentSimplifyDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
+import org.apache.dolphinscheduler.dao.entity.TaskSearchResult;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 
@@ -228,4 +229,15 @@ public interface WorkflowDefinitionService {
                              long workflowDefinitionCode,
                              int workflowDefinitionVersion,
                              List<TaskDefinitionLog> taskDefinitionLogList);
+
+    /**
+     * Search task definitions by name across a project, returning task info
+     * together with the parent workflow definition info.
+     *
+     * @param loginUser   login user
+     * @param projectCode project code
+     * @param searchVal   search value for task name (partial match). If empty, returns all tasks.
+     * @return list of task search results with workflow info
+     */
+    List<TaskSearchResult> searchTaskDefinitionsByName(User loginUser, long projectCode, String searchVal);
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/WorkflowDefinitionServiceImpl.java
@@ -68,6 +68,7 @@ import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.dao.entity.TaskSearchResult;
 import org.apache.dolphinscheduler.dao.entity.User;
 import org.apache.dolphinscheduler.dao.entity.UserWithWorkflowDefinitionCode;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
@@ -1895,5 +1896,16 @@ public class WorkflowDefinitionServiceImpl extends BaseServiceImpl implements Wo
                         "SubWorkflowDefinition " + subWorkflowDefinition.getName() + " is not online");
             }
         }
+    }
+
+    @Override
+    public List<TaskSearchResult> searchTaskDefinitionsByName(User loginUser, long projectCode, String searchVal) {
+        Project project = projectDao.queryByCode(projectCode)
+                .orElseThrow(() -> new ServiceException(Status.PROJECT_NOT_FOUND, projectCode));
+        if (!projectService.hasReadPermission(loginUser, project)) {
+            throw new ServiceException(Status.USER_NO_OPERATION_PROJECT_PERM, loginUser.getUserName(),
+                    project.getName());
+        }
+        return taskDefinitionDao.searchTaskDefinitionsByName(projectCode, searchVal);
     }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/TaskSearchResult.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/TaskSearchResult.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.dao.entity;
+
+import org.apache.dolphinscheduler.common.enums.ReleaseState;
+
+import java.util.Date;
+
+import lombok.Data;
+
+/**
+ * Task search result: contains task info and its parent workflow info.
+ * Used by the read-only task search API.
+ */
+@Data
+public class TaskSearchResult {
+
+    private long taskCode;
+
+    private String taskName;
+
+    private int taskVersion;
+
+    private String taskType;
+
+    private Date taskCreateTime;
+
+    private Date taskUpdateTime;
+
+    private long workflowDefinitionCode;
+
+    private int workflowDefinitionVersion;
+
+    private String workflowDefinitionName;
+
+    private ReleaseState workflowReleaseState;
+
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionMapper.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.dao.mapper;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
 import org.apache.dolphinscheduler.dao.entity.TaskMainInfo;
+import org.apache.dolphinscheduler.dao.entity.TaskSearchResult;
 import org.apache.dolphinscheduler.dao.model.WorkflowDefinitionCountDto;
 
 import org.apache.ibatis.annotations.Param;
@@ -122,4 +123,15 @@ public interface TaskDefinitionMapper extends BaseMapper<TaskDefinition> {
     void deleteByWorkflowDefinitionCodeAndVersion(long workflowDefinitionCode, int workflowDefinitionVersion);
 
     List<TaskDefinition> queryDefinitionsByTaskType(@Param("taskType") String taskType);
+
+    /**
+     * Search task definitions by name across a project, returning task info
+     * together with the parent workflow definition info.
+     *
+     * @param projectCode project code
+     * @param searchVal   search value for task name (partial match). If empty, returns all tasks.
+     * @return list of task search results with workflow info
+     */
+    List<TaskSearchResult> searchTaskDefinitionsByName(@Param("projectCode") long projectCode,
+                                                       @Param("searchVal") String searchVal);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TaskDefinitionDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/TaskDefinitionDao.java
@@ -18,6 +18,7 @@
 package org.apache.dolphinscheduler.dao.repository;
 
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
+import org.apache.dolphinscheduler.dao.entity.TaskSearchResult;
 
 import java.util.Collection;
 import java.util.List;
@@ -66,4 +67,14 @@ public interface TaskDefinitionDao extends IDao<TaskDefinition> {
     List<TaskDefinition> queryByEnvironmentCodeAndWorkerGroup(long environmentCode, String workerGroup);
 
     List<String> queryAllTaskDefinitionWorkerGroups(long projectCode);
+
+    /**
+     * Search task definitions by name across a project, returning task info
+     * together with the parent workflow definition info.
+     *
+     * @param projectCode project code
+     * @param searchVal   search value for task name (partial match). If empty, returns all tasks.
+     * @return list of task search results with workflow info
+     */
+    List<TaskSearchResult> searchTaskDefinitionsByName(long projectCode, String searchVal);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TaskDefinitionDaoImpl.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/repository/impl/TaskDefinitionDaoImpl.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.dao.repository.impl;
 
 import org.apache.dolphinscheduler.dao.entity.TaskDefinition;
 import org.apache.dolphinscheduler.dao.entity.TaskDefinitionLog;
+import org.apache.dolphinscheduler.dao.entity.TaskSearchResult;
 import org.apache.dolphinscheduler.dao.entity.WorkflowDefinition;
 import org.apache.dolphinscheduler.dao.entity.WorkflowTaskRelationLog;
 import org.apache.dolphinscheduler.dao.mapper.TaskDefinitionLogMapper;
@@ -146,5 +147,10 @@ public class TaskDefinitionDaoImpl extends BaseDao<TaskDefinition, TaskDefinitio
     @Override
     public List<String> queryAllTaskDefinitionWorkerGroups(long projectCode) {
         return mybatisMapper.queryAllTaskDefinitionWorkerGroups(projectCode);
+    }
+
+    @Override
+    public List<TaskSearchResult> searchTaskDefinitionsByName(long projectCode, String searchVal) {
+        return mybatisMapper.searchTaskDefinitionsByName(projectCode, searchVal);
     }
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskDefinitionMapper.xml
@@ -153,4 +153,29 @@
         where task_type = #{taskType}
     </select>
 
+    <select id="searchTaskDefinitionsByName" resultType="org.apache.dolphinscheduler.dao.entity.TaskSearchResult">
+        select
+            td.code as task_code,
+            td.name as task_name,
+            td.version as task_version,
+            td.task_type,
+            td.create_time as task_create_time,
+            td.update_time as task_update_time,
+            wd.code as workflow_definition_code,
+            wd.version as workflow_definition_version,
+            wd.name as workflow_definition_name,
+            wd.release_state as workflow_release_state
+        from t_ds_task_definition td
+        inner join t_ds_workflow_task_relation ptr on ptr.project_code = td.project_code
+            and td.code = ptr.post_task_code
+            and td.version = ptr.post_task_version
+        inner join t_ds_workflow_definition wd on wd.code = ptr.workflow_definition_code
+            and wd.version = ptr.workflow_definition_version
+        where td.project_code = #{projectCode}
+        <if test="searchVal != null and searchVal != ''">
+            and td.name like concat('%', #{searchVal}, '%')
+        </if>
+        order by td.update_time desc, td.id asc
+    </select>
+
 </mapper>


### PR DESCRIPTION
Fixes #18402 and #17550:

### Task Search API (#18402)

Added a read-only API endpoint to search tasks by name and locate which workflow they belong to. After DSIP-59 removed the standalone Task Definition page, there was no way to search for tasks across workflows.

Changes:
- New `TaskSearchResult` entity
- New search endpoint in `WorkflowDefinitionController`
- Task search logic in `WorkflowDefinitionServiceImpl`
- DAO layer support for task search queries

### DB TLS Helm Chart (#17550)

Added support for connecting to external databases with TLS/SSL connections in the Helm Chart.

Changes:
- New `secret-external-database-ssl.yaml` template for TLS certificates
- Updated `_helpers.tpl` with TLS configuration helpers
- Updated all component deployments to mount TLS secrets
- Updated `values.yaml` with new TLS configuration options