### PR TITLE
[Fix-18576][Dependent Task] Fix parsing for ALL dependent tasks

### DIFF
--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItem.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/main/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItem.java
@@ -44,13 +44,15 @@ public class DependentItem {
 
     public DependentItem fromKey(String key) {
         String[] parts = key.split("-");
-        if (parts.length != 4) {
+        boolean isNegativeDepTaskCode = parts.length == 5 && parts[1].isEmpty();
+        if (parts.length != 4 && !isNegativeDepTaskCode) {
             throw new IllegalArgumentException("Invalid key format");
         }
+        int offset = isNegativeDepTaskCode ? 1 : 0;
         setDefinitionCode(Long.parseLong(parts[0]));
-        setDepTaskCode(Long.parseLong(parts[1]));
-        setCycle(parts[2]);
-        setDateValue(parts[3]);
+        setDepTaskCode(Long.parseLong(isNegativeDepTaskCode ? "-" + parts[2] : parts[1]));
+        setCycle(parts[2 + offset]);
+        setDateValue(parts[3 + offset]);
         return this;
     }
 

--- a/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItemTest.java
+++ b/dolphinscheduler-task-plugin/dolphinscheduler-task-api/src/test/java/org/apache/dolphinscheduler/plugin/task/api/model/DependentItemTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.plugin.task.api.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class DependentItemTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "123, 2001-123-hour-currentHour, hour, currentHour",
+            "0, 2001-0-week-lastWeek, week, lastWeek",
+            "-1, 2001--1-day-today, day, today",
+            "-9223372036854775808, 2001--9223372036854775808-month-lastMonthEnd, month, lastMonthEnd"
+    })
+    public void testKeyRoundTrip(long depTaskCode, String key, String cycle, String dateValue) {
+        DependentItem dependentItem = new DependentItem();
+        dependentItem.setDefinitionCode(2001);
+        dependentItem.setDepTaskCode(depTaskCode);
+        dependentItem.setCycle(cycle);
+        dependentItem.setDateValue(dateValue);
+
+        Assertions.assertEquals(key, dependentItem.getKey());
+
+        DependentItem parsedDependentItem = new DependentItem().fromKey(key);
+        Assertions.assertEquals(dependentItem.getDefinitionCode(), parsedDependentItem.getDefinitionCode());
+        Assertions.assertEquals(dependentItem.getDepTaskCode(), parsedDependentItem.getDepTaskCode());
+        Assertions.assertEquals(dependentItem.getCycle(), parsedDependentItem.getCycle());
+        Assertions.assertEquals(dependentItem.getDateValue(), parsedDependentItem.getDateValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "invalid-key",
+            "2001-1-day",
+            "2001-1-day-",
+            "2001-1-day-today-extra",
+            "2001---1-day-today"
+    })
+    public void testFromKeyWithInvalidFormat(String key) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new DependentItem().fromKey(key));
+    }
+}


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. The implementation and regression tests were AI-assisted. All changes were manually reviewed and verified.

## Purpose of the pull request

Fix dependent tasks configured with **Task Name** set to `ALL`.

The special `depTaskCode` value `-1` adds a second hyphen to the serialized key, so `DependentItem#fromKey()` currently rejects it as malformed. This change restores the negative sign while preserving the existing key format and behavior for regular task codes.

Closes #18576

## Brief change log

- Parse negative `depTaskCode` values from dependent-item keys.
- Preserve the existing serialized key format.
- Add regression coverage for positive task codes, workflow-level code `0`, `ALL` code `-1`, `Long.MIN_VALUE`, and malformed keys.

## Verify this pull request

This change added tests and can be verified as follows:

- Added `DependentItemTest` for key round trips and malformed keys.
- Run `./mvnw -pl dolphinscheduler-task-plugin/dolphinscheduler-task-api -am -Dtest=DependentItemTest -Dsurefire.failIfNoSpecifiedTests=false test`.
- Run `./mvnw spotless:check`.

## Pull Request Notice
[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)

If this pull request contains an incompatible change, it should also be added to `docs/docs/en/guide/upgrade/incompatible.md`.