### PR TITLE
[Fix-17139][Common] Fix multibyte log preview truncation

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LogUtils.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -86,22 +85,22 @@ public class LogUtils {
 
     public static String rollViewLogLines(List<String> lines) {
         StringBuilder builder = new StringBuilder();
-        final int MaxResponseLogSize = 65535;
-        int totalLogByteSize = 0;
+        final int maxLogCharSize = 65535;
+        int totalLogCharSize = 0;
         for (String line : lines) {
-            // If a single line of log is exceed max response size, cut off the line
-            final int lineByteSize = line.getBytes(StandardCharsets.UTF_8).length;
-            if (lineByteSize >= MaxResponseLogSize) {
-                builder.append(line, 0, MaxResponseLogSize)
-                        .append(" [this line's size ").append(lineByteSize).append(" bytes is exceed ")
-                        .append(MaxResponseLogSize).append(" bytes, so only ")
-                        .append(MaxResponseLogSize).append(" characters are reserved for performance reasons.]")
+            // If a single log line exceeds the character limit, cut off the line.
+            final int lineCharSize = line.length();
+            if (lineCharSize >= maxLogCharSize) {
+                builder.append(line, 0, maxLogCharSize)
+                        .append(" [this line's size ").append(lineCharSize).append(" characters exceeds ")
+                        .append(maxLogCharSize).append(" characters, so only ")
+                        .append(maxLogCharSize).append(" characters are reserved for performance reasons.]")
                         .append("\r\n");
             } else {
                 builder.append(line).append("\r\n");
             }
-            totalLogByteSize += lineByteSize;
-            if (totalLogByteSize >= MaxResponseLogSize) {
+            totalLogCharSize += lineCharSize;
+            if (totalLogCharSize >= maxLogCharSize) {
                 break;
             }
         }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/LogUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+class LogUtilsTest {
+
+    @Test
+    void testRollViewLogLinesWithMultibyteCharacters() {
+        String line = StringUtils.repeat("中", 22000);
+
+        assertEquals(line + "\r\n", LogUtils.rollViewLogLines(Collections.singletonList(line)));
+    }
+
+    @Test
+    void testRollViewLogLinesTruncatesLongLines() {
+        for (String character : Arrays.asList("a", "中")) {
+            String line = StringUtils.repeat(character, 65536);
+            String expected = StringUtils.repeat(character, 65535)
+                    + " [this line's size 65536 characters exceeds 65535 characters, so only "
+                    + "65535 characters are reserved for performance reasons.]\r\n";
+
+            assertEquals(expected, LogUtils.rollViewLogLines(Collections.singletonList(line)));
+        }
+    }
+
+    @Test
+    void testRollViewLogLinesStopsAtCharacterLimit() {
+        String line = StringUtils.repeat("中", 32768);
+
+        assertEquals(line + "\r\n" + line + "\r\n",
+                LogUtils.rollViewLogLines(Arrays.asList(line, line, "omitted")));
+    }
+}


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

YES. OpenAI Codex assisted with the implementation, regression tests, and validation.

## Purpose of the pull request

Fixes #17139, which is still reproducible on current `dev`. The previous PR #17140 was closed without merging.

`rollViewLogLines` checks the UTF-8 byte length but uses the 65,535 limit as a string index. A line containing 22,000 Chinese characters is 66,000 bytes, so log preview attempts to read past the end of the string and throws `IndexOutOfBoundsException`.

## Brief change log

Use character counts consistently for the single-line cutoff, accumulated page limit, and truncation message, following the approach discussed in #17140. Add regression coverage for multibyte lines, ASCII and multibyte truncation, and the accumulated character limit.

## Verify this pull request

The new multibyte cases reproduce the exception before the fix. With JDK 17 and the repository's dependency versions, the following checks pass:

```sh
./mvnw -o -pl dolphinscheduler-common '-DspotlessFiles=.*LogUtils.*[.]java' spotless:apply
./mvnw -o -pl dolphinscheduler-common -Dtest=LogUtilsTest test
git diff --check
```

All 3 tests pass. The Maven test command also passes the module's Spotless check. The full repository test suite was not run.

## Pull Request Notice

[Pull Request Notice](https://github.com/apache/dolphinscheduler/blob/dev/docs/docs/en/contribute/join/pull-request.md)
