### PR TITLE
[Bug][Master] Fix recovering failed workflow changes forced-success task to SUCCESS

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskForceSuccessStateAction.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/engine/task/statemachine/TaskForceSuccessStateAction.java
@@ -17,7 +17,10 @@
 
 package org.apache.dolphinscheduler.server.master.engine.task.statemachine;
 
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.plugin.task.api.enums.TaskExecutionStatus;
+import org.apache.dolphinscheduler.server.master.engine.task.execution.ITaskExecution;
+import org.apache.dolphinscheduler.server.master.engine.task.lifecycle.event.TaskSuccessLifecycleEvent;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,5 +33,16 @@ public class TaskForceSuccessStateAction extends TaskSuccessStateAction {
     @Override
     public TaskExecutionStatus matchState() {
         return TaskExecutionStatus.FORCED_SUCCESS;
+    }
+
+    @Override
+    protected void persistentTaskInstanceSuccessEventToDB(final ITaskExecution taskExecution,
+                                                          final TaskSuccessLifecycleEvent taskSuccessEvent) {
+        final TaskInstance taskInstance = taskExecution.getTaskInstance();
+        taskInstance.setState(TaskExecutionStatus.FORCED_SUCCESS);
+        if (taskInstance.getEndTime() == null) {
+            taskInstance.setEndTime(taskSuccessEvent.getEndTime());
+        }
+        taskInstanceDao.updateById(taskInstance);
     }
 }


### PR DESCRIPTION
Fixes #18604: When a failed workflow is recovered, tasks that were manually set to forced success get their status changed from FORCED_SUCCESS to SUCCESS.

### Root Cause

TaskForceSuccessStateAction inherited persistentTaskInstanceSuccessEventToDB from TaskSuccessStateAction, which always sets status to SUCCESS.

### Fix

Overrode persistentTaskInstanceSuccessEventToDB in TaskForceSuccessStateAction to persist FORCED_SUCCESS status instead of SUCCESS.